### PR TITLE
Add DSv4 SM120 decode fast paths

### DIFF
--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -93,7 +93,18 @@ def _broadcast_gather_object(local_object: object, group: ProcessGroup) -> list[
     all_objects: list[list[object | None]] = [[None] for _ in range(world_size)]
     all_objects[rank][0] = local_object
     for index, src_rank in enumerate(_group_ranks(group)):
-        dist.broadcast_object_list(all_objects[index], src=src_rank, group=group, device="cpu")
+        try:
+            dist.broadcast_object_list(all_objects[index], src=src_rank, group=group, device="cpu")
+        except RuntimeError as exc:
+            if "No backend type associated with device type cpu" not in str(exc):
+                raise
+            cuda_index = torch.cuda.current_device()
+            dist.broadcast_object_list(
+                all_objects[index],
+                src=src_rank,
+                group=group,
+                device=torch.device("cuda", cuda_index),
+            )
     return [entry[0] for entry in all_objects]
 
 

--- a/b12x/integration/_silu_dsv4_decode.py
+++ b/b12x/integration/_silu_dsv4_decode.py
@@ -1,0 +1,114 @@
+"""DSv4-Flash specialized SiLU MoE decode dispatch for SM_120.
+
+EXACT shape specialization for DSv4-Flash decode:
+- Hidden K = 4096
+- Intermediate N = 2048
+- Num experts E = 256 (TP=4 → 64 per rank)
+- Top_k = 6 (avg 1.5 per rank)
+- Activation = silu (gated)
+- m ∈ {1..8} (decode bs=1 + EAGLE expansion)
+
+Microbench data (single GPU, E=256):
+  m=1: b12x_moe_fp4 = 0.246ms (efficiency 23.6% of bandwidth)
+  m=4: b12x_moe_fp4 = 0.323ms (efficiency 18.0%)
+  Theoretical floor: 0.058ms
+
+Goal: replace dispatch overhead with an exact-shape direct decode path.
+Target speedup: remove the remaining Python/backend-selection overhead around
+the already-tuned b12x NVFP4 compact microkernel for m=1-8 SiLU DSv4 shapes.
+
+CURRENT DESIGN:
+1. Static exact-shape gate: no generic backend selection on DSv4 decode.
+2. Force the compact static/micro topology for m<=8, top_k=6.
+3. Reuse the existing NVFP4 SiLU microkernel and workspace pool.
+4. Reuse preflattened routing when sparse routing already produced it.
+
+Memory footprint per CTA at m=1, top_k=6:
+- Input a: 1 * 4096 * 2B = 8KB BF16
+- Per-expert w1+w3: 2 * 2048 * 4096 * 0.5B = 8MB FP4 (need streamed access)
+- Per-expert w2: 4096 * 2048 * 0.5B = 4MB FP4
+- TOO BIG for SMEM. Need TMA + cooperative loading
+
+This module owns the exact DSv4 predicate and a narrow launcher shim. The
+launcher delegates to a private tp_moe helper, not to the public b12x_moe_fp4
+entrypoint, so the direct path cannot recurse through generic dispatch.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+# DSv4-Flash exact shapes (must match these to take fast path)
+DSV4_HIDDEN_K = 4096
+DSV4_INTERMEDIATE_N = 2048
+DSV4_NUM_EXPERTS = 256
+DSV4_TOP_K = 6
+DSV4_W1_FP4_SHAPE_GLOBAL = (DSV4_NUM_EXPERTS, 2 * DSV4_INTERMEDIATE_N, DSV4_HIDDEN_K // 2)  # (256, 4096, 2048) gated
+DSV4_W2_FP4_SHAPE_GLOBAL = (DSV4_NUM_EXPERTS, DSV4_HIDDEN_K, DSV4_INTERMEDIATE_N // 2)      # (256, 4096, 1024)
+DSV4_BS_SUPPORTED = (1, 2, 3, 4, 5, 6, 7, 8)
+
+# TP=4 partition shapes (each rank has E/4 experts)
+DSV4_W1_FP4_SHAPE_TP4 = (DSV4_NUM_EXPERTS // 4, 2 * DSV4_INTERMEDIATE_N, DSV4_HIDDEN_K // 2)
+DSV4_W2_FP4_SHAPE_TP4 = (DSV4_NUM_EXPERTS // 4, DSV4_HIDDEN_K, DSV4_INTERMEDIATE_N // 2)
+
+
+def is_exact_silu_dsv4_case(
+    *, activation: str, a: torch.Tensor, w1_fp4: torch.Tensor, w2_fp4: torch.Tensor,
+    topk_weights: torch.Tensor, topk_ids: torch.Tensor,
+    a1_gscale: torch.Tensor, a2_gscale: torch.Tensor,
+) -> bool:
+    """Gate for DSv4-silu specialized path. Accepts both global and TP=4 partition shapes."""
+    if os.environ.get("B12X_DSV4_SILU_DIRECT", "1") == "0":
+        return False
+    if activation != "silu":
+        return False
+    if a.dtype != torch.bfloat16:
+        return False
+    if a.dim() != 2 or a.shape[1] != DSV4_HIDDEN_K:
+        return False
+    if topk_ids.dim() != 2 or topk_ids.shape[1] != DSV4_TOP_K:
+        return False
+    if topk_weights.shape != topk_ids.shape:
+        return False
+    if a1_gscale.numel() != 1 or a2_gscale.numel() != 1:
+        return False
+    if a.shape[0] not in DSV4_BS_SUPPORTED:
+        return False
+    if topk_ids.shape[0] != a.shape[0]:
+        return False
+    # Accept either global or TP=4-sliced shapes
+    if tuple(w1_fp4.shape) == DSV4_W1_FP4_SHAPE_GLOBAL and tuple(w2_fp4.shape) == DSV4_W2_FP4_SHAPE_GLOBAL:
+        return True
+    if tuple(w1_fp4.shape) == DSV4_W1_FP4_SHAPE_TP4 and tuple(w2_fp4.shape) == DSV4_W2_FP4_SHAPE_TP4:
+        return True
+    return False
+
+
+def launch_exact_silu_dsv4(
+    *, workspace, a, a1_gscale, w1_fp4, w1_blockscale, w1_alphas,
+    a2_gscale, w2_fp4, w2_blockscale, w2_alphas,
+    topk_weights, topk_ids, output,
+    apply_router_weight_on_input, input_scales_are_reciprocal,
+    fast_math: bool = True,
+    flat_ids: torch.Tensor | None = None,
+    flat_weights: torch.Tensor | None = None,
+):
+    """Launch the exact DSv4-SiLU decode path without public-entry recursion."""
+    if apply_router_weight_on_input:
+        raise NotImplementedError("apply_router_weight_on_input is not implemented in DSv4 SiLU direct path")
+    from b12x.integration.tp_moe import _launch_exact_silu_dsv4_decode
+
+    return _launch_exact_silu_dsv4_decode(
+        a=a, a1_gscale=a1_gscale,
+        w1_fp4=w1_fp4, w1_blockscale=w1_blockscale, w1_alphas=w1_alphas,
+        a2_gscale=a2_gscale, w2_fp4=w2_fp4, w2_blockscale=w2_blockscale, w2_alphas=w2_alphas,
+        topk_weights=topk_weights, topk_ids=topk_ids,
+        workspace=workspace, output=output,
+        input_scales_are_reciprocal=input_scales_are_reciprocal,
+        input_scales_static=(a1_gscale.numel() == 1 and a2_gscale.numel() == 1),
+        fast_math=fast_math,
+        flat_ids=flat_ids,
+        flat_weights=flat_weights,
+    )

--- a/b12x/integration/dsv4_allreduce_patch.py
+++ b/b12x/integration/dsv4_allreduce_patch.py
@@ -1,0 +1,609 @@
+"""Monkey-patch sglang allreduce dispatch to use the b12x PCIe oneshot kernel.
+
+Activated by setting ``B12X_USE_PCIE_AR=1`` in the environment.  When activated,
+``apply_dsv4_allreduce_patch()`` replaces
+
+* ``sglang.srt.distributed.communication_op.tensor_model_parallel_all_reduce``
+* ``sglang.srt.distributed.parallel_state.GroupCoordinator.all_reduce``
+* ``sglang.srt.distributed.parallel_state.GroupCoordinator.graph_capture``
+
+so that BF16 allreduces on (T, 4096) with T <= 32 are handled by
+:class:`b12x.distributed.PCIeOneshotAllReduce`.  All other shapes/dtypes fall
+through to the original NCCL/sglang path.
+
+v2 changes (track-A v2):
+- The graph_capture wrapper now PRE-INITIALISES the b12x runtime and PRE-WARMS
+  the kernel for every (shape, dtype) we expect inside graph capture.  This
+  drains all IPC handle exchanges, JIT compilation and ``cudaMalloc``s out of
+  the capture window, so capture never touches NCCL or allocator paths that
+  invalidate ``cudaStreamCaptureStatus``.
+- A persistent output-buffer pool is allocated up-front (one BF16 tensor of
+  ``max_bs * 4096`` per shape) and reused on the patched call.  If a request
+  arrives during capture for a shape we did NOT pre-warm, we fall through to
+  the original NCCL path instead of allocating a new buffer.
+- ``B12X_PCIE_AR_PREWARM_SHAPES`` env var
+  (default ``"1,4096;4,4096;5,4096;8,4096;16,4096;32,4096"``)
+  controls the set of shapes warmed before capture.
+- ``B12X_USE_PCIE_AR_NOGRAPH=1`` remains as a final fallback that disables
+  b12x while a stream is being captured.
+
+The patch is idempotent (safe to call repeatedly) and tolerant of sglang or
+torch.distributed not being initialized yet — the b12x runtime is constructed
+lazily on the first eligible call.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import torch
+from torch.distributed import ProcessGroup
+
+from b12x.distributed.pcie_oneshot import (
+    PCIeOneshotAllReduce,
+    SUPPORTED_WORLD_SIZES,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration knobs
+# ---------------------------------------------------------------------------
+
+# Hidden dimensions for DSv4-Flash decode allreduces.  Prologue/MQA path uses
+# 4096; MoE intermediate paths surface 2048 and 7168.
+_DSV4_HIDDEN = 4096
+_DSV4_HIDDENS_FAST_PATH = (4096,)
+# Maximum number of tokens (rows) we accept on the fast path.  The standalone
+# PCIe oneshot path has a verified small-T win, but the known T=64 broadening
+# regressed against NCCL.  Keep this ceiling conservative unless a benchmark
+# proves a new fused/overlapped path.
+_DSV4_MAX_TOKENS = 32
+# Default eager-buffer size — needs to fit the largest fast-path AR.
+# 64 tokens * 4096 hidden * 2 bytes BF16 = 512 KB.  Round up to 1 MB.
+_DEFAULT_EAGER_BYTES = 1 * 1024 * 1024  # 1 MB
+
+# Module-level latch / singletons so that the patch is idempotent and the b12x
+# runtime survives across all workers in a single process.
+_PATCH_LOCK = threading.Lock()
+_PATCH_APPLIED = False
+_RUNTIME_LOCK = threading.Lock()
+_RUNTIMES: dict[Tuple[int, int, int], "_RuntimeBundle"] = {}
+
+_ENV_ENABLE = "B12X_USE_PCIE_AR"
+_ENV_ENABLE_NOGRAPH = "B12X_USE_PCIE_AR_NOGRAPH"
+_ENV_VERBOSE = "B12X_PCIE_AR_VERBOSE"
+_ENV_PREWARM = "B12X_PCIE_AR_PREWARM_SHAPES"
+_ENV_MAX_TOKENS = "B12X_PCIE_AR_MAX_TOKENS"
+_DEFAULT_PREWARM = "1,4096;4,4096;5,4096;8,4096;16,4096;32,4096"
+
+
+def _verbose() -> bool:
+    return os.environ.get(_ENV_VERBOSE, "0") in ("1", "true", "yes")
+
+
+def _enabled() -> bool:
+    return os.environ.get(_ENV_ENABLE, "0") in ("1", "true", "yes")
+
+
+def _max_tokens() -> int:
+    raw = os.environ.get(_ENV_MAX_TOKENS)
+    if raw is None:
+        return _DSV4_MAX_TOKENS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DSV4_MAX_TOKENS
+    eager_limit = _DEFAULT_EAGER_BYTES // (_DSV4_HIDDEN * 2)
+    # This env var may narrow the fast path for diagnostics, but it must not
+    # raise the standalone oneshot path into the known-regressing T=64 bucket.
+    return max(1, min(value, _DSV4_MAX_TOKENS, eager_limit))
+
+
+def _graph_disabled() -> bool:
+    """If set, b12x AR is only used in eager mode (no graph capture)."""
+    return os.environ.get(_ENV_ENABLE_NOGRAPH, "0") in ("1", "true", "yes")
+
+
+def _parse_prewarm_shapes(value: Optional[str]) -> List[Tuple[int, int]]:
+    """Parse ``"T1,H1;T2,H2;..."`` into a list of (T, H) shapes.
+
+    Empty / malformed entries are silently skipped.  Always returns a list
+    deduplicated in input order.
+    """
+    text = (value if value is not None else _DEFAULT_PREWARM).strip()
+    if not text:
+        return []
+    seen: set[Tuple[int, int]] = set()
+    out: List[Tuple[int, int]] = []
+    for chunk in text.split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = chunk.split(",")
+        if len(parts) != 2:
+            continue
+        try:
+            t = int(parts[0])
+            h = int(parts[1])
+        except ValueError:
+            continue
+        if t <= 0 or h <= 0:
+            continue
+        key = (t, h)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def _is_fast_shape(shape: Tuple[int, ...], element_size: int) -> bool:
+    if len(shape) < 1:
+        return False
+    last = shape[-1]
+    if last not in _DSV4_HIDDENS_FAST_PATH:
+        return False
+    rows = 1
+    for s in shape[:-1]:
+        rows *= s
+    if rows == 0 or rows > _max_tokens():
+        return False
+    if rows * last * element_size > _DEFAULT_EAGER_BYTES:
+        return False
+    return True
+
+
+def _capture_prewarm_shapes(value: Optional[str]) -> List[Tuple[int, int]]:
+    """Return graph-capture warmup shapes that are eligible for oneshot AR.
+
+    Warmup happens before capture, but warming unsupported rows is still
+    misleading and can leave output buffers around for shapes the production
+    predicate must not use.  In particular, never warm T=64 for the standalone
+    oneshot path.
+    """
+    shapes = _parse_prewarm_shapes(value)
+    if (1, _DSV4_HIDDEN) not in shapes:
+        shapes = [(1, _DSV4_HIDDEN), *shapes]
+    element_size = torch.tensor([], dtype=torch.bfloat16).element_size()
+    return [shape for shape in shapes if _is_fast_shape(shape, element_size)]
+
+
+# ---------------------------------------------------------------------------
+# Runtime bundle: caches a PCIeOneshotAllReduce per (group, world_size, device)
+# plus a per-shape persistent output buffer pool.
+# ---------------------------------------------------------------------------
+
+
+class _RuntimeBundle:
+    """Owns a :class:`PCIeOneshotAllReduce` plus persistent output and input
+    buffer pools keyed by ``(shape, dtype)``.
+
+    Buffers are pre-allocated by :meth:`warmup` BEFORE graph capture begins so
+    that the patched ``all_reduce`` call performs zero allocations even under
+    ``cudaStreamCaptureStatusActive``.
+    """
+
+    def __init__(self, runtime: PCIeOneshotAllReduce):
+        self.runtime = runtime
+        # Output-buffer pool keyed by ``(shape, dtype)``.  Allocated up front
+        # by :meth:`warmup` so subsequent allreduce calls can reuse a stable
+        # device pointer (critical for cuda graph replay).
+        self._out_pool: Dict[Tuple[Tuple[int, ...], torch.dtype], torch.Tensor] = {}
+        # Persistent input scratch pool used during warmup so the kernel JITs
+        # and registers IPC handles against device pointers that survive past
+        # the warmup function.  Keeping these alive also guarantees that the
+        # eager dbuf machinery has live peer pointers for the duration of the
+        # patch.
+        self._warmup_inputs: Dict[Tuple[Tuple[int, ...], torch.dtype], torch.Tensor] = {}
+        self._warmup_done: set[Tuple[Tuple[int, ...], torch.dtype]] = set()
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Buffer-pool helpers
+    # ------------------------------------------------------------------
+
+    def get_output(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype,
+        *,
+        allow_alloc: bool,
+    ) -> Optional[torch.Tensor]:
+        """Return a cached output buffer for ``(shape, dtype)``.
+
+        If no buffer exists and ``allow_alloc`` is False (we're inside graph
+        capture) returns ``None`` so the caller falls through to NCCL.  If
+        ``allow_alloc`` is True we lazily allocate one and add it to the pool.
+        """
+        key = (tuple(shape), dtype)
+        with self._lock:
+            cached = self._out_pool.get(key)
+            if cached is not None:
+                return cached
+            if not allow_alloc:
+                return None
+            out = torch.empty(shape, dtype=dtype, device=self.runtime.device)
+            self._out_pool[key] = out
+            return out
+
+    def has_output(self, shape: Tuple[int, ...], dtype: torch.dtype) -> bool:
+        return (tuple(shape), dtype) in self._out_pool
+
+    # ------------------------------------------------------------------
+    # Warmup: drain IPC + JIT + per-shape pool allocations BEFORE capture
+    # ------------------------------------------------------------------
+
+    def warmup(self, shapes: Iterable[Tuple[int, int]], dtype: torch.dtype = torch.bfloat16) -> None:
+        """Pre-init IPC handles and pre-allocate output buffers for every
+        shape we may see during graph capture.
+
+        For each shape we:
+            1. Allocate a persistent input tensor (kept alive in
+               ``self._warmup_inputs``).
+            2. Allocate an output tensor in the pool.
+            3. Run ``runtime.all_reduce`` once outside graph capture to JIT
+               the kernel and ensure dbuf peer-pointer machinery is wired up.
+            4. Synchronise the device so any deferred init in the kernel /
+               extension is fully drained before capture starts.
+
+        This is idempotent — re-running with the same shapes is a no-op.
+        """
+        device = self.runtime.device
+        for t, h in shapes:
+            key = ((t, h), dtype)
+            with self._lock:
+                if key in self._warmup_done:
+                    continue
+            shape = (t, h)
+            # 1. Persistent input tensor (kept alive on the bundle).
+            inp = torch.zeros(shape, dtype=dtype, device=device)
+            # 2. Persistent output tensor in the pool.
+            out = torch.empty(shape, dtype=dtype, device=device)
+            with self._lock:
+                self._warmup_inputs[key] = inp
+                self._out_pool[key] = out
+            # 3. Drive the kernel once (eager, NOT under capture).  This
+            #    triggers extension JIT, dbuf slot init, kernel dispatch warm
+            #    on the current stream.  We deliberately ignore numerical
+            #    correctness — we only need the side-effects.
+            try:
+                if self.runtime.should_allreduce(inp):
+                    self.runtime.all_reduce(inp, out=out)
+            except Exception as exc:  # noqa: BLE001
+                # If warmup itself fails we still register the shape as
+                # "tried" so we don't loop, but we surface a warning.  The
+                # patch will fall through to NCCL for this shape.
+                logger.warning(
+                    "[b12x AR] warmup failed for shape=%s dtype=%s: %s",
+                    shape,
+                    dtype,
+                    exc,
+                )
+            with self._lock:
+                self._warmup_done.add(key)
+        # 4. Final sync: ensure every async init is committed before the
+        #    caller starts a graph capture on this device.
+        torch.cuda.synchronize(device=device)
+
+
+def _runtime_key(group: ProcessGroup, device: torch.device) -> Tuple[int, int, int]:
+    """Stable key — id() of the group object plus the device index."""
+    import torch.distributed as dist
+
+    world_size = dist.get_world_size(group=group)
+    device_index = device.index if device.index is not None else 0
+    return (id(group), world_size, device_index)
+
+
+def _get_or_create_runtime(
+    group: ProcessGroup, device: torch.device, *, allow_create: bool = True
+) -> Optional[_RuntimeBundle]:
+    import torch.distributed as dist
+
+    world_size = dist.get_world_size(group=group)
+    if world_size not in SUPPORTED_WORLD_SIZES:
+        if _verbose():
+            logger.warning(
+                "[b12x AR] world size %d not supported by PCIe oneshot; falling through",
+                world_size,
+            )
+        return None
+
+    key = _runtime_key(group, device)
+    bundle = _RUNTIMES.get(key)
+    if bundle is not None:
+        return bundle
+    if not allow_create:
+        return None
+
+    # Construction MUST NOT run under cuda graph capture: it does IPC handle
+    # exchange (NCCL CPU broadcast) and ``cudaMalloc``s.  Refuse to construct
+    # if the current stream is capturing — caller should pre-warm via the
+    # graph_capture wrapper instead.
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        if _verbose():
+            logger.warning(
+                "[b12x AR] refusing to construct runtime under stream capture; "
+                "falling through to NCCL"
+            )
+        return None
+
+    with _RUNTIME_LOCK:
+        bundle = _RUNTIMES.get(key)
+        if bundle is not None:
+            return bundle
+        try:
+            runtime = PCIeOneshotAllReduce.from_exchange_group(
+                exchange_group=group,
+                device=device,
+                eager_buffer_bytes=_DEFAULT_EAGER_BYTES,
+                max_size=_DEFAULT_EAGER_BYTES,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[b12x AR] failed to initialise PCIe oneshot runtime (world_size=%d, device=%s): %s",
+                world_size,
+                device,
+                exc,
+            )
+            return None
+        bundle = _RuntimeBundle(runtime)
+        _RUNTIMES[key] = bundle
+        if _verbose():
+            logger.info(
+                "[b12x AR] PCIe oneshot runtime ready (world_size=%d, device=%s)",
+                world_size,
+                device,
+            )
+        return bundle
+
+
+# ---------------------------------------------------------------------------
+# Fast-path predicate
+# ---------------------------------------------------------------------------
+
+
+def _is_fast_path(inp: torch.Tensor) -> bool:
+    if inp.dtype != torch.bfloat16:
+        return False
+    if inp.device.type != "cuda":
+        return False
+    if not inp.is_contiguous():
+        return False
+    return _is_fast_shape(tuple(inp.shape), inp.element_size())
+
+
+# ---------------------------------------------------------------------------
+# Allreduce dispatch helper
+# ---------------------------------------------------------------------------
+
+
+def _b12x_all_reduce(group_coordinator: Any, input_: torch.Tensor) -> Optional[torch.Tensor]:
+    """Run b12x oneshot AR if eligible; return ``None`` on fall-through."""
+
+    if group_coordinator.world_size == 1:
+        return input_
+    if not _is_fast_path(input_):
+        return None
+
+    capturing = torch.cuda.is_current_stream_capturing() if torch.cuda.is_available() else False
+    if _graph_disabled() and capturing:
+        return None
+
+    # IPC handle exchange uses ``broadcast_object_list(..., device="cpu")`` so
+    # we MUST pass the Gloo CPU group; the NCCL device_group has no CPU backend
+    # and triggers ``No backend type associated with device type cpu``.
+    exchange_group = getattr(group_coordinator, "cpu_group", None)
+    if exchange_group is None:
+        exchange_group = getattr(group_coordinator, "device_group", None)
+    if exchange_group is None:
+        return None
+    device = getattr(group_coordinator, "device", None)
+    if device is None or not isinstance(device, torch.device) or device.type != "cuda":
+        return None
+
+    # Construction is NOT permitted while a stream is being captured.  If we
+    # haven't seen this group/device before AND we're inside capture, fall
+    # through — the prewarm path should have been called earlier.
+    bundle = _get_or_create_runtime(exchange_group, device, allow_create=not capturing)
+    if bundle is None:
+        return None
+
+    runtime = bundle.runtime
+    if not runtime.should_allreduce(input_):
+        return None
+
+    # Output buffer: must come from the pre-allocated pool when capturing.
+    out = bundle.get_output(tuple(input_.shape), input_.dtype, allow_alloc=not capturing)
+    if out is None:
+        # Capture-time fall-through: shape was not pre-warmed.  Logging this
+        # at WARN once per (capture, shape) would be ideal but we keep it
+        # cheap and let the warning fire on every uncaptured warmup miss.
+        if _verbose():
+            logger.warning(
+                "[b12x AR] output buffer for shape=%s dtype=%s missing during "
+                "capture; falling through to NCCL",
+                tuple(input_.shape),
+                input_.dtype,
+            )
+        return None
+
+    try:
+        runtime.all_reduce(input_, out=out)
+    except Exception as exc:  # noqa: BLE001
+        # Surface the first failure loudly but continue via fall-through.
+        logger.warning(
+            "[b12x AR] PCIe oneshot allreduce failed (shape=%s, dtype=%s): %s — falling back to NCCL",
+            tuple(input_.shape),
+            input_.dtype,
+            exc,
+        )
+        return None
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Graph-capture wrapper: register IPC handles after each capture
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_capture_wrapper(original_graph_capture):
+    """Wrap ``GroupCoordinator.graph_capture`` so we
+
+    1. construct the b12x runtime up-front (out of capture),
+    2. pre-warm it for every shape we expect inside capture, and
+    3. register graph buffers post-capture so replays can resolve peer ptrs.
+    """
+
+    @contextmanager
+    def graph_capture_wrapper(self, *args, **kwargs):
+        # PCIe oneshot's IPC-handle exchange needs a Gloo CPU group;
+        # ``self.device_group`` is NCCL-only.
+        exchange_group = getattr(self, "cpu_group", None) or getattr(self, "device_group", None)
+        device = getattr(self, "device", None)
+        bundle: Optional[_RuntimeBundle] = None
+
+        if (
+            exchange_group is not None
+            and isinstance(device, torch.device)
+            and device.type == "cuda"
+            and not _graph_disabled()
+        ):
+            try:
+                bundle = _get_or_create_runtime(exchange_group, device, allow_create=True)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[b12x AR] runtime construction inside graph_capture wrapper failed: %s",
+                    exc,
+                )
+                bundle = None
+
+            if bundle is not None:
+                shapes = _capture_prewarm_shapes(os.environ.get(_ENV_PREWARM))
+                try:
+                    bundle.warmup(shapes, dtype=torch.bfloat16)
+                    if _verbose():
+                        logger.info(
+                            "[b12x AR] pre-warmed %d shape(s) before graph capture: %s",
+                            len(shapes),
+                            shapes,
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "[b12x AR] warmup before graph capture failed: %s — capture "
+                        "will fall through to NCCL for affected shapes",
+                        exc,
+                    )
+
+        with original_graph_capture(self, *args, **kwargs) as ctx:
+            try:
+                yield ctx
+            finally:
+                # After capture, register graph buffers so future replays can
+                # resolve peer pointers.  This is a CPU-side IPC handle
+                # exchange (broadcast_object_list) — safe outside capture.
+                if bundle is not None:
+                    try:
+                        bundle.runtime.register_graph_buffers()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "[b12x AR] register_graph_buffers failed: %s",
+                            exc,
+                        )
+
+    return graph_capture_wrapper
+
+
+# ---------------------------------------------------------------------------
+# Top-level patch entry point
+# ---------------------------------------------------------------------------
+
+
+def apply_dsv4_allreduce_patch(force: bool = False) -> bool:
+    """Install the monkey-patch.  Returns True if the patch was applied (or
+    was already applied).
+
+    v2 also installs a graph_capture wrapper that pre-warms IPC handles and
+    output buffers for every shape in ``B12X_PCIE_AR_PREWARM_SHAPES`` (default
+    ``"1,4096;4,4096;5,4096"``) before sglang starts capturing.  Without this
+    pre-warm the kernel's first invocation under capture allocates IPC peers
+    on the fly and triggers ``cudaErrorStreamCaptureInvalidated``.
+    """
+
+    global _PATCH_APPLIED
+    if not force and not _enabled():
+        if _verbose():
+            logger.info(
+                "[b12x AR] %s not set; skipping patch install",
+                _ENV_ENABLE,
+            )
+        return False
+
+    with _PATCH_LOCK:
+        if _PATCH_APPLIED:
+            return True
+
+        try:
+            from sglang.srt.distributed import communication_op as comm_op
+            from sglang.srt.distributed import parallel_state as ps
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[b12x AR] sglang not importable: %s", exc)
+            return False
+
+        original_tmp_ar = comm_op.tensor_model_parallel_all_reduce
+        original_group_all_reduce = ps.GroupCoordinator.all_reduce
+        original_graph_capture = ps.GroupCoordinator.graph_capture
+
+        def patched_tmp_ar(input_: torch.Tensor) -> torch.Tensor:
+            group = ps.get_tp_group()
+            result = _b12x_all_reduce(group, input_)
+            if result is not None:
+                return result
+            return original_tmp_ar(input_)
+
+        def patched_group_all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
+            result = _b12x_all_reduce(self, input_)
+            if result is not None:
+                return result
+            return original_group_all_reduce(self, input_)
+
+        comm_op.tensor_model_parallel_all_reduce = patched_tmp_ar
+        ps.GroupCoordinator.all_reduce = patched_group_all_reduce
+        ps.GroupCoordinator.graph_capture = _make_graph_capture_wrapper(original_graph_capture)
+
+        # Stash originals on the modules so unpatch (if needed) can restore.
+        comm_op._b12x_original_tmp_ar = original_tmp_ar
+        ps.GroupCoordinator._b12x_original_all_reduce = original_group_all_reduce
+        ps.GroupCoordinator._b12x_original_graph_capture = original_graph_capture
+
+        _PATCH_APPLIED = True
+        if _verbose():
+            logger.info("[b12x AR] PCIe oneshot allreduce patch installed")
+        return True
+
+
+def is_patch_applied() -> bool:
+    return _PATCH_APPLIED
+
+
+def reset_runtime_cache() -> None:
+    """Drop cached runtimes — primarily for tests."""
+    with _RUNTIME_LOCK:
+        for bundle in list(_RUNTIMES.values()):
+            try:
+                bundle.runtime.close()
+            except Exception:  # noqa: BLE001
+                pass
+        _RUNTIMES.clear()
+
+
+__all__ = [
+    "apply_dsv4_allreduce_patch",
+    "is_patch_applied",
+    "reset_runtime_cache",
+]

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Dict, Tuple
@@ -17,6 +18,7 @@ from b12x.cute.fp4 import align_up, as_grouped_scale_view
 from b12x.cute.utils import current_cuda_stream, get_max_active_clusters, get_num_sm, make_ptr
 from b12x.integration.triton_compact import compact_topk_ids as triton_compact_topk_ids
 from b12x.integration.triton_route import route_topk as triton_route_topk
+from b12x.integration._silu_dsv4_decode import is_exact_silu_dsv4_case
 from b12x.moe.fused.relu2 import (
     MoEDynamicKernelRelu2,
     MoEMicroKernelRelu2,
@@ -35,6 +37,9 @@ _RUNTIME_MEMREF_LIMIT = (1 << 31) - 1
 _LEVEL_TILE_M = 128
 _LEVEL_TILE_N = 128
 _DYNAMIC_SLICE_CHUNK = 2
+_LOGGER = logging.getLogger(__name__)
+_DSV4_SILU_DIRECT_HITS = 0
+_DSV4_SILU_DIRECT_LOGGED = False
 
 
 @dataclass(kw_only=True)
@@ -325,6 +330,8 @@ def clear_tp_moe_caches() -> None:
     global _STATIC_COMPACT_CUTOVER_PAIRS_CACHE
     global _DYNAMIC_MULTICTA_CACHE
     global _DYNAMIC_CHUNK_MULTIPLIER_CACHE
+    global _DSV4_SILU_DIRECT_HITS
+    global _DSV4_SILU_DIRECT_LOGGED
     _WEIGHT_CACHE.clear()
     _MICRO_KERNEL_CACHE.clear()
     _STATIC_KERNEL_CACHE.clear()
@@ -336,6 +343,8 @@ def clear_tp_moe_caches() -> None:
     _STATIC_COMPACT_CUTOVER_PAIRS_CACHE = None
     _DYNAMIC_MULTICTA_CACHE = None
     _DYNAMIC_CHUNK_MULTIPLIER_CACHE = None
+    _DSV4_SILU_DIRECT_HITS = 0
+    _DSV4_SILU_DIRECT_LOGGED = False
     _LAST_WEIGHTS = (None, None)
     _LAST_KERNEL = (None, None)
     _LAST_EXACT_RELU2_BS1_NEMOTRON = (None, None)
@@ -414,6 +423,15 @@ def _get_relu2_bs1_spark_micro_cap() -> int:
     if cap is None:
         return 42
     return max(1, int(cap))
+
+
+def _dsv4_silu_direct_enabled() -> bool:
+    return os.environ.get("B12X_DSV4_SILU_DIRECT", "1") != "0"
+
+
+def get_tp_moe_debug_counters() -> dict[str, int]:
+    """Return lightweight process-local counters for integration smoke tests."""
+    return {"dsv4_silu_direct_hits": int(_DSV4_SILU_DIRECT_HITS)}
 
 
 def _flatten_routing_ids(topk_ids: torch.Tensor) -> torch.Tensor:
@@ -1103,6 +1121,30 @@ def _make_exact_relu2_bs1_nemotron_plan(
         max_rows=total_pairs,
         k=1024,
         n=2688,
+        num_topk=num_topk,
+        device=device,
+        dtype=dtype,
+        max_tokens_per_launch=num_tokens,
+    )
+
+
+def _make_exact_silu_dsv4_decode_plan(
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    num_tokens: int,
+    weight_E: int,
+) -> TPMoEPlan:
+    num_topk = 6
+    total_pairs = num_topk * num_tokens
+    return TPMoEPlan(
+        implementation="static",
+        state_E=total_pairs,
+        weight_E=weight_E,
+        routed_rows=total_pairs,
+        max_rows=total_pairs,
+        k=4096,
+        n=2048,
         num_topk=num_topk,
         device=device,
         dtype=dtype,
@@ -2253,6 +2295,130 @@ def _launch_exact_relu2_bs1_nemotron(
     return scatter_output
 
 
+def _launch_exact_silu_dsv4_decode(
+    *,
+    workspace: TPMoEWorkspace | TPMoEWorkspacePool,
+    a: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    output: torch.Tensor | None,
+    input_scales_are_reciprocal: bool,
+    input_scales_static: bool,
+    fast_math: bool,
+    flat_ids: torch.Tensor | None = None,
+    flat_weights: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Exact DSv4 SiLU decode dispatch over the compact NVFP4 microkernel.
+
+    This bypasses the generic backend planner for the live DSv4 TP=4 decode
+    buckets. It keeps production on b12x NVFP4 kernels while adopting Sonic's
+    compact token/expert queue idea: the launch sees only the active top-k
+    routed pairs, with optional preflattened routing supplied by the sparse
+    wrapper.
+    """
+    global _DSV4_SILU_DIRECT_HITS
+    global _DSV4_SILU_DIRECT_LOGGED
+
+    m, k = a.shape
+    weight_E = w1_fp4.shape[0]
+    n = w2_fp4.shape[2] * 2
+    num_topk = topk_ids.shape[1]
+    routed_rows = m * num_topk
+    device = a.device
+    plan = _make_exact_silu_dsv4_decode_plan(
+        device=device,
+        dtype=a.dtype,
+        num_tokens=m,
+        weight_E=weight_E,
+    )
+    s = _resolve_workspace(
+        workspace,
+        plan=plan,
+        a1_gscale=a1_gscale,
+        a2_gscale=a2_gscale,
+        input_scales_static=input_scales_static,
+    )
+    assert isinstance(s, TPCompactStaticWorkspace)
+
+    scatter_output = _resolve_scatter_output(
+        a=a,
+        output=output,
+        device=device,
+        m=m,
+        k=k,
+    )
+    activation_spec = _get_activation_kernel_spec("silu")
+    wv = _get_weight_views(
+        w1_fp4,
+        w1_blockscale,
+        w2_fp4,
+        w2_blockscale,
+        w1_alphas,
+        w2_alphas,
+        n,
+        k,
+        activation_spec=activation_spec,
+    )
+    launch_ids = flat_ids if flat_ids is not None else _flatten_routing_ids(topk_ids)
+    launch_weights = flat_weights if flat_weights is not None else _flatten_routing_weights(topk_weights)
+    if launch_ids.dtype not in (torch.int32, torch.int64):
+        launch_ids = launch_ids.to(torch.int32)
+    if not launch_ids.is_contiguous():
+        launch_ids = launch_ids.contiguous()
+    if launch_weights.dtype != torch.float32:
+        launch_weights = launch_weights.to(torch.float32)
+    if not launch_weights.is_contiguous():
+        launch_weights = launch_weights.contiguous()
+
+    input_gs = _prepare_expert_scale(a1_gscale, weight_E)
+    down_input_scale = _prepare_expert_scale(a2_gscale, weight_E)
+    _DSV4_SILU_DIRECT_HITS += 1
+    if not _DSV4_SILU_DIRECT_LOGGED:
+        _LOGGER.warning(
+            "b12x DSv4 SiLU direct MoE path active: m=%d topk=%d E=%d K=%d N=%d; "
+            "bypassing generic flashinfer/backend dispatch",
+            m,
+            num_topk,
+            weight_E,
+            k,
+            n,
+        )
+        _DSV4_SILU_DIRECT_LOGGED = True
+
+    _launch_compact_static(
+        workspace=s,
+        weights=wv,
+        a=a,
+        flat_ids=launch_ids,
+        flat_weights=launch_weights,
+        input_gs=input_gs,
+        down_input_scale=down_input_scale,
+        scatter_output=scatter_output,
+        weight_E=weight_E,
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+        routed_rows=routed_rows,
+        topk_ids_dtype=launch_ids.dtype,
+        input_scales_are_reciprocal=input_scales_are_reciprocal,
+        fast_math=fast_math,
+        stream=current_cuda_stream(),
+        share_input_across_experts=(a1_gscale.numel() == 1),
+        share_expert_scales=(a1_gscale.numel() == 1 and a2_gscale.numel() == 1),
+        activation="silu",
+    )
+    return scatter_output
+
+
 def _launch_dynamic(
     *,
     workspace: TPDynamicWorkspace,
@@ -2489,6 +2655,37 @@ def b12x_moe_fp4(
         input_scales_static
         or (a1_gscale.numel() == 1 and a2_gscale.numel() == 1)
     )
+    if (
+        _dsv4_silu_direct_enabled()
+        and is_exact_silu_dsv4_case(
+            activation=activation,
+            a=a,
+            w1_fp4=w1_fp4,
+            w2_fp4=w2_fp4,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            a1_gscale=a1_gscale,
+            a2_gscale=a2_gscale,
+        )
+    ):
+        return _launch_exact_silu_dsv4_decode(
+            workspace=workspace,
+            a=a,
+            a1_gscale=a1_gscale,
+            w1_fp4=w1_fp4,
+            w1_blockscale=w1_blockscale,
+            w1_alphas=w1_alphas,
+            a2_gscale=a2_gscale,
+            w2_fp4=w2_fp4,
+            w2_blockscale=w2_blockscale,
+            w2_alphas=w2_alphas,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            output=output,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            input_scales_static=effective_input_scales_static,
+            fast_math=fast_math,
+        )
     if _is_exact_relu2_bs1_nemotron_case(
         activation=activation,
         a=a,
@@ -3054,25 +3251,64 @@ def b12x_sparse_moe_fp4(
 
     _validate_sparse_routing(hidden_states, selected)
 
-    routed_output = b12x_moe_fp4(
-        hidden_states,
-        experts.a1_gscale,
-        experts.w1_fp4,
-        experts.w1_blockscale,
-        experts.w1_alphas,
-        experts.a2_gscale,
-        experts.w2_fp4,
-        experts.w2_blockscale,
-        experts.w2_alphas,
-        selected.topk_weights,
-        selected.topk_ids,
-        workspace=workspace,
-        output=output,
-        input_scales_are_reciprocal=input_scales_are_reciprocal,
-        input_scales_static=input_scales_static,
-        fast_math=fast_math,
-        activation=activation,
-    )
+    if fast_math is None:
+        fast_math = _FAST_MATH_DEFAULT
+    if (
+        _dsv4_silu_direct_enabled()
+        and is_exact_silu_dsv4_case(
+            activation=activation,
+            a=hidden_states,
+            w1_fp4=experts.w1_fp4,
+            w2_fp4=experts.w2_fp4,
+            topk_weights=selected.topk_weights,
+            topk_ids=selected.topk_ids,
+            a1_gscale=experts.a1_gscale,
+            a2_gscale=experts.a2_gscale,
+        )
+    ):
+        routed_output = _launch_exact_silu_dsv4_decode(
+            workspace=workspace,
+            a=hidden_states,
+            a1_gscale=experts.a1_gscale,
+            w1_fp4=experts.w1_fp4,
+            w1_blockscale=experts.w1_blockscale,
+            w1_alphas=experts.w1_alphas,
+            a2_gscale=experts.a2_gscale,
+            w2_fp4=experts.w2_fp4,
+            w2_blockscale=experts.w2_blockscale,
+            w2_alphas=experts.w2_alphas,
+            topk_weights=selected.topk_weights,
+            topk_ids=selected.topk_ids,
+            output=output,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            input_scales_static=(
+                input_scales_static
+                or (experts.a1_gscale.numel() == 1 and experts.a2_gscale.numel() == 1)
+            ),
+            fast_math=fast_math,
+            flat_ids=selected.flat_ids,
+            flat_weights=selected.flat_weights,
+        )
+    else:
+        routed_output = b12x_moe_fp4(
+            hidden_states,
+            experts.a1_gscale,
+            experts.w1_fp4,
+            experts.w1_blockscale,
+            experts.w1_alphas,
+            experts.a2_gscale,
+            experts.w2_fp4,
+            experts.w2_blockscale,
+            experts.w2_alphas,
+            selected.topk_weights,
+            selected.topk_ids,
+            workspace=workspace,
+            output=output,
+            input_scales_are_reciprocal=input_scales_are_reciprocal,
+            input_scales_static=input_scales_static,
+            fast_math=fast_math,
+            activation=activation,
+        )
     if routed_scaling_factor != 1.0:
         routed_output.mul_(routed_scaling_factor)
     if return_routing:

--- a/b12x/moe/fused/static.py
+++ b/b12x/moe/fused/static.py
@@ -72,6 +72,7 @@ class _MoEStaticKernelBase:
         self.fast_math = fast_math
         self.activation = activation
         self.is_gated = activation == "silu"
+        self.share_gated_smem = self.is_gated and mma_tiler_mn[1] > 128
         tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -189,7 +190,7 @@ class _MoEStaticKernelBase:
             cute.size_in_bytes(self.sf_dtype, sfb_smem_staged),
             cute.size_in_bytes(cutlass.BFloat16, epi_smem_staged),
         ]
-        if self.is_gated:
+        if self.is_gated and not self.share_gated_smem:
             buffers.insert(2, cute.size_in_bytes(self.b_dtype, b_smem_staged))
             buffers.insert(5, cute.size_in_bytes(self.sf_dtype, sfb_smem_staged))
         offset = _align_up(offset, self.buffer_align_bytes)
@@ -322,6 +323,37 @@ def _compact_static_get_work_tile(
         Int32(cur_cluster_coord[2]),
     )
     return cur_tile_coord, is_valid, current_local_expert_idx, accum_tile_m
+
+
+@cute.jit
+def _copy_sfb_k(
+    smem_copy_SFB: cute.TiledCopy,
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    k_block,
+    wide_n: cutlass.Constexpr,
+):
+    if cutlass.const_expr(wide_n):
+        src_k = cute.append_ones(src[None, None, k_block], up_to_rank=3)
+        cute.copy(smem_copy_SFB, src_k, dst[None, None, None, k_block])
+    else:
+        cute.copy(smem_copy_SFB, src[None, None, k_block], dst[None, None, k_block])
+
+
+@cute.jit
+def _set_mma_sfb(
+    mma_atom: cute.MmaAtom,
+    field: cutlass.Constexpr,
+    frag: cute.Tensor,
+    nt: cutlass.Constexpr,
+    k_block: cutlass.Constexpr,
+    wide_n: cutlass.Constexpr,
+    n_split: cutlass.Constexpr,
+):
+    if cutlass.const_expr(wide_n):
+        mma_atom.set(field, frag[None, nt % n_split, nt // n_split, k_block].iterator)
+    else:
+        mma_atom.set(field, frag[None, nt, k_block].iterator)
 
 
 @dsl_user_op
@@ -755,7 +787,43 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                 self.buffer_align_bytes,
             ]
 
-        storage = smem.allocate(StorageGated if self.is_gated else StorageRelu2)
+        @cute.struct
+        class StorageGatedShared:
+            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            phase2_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
+            scatter_tok_cache: cute.struct.MemRange[cutlass.Int32, _COMPACT_STATIC_TILE_M]
+            scatter_weight_cache: cute.struct.MemRange[cutlass.Float32, _COMPACT_STATIC_TILE_M]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[self.b_dtype, cute.cosize(b_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfa_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[self.sf_dtype, cute.cosize(sfb_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(epi_smem_staged)],
+                self.buffer_align_bytes,
+            ]
+
+        if cutlass.const_expr(self.is_gated):
+            storage = smem.allocate(
+                StorageGatedShared
+                if cutlass.const_expr(self.share_gated_smem)
+                else StorageGated
+            )
+        else:
+            storage = smem.allocate(StorageRelu2)
 
         prod_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
         cons_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, self.num_mma_warps)
@@ -768,8 +836,8 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
-        up_pipeline = (
-            pipeline.PipelineTmaAsync.create(
+        if cutlass.const_expr(self.is_gated):
+            up_pipeline = pipeline.PipelineTmaAsync.create(
                 num_stages=self.ab_stage,
                 producer_group=prod_group,
                 consumer_group=cons_group,
@@ -777,9 +845,8 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                 barrier_storage=storage.up_pipeline_array.data_ptr(),
                 cta_layout_vmnk=cta_layout_vmnk,
             )
-            if self.is_gated
-            else ml_pipeline
-        )
+        else:
+            up_pipeline = ml_pipeline
         phase2_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
             producer_group=prod_group,
@@ -799,13 +866,17 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
         sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
         sSFA_u8 = cute.recast_tensor(sSFA, cutlass.Uint8)
         sSFB_u8 = cute.recast_tensor(sSFB, cutlass.Uint8)
-        sB_up = (
-            storage.sB_up.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
-            if self.is_gated
-            else sB
-        )
+        if cutlass.const_expr(self.is_gated and not self.share_gated_smem):
+            sB_up = storage.sB_up.get_tensor(
+                b_smem_staged.outer, swizzle=b_smem_staged.inner,
+            )
+        else:
+            sB_up = sB
         sB_up_u8 = cute.recast_tensor(sB_up, cutlass.Uint8)
-        sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged) if self.is_gated else sSFB
+        if cutlass.const_expr(self.is_gated and not self.share_gated_smem):
+            sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
+        else:
+            sSFB_up = sSFB
         sSFB_up_u8 = cute.recast_tensor(sSFB_up, cutlass.Uint8)
         sC = storage.sC.get_tensor(
             epi_smem_staged.outer, swizzle=epi_smem_staged.inner,
@@ -1213,6 +1284,8 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                 epi_rest_m = self.tile_shape_mnk[0] // self.epi_tile[0]
                 MmaMPerEpiM = self.epi_tile[0] // mma_tile_m
                 MmaNPerEpiN = self.epi_tile[1] // mma_tile_n
+                fc2_k_chunks = self.tile_shape_mnk[1] // self.tile_shape_mnk[2]
+                MmaNPerFc2K = MmaNPerEpiN // fc2_k_chunks
                 fc1_m_tiles = cute.size(tCrA_tile, mode=[1])
                 fc1_n_tiles = cute.size(tCrB, mode=[1])
                 fc2_m_tiles = fc1_m_tiles
@@ -1239,7 +1312,10 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                 fz_csSFA_p = cute.filter_zeros(csSFA_p)
                 fz_csSFB_p = cute.filter_zeros(csSFB_p)
                 cute.copy(smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0])
-                cute.copy(smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0])
+                _copy_sfb_k(
+                    smem_copy_SFB, fz_csSFB_p, fz_crSFB, Int32(0),
+                    cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                )
                 for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -1258,7 +1334,11 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                             for _mt in range(self.num_m_tiles):
                                 for _nt in range(self.num_n_tiles):
                                     mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                    mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                    _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                     cute.gemm(
                                         mma_atom,
                                         gate_acc[None, _mt, _nt],
@@ -1270,7 +1350,11 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                             for _mt in cutlass.range_constexpr(fc1_m_tiles):
                                 for _nt in cutlass.range_constexpr(fc1_n_tiles):
                                     mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                    mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                    _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                     cute.gemm(
                                         mma_atom,
                                         gate_acc[None, _mt, _nt],
@@ -1283,7 +1367,10 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                         fz_csSFA_cur = cute.filter_zeros(csSFA_tile[None, None, None, cons_state.index])
                         fz_csSFB_cur = cute.filter_zeros(csSFB_tile[None, None, None, cons_state.index])
                         cute.copy(smem_copy_SFA, fz_csSFA_cur[None, None, k_next], fz_crSFA[None, None, k_next])
-                        cute.copy(smem_copy_SFB, fz_csSFB_cur[None, None, k_next], fz_crSFB[None, None, k_next])
+                        _copy_sfb_k(
+                            smem_copy_SFB, fz_csSFB_cur, fz_crSFB, k_next,
+                            cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                        )
                 for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                     k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
                     if k_block_idx == num_k_blocks - 1:
@@ -1293,12 +1380,19 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                         cute.copy(smem_copy_A, csA_p[None, None, k_next], crA_tile[None, None, k_next])
                         cute.copy(smem_copy_B, csB_p[None, None, k_next], crB[None, None, k_next])
                         cute.copy(smem_copy_SFA, fz_csSFA_p[None, None, k_next], fz_crSFA[None, None, k_next])
-                        cute.copy(smem_copy_SFB, fz_csSFB_p[None, None, k_next], fz_crSFB[None, None, k_next])
+                        _copy_sfb_k(
+                            smem_copy_SFB, fz_csSFB_p, fz_crSFB, k_next,
+                            cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                        )
                     if cutlass.const_expr(self.is_gated):
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):
                                 mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                 cute.gemm(
                                     mma_atom,
                                     gate_acc[None, _mt, _nt],
@@ -1310,7 +1404,11 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                         for _mt in cutlass.range_constexpr(fc1_m_tiles):
                             for _nt in cutlass.range_constexpr(fc1_n_tiles):
                                 mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                 cute.gemm(
                                     mma_atom,
                                     gate_acc[None, _mt, _nt],
@@ -1336,7 +1434,10 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                     fz_csSFA_p = cute.filter_zeros(csSFA_p)
                     fz_csSFB_p = cute.filter_zeros(csSFB_p)
                     cute.copy(smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0])
-                    cute.copy(smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0])
+                    _copy_sfb_k(
+                        smem_copy_SFB, fz_csSFB_p, fz_crSFB, Int32(0),
+                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                    )
                     for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):
                         for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                             k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -1354,7 +1455,11 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                             for _mt in range(self.num_m_tiles):
                                 for _nt in range(self.num_n_tiles):
                                     mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                    mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                    _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                     cute.gemm(
                                         mma_atom,
                                         up_acc[None, _mt, _nt],
@@ -1365,7 +1470,10 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                             cute.copy(smem_copy_A, csA_p[None, None, k_next], crA_tile[None, None, k_next])
                             cute.copy(smem_copy_B, csB_p[None, None, k_next], crB[None, None, k_next])
                             cute.copy(smem_copy_SFA, fz_csSFA_p[None, None, k_next], fz_crSFA[None, None, k_next])
-                            cute.copy(smem_copy_SFB, fz_csSFB_p[None, None, k_next], fz_crSFB[None, None, k_next])
+                            _copy_sfb_k(
+                                smem_copy_SFB, fz_csSFB_p, fz_crSFB, k_next,
+                                cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                            )
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
                         if k_block_idx == num_k_blocks - 1:
@@ -1375,11 +1483,18 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                             cute.copy(smem_copy_A, csA_p[None, None, k_next], crA_tile[None, None, k_next])
                             cute.copy(smem_copy_B, csB_p[None, None, k_next], crB[None, None, k_next])
                             cute.copy(smem_copy_SFA, fz_csSFA_p[None, None, k_next], fz_crSFA[None, None, k_next])
-                            cute.copy(smem_copy_SFB, fz_csSFB_p[None, None, k_next], fz_crSFB[None, None, k_next])
+                            _copy_sfb_k(
+                                smem_copy_SFB, fz_csSFB_p, fz_crSFB, k_next,
+                                cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                            )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):
                                 mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                mma_atom.set(WarpField.SFB, tCrSFB_tile[None, _nt, k_block_idx].iterator)
+                                _set_mma_sfb(
+                                        mma_atom, WarpField.SFB, tCrSFB_tile, _nt, k_block_idx,
+                                        cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                        cutlass.const_expr(self.num_n_tiles // 2),
+                                    )
                                 cute.gemm(
                                     mma_atom,
                                     up_acc[None, _mt, _nt],
@@ -1388,7 +1503,22 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                                     up_acc[None, _mt, _nt],
                                 )
 
-                # Activation + quant into sA
+                if cutlass.const_expr(self.share_gated_smem):
+                    # The 128x256 prototype reuses sB/sSFB for the gated up
+                    # pass to keep dynamic smem under SM120's launch limit.
+                    # Do not let the DMA warp prefetch FC2 B_down into those
+                    # buffers until all MMA warps have consumed up.
+                    self.pass_sync_barrier.arrive_and_wait()
+
+                scatter_N = Int32(scatter_output.shape[1])
+                lane_id = Int32(tidx) & Int32(31)
+                warp_in_tile = Int32(tidx) >> Int32(5)
+                warp_m_base = (warp_in_tile >> Int32(1)) * Int32(64)
+                warp_n_base = (warp_in_tile & Int32(1)) * Int32(64)
+                scatter_n_chunks = self.tile_shape_mnk[1] // 128
+
+                csA_phase2 = csA_tile[None, None, None, 0]
+                csSFA_phase2 = csSFA_tile[None, None, None, 0]
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
                 sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
@@ -1399,257 +1529,243 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                     else:
                         gs_value = cutlass.Float32(1.0) / gs_value
 
-                for epi_m in cutlass.range_constexpr(epi_rest_m):
-                    epi_m_valid = valid_rows - tile_m_base - Int32(epi_m) * Int32(self.epi_tile[0])
-                    epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
-                    if epi_m_valid > Int32(0):
-                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
-                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
-                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
-                                mma_n = mma_n_in_epi
-                                tRS_rD_slice = tRS_rD[(None, mma_m_in_epi, mma_n_in_epi)]
-                                gate_slice = tRS_rGate[(None, mma_m, mma_n)]
-                                if cutlass.const_expr(self.is_gated):
-                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
-                                    for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
-                                        g = alpha_value * gate_slice[elem_idx]
-                                        u = alpha_value * up_slice[elem_idx]
-                                        sigmoid_g = cute.arch.rcp_approx(
-                                            cutlass.Float32(1.0) + cute.math.exp(-g, fastmath=self.fast_math),
-                                        )
-                                        tRS_rD_slice[elem_idx] = g * sigmoid_g * u
-                                else:
-                                    for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
-                                        g = alpha_value * gate_slice[elem_idx]
-                                        relu_g = fmax_f32(g, cutlass.Float32(0.0))
-                                        tRS_rD_slice[elem_idx] = relu_g * relu_g
+                for fc2_k_chunk in cutlass.range_constexpr(fc2_k_chunks):
+                    fc2_k_col_base = Int32(fc2_k_chunk * self.tile_shape_mnk[2])
 
-                        acc_vec = tRS_rD.load()
-                        acc_vec = acc_vec.to(cutlass.BFloat16)
-                        tRS_rD_out.store(acc_vec)
-                        cute.copy(
-                            tiled_copy_r2s,
-                            tRS_rD_out,
-                            tRS_sD[(None, None, None, epi_buffer)],
-                        )
-                        cute.arch.fence_proxy("async.shared", space="cta")
-                    self.epilog_sync_barrier.arrive_and_wait()
-
-                    rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
-                    epi_rows = epi_m_valid
-                    if epi_rows > Int32(self.epi_tile[0]):
-                        epi_rows = Int32(self.epi_tile[0])
-                    if epi_rows < Int32(0):
-                        epi_rows = Int32(0)
-                    quant_idx = Int32(tidx)
-                    while quant_idx < epi_rows * sf_blocks_per_row:
-                        local_row = quant_idx // sf_blocks_per_row
-                        row = sa_row_base + rows_offset + local_row
-                        sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(16)
-
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                        block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
-                            value = cutlass.Float32(
-                                sC[local_row, block_start + elem_idx, epi_buffer]
-                            )
-                            values[elem_idx] = value
-                            block_max = fmax_f32(block_max, fabs_f32(value))
-
-                        packed64 = Uint64(0)
-                        scale_byte = Uint8(0)
-                        if cutlass.const_expr(self.is_gated):
-                            if self.fast_math:
-                                packed64, scale_byte = quantize_block_fp4_fast(values, block_max, gs_value)
-                            else:
-                                packed64, scale_byte = quantize_block_fp4(values, block_max, gs_value)
-                        else:
-                            packed64, scale_byte = quantize_block_fp4(values, block_max, gs_value)
-                        packed_base = sf_block << Int32(3)
-                        dst_pcol = row & Int32(63)
-                        xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                        row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(8):
-                            src_pcol = packed_base + Int32(byte_idx)
-                            dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                            dst_flat = dst_row * packed_cols + dst_pcol
-                            byte_val = Uint8(
-                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                            )
-                            sA_u8[dst_flat] = byte_val
-
-                        outer_m_idx = row % Int32(32)
-                        inner_m_idx = row // Int32(32)
-                        inner_k_idx = sf_block % Int32(4)
-                        k_tile_idx = sf_block // Int32(4)
-                        sf_raw_idx = (
-                            k_tile_idx * Int32(32 * 4 * 4)
-                            + outer_m_idx * Int32(4 * 4)
-                            + inner_m_idx * Int32(4)
-                            + inner_k_idx
-                        )
-                        st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
-                        quant_idx += Int32(self.num_mma_warps * self.num_threads_per_warp)
-
-                cute.arch.fence_proxy("async.shared", space="cta")
-                # epilog_sync: MMA-only barrier. DMA warp doesn't need to wait
-                # for quant — it only loads B_down into sB (separate buffer).
-                # This allows DMA to prefetch B_down tiles earlier.
-                self.epilog_sync_barrier.arrive_and_wait()
-
-                # ============================================================
-                # PHASE B: Sweep ALL FC2 output tiles using cached sA
-                # No CTA-wide barrier needed here: FC1 has drained its staging
-                # buffers, and the phase2_pipeline handles B_down availability
-                # for FC2 GEMM.
-                # ============================================================
-                scatter_N = Int32(scatter_output.shape[1])
-                lane_id = Int32(tidx) & Int32(31)
-                warp_in_tile = Int32(tidx) >> Int32(5)
-                warp_m_base = (warp_in_tile >> Int32(1)) * Int32(64)
-                warp_n_base = (warp_in_tile & Int32(1)) * Int32(64)
-
-                csA_phase2 = csA_tile[None, None, None, 0]
-                csSFA_phase2 = csSFA_tile[None, None, None, 0]
-
-                # Consume all output tiles continuously from phase2_pipeline.
-
-                # Hoist A-side register loads: sA is constant across all
-                # FC2 output tiles (quantized intermediate). Load crA and
-                # crSFA for all k-blocks once, reuse for all 32 tiles.
-                fz_crSFA_p2 = cute.filter_zeros(crSFA_tile)
-                cute.copy(smem_copy_A, csA_phase2[None, None, 0], crA_tile[None, None, 0])
-                fz_csSFA_p2 = cute.filter_zeros(csSFA_phase2)
-                cute.copy(smem_copy_SFA, fz_csSFA_p2[None, None, 0], fz_crSFA_p2[None, None, 0])
-                for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
-                    k_pre = _kb_pre + 1
-                    cute.copy(smem_copy_A, csA_phase2[None, None, k_pre], crA_tile[None, None, k_pre])
-                    cute.copy(smem_copy_SFA, fz_csSFA_p2[None, None, k_pre], fz_crSFA_p2[None, None, k_pre])
-
-                phase2_cons_state.reset_count()
-                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):
-                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
-                        sSFB_phase2_tile = cute.local_tile(
-                            sSFB,
-                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
-                            (output_tile_idx % self.sfb_tiles_per_block, 0, None),
-                        )
-                        csSFB_phase2_tile = thr_ld_SFB.partition_S(sSFB_phase2_tile)
-                        tCrSFB_phase2 = self._dense_cls._partition_fragment_SFB(
-                            self, sSFB_phase2_tile[None, None, 0], thr_mma, tidx,
-                        )
-                        crSFB_phase2 = thr_ld_SFB.retile(tCrSFB_phase2)
-                    else:
-                        csSFB_phase2_tile = csSFB_full
-                        tCrSFB_phase2 = tCrSFB_full
-                        crSFB_phase2 = crSFB_full
-                    phase2_peek = phase2_pipeline.consumer_try_wait(phase2_cons_state)
-                    phase2_pipeline.consumer_wait(phase2_cons_state, phase2_peek)
-                    csB_phase2 = csB[None, None, None, phase2_cons_state.index]
-                    csSFB_phase2 = csSFB_phase2_tile[None, None, None, phase2_cons_state.index]
-
-                    # Only load B-side (B_down changes per output tile; A is hoisted)
-                    cute.copy(smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0])
-                    f2 = cute.filter_zeros(csSFB_phase2)
-                    f4 = cute.filter_zeros(crSFB_phase2)
-                    cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
-
-                    down_acc.fill(0.0)
-                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                        k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                        if k_block_idx == num_k_blocks - 1:
-                            phase2_pipeline.consumer_release(phase2_cons_state)
-                            phase2_cons_state.advance()
-                        if k_next > 0:
-                            # Only B-side for next k-block (A already in registers)
-                            cute.copy(smem_copy_B, csB_phase2[None, None, k_next], crB[None, None, k_next])
-                            f2 = cute.filter_zeros(csSFB_phase2)
-                            f4 = cute.filter_zeros(crSFB_phase2)
-                            cute.copy(smem_copy_SFB, f2[None, None, k_next], f4[None, None, k_next])
-                        if cutlass.const_expr(self.is_gated):
-                            for _mt in range(self.num_m_tiles):
-                                for _nt in range(self.num_n_tiles):
-                                    mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                    mma_atom.set(WarpField.SFB, tCrSFB_phase2[None, _nt, k_block_idx].iterator)
-                                    cute.gemm(mma_atom, down_acc[None, _mt, _nt], tCrA_tile[None, _mt, k_block_idx], tCrB[None, _nt, k_block_idx], down_acc[None, _mt, _nt])
-                        else:
-                            for _mt in cutlass.range_constexpr(fc2_m_tiles):
-                                for _nt in cutlass.range_constexpr(fc2_n_tiles):
-                                    mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
-                                    mma_atom.set(WarpField.SFB, tCrSFB_phase2[None, _nt, k_block_idx].iterator)
-                                    cute.gemm(mma_atom, down_acc[None, _mt, _nt], tCrA_tile[None, _mt, k_block_idx], tCrB[None, _nt, k_block_idx], down_acc[None, _mt, _nt])
-
-                    # Scatter using precomputed metadata (no redundant gmem loads)
-                    tile_n_base_cur = output_tile_idx * Int32(self.tile_shape_mnk[1])
+                    # Materialize and quantize one 128-wide FC2 reduction chunk
+                    # from the wider FC1 accumulator tile into sA/sSFA.
                     for epi_m in cutlass.range_constexpr(epi_rest_m):
-                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
-                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
-                                mma_n = mma_n_in_epi
-                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
-                                tRS_rD_slice = tRS_rD[(None, mma_m_in_epi, mma_n_in_epi)]
-                                down_epi_acc_slice = down_acc[(None, mma_m, mma_n)]
-                                for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
-                                    tRS_rD_slice[elem_idx] = down_alpha_value * down_epi_acc_slice[elem_idx]
-
-                        acc_vec = tRS_rD.load()
-                        acc_vec = acc_vec.to(cutlass.BFloat16)
-                        tRS_rD_out.store(acc_vec)
+                        epi_m_valid = valid_rows - tile_m_base - Int32(epi_m) * Int32(self.epi_tile[0])
                         epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
-                        cute.copy(
-                            tiled_copy_r2s,
-                            tRS_rD_out,
-                            tRS_sD[(None, None, None, epi_buffer)],
-                        )
-                        cute.arch.fence_proxy("async.shared", space="cta")
-                        # StMatrix ownership is interleaved across MMA warps for
-                        # both 128x128 and underfilled tiles, so the scatter path
-                        # must wait for every warp's store before reading sC.
+                        if epi_m_valid > Int32(0):
+                            for mma_n_in_chunk in cutlass.range_constexpr(MmaNPerFc2K):
+                                mma_n_in_epi = fc2_k_chunk * MmaNPerFc2K + mma_n_in_chunk
+                                for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                    mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                    mma_n = mma_n_in_epi
+                                    tRS_rD_slice = tRS_rD[(None, mma_m_in_epi, mma_n_in_epi)]
+                                    gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                    if cutlass.const_expr(self.is_gated):
+                                        up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                        for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            u = alpha_value * up_slice[elem_idx]
+                                            sigmoid_g = cute.arch.rcp_approx(
+                                                cutlass.Float32(1.0) + cute.math.exp(-g, fastmath=self.fast_math),
+                                            )
+                                            tRS_rD_slice[elem_idx] = g * sigmoid_g * u
+                                    else:
+                                        for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                            tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                            acc_vec = tRS_rD.load()
+                            acc_vec = acc_vec.to(cutlass.BFloat16)
+                            tRS_rD_out.store(acc_vec)
+                            cute.copy(
+                                tiled_copy_r2s,
+                                tRS_rD_out,
+                                tRS_sD[(None, None, None, epi_buffer)],
+                            )
+                            cute.arch.fence_proxy("async.shared", space="cta")
                         self.epilog_sync_barrier.arrive_and_wait()
 
                         rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                        epi_rows = epi_m_valid
+                        if epi_rows > Int32(self.epi_tile[0]):
+                            epi_rows = Int32(self.epi_tile[0])
+                        if epi_rows < Int32(0):
+                            epi_rows = Int32(0)
+                        quant_idx = Int32(tidx)
+                        while quant_idx < epi_rows * sf_blocks_per_row:
+                            local_row = quant_idx // sf_blocks_per_row
+                            row = sa_row_base + rows_offset + local_row
+                            sf_block = quant_idx - local_row * sf_blocks_per_row
+                            block_start = fc2_k_col_base + sf_block * Int32(16)
 
-                        # Per-warp scatter: each warp scatters its own quadrant
-                        # of sC (64 M-rows × 64 N-cols) after the collective
-                        # StMatrix writeback above has completed.
-                        warp_epi_rows = valid_rows - tile_m_base - rows_offset - warp_m_base
-                        if warp_epi_rows > Int32(64):
-                            warp_epi_rows = Int32(64)
-                        if warp_epi_rows < Int32(0):
-                            warp_epi_rows = Int32(0)
+                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(16):
+                                value = cutlass.Float32(
+                                    sC[local_row, block_start + elem_idx, epi_buffer]
+                                )
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
 
-                        pair_idx = lane_id
-                        while pair_idx < warp_epi_rows * Int32(32):
-                            local_row = pair_idx >> Int32(5)  # / 32
-                            local_pair_col = pair_idx & Int32(31)  # % 32
-                            global_row = tile_m_base + rows_offset + warp_m_base + local_row
-                            global_col = tile_n_base_cur + warp_n_base + local_pair_col * Int32(2)
-                            cached_row = rows_offset + warp_m_base + local_row
-                            # Only lane 0 loads tok/wv from gmem; broadcast via shuffle.
-                            tok = Int32(0)
-                            wv = cutlass.Float32(0.0)
-                            if lane_id == Int32(0):
-                                tok = _ld_shared_i32(scatter_tok_base_addr + cached_row * Int32(4))
-                                wv = _ld_shared_f32(scatter_weight_base_addr + cached_row * Int32(4))
-                            tok = cute.arch.shuffle_sync(tok, Int32(0))
-                            wv = cute.arch.shuffle_sync(wv, Int32(0))
-                            sc_v0 = cutlass.Float32(
-                                sC[warp_m_base + local_row, warp_n_base + local_pair_col * Int32(2), epi_buffer]
-                            )
-                            sc_v1 = cutlass.Float32(
-                                sC[warp_m_base + local_row, warp_n_base + local_pair_col * Int32(2) + Int32(1), epi_buffer]
-                            )
-                            scatter_add_bf16x2(
-                                get_ptr_as_int64(scatter_output, tok * scatter_N + global_col),
-                                wv * sc_v0,
-                                wv * sc_v1,
-                            )
-                            pair_idx += Int32(self.num_threads_per_warp)
+                            packed64 = Uint64(0)
+                            scale_byte = Uint8(0)
+                            if cutlass.const_expr(self.is_gated):
+                                if self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(values, block_max, gs_value)
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(values, block_max, gs_value)
+                            else:
+                                packed64, scale_byte = quantize_block_fp4(values, block_max, gs_value)
+                            packed_base = sf_block << Int32(3)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                byte_val = Uint8(
+                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                                sA_u8[dst_flat] = byte_val
 
-                        # Post-scatter barrier: needed to ensure all warps
-                        # finish scatter before next output tile's pipeline ops
-                        # (pipeline consumer is collective across all MMA warps).
-                        self.epilog_sync_barrier.arrive_and_wait()
+                            outer_m_idx = row % Int32(32)
+                            inner_m_idx = row // Int32(32)
+                            inner_k_idx = sf_block % Int32(4)
+                            k_tile_idx = sf_block // Int32(4)
+                            sf_raw_idx = (
+                                k_tile_idx * Int32(32 * 4 * 4)
+                                + outer_m_idx * Int32(4 * 4)
+                                + inner_m_idx * Int32(4)
+                                + inner_k_idx
+                            )
+                            st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
+                            quant_idx += Int32(self.num_mma_warps * self.num_threads_per_warp)
+
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    # Hoist A-side register loads for this FC2 K chunk.
+                    fz_crSFA_p2 = cute.filter_zeros(crSFA_tile)
+                    cute.copy(smem_copy_A, csA_phase2[None, None, 0], crA_tile[None, None, 0])
+                    fz_csSFA_p2 = cute.filter_zeros(csSFA_phase2)
+                    cute.copy(smem_copy_SFA, fz_csSFA_p2[None, None, 0], fz_crSFA_p2[None, None, 0])
+                    for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
+                        k_pre = _kb_pre + 1
+                        cute.copy(smem_copy_A, csA_phase2[None, None, k_pre], crA_tile[None, None, k_pre])
+                        cute.copy(smem_copy_SFA, fz_csSFA_p2[None, None, k_pre], fz_crSFA_p2[None, None, k_pre])
+
+                    phase2_cons_state.reset_count()
+                    for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):
+                        if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                            sSFB_phase2_tile = cute.local_tile(
+                                sSFB,
+                                cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                                (output_tile_idx % self.sfb_tiles_per_block, 0, None),
+                            )
+                            csSFB_phase2_tile = thr_ld_SFB.partition_S(sSFB_phase2_tile)
+                            tCrSFB_phase2 = self._dense_cls._partition_fragment_SFB(
+                                self, sSFB_phase2_tile[None, None, 0], thr_mma, tidx,
+                            )
+                            crSFB_phase2 = thr_ld_SFB.retile(tCrSFB_phase2)
+                        else:
+                            csSFB_phase2_tile = csSFB_full
+                            tCrSFB_phase2 = tCrSFB_full
+                            crSFB_phase2 = crSFB_full
+                        phase2_peek = phase2_pipeline.consumer_try_wait(phase2_cons_state)
+                        phase2_pipeline.consumer_wait(phase2_cons_state, phase2_peek)
+                        csB_phase2 = csB[None, None, None, phase2_cons_state.index]
+                        csSFB_phase2 = csSFB_phase2_tile[None, None, None, phase2_cons_state.index]
+
+                        cute.copy(smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0])
+                        f2 = cute.filter_zeros(csSFB_phase2)
+                        f4 = cute.filter_zeros(crSFB_phase2)
+                        _copy_sfb_k(
+                            smem_copy_SFB, f2, f4, Int32(0),
+                            cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                        )
+
+                        down_acc.fill(0.0)
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                            if k_block_idx == num_k_blocks - 1:
+                                phase2_pipeline.consumer_release(phase2_cons_state)
+                                phase2_cons_state.advance()
+                            if k_next > 0:
+                                cute.copy(smem_copy_B, csB_phase2[None, None, k_next], crB[None, None, k_next])
+                                f2 = cute.filter_zeros(csSFB_phase2)
+                                f4 = cute.filter_zeros(crSFB_phase2)
+                                _copy_sfb_k(
+                                    smem_copy_SFB, f2, f4, k_next,
+                                    cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                )
+                            if cutlass.const_expr(self.is_gated):
+                                for _mt in range(self.num_m_tiles):
+                                    for _nt in range(self.num_n_tiles):
+                                        mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
+                                        _set_mma_sfb(
+                                            mma_atom, WarpField.SFB, tCrSFB_phase2, _nt, k_block_idx,
+                                            cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                            cutlass.const_expr(self.num_n_tiles // 2),
+                                        )
+                                        cute.gemm(mma_atom, down_acc[None, _mt, _nt], tCrA_tile[None, _mt, k_block_idx], tCrB[None, _nt, k_block_idx], down_acc[None, _mt, _nt])
+                            else:
+                                for _mt in cutlass.range_constexpr(fc2_m_tiles):
+                                    for _nt in cutlass.range_constexpr(fc2_n_tiles):
+                                        mma_atom.set(WarpField.SFA, tCrSFA_tile[None, _mt, k_block_idx].iterator)
+                                        _set_mma_sfb(
+                                            mma_atom, WarpField.SFB, tCrSFB_phase2, _nt, k_block_idx,
+                                            cutlass.const_expr(self.tile_shape_mnk[1] > 128),
+                                            cutlass.const_expr(self.num_n_tiles // 2),
+                                        )
+                                        cute.gemm(mma_atom, down_acc[None, _mt, _nt], tCrA_tile[None, _mt, k_block_idx], tCrB[None, _nt, k_block_idx], down_acc[None, _mt, _nt])
+
+                        tile_n_base_cur = output_tile_idx * Int32(self.tile_shape_mnk[1])
+                        for epi_m in cutlass.range_constexpr(epi_rest_m):
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                    mma_n = mma_n_in_epi
+                                    mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                    tRS_rD_slice = tRS_rD[(None, mma_m_in_epi, mma_n_in_epi)]
+                                    down_epi_acc_slice = down_acc[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(cute.size(tRS_rD_slice)):
+                                        tRS_rD_slice[elem_idx] = down_alpha_value * down_epi_acc_slice[elem_idx]
+
+                            acc_vec = tRS_rD.load()
+                            acc_vec = acc_vec.to(cutlass.BFloat16)
+                            tRS_rD_out.store(acc_vec)
+                            epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                            cute.copy(
+                                tiled_copy_r2s,
+                                tRS_rD_out,
+                                tRS_sD[(None, None, None, epi_buffer)],
+                            )
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                            self.epilog_sync_barrier.arrive_and_wait()
+
+                            rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+
+                            warp_epi_rows = valid_rows - tile_m_base - rows_offset - warp_m_base
+                            if warp_epi_rows > Int32(64):
+                                warp_epi_rows = Int32(64)
+                            if warp_epi_rows < Int32(0):
+                                warp_epi_rows = Int32(0)
+
+                            for scatter_n_chunk in cutlass.range_constexpr(scatter_n_chunks):
+                                chunk_n_base = warp_n_base + Int32(scatter_n_chunk * 128)
+                                pair_idx = lane_id
+                                while pair_idx < warp_epi_rows * Int32(32):
+                                    local_row = pair_idx >> Int32(5)
+                                    local_pair_col = pair_idx & Int32(31)
+                                    global_col = tile_n_base_cur + chunk_n_base + local_pair_col * Int32(2)
+                                    cached_row = rows_offset + warp_m_base + local_row
+                                    tok = Int32(0)
+                                    wv = cutlass.Float32(0.0)
+                                    if lane_id == Int32(0):
+                                        tok = _ld_shared_i32(scatter_tok_base_addr + cached_row * Int32(4))
+                                        wv = _ld_shared_f32(scatter_weight_base_addr + cached_row * Int32(4))
+                                    tok = cute.arch.shuffle_sync(tok, Int32(0))
+                                    wv = cute.arch.shuffle_sync(wv, Int32(0))
+                                    sc_v0 = cutlass.Float32(
+                                        sC[warp_m_base + local_row, chunk_n_base + local_pair_col * Int32(2), epi_buffer]
+                                    )
+                                    sc_v1 = cutlass.Float32(
+                                        sC[warp_m_base + local_row, chunk_n_base + local_pair_col * Int32(2) + Int32(1), epi_buffer]
+                                    )
+                                    scatter_add_bf16x2(
+                                        get_ptr_as_int64(scatter_output, tok * scatter_N + global_col),
+                                        wv * sc_v0,
+                                        wv * sc_v1,
+                                    )
+                                    pair_idx += Int32(self.num_threads_per_warp)
+
+                            self.epilog_sync_barrier.arrive_and_wait()
 
                 # Final pass_sync: protect sA from next task's FC1 loads.
                 # DMA warp waits here too after finishing all B_down loads.
@@ -1747,20 +1863,31 @@ class MoEStaticKernelBackend(_MoEStaticKernelBase):
                         up_pipeline.producer_commit(up_prod_state)
                         up_prod_state.advance()
 
+                if cutlass.const_expr(self.share_gated_smem):
+                    # sB/sSFB also back the up pass in the wide-N prototype.
+                    # Wait until MMA has consumed up before loading FC2 B_down.
+                    self.pass_sync_barrier.arrive_and_wait()
+
                 # ---- FC2 B_down loads: continuous pipeline ----
-                # No barrier needed: sB/sSFB are free (gate done, up uses
-                # sB_up/sSFB_up). phase2_pipeline handles data availability.
+                # In the default gated path, sB/sSFB are free because up uses
+                # sB_up/sSFB_up. The wide-N prototype above waits when those
+                # buffers are shared. phase2_pipeline handles data availability.
                 # intermediate_slice selects the K-tile of GEMM2 (FC1 output N-tile
                 # = GEMM2 K-tile since intermediate dim is the reduction dim).
                 # Load ALL FC2 tiles continuously once stage1 no longer needs
                 # the gate staging buffers.
                 phase2_prod_state.reset_count()
-                for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):
-                    phase2_pipeline.producer_acquire(phase2_prod_state)
-                    cute.copy(tma_b_down, tBgB_down[(None, output_tile_idx, intermediate_slice, weight_expert_idx)], tBsB_down[(None, phase2_prod_state.index)], tma_bar_ptr=phase2_pipeline.producer_get_barrier(phase2_prod_state))
-                    cute.copy(tma_sfb_down, tBgSFB_down[(None, output_tile_idx // self.sfb_tiles_per_block, intermediate_slice, weight_expert_idx)], tBsSFB_down[(None, phase2_prod_state.index)], tma_bar_ptr=phase2_pipeline.producer_get_barrier(phase2_prod_state))
-                    phase2_pipeline.producer_commit(phase2_prod_state)
-                    phase2_prod_state.advance()
+                fc2_k_chunks = self.tile_shape_mnk[1] // self.tile_shape_mnk[2]
+                for fc2_k_chunk in cutlass.range_constexpr(fc2_k_chunks):
+                    phase2_intermediate_slice = (
+                        intermediate_slice * Int32(fc2_k_chunks) + Int32(fc2_k_chunk)
+                    )
+                    for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):
+                        phase2_pipeline.producer_acquire(phase2_prod_state)
+                        cute.copy(tma_b_down, tBgB_down[(None, output_tile_idx, phase2_intermediate_slice, weight_expert_idx)], tBsB_down[(None, phase2_prod_state.index)], tma_bar_ptr=phase2_pipeline.producer_get_barrier(phase2_prod_state))
+                        cute.copy(tma_sfb_down, tBgSFB_down[(None, output_tile_idx // self.sfb_tiles_per_block, phase2_intermediate_slice, weight_expert_idx)], tBsSFB_down[(None, phase2_prod_state.index)], tma_bar_ptr=phase2_pipeline.producer_get_barrier(phase2_prod_state))
+                        phase2_pipeline.producer_commit(phase2_prod_state)
+                        phase2_prod_state.advance()
 
                 # Final pass_sync: match MMA warps' barrier after FC2 sweep.
                 # Ensures MMA warps finish scatter before DMA starts next task's FC1.

--- a/tests/test_dsv4_allreduce_patch.py
+++ b/tests/test_dsv4_allreduce_patch.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _load_ar_module():
+    module_name = "_test_dsv4_allreduce_patch"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    pcie_stub = type(sys)("b12x.distributed.pcie_oneshot")
+    pcie_stub.PCIeOneshotAllReduce = object
+    pcie_stub.SUPPORTED_WORLD_SIZES = (2, 4, 6, 8)
+    sys.modules.setdefault("b12x.distributed.pcie_oneshot", pcie_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        Path(__file__).resolve().parents[1] / "b12x" / "integration" / "dsv4_allreduce_patch.py",
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+ar = _load_ar_module()
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        shape: tuple[int, ...],
+        *,
+        dtype: torch.dtype = torch.bfloat16,
+        device_type: str = "cuda",
+        contiguous: bool = True,
+        element_size: int = 2,
+    ):
+        self.shape = shape
+        self.dtype = dtype
+        self.device = SimpleNamespace(type=device_type)
+        self._contiguous = contiguous
+        self._element_size = element_size
+
+    def is_contiguous(self) -> bool:
+        return self._contiguous
+
+    def element_size(self) -> int:
+        return self._element_size
+
+
+@pytest.fixture(autouse=True)
+def _clear_ar_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("B12X_PCIE_AR_MAX_TOKENS", raising=False)
+    monkeypatch.delenv("B12X_PCIE_AR_PREWARM_SHAPES", raising=False)
+
+
+@pytest.mark.parametrize("tokens", [1, 4, 5, 8, 16, 32])
+def test_fast_path_keeps_verified_small_t_buckets(tokens: int) -> None:
+    assert ar._is_fast_path(_FakeTensor((tokens, 4096)))
+
+
+def test_fast_path_rejects_t64_regression_bucket_by_default() -> None:
+    assert not ar._is_fast_path(_FakeTensor((64, 4096)))
+
+
+def test_max_tokens_env_can_narrow_but_not_broaden_to_t64(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B12X_PCIE_AR_MAX_TOKENS", "8")
+    assert ar._is_fast_path(_FakeTensor((8, 4096)))
+    assert not ar._is_fast_path(_FakeTensor((16, 4096)))
+
+    monkeypatch.setenv("B12X_PCIE_AR_MAX_TOKENS", "64")
+    assert ar._is_fast_path(_FakeTensor((32, 4096)))
+    assert not ar._is_fast_path(_FakeTensor((64, 4096)))
+
+
+def test_fast_path_rejects_non_dsv4_shapes_and_dtypes() -> None:
+    assert not ar._is_fast_path(_FakeTensor((32, 2048)))
+    assert not ar._is_fast_path(_FakeTensor((32, 4096), dtype=torch.float16))
+    assert not ar._is_fast_path(_FakeTensor((32, 4096), device_type="cpu"))
+    assert not ar._is_fast_path(_FakeTensor((32, 4096), contiguous=False))
+
+
+def test_capture_prewarm_shapes_filter_to_fast_path() -> None:
+    shapes = ar._capture_prewarm_shapes("4,4096;32,4096;64,4096;1,2048;bad")
+    assert shapes == [(1, 4096), (4, 4096), (32, 4096)]
+
+
+def test_default_capture_prewarm_includes_t32_and_excludes_t64() -> None:
+    shapes = ar._capture_prewarm_shapes(None)
+    assert (32, 4096) in shapes
+    assert (64, 4096) not in shapes

--- a/tests/test_track_f2_dsv4_silu_direct.py
+++ b/tests/test_track_f2_dsv4_silu_direct.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import torch
+
+import b12x.integration.tp_moe as tp_moe
+from b12x.integration._silu_dsv4_decode import is_exact_silu_dsv4_case
+from b12x.integration.tp_moe import B12XFP4ExpertWeights, B12XTopKRouting
+
+
+def test_dsv4_silu_exact_gate_accepts_tp4_decode_meta_tensors() -> None:
+    a = torch.empty((8, 4096), dtype=torch.bfloat16, device="meta")
+    w1 = torch.empty((64, 4096, 2048), dtype=torch.uint8, device="meta")
+    w2 = torch.empty((64, 4096, 1024), dtype=torch.uint8, device="meta")
+    topk_ids = torch.empty((8, 6), dtype=torch.int32, device="meta")
+    topk_weights = torch.empty((8, 6), dtype=torch.float32, device="meta")
+    scale = torch.empty((), dtype=torch.float32, device="meta")
+
+    assert is_exact_silu_dsv4_case(
+        activation="silu",
+        a=a,
+        w1_fp4=w1,
+        w2_fp4=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        a1_gscale=scale,
+        a2_gscale=scale,
+    )
+
+    assert not is_exact_silu_dsv4_case(
+        activation="silu",
+        a=torch.empty((9, 4096), dtype=torch.bfloat16, device="meta"),
+        w1_fp4=w1,
+        w2_fp4=w2,
+        topk_weights=torch.empty((9, 6), dtype=torch.float32, device="meta"),
+        topk_ids=torch.empty((9, 6), dtype=torch.int32, device="meta"),
+        a1_gscale=scale,
+        a2_gscale=scale,
+    )
+
+
+def test_b12x_moe_fp4_uses_dsv4_direct_before_generic_planning(monkeypatch) -> None:
+    captured = {}
+
+    def fake_direct(**kwargs):
+        captured.update(kwargs)
+        return torch.full_like(kwargs["a"], 3.0)
+
+    monkeypatch.setattr(tp_moe, "_dsv4_silu_direct_enabled", lambda: True)
+    monkeypatch.setattr(tp_moe, "is_exact_silu_dsv4_case", lambda **_kwargs: True)
+    monkeypatch.setattr(tp_moe, "_launch_exact_silu_dsv4_decode", fake_direct)
+
+    a = torch.randn(1, 4, dtype=torch.bfloat16)
+    out = tp_moe.b12x_moe_fp4(
+        a,
+        torch.ones(()),
+        torch.zeros((2, 4, 2), dtype=torch.uint8),
+        torch.zeros((2, 1), dtype=torch.uint8),
+        torch.ones(2),
+        torch.ones(()),
+        torch.zeros((2, 4, 1), dtype=torch.uint8),
+        torch.zeros((2, 1), dtype=torch.uint8),
+        torch.ones(2),
+        torch.ones((1, 2)),
+        torch.zeros((1, 2), dtype=torch.int32),
+        workspace=object(),
+    )
+
+    torch.testing.assert_close(out, torch.full_like(a, 3.0))
+    assert captured["input_scales_static"] is True
+
+
+def test_sparse_wrapper_passes_preflattened_routing_to_dsv4_direct(monkeypatch) -> None:
+    captured = {}
+
+    def fake_direct(**kwargs):
+        captured.update(kwargs)
+        return torch.full_like(kwargs["a"], 5.0)
+
+    monkeypatch.setattr(tp_moe, "_dsv4_silu_direct_enabled", lambda: True)
+    monkeypatch.setattr(tp_moe, "is_exact_silu_dsv4_case", lambda **_kwargs: True)
+    monkeypatch.setattr(tp_moe, "_launch_exact_silu_dsv4_decode", fake_direct)
+
+    experts = B12XFP4ExpertWeights(
+        a1_gscale=torch.ones(()),
+        w1_fp4=torch.zeros((2, 4, 2), dtype=torch.uint8),
+        w1_blockscale=torch.zeros((2, 1), dtype=torch.uint8),
+        w1_alphas=torch.ones(2),
+        a2_gscale=torch.ones(()),
+        w2_fp4=torch.zeros((2, 4, 1), dtype=torch.uint8),
+        w2_blockscale=torch.zeros((2, 1), dtype=torch.uint8),
+        w2_alphas=torch.ones(2),
+    )
+    topk_ids = torch.tensor([[1, 0]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.75, 0.25]], dtype=torch.float32)
+    routing = B12XTopKRouting(
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        flat_ids=topk_ids.view(-1),
+        flat_weights=topk_weights.view(-1),
+    )
+    hidden = torch.randn(1, 4, dtype=torch.bfloat16)
+
+    out = tp_moe.b12x_sparse_moe_fp4(
+        hidden,
+        experts=experts,
+        workspace=object(),
+        routing=routing,
+    )
+
+    torch.testing.assert_close(out, torch.full_like(hidden, 5.0))
+    assert captured["flat_ids"] is routing.flat_ids
+    assert captured["flat_weights"] is routing.flat_weights

--- a/tests/track_f2_dsv4_silu_direct_validate.py
+++ b/tests/track_f2_dsv4_silu_direct_validate.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Focused docker validation for Track F2 DSv4 SiLU direct MoE dispatch.
+
+This is intentionally a runtime helper rather than a pytest-only test: it is
+meant to run inside the b12x/cutlass docker image before any model C1/C8 sweep.
+It compares the generic b12x MoE path with B12X_DSV4_SILU_DIRECT=0 against the
+exact DSv4 direct path with B12X_DSV4_SILU_DIRECT=1 on live decode dimensions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import logging
+import os
+import pathlib
+import sys
+import time
+
+import torch
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from b12x.cute.fp4 import swizzle_block_scale
+from b12x.integration.tp_moe import (
+    allocate_tp_moe_workspace_pool,
+    b12x_moe_fp4,
+    clear_tp_moe_caches,
+    get_tp_moe_debug_counters,
+)
+
+
+EXPECTED_LOG_FRAGMENT = "bypassing generic flashinfer/backend dispatch"
+
+
+@contextlib.contextmanager
+def _env(name: str, value: str):
+    old = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = old
+
+
+def _make_scale_storage(experts: int, rows: int, cols: int, *, device: torch.device) -> torch.Tensor:
+    cols_blocks = cols // 16
+    scale = torch.full(
+        (experts, rows, cols_blocks),
+        0.015625,
+        dtype=torch.float32,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+    return swizzle_block_scale(scale)
+
+
+def make_case(tokens: int, *, experts: int, hidden: int, intermediate: int, topk: int, seed: int):
+    torch.manual_seed(seed + tokens)
+    device = torch.device("cuda")
+    x = (torch.randn(tokens, hidden, dtype=torch.float32, device=device) * 0.02).to(torch.bfloat16)
+    logits = torch.randn(tokens, experts, dtype=torch.float32, device=device)
+    topk_logits, topk_ids = torch.topk(logits, topk, dim=-1)
+    topk_weights = torch.softmax(topk_logits, dim=-1).contiguous()
+    topk_ids = topk_ids.to(torch.int32).contiguous()
+
+    # Exact DSv4 TP=4 tensor shapes:
+    # w1: [64, 4096, 2048] uint8, w2: [64, 4096, 1024] uint8.
+    w1_fp4 = torch.randint(
+        0,
+        256,
+        (experts, 2 * intermediate, hidden // 2),
+        dtype=torch.uint8,
+        device=device,
+    )
+    w2_fp4 = torch.randint(
+        0,
+        256,
+        (experts, hidden, intermediate // 2),
+        dtype=torch.uint8,
+        device=device,
+    )
+    w1_blockscale = _make_scale_storage(experts, 2 * intermediate, hidden, device=device)
+    w2_blockscale = _make_scale_storage(experts, hidden, intermediate, device=device)
+    w1_alphas = torch.full((experts,), 0.25, dtype=torch.float32, device=device)
+    w2_alphas = torch.full((experts,), 0.25, dtype=torch.float32, device=device)
+    a1_gscale = torch.ones((), dtype=torch.float32, device=device)
+    a2_gscale = torch.ones((), dtype=torch.float32, device=device)
+    return (
+        x,
+        a1_gscale,
+        w1_fp4,
+        w1_blockscale,
+        w1_alphas,
+        a2_gscale,
+        w2_fp4,
+        w2_blockscale,
+        w2_alphas,
+        topk_weights,
+        topk_ids,
+    )
+
+
+def run_once(case, *, direct: bool, output: torch.Tensor | None = None):
+    workspace = allocate_tp_moe_workspace_pool()
+    with _env("B12X_DSV4_SILU_DIRECT", "1" if direct else "0"):
+        return b12x_moe_fp4(
+            *case,
+            workspace=workspace,
+            output=output,
+            input_scales_are_reciprocal=True,
+            input_scales_static=True,
+            activation="silu",
+        )
+
+
+def wall_ms(fn, *, warmup: int, reps: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    for _ in range(reps):
+        fn()
+        torch.cuda.synchronize()
+    end = time.perf_counter()
+    return (end - start) * 1000.0 / reps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", default="1,2,4,8")
+    parser.add_argument("--experts", type=int, default=64)
+    parser.add_argument("--hidden", type=int, default=4096)
+    parser.add_argument("--intermediate", type=int, default=2048)
+    parser.add_argument("--topk", type=int, default=6)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--reps", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=20260428)
+    parser.add_argument("--rtol", type=float, default=0.0)
+    parser.add_argument("--atol", type=float, default=0.0)
+    parser.add_argument("--min-speedup", type=float, default=1.0)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("FAIL: CUDA is unavailable", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(level=logging.WARNING)
+    tokens_list = [int(x) for x in args.tokens.split(",") if x.strip()]
+    print(
+        "Track F2 DSv4 SiLU direct validation "
+        f"E={args.experts} H={args.hidden} I={args.intermediate} topk={args.topk}"
+    )
+    print(f"expected_log_fragment={EXPECTED_LOG_FRAGMENT!r}")
+
+    failures: list[str] = []
+    for tokens in tokens_list:
+        clear_tp_moe_caches()
+        case = make_case(
+            tokens,
+            experts=args.experts,
+            hidden=args.hidden,
+            intermediate=args.intermediate,
+            topk=args.topk,
+            seed=args.seed,
+        )
+
+        generic = run_once(case, direct=False).detach().clone()
+        torch.cuda.synchronize()
+
+        clear_tp_moe_caches()
+        log_stream = io.StringIO()
+        handler = logging.StreamHandler(log_stream)
+        logger = logging.getLogger("b12x.integration.tp_moe")
+        logger.addHandler(handler)
+        try:
+            direct = run_once(case, direct=True).detach().clone()
+            torch.cuda.synchronize()
+        finally:
+            logger.removeHandler(handler)
+
+        max_abs = (generic.float() - direct.float()).abs().max().item()
+        same = torch.allclose(generic, direct, rtol=args.rtol, atol=args.atol)
+        counters = get_tp_moe_debug_counters()
+        log_text = log_stream.getvalue()
+        fired = counters.get("dsv4_silu_direct_hits", 0) > 0
+        logged = EXPECTED_LOG_FRAGMENT in log_text
+
+        generic_out = torch.empty_like(case[0])
+        direct_out = torch.empty_like(case[0])
+        clear_tp_moe_caches()
+        generic_ms = wall_ms(
+            lambda: run_once(case, direct=False, output=generic_out),
+            warmup=args.warmup,
+            reps=args.reps,
+        )
+        clear_tp_moe_caches()
+        direct_ms = wall_ms(
+            lambda: run_once(case, direct=True, output=direct_out),
+            warmup=args.warmup,
+            reps=args.reps,
+        )
+        speedup = generic_ms / direct_ms if direct_ms > 0 else float("inf")
+
+        print(
+            f"tokens={tokens} generic_ms={generic_ms:.4f} direct_ms={direct_ms:.4f} "
+            f"speedup={speedup:.3f} max_abs={max_abs:.6g} "
+            f"direct_hits={counters.get('dsv4_silu_direct_hits', 0)} logged={logged}"
+        )
+
+        if not same:
+            failures.append(f"tokens={tokens}: direct output differs from generic, max_abs={max_abs:.6g}")
+        if not fired:
+            failures.append(f"tokens={tokens}: dsv4_silu_direct_hits did not increment")
+        if not logged:
+            failures.append(f"tokens={tokens}: missing log fragment {EXPECTED_LOG_FRAGMENT!r}")
+        if speedup < args.min_speedup:
+            failures.append(
+                f"tokens={tokens}: direct speedup {speedup:.3f} < required {args.min_speedup:.3f}"
+            )
+
+    if failures:
+        print("FAIL:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print("PASS: direct path fired, matched generic output, and met microbench threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the validated DSv4-Flash SM120 decode fast paths used by the TP4 C8 stack that reached >700 output tokens/sec locally:

- graph-capture-safe PCIe oneshot allreduce patch for small `(T, 4096)` BF16 allreduces
- exact DSv4 SiLU/NVFP4 MoE decode dispatch for TP4 shapes
- shared-SMEM/static SiLU kernel changes needed by the DSv4 decode path
- unit/runtime validators for the allreduce predicate and DSv4 direct MoE path

## Validation

- `python3 -m pytest -q tests/test_dsv4_allreduce_patch.py tests/test_track_f2_dsv4_silu_direct.py` inside the SM120 image: `14 passed`
- `python3 tests/track_f2_dsv4_silu_direct_validate.py --tokens 1,2 --warmup 1 --reps 2 --min-speedup 1.0` inside the SM120 image: PASS, direct path fired and matched generic output
- Full local model run notes: `/home/ubuntu/dsv4flash-200-plan-20260427/dsv4-bench/notes/rc258-260-hit700-output-tps-20260501.md`
  - C1: 184.72 output tok/s
  - C2: 311.71 output tok/s
  - C4: 486.92 output tok/s
  - C8: 775.75 and 784.72 output tok/s on repeat runs

## Notes

This intentionally excludes the experimental sparse MLA/prologue prototype files because they were not part of the promoted C8 target stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optimized fast-path execution for specific inference workload configurations.
  * Introduced enhanced allreduce operations with hardware-specific optimizations.

* **Improvements**
  * Improved error handling with automatic fallback mechanisms for device compatibility.
  * Optimized memory utilization and tensor layout handling for improved performance.
  * Enhanced shared memory reuse strategy for tensor operations.

* **Tests**
  * Added comprehensive test suites for new optimization paths and integration modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->