### PR TITLE
Optimize W4A16 small-M decode path

### DIFF
--- a/b12x/attention/mla/api.py
+++ b/b12x/attention/mla/api.py
@@ -9,6 +9,13 @@ from typing import Literal
 
 import torch
 
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # Keep the pure-PyTorch fallback usable outside vLLM images.
+    triton = None
+    tl = None
+
 from .kernel import (
     clear_sparse_mla_kernel_cache,
     run_sparse_mla_kernel,
@@ -30,6 +37,47 @@ _MLA_FORCE_SPLIT_ENV = "B12X_MLA_FORCE_SPLIT"
 _MLA_SINGLE_PASS_TARGET_Q_ROWS = 2048
 _MLA_SINGLE_PASS_TARGET_TOPK = 2048
 _LN2 = math.log(2.0)
+
+
+if triton is not None and tl is not None:
+
+    @triton.jit
+    def _split_decode_final_lse_kernel(
+        tmp_lse_ptr,
+        num_chunks_ptr,
+        out_lse_ptr,
+        tmp_lse_stride_b: tl.constexpr,
+        tmp_lse_stride_h: tl.constexpr,
+        tmp_lse_stride_c: tl.constexpr,
+        out_lse_stride_b: tl.constexpr,
+        out_lse_stride_h: tl.constexpr,
+        max_chunks: tl.constexpr,
+        block_c: tl.constexpr,
+        natural_scale: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        head = tl.program_id(1)
+        offs = tl.arange(0, block_c)
+        chunk_count = tl.minimum(tl.load(num_chunks_ptr), max_chunks)
+        valid = offs < chunk_count
+        vals = tl.load(
+            tmp_lse_ptr
+            + row * tmp_lse_stride_b
+            + head * tmp_lse_stride_h
+            + offs * tmp_lse_stride_c,
+            mask=valid,
+            other=-float("inf"),
+        )
+        vals = tl.where(vals != vals, -float("inf"), vals)
+        lse_max = tl.max(vals, axis=0)
+        safe_max = tl.where(lse_max == -float("inf"), 0.0, lse_max)
+        lse_sum = tl.sum(tl.exp2(vals - safe_max), axis=0)
+        lse_base2 = safe_max + tl.log2(lse_sum)
+        out = lse_base2
+        if natural_scale:
+            out = out * 0.69314718055994530942
+        out = tl.where(lse_max == -float("inf"), -float("inf"), out)
+        tl.store(out_lse_ptr + row * out_lse_stride_b + head * out_lse_stride_h, out)
 
 
 @dataclass(frozen=True)
@@ -510,6 +558,28 @@ def _final_lse_from_split_workspace(
         raise TypeError(
             f"workspace split MLA LSE buffer must be FP32, got {chunk_lse.dtype}"
         )
+    if (
+        triton is not None
+        and chunk_lse.device.type == "cuda"
+        and final_lse.device == chunk_lse.device
+    ):
+        if workspace.num_chunks_ptr is None:
+            raise RuntimeError("workspace is missing split MLA chunk-count buffer")
+        block_c = triton.next_power_of_2(chunk_count)
+        _split_decode_final_lse_kernel[(q_rows, num_heads)](
+            chunk_lse,
+            workspace.num_chunks_ptr,
+            final_lse,
+            chunk_lse.stride(0),
+            chunk_lse.stride(1),
+            chunk_lse.stride(2),
+            final_lse.stride(0),
+            final_lse.stride(1),
+            chunk_count,
+            block_c,
+            scale == "natural",
+        )
+        return final_lse
     chunk_lse.mul_(_LN2)
     torch.logsumexp(chunk_lse, dim=-1, out=final_lse)
     if scale == "natural":

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import weakref
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from typing import Dict, Tuple
@@ -472,7 +473,7 @@ _DYNAMIC_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
 _MAC_CACHE: Dict[Tuple[int, str], int] = {}  # (device_idx, impl) → max_active_clusters
 _PLAIN_PARAM_CACHE: Dict[
     Tuple[int, Tuple[int, ...], Tuple[int, ...], torch.dtype, torch.dtype, int],
-    torch.Tensor,
+    tuple[weakref.ReferenceType[torch.Tensor], torch.Tensor],
 ] = {}
 _W4A16_ALPHA_CACHE: Dict[Tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
 _MICRO_COMPACT_CUTOVER_PAIRS_DEFAULT = 20
@@ -706,11 +707,14 @@ def _get_plain_cuda_tensor(
         )
         cached = _PLAIN_PARAM_CACHE.get(key)
         if cached is not None:
-            return cached
+            cached_source, cached_plain = cached
+            if cached_source() is t:
+                return cached_plain
+            _PLAIN_PARAM_CACHE.pop(key, None)
         plain = torch.empty(tuple(t.shape), dtype=target_dtype, device=t.device)
         with record_function("tp_moe.get_plain_cuda_tensor.copy"):
             plain.copy_(t.to(target_dtype) if t.dtype != target_dtype else t)
-        _PLAIN_PARAM_CACHE[key] = plain
+        _PLAIN_PARAM_CACHE[key] = (weakref.ref(t), plain)
         return plain
 
 

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -53,6 +53,8 @@ _FP4_SOURCE_FORMATS = {
     "mxfp4_native": "mxfp4_native",
     "compressed_tensors": "compressed_tensors",
 }
+_MODEL_OPT_NVFP4_SOURCE_FORMATS = {"modelopt_nvfp4"}
+_MODEL_OPT_W13_LAYOUTS = {"up_gate", "gate_up"}
 
 
 @dataclass(kw_only=True)
@@ -418,12 +420,22 @@ def _normalize_fp4_source_format(source_format: str) -> str:
 def _validate_fp4_source_format_for_quant_mode(
     *, source_format: str, quant_mode: str
 ) -> None:
-    if source_format != "modelopt_nvfp4" and quant_mode != "w4a16":
+    if source_format not in _MODEL_OPT_NVFP4_SOURCE_FORMATS and quant_mode != "w4a16":
         raise ValueError(
             f"source_format={source_format!r} is only supported with "
             "quant_mode='w4a16'; the NVFP4 kernels currently support only "
             "source_format='modelopt_nvfp4'"
         )
+
+
+def _normalize_w13_layout(w13_layout: str) -> str:
+    normalized = w13_layout.lower()
+    if normalized not in _MODEL_OPT_W13_LAYOUTS:
+        raise ValueError(
+            "w13_layout must be one of 'up_gate' or 'gate_up', "
+            f"got {w13_layout!r}"
+        )
+    return normalized
 
 
 def _assert_reciprocal_input_scale_contract(
@@ -467,6 +479,7 @@ def _dynamic_tile_m(quant_mode: str = "nvfp4") -> int:
 
 _WEIGHT_CACHE: Dict[Tuple[int, int, int], _WeightViews] = {}
 _W4A16_PACKED_WEIGHT_CACHE: Dict[Tuple[object, ...], object] = {}
+_W4A16_MODEL_OPT_WEIGHT_CACHE: Dict[Tuple[object, ...], object] = {}
 _MICRO_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
 _STATIC_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
 _DYNAMIC_KERNEL_CACHE: Dict[Tuple, Tuple] = {}
@@ -531,6 +544,7 @@ def clear_tp_moe_caches() -> None:
     global _DYNAMIC_DOWN_SCALE_CACHE
     _WEIGHT_CACHE.clear()
     _W4A16_PACKED_WEIGHT_CACHE.clear()
+    _W4A16_MODEL_OPT_WEIGHT_CACHE.clear()
     clear_w4a16_kernel_cache()
     _MICRO_KERNEL_CACHE.clear()
     _STATIC_KERNEL_CACHE.clear()
@@ -1576,6 +1590,7 @@ def _get_w4a16_packed_weights(
     activation: str,
     params_dtype: torch.dtype,
     source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
     reuse_input_storage: bool = False,
 ):
     from b12x.moe.fused.w4a16.prepare import (
@@ -1585,6 +1600,7 @@ def _get_w4a16_packed_weights(
     )
 
     source_format = _normalize_fp4_source_format(source_format)
+    w13_layout = _normalize_w13_layout(w13_layout)
     key = (
         w1_fp4.data_ptr(),
         w1_blockscale.data_ptr(),
@@ -1595,6 +1611,7 @@ def _get_w4a16_packed_weights(
         activation,
         params_dtype,
         source_format,
+        w13_layout,
         reuse_input_storage,
     )
     cached = _W4A16_PACKED_WEIGHT_CACHE.get(key)
@@ -1608,6 +1625,9 @@ def _get_w4a16_packed_weights(
         prepare_weights = prepare_w4a16_mxfp4_native_weights
     else:
         raise AssertionError(f"unhandled W4A16 source_format {source_format!r}")
+    prepare_kwargs = {}
+    if source_format in _MODEL_OPT_NVFP4_SOURCE_FORMATS:
+        prepare_kwargs["w13_layout"] = w13_layout
     prepared = prepare_weights(
         w1_fp4,
         w1_blockscale,
@@ -1618,8 +1638,60 @@ def _get_w4a16_packed_weights(
         activation=activation,
         params_dtype=params_dtype,
         reuse_input_storage=reuse_input_storage,
+        **prepare_kwargs,
     )
     _W4A16_PACKED_WEIGHT_CACHE[key] = prepared
+    return prepared
+
+def _get_w4a16_modelopt_weights(
+    w1_fp4: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w1_alphas: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_alphas: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype,
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
+):
+    from b12x.moe.fused.w4a16.prepare import prepare_w4a16_modelopt_native_weights
+
+    source_format = _normalize_fp4_source_format(source_format)
+    if source_format not in _MODEL_OPT_NVFP4_SOURCE_FORMATS:
+        raise ValueError(
+            "native W4A16 ModelOpt weights require source_format='modelopt_nvfp4'"
+        )
+    w13_layout = _normalize_w13_layout(w13_layout)
+    key = (
+        w1_fp4.data_ptr(),
+        w1_blockscale.data_ptr(),
+        w1_alphas.data_ptr(),
+        w2_fp4.data_ptr(),
+        w2_blockscale.data_ptr(),
+        w2_alphas.data_ptr(),
+        activation,
+        params_dtype,
+        source_format,
+        w13_layout,
+    )
+    cached = _W4A16_MODEL_OPT_WEIGHT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    prepared = prepare_w4a16_modelopt_native_weights(
+        w1_fp4,
+        w1_blockscale,
+        w1_alphas,
+        w2_fp4,
+        w2_blockscale,
+        w2_alphas,
+        activation=activation,
+        params_dtype=params_dtype,
+        source_format=source_format,
+        w13_layout=w13_layout,
+    )
+    _W4A16_MODEL_OPT_WEIGHT_CACHE[key] = prepared
     return prepared
 
 
@@ -1637,6 +1709,7 @@ def prepare_b12x_w4a16_packed_weights(
     params_dtype: torch.dtype,
     quant_mode: str | None = "w4a16",
     source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
     reuse_input_storage: bool = False,
 ) -> object:
     """Prepare W4A16 packed weights using the same contract as b12x_moe_fp4."""
@@ -1645,6 +1718,7 @@ def prepare_b12x_w4a16_packed_weights(
     if quant_mode != "w4a16":
         raise ValueError("W4A16 packed weights require quant_mode='w4a16'")
     source_format = _normalize_fp4_source_format(source_format)
+    w13_layout = _normalize_w13_layout(w13_layout)
     _validate_fp4_source_format_for_quant_mode(
         source_format=source_format,
         quant_mode=quant_mode,
@@ -1665,6 +1739,7 @@ def prepare_b12x_w4a16_packed_weights(
         activation=activation,
         params_dtype=params_dtype,
         source_format=source_format,
+        w13_layout=w13_layout,
         reuse_input_storage=reuse_input_storage,
     )
 
@@ -1683,6 +1758,7 @@ def prepare_b12x_w4a16_modelopt_nvfp4_weights(
     params_dtype: torch.dtype,
     quant_mode: str | None = "w4a16",
     source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
     reuse_input_storage: bool = False,
 ) -> object:
     """Prepare ModelOpt NVFP4 W4A16 weights from the normal NVFP4 scale contract.
@@ -1700,16 +1776,17 @@ def prepare_b12x_w4a16_modelopt_nvfp4_weights(
         source_format=source_format,
         quant_mode=quant_mode,
     )
-    if source_format != "modelopt_nvfp4":
+    if source_format not in _MODEL_OPT_NVFP4_SOURCE_FORMATS:
         raise ValueError(
             "W4A16 ModelOpt NVFP4 weights require source_format='modelopt_nvfp4'"
         )
+    w13_layout = _normalize_w13_layout(w13_layout)
 
     weight_E = int(w1_fp4.shape[0])
     w1_alphas = _w4a16_default_alpha(w1_alphas, a1_gscale, weight_E)
     w2_alphas = _w4a16_default_alpha(w2_alphas, a2_gscale, weight_E)
 
-    return _get_w4a16_packed_weights(
+    return _get_w4a16_modelopt_weights(
         w1_fp4,
         w1_blockscale,
         w1_alphas,
@@ -1719,7 +1796,7 @@ def prepare_b12x_w4a16_modelopt_nvfp4_weights(
         activation=activation,
         params_dtype=params_dtype,
         source_format=source_format,
-        reuse_input_storage=reuse_input_storage,
+        w13_layout=w13_layout,
     )
 
 
@@ -2024,6 +2101,7 @@ def _validate_frozen_w4a16_launch(
     apply_router_weight_on_input: bool,
     swiglu_limit: float | None,
     weight_layout: str,
+    w13_layout: str = "packed",
 ) -> None:
     token_count = int(plan.max_tokens_per_launch)
     planned_capacity = min(
@@ -2049,15 +2127,25 @@ def _validate_frozen_w4a16_launch(
             "frozen W4A16 MoE workspace swiglu_limit mismatch: "
             f"requested={requested_limit}, planned={workspace.planned_swiglu_limit}"
         )
-    fused = workspace.planned_fused_moe_launches.get((weight_layout, planned_capacity))
+    fused = workspace.planned_fused_moe_launches.get(
+        (weight_layout, w13_layout, planned_capacity)
+    )
+    if fused is None:
+        fused = workspace.planned_fused_moe_launches.get(
+            (weight_layout, planned_capacity)
+        )
     if fused is None:
         legacy_fused = workspace.planned_fused_moe_launches.get(planned_capacity)
-        if getattr(legacy_fused, "weight_layout", "packed") == weight_layout:
+        if (
+            getattr(legacy_fused, "weight_layout", "packed") == weight_layout
+            and getattr(legacy_fused, "w13_layout", "packed") == w13_layout
+        ):
             fused = legacy_fused
     if fused is None:
         raise RuntimeError(
             "frozen W4A16 MoE workspace is missing its preplanned fused launch "
-            f"for capacity={planned_capacity}, weight_layout={weight_layout!r}"
+            f"for capacity={planned_capacity}, weight_layout={weight_layout!r}, "
+            f"w13_layout={w13_layout!r}"
         )
     if planned_capacity not in workspace.planned_topk_sum_launches:
         raise RuntimeError(
@@ -2071,6 +2159,7 @@ def _w4a16_preplanned_launches(
     *,
     token_count: int,
     weight_layout: str,
+    w13_layout: str = "packed",
 ) -> tuple[object | None, object | None]:
     token_count = int(token_count)
     if not workspace.planned_token_counts:
@@ -2084,16 +2173,26 @@ def _w4a16_preplanned_launches(
             "W4A16 MoE workspace was asked to launch an unplanned token count: "
             f"tokens={token_count}, planned={sorted(workspace.planned_token_counts)}"
         )
-    fused = workspace.planned_fused_moe_launches.get((weight_layout, planned_capacity))
+    fused = workspace.planned_fused_moe_launches.get(
+        (weight_layout, w13_layout, planned_capacity)
+    )
+    if fused is None:
+        fused = workspace.planned_fused_moe_launches.get(
+            (weight_layout, planned_capacity)
+        )
     if fused is None:
         legacy_fused = workspace.planned_fused_moe_launches.get(planned_capacity)
-        if getattr(legacy_fused, "weight_layout", "packed") == weight_layout:
+        if (
+            getattr(legacy_fused, "weight_layout", "packed") == weight_layout
+            and getattr(legacy_fused, "w13_layout", "packed") == w13_layout
+        ):
             fused = legacy_fused
     topk_sum = workspace.planned_topk_sum_launches.get(planned_capacity)
     if fused is None or topk_sum is None:
         raise RuntimeError(
             "W4A16 MoE workspace is missing preplanned launches for "
-            f"capacity={planned_capacity}, weight_layout={weight_layout!r}"
+            f"capacity={planned_capacity}, weight_layout={weight_layout!r}, "
+            f"w13_layout={w13_layout!r}"
         )
     return fused, topk_sum
 
@@ -2108,6 +2207,7 @@ def _resolve_workspace(
     apply_router_weight_on_input: bool = False,
     swiglu_limit: float | None = None,
     weight_layout: str = "packed",
+    w13_layout: str = "packed",
 ) -> object:
     if isinstance(workspace, (TPMoEWorkspace, TPW4A16Workspace)):
         _validate_workspace(workspace, plan=plan)
@@ -2255,6 +2355,7 @@ def _resolve_workspace(
             apply_router_weight_on_input=apply_router_weight_on_input,
             swiglu_limit=swiglu_limit,
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
         )
 
     if isinstance(resolved, TPDynamicWorkspace):
@@ -2520,24 +2621,31 @@ def _prewarm_w4a16_planned_launches(
                 workspace.weight_E,
             )
             max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
-            weight_layout = "packed"
-            fused_launches[(weight_layout, token_count)] = compile_w4a16_fused_moe(
-                size_m=token_count,
-                hidden_size=workspace.k,
-                intermediate_size=workspace.n,
-                num_experts=workspace.weight_E,
-                top_k=workspace.num_topk,
-                activation=workspace.activation,
-                apply_router_weight_on_input=bool(apply_router_weight_on_input),
-                zero_fc2_output=False,
-                moe_block_size=block_size_m,
-                max_m_blocks=max_m_blocks,
-                element_dtype=element_dtype,
-                sms=sms,
-                max_shared_mem=max_shared_mem,
-                swiglu_limit=swiglu_limit,
-                weight_layout=weight_layout,
-            )
+            for weight_layout, w13_layout in (
+                ("packed", "packed"),
+                ("modelopt", "up_gate"),
+                ("modelopt", "gate_up"),
+            ):
+                fused_launches[
+                    (weight_layout, w13_layout, token_count)
+                ] = compile_w4a16_fused_moe(
+                    size_m=token_count,
+                    hidden_size=workspace.k,
+                    intermediate_size=workspace.n,
+                    num_experts=workspace.weight_E,
+                    top_k=workspace.num_topk,
+                    activation=workspace.activation,
+                    apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                    zero_fc2_output=False,
+                    moe_block_size=block_size_m,
+                    max_m_blocks=max_m_blocks,
+                    element_dtype=element_dtype,
+                    sms=sms,
+                    max_shared_mem=max_shared_mem,
+                    swiglu_limit=swiglu_limit,
+                    weight_layout=weight_layout,
+                    w13_layout=w13_layout,
+                )
             topk_sum_launches[token_count] = compile_w4a16_topk_sum(
                 m=token_count,
                 topk=workspace.num_topk,
@@ -4129,6 +4237,7 @@ def b12x_moe_fp4(
     quant_mode: str | None = None,
     unit_scale_contract: bool = False,
     source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
     prepared_w4a16: object | None = None,
     swiglu_limit: float | None = None,
 ) -> torch.Tensor:
@@ -4142,6 +4251,7 @@ def b12x_moe_fp4(
     quant_mode_arg = quant_mode
     quant_mode = _normalize_quant_mode(quant_mode_arg)
     source_format = _normalize_fp4_source_format(source_format)
+    w13_layout = _normalize_w13_layout(w13_layout)
     _validate_fp4_source_format_for_quant_mode(
         source_format=source_format,
         quant_mode=quant_mode,
@@ -4186,7 +4296,7 @@ def b12x_moe_fp4(
         prepared_w4a16 is None
         and quant_mode_arg is None
         and quant_mode == "w4a16"
-        and source_format != "modelopt_nvfp4"
+        and source_format not in _MODEL_OPT_NVFP4_SOURCE_FORMATS
     ):
         w1_alphas = _w4a16_default_alpha(
             w1_alphas,
@@ -4231,7 +4341,7 @@ def b12x_moe_fp4(
 
         prepared = prepared_w4a16
         if prepared is None:
-            if source_format == "modelopt_nvfp4":
+            if source_format in _MODEL_OPT_NVFP4_SOURCE_FORMATS:
                 w1_prepare_alphas = _w4a16_default_alpha(
                     w1_alphas,
                     a1_gscale,
@@ -4242,21 +4352,39 @@ def b12x_moe_fp4(
                     a2_gscale,
                     weight_E,
                 )
+                prepared = _get_w4a16_modelopt_weights(
+                    w1_fp4,
+                    w1_blockscale,
+                    w1_prepare_alphas,
+                    w2_fp4,
+                    w2_blockscale,
+                    w2_prepare_alphas,
+                    activation=activation,
+                    params_dtype=a.dtype,
+                    source_format=source_format,
+                    w13_layout=w13_layout,
+                )
             else:
-                w1_prepare_alphas = w1_alphas
-                w2_prepare_alphas = w2_alphas
-            prepared = _get_w4a16_packed_weights(
-                w1_fp4,
-                w1_blockscale,
-                w1_prepare_alphas,
-                w2_fp4,
-                w2_blockscale,
-                w2_prepare_alphas,
-                activation=activation,
-                params_dtype=a.dtype,
-                source_format=source_format,
-            )
+                prepared = _get_w4a16_packed_weights(
+                    w1_fp4,
+                    w1_blockscale,
+                    w1_alphas,
+                    w2_fp4,
+                    w2_blockscale,
+                    w2_alphas,
+                    activation=activation,
+                    params_dtype=a.dtype,
+                    source_format=source_format,
+                    w13_layout=w13_layout,
+                )
         weight_layout = getattr(prepared, "weight_layout", "packed")
+        w13_layout = getattr(
+            prepared,
+            "w13_layout",
+            "up_gate" if weight_layout == "modelopt" else "packed",
+        )
+        if weight_layout != "modelopt":
+            w13_layout = "packed"
         plan = _make_workspace_plan(
             num_tokens=m,
             weight_E=weight_E,
@@ -4277,6 +4405,7 @@ def b12x_moe_fp4(
             apply_router_weight_on_input=apply_router_weight_on_input,
             swiglu_limit=swiglu_limit,
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
         )
         if not isinstance(w4a16_workspace, TPW4A16Workspace):
             raise TypeError("expected a TPW4A16Workspace for the W4A16 backend")
@@ -4296,6 +4425,7 @@ def b12x_moe_fp4(
             w4a16_workspace,
             token_count=m,
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
         )
         return run_w4a16_moe(
             a,

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import cuda.bindings.driver as cuda
 import cutlass
@@ -67,6 +69,7 @@ from b12x.moe.fused.w4a16.host import (
     select_route_block_size_m,
     validate_activation,
 )
+from b12x.moe.fused.micro import MoEMicroKernelBackend
 from b12x.runtime_control import raise_if_kernel_resolution_frozen
 
 
@@ -78,6 +81,7 @@ _DEFAULT_MAX_SHARED_MEM = 101_376
 _WEIGHT_LAYOUTS = {"packed", "modelopt"}
 _MODEL_OPT_W13_LAYOUTS = {"up_gate", "gate_up"}
 _MAX_DIRECT_TOPK_ROUTE_M = 6
+_W4A16_SMALL_M_DIRECT_MAX_M = 8
 
 
 # The W4A16 launch model chooses blocks/SM from static resource usage
@@ -354,6 +358,75 @@ class W4A16FusedMoeCompileResult:
 class _W4A16GemmLaunch:
     kernel: W4A16GemmCompileResult
     c_tmp: torch.Tensor
+
+
+class _W4A16SmallMDirectLaunch(NamedTuple):
+    compiled: object
+    grid_x: int
+    m: int
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    topk: int
+    activation: str
+    fast_math: bool
+    topk_ids_dtype: torch.dtype
+
+
+class _W4A16SmallMDirectKernel(MoEMicroKernelBackend):
+    """Decode-sized W4A16 specialization using the native ModelOpt layout."""
+
+    _SUPPORTED_M = (1, 2, 4, 8)
+
+    @classmethod
+    def is_supported(
+        cls,
+        *,
+        m: int,
+        hidden_size: int,
+        intermediate_size: int,
+        topk: int,
+        num_experts: int,
+    ) -> bool:
+        return (
+            int(m) in cls._SUPPORTED_M
+            and int(m) <= _W4A16_SMALL_M_DIRECT_MAX_M
+            and int(hidden_size) > 0
+            and int(hidden_size) % 128 == 0
+            and int(intermediate_size) > 0
+            and int(intermediate_size) % 16 == 0
+            and 0 < int(topk) <= 32
+            and int(num_experts) > 0
+            and MoEMicroKernelBackend.is_supported(
+                int(m),
+                int(hidden_size),
+                int(intermediate_size),
+                int(topk),
+                int(num_experts),
+            )
+        )
+
+    def __init__(
+        self,
+        *,
+        activation: str,
+        fast_math: bool,
+        share_input_across_experts: bool,
+        share_expert_scales: bool,
+        single_token: bool,
+    ):
+        super().__init__(
+            sf_vec_size=16,
+            mma_tiler_mn=(64, 128),
+            output_tile_count_n=1,
+            fast_math=fast_math,
+            activation=activation,
+            share_input_across_experts=share_input_across_experts,
+            share_expert_scales=share_expert_scales,
+            single_token=single_token,
+            dynamic_down_scale=False,
+            w4a16_mode=True,
+        )
 
 
 class W4A16GemmKernel:
@@ -3474,6 +3547,7 @@ _CACHE: dict[tuple, W4A16GemmCompileResult] = {}
 _FUSED_CACHE: dict[tuple, W4A16FusedMoeCompileResult] = {}
 _ACTIVATION_CACHE: dict[tuple, W4A16ActivationCompileResult] = {}
 _SUM_CACHE: dict[tuple, W4A16TopKSumCompileResult] = {}
+_SMALL_M_DIRECT_CACHE: dict[tuple, _W4A16SmallMDirectLaunch] = {}
 
 
 def _normalize_element_dtype(dtype: torch.dtype) -> str:
@@ -3490,6 +3564,137 @@ def _cutlass_element_dtype(element_dtype: str):
     if element_dtype == "fp16":
         return cutlass.Float16
     raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+
+
+def _small_m_direct_supported(
+    *,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    swiglu_limit: float | None,
+    element_dtype: str,
+    weight_layout: str,
+    w13_layout: str,
+    expert_map: torch.Tensor | None = None,
+) -> bool:
+    if os.environ.get("B12X_W4A16_SMALL_M_DIRECT", "1") == "0":
+        return False
+    if activation not in {"silu", "relu2"}:
+        return False
+    return (
+        element_dtype == "bf16"
+        and weight_layout == "modelopt"
+        and w13_layout == "up_gate"
+        and not bool(apply_router_weight_on_input)
+        and swiglu_limit is None
+        and expert_map is None
+        and _W4A16SmallMDirectKernel.is_supported(
+            m=m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            topk=topk,
+            num_experts=num_experts,
+        )
+    )
+
+
+def _compile_w4a16_small_m_direct(
+    *,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+    activation: str,
+    fast_math: bool,
+    topk_ids_dtype: torch.dtype,
+    device: torch.device | None,
+) -> _W4A16SmallMDirectLaunch:
+    if topk_ids_dtype not in (torch.int32, torch.int64):
+        raise TypeError("small-M W4A16 direct path requires int32/int64 topk_ids")
+    cache_key = (
+        "w4a16_small_m_direct",
+        None if device is None else int(device.index or 0),
+        int(m),
+        int(hidden_size),
+        int(intermediate_size),
+        int(num_experts),
+        int(topk),
+        activation,
+        bool(fast_math),
+        topk_ids_dtype,
+    )
+    cached = _SMALL_M_DIRECT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    kernel = _W4A16SmallMDirectKernel(
+        activation=activation,
+        fast_math=bool(fast_math),
+        share_input_across_experts=(int(m) == 1),
+        share_expert_scales=True,
+        single_token=(int(m) == 1),
+    )
+    kernel.configure(
+        int(m),
+        int(hidden_size),
+        int(intermediate_size),
+        int(topk),
+        int(num_experts),
+        device=device,
+    )
+
+    def dummy(dt):
+        return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+    ids_dtype = cutlass.Int32 if topk_ids_dtype == torch.int32 else cutlass.Int64
+    barrier_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (1,),
+        assumed_align=4,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = cute.compile(
+        kernel,
+        dummy(cutlass.BFloat16),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Float32),
+        dummy(cutlass.Uint32),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Uint8),
+        dummy(cutlass.Float32),
+        dummy(ids_dtype),
+        dummy(cutlass.Float32),
+        dummy(cutlass.BFloat16),
+        barrier_fake,
+        barrier_fake,
+        Int32(m),
+        Int32(kernel.grid_x),
+        current_cuda_stream(),
+    )
+    launch = _W4A16SmallMDirectLaunch(
+        compiled=compiled,
+        grid_x=int(kernel.grid_x),
+        m=int(m),
+        hidden_size=int(hidden_size),
+        intermediate_size=int(intermediate_size),
+        num_experts=int(num_experts),
+        topk=int(topk),
+        activation=activation,
+        fast_math=bool(fast_math),
+        topk_ids_dtype=topk_ids_dtype,
+    )
+    _SMALL_M_DIRECT_CACHE[cache_key] = launch
+    return launch
 
 
 def compile_w4a16_gemm(
@@ -3763,6 +3968,32 @@ def compile_w4a16_fused_moe(
     if cached is not None:
         return cached
 
+    if _small_m_direct_supported(
+        m=size_m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        topk=top_k,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        swiglu_limit=swiglu_limit,
+        element_dtype=element_dtype,
+        weight_layout=weight_layout,
+        w13_layout=w13_layout,
+    ):
+        for ids_dtype in (torch.int32, torch.int64):
+            _compile_w4a16_small_m_direct(
+                m=size_m,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                topk=top_k,
+                activation=activation,
+                fast_math=fast_math,
+                topk_ids_dtype=ids_dtype,
+                device=torch.device("cuda", device) if device is not None else None,
+            )
+
     packed_route_fake_elements = (
         int(size_m) * int(top_k)
         if direct_topk_routes
@@ -3948,6 +4179,7 @@ def clear_w4a16_kernel_cache() -> None:
     _FUSED_CACHE.clear()
     _ACTIVATION_CACHE.clear()
     _SUM_CACHE.clear()
+    _SMALL_M_DIRECT_CACHE.clear()
 
 
 def compile_w4a16_activation(
@@ -4289,6 +4521,92 @@ def run_w4a16_moe(
         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
 
     stream = current_cuda_stream() if stream is None else stream
+    if _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=int(prepared.intermediate_size),
+        num_experts=int(prepared.num_experts),
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+        swiglu_limit=swiglu_limit,
+        element_dtype=element_dtype,
+        weight_layout=weight_layout,
+        w13_layout=w13_layout,
+        expert_map=expert_map,
+    ):
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError("W4A16 small-M direct path requires int32/int64 topk_ids")
+        if not topk_ids.is_cuda:
+            raise ValueError("W4A16 small-M direct path requires CUDA topk_ids")
+        if not intermediate_cache2.is_contiguous() or not output.is_contiguous():
+            raise ValueError(
+                "W4A16 small-M direct path requires contiguous intermediate_cache2 and output"
+            )
+        if intermediate_cache2.dtype != a_input.dtype:
+            raise TypeError(f"intermediate_cache2 must be {a_input.dtype}")
+        if int(prepared.workspace.numel()) < 2:
+            raise ValueError("prepared W4A16 workspace is too small for small-M direct")
+        intermediate_size = int(prepared.intermediate_size)
+        fc2_n_chunks = ((intermediate_size // 2) + 127) // 128
+        inter_u32_per_m = fc2_n_chunks * 128 * topk
+        inter_u32 = intermediate_cache2.view(-1).view(torch.uint32)
+        if int(inter_u32.numel()) < m * inter_u32_per_m:
+            raise ValueError(
+                "intermediate_cache2 is smaller than the W4A16 small-M direct scratch "
+                f"requirement: have_u32={int(inter_u32.numel())}, "
+                f"need_u32={m * inter_u32_per_m}"
+            )
+        direct_launch = _compile_w4a16_small_m_direct(
+            m=m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=int(prepared.num_experts),
+            topk=topk,
+            activation=activation,
+            fast_math=bool(fast_math),
+            topk_ids_dtype=topk_ids.dtype,
+            device=a_input.device,
+        )
+        micro_w13_scale = getattr(prepared, "micro_w13_scale", None)
+        micro_w2_scale = getattr(prepared, "micro_w2_scale", None)
+        micro_w13_global = getattr(prepared, "micro_w13_global_scale", None)
+        micro_w2_global = getattr(prepared, "micro_w2_global_scale", None)
+        if (
+            micro_w13_scale is None
+            or micro_w2_scale is None
+            or micro_w13_global is None
+            or micro_w2_global is None
+        ):
+            raise RuntimeError(
+                "W4A16 small-M direct path requires native ModelOpt micro scale metadata"
+            )
+        barrier_count = prepared.workspace[-2:-1]
+        barrier_epoch = prepared.workspace[-1:]
+        barrier_count.zero_()
+        barrier_epoch.zero_()
+        MoEMicroKernelBackend.launch(
+            direct_launch.compiled,
+            x=a_input,
+            w1_fp4=prepared.w13.view(torch.uint8),
+            w1_blockscale=micro_w13_scale,
+            w1_alphas=micro_w13_global,
+            a1_gscale=micro_w13_global,
+            a2_gscale=micro_w2_global,
+            inter_fp32=inter_u32[: m * inter_u32_per_m],
+            w2_fp4=prepared.w2.view(torch.uint8),
+            w2_blockscale=micro_w2_scale,
+            w2_alphas=micro_w2_global,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            out=output,
+            barrier_count=barrier_count,
+            barrier_epoch=barrier_epoch,
+            m=m,
+            grid_x=direct_launch.grid_x,
+        )
+        return output
+
     direct_topk_eligible = (
         m <= _MAX_DIRECT_TOPK_ROUTE_M
         and weight_layout == "packed"

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -9,7 +9,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass.cutlass_dsl import Int32, Uint32
+from cutlass.cutlass_dsl import Int32, Int64, Uint32
 
 from b12x.cute.fp4 import (
     atomic_add_global_i32,
@@ -75,7 +75,8 @@ _PACK_FACTOR = 8
 _STAGES = 4
 _DEVICE_MAX_REG_BYTES = 255 * 1024
 _DEFAULT_MAX_SHARED_MEM = 101_376
-_WEIGHT_LAYOUTS = {"packed"}
+_WEIGHT_LAYOUTS = {"packed", "modelopt"}
+_MODEL_OPT_W13_LAYOUTS = {"up_gate", "gate_up"}
 _MAX_DIRECT_TOPK_ROUTE_M = 6
 
 
@@ -303,6 +304,7 @@ class W4A16GemmCompileResult:
     max_m_blocks: int
     blocks_per_sm: int
     weight_layout: str = "packed"
+    w13_layout: str = "up_gate"
 
 
 @dataclass(frozen=True)
@@ -344,6 +346,7 @@ class W4A16FusedMoeCompileResult:
     max_m_blocks: int
     blocks_per_sm: int
     weight_layout: str = "packed"
+    w13_layout: str = "up_gate"
     direct_topk_routes: bool = False
 
 
@@ -370,6 +373,8 @@ class W4A16GemmKernel:
         element_dtype: str = "bf16",
         epilogue_activation: str | None = None,
         weight_layout: str = "packed",
+        w13_layout: str = "up_gate",
+        source_n_rotation: int = 0,
         single_token_route_fast_path: bool = False,
         direct_topk_routes: bool = False,
     ):
@@ -377,6 +382,12 @@ class W4A16GemmKernel:
             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
         if weight_layout not in _WEIGHT_LAYOUTS:
             raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+        if weight_layout == "modelopt":
+            if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+                raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        else:
+            w13_layout = "packed"
+            source_n_rotation = 0
         if epilogue_activation not in (None, "relu2"):
             raise ValueError(
                 "W4A16 GEMM epilogue activation currently supports only relu2"
@@ -410,6 +421,8 @@ class W4A16GemmKernel:
         self.is_fp16 = element_dtype == "fp16"
         self.epilogue_relu2 = epilogue_activation == "relu2"
         self.weight_layout = weight_layout
+        self.w13_layout = w13_layout
+        self.source_n_rotation = int(source_n_rotation)
         self.single_token_route_fast_path = bool(single_token_route_fast_path)
         self.direct_topk_routes = bool(direct_topk_routes)
         self.cta_m_blocks = int(_covering_count(moe_block_size, 16))
@@ -1917,14 +1930,22 @@ class W4A16GemmKernel:
         pipe: Int32,
         kk: Int32,
     ):
-        b_addr = self._int4_addr(
-            smem_base,
-            Int32(self.sh_b_off)
-            + pipe * Int32(self.b_sh_stage)
-            + Int32(self.b_sh_stride) * kk
-            + b_sh_rd,
-        )
-        q0, q1, q2, q3 = ld_shared_v4_u32(b_addr)
+        if cutlass.const_expr(self.weight_layout == "modelopt"):
+            q0, q1, q2, q3 = self._load_b_registers_modelopt_shared(
+                smem_base,
+                b_sh_rd,
+                pipe,
+                kk,
+            )
+        else:
+            b_addr = self._int4_addr(
+                smem_base,
+                Int32(self.sh_b_off)
+                + pipe * Int32(self.b_sh_stage)
+                + Int32(self.b_sh_stride) * kk
+                + b_sh_rd,
+            )
+            q0, q1, q2, q3 = ld_shared_v4_u32(b_addr)
 
         warp_id = tid // Int32(32)
         warp_row = warp_id // Int32(self.tb_n_warps)
@@ -2128,6 +2149,146 @@ class W4A16GemmKernel:
         acc[mb, jj, 1, 3] = d3
 
     @cute.jit
+    def _source_n_from_logical(self, logical_n: Int32) -> Int32:
+        source_n = logical_n
+        if cutlass.const_expr(self.source_n_rotation != 0):
+            source_n += Int32(self.source_n_rotation)
+            if source_n >= Int32(self.size_n):
+                source_n -= Int32(self.size_n)
+        return source_n
+
+    @cute.jit
+    def _stage_b_tile_modelopt_native(
+        self,
+        b_u8_flat: cute.Tensor,
+        smem_addr: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        tile_idx: Int32,
+        local_int4: Int32,
+    ):
+        chunks_per_row = Int32(self.tile_k // 32)
+        local_n = local_int4 // chunks_per_row
+        local_k_vec = local_int4 - local_n * chunks_per_row
+        logical_n = output_n_tile * Int32(self.tile_n) + local_n
+        source_n = self._source_n_from_logical(logical_n)
+        packed_cols = Int32(self.size_k // 2)
+        byte_offset = (
+            Int64(expert_idx) * Int64(self.size_n * (self.size_k // 2))
+            + Int64(source_n) * Int64(packed_cols)
+            + Int64(tile_idx * Int32(self.tile_k // 2))
+            + Int64(local_k_vec * Int32(16))
+        )
+        cp_async4_shared_global(
+            smem_addr,
+            get_ptr_as_int64(b_u8_flat, byte_offset),
+        )
+
+    @cute.jit
+    def _load_modelopt_shared_byte(
+        self,
+        smem_base: Int32,
+        pipe: Int32,
+        n_tile: Int32,
+        k_tile: Int32,
+        warp_id: Int32,
+        tc_col: Int32,
+        tc_row: Int32,
+        n_delta: cutlass.Constexpr[int],
+        k_delta: cutlass.Constexpr[int],
+    ) -> Uint32:
+        local_n = (
+            n_tile * Int32(64)
+            + warp_id * Int32(16)
+            + tc_col
+            + Int32(n_delta)
+        )
+        local_k = k_tile * Int32(16) + tc_row + Int32(k_delta)
+        byte_offset = local_n * Int32(self.tile_k // 2) + local_k // Int32(2)
+        word_byte_offset = byte_offset - (byte_offset & Int32(3))
+        word = ld_shared_u32(
+            smem_base
+            + Int32(self.sh_b_off * 16)
+            + pipe * Int32(self.b_sh_stage * 16)
+            + word_byte_offset
+        )
+        shift = Uint32((byte_offset - word_byte_offset) * Int32(8))
+        return (word >> shift) & Uint32(0xFF)
+
+    @cute.jit
+    def _pack_modelopt_byte_pair(
+        self,
+        word: Uint32,
+        q: Uint32,
+        low_shift: cutlass.Constexpr[int],
+        high_shift: cutlass.Constexpr[int],
+    ) -> Uint32:
+        low = q & Uint32(0xF)
+        high = (q >> Uint32(4)) & Uint32(0xF)
+        return word | (low << Uint32(low_shift)) | (high << Uint32(high_shift))
+
+    @cute.jit
+    def _load_modelopt_shared_packed_word_for_lane(
+        self,
+        smem_base: Int32,
+        pipe: Int32,
+        n_tile: Int32,
+        k_tile: Int32,
+        warp_id: Int32,
+        tc_col: Int32,
+        tc_row: Int32,
+    ) -> Uint32:
+        q0 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 0, 0
+        )
+        q1 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 0, 8
+        )
+        q2 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 8, 0
+        )
+        q3 = self._load_modelopt_shared_byte(
+            smem_base, pipe, n_tile, k_tile, warp_id, tc_col, tc_row, 8, 8
+        )
+        word = Uint32(0)
+        word = self._pack_modelopt_byte_pair(word, q0, 0, 16)
+        word = self._pack_modelopt_byte_pair(word, q1, 4, 20)
+        word = self._pack_modelopt_byte_pair(word, q2, 8, 24)
+        word = self._pack_modelopt_byte_pair(word, q3, 12, 28)
+        return word
+
+    @cute.jit
+    def _load_b_registers_modelopt_shared(
+        self,
+        smem_base: Int32,
+        b_sh_rd: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        packed_word_index = (Int32(self.b_sh_stride) * kk + b_sh_rd) * Int32(4)
+        words_per_k_tile = Int32((self.tile_n // 64) * 128)
+        k_tile = packed_word_index // words_per_k_tile
+        pos_in_k_tile = packed_word_index - k_tile * words_per_k_tile
+        n_tile = pos_in_k_tile // Int32(128)
+        pos = pos_in_k_tile - n_tile * Int32(128)
+        th_id = pos // Int32(4)
+        tc_col = th_id // Int32(4)
+        tc_row = (th_id - tc_col * Int32(4)) * Int32(2)
+        q0 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(0), tc_col, tc_row
+        )
+        q1 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(1), tc_col, tc_row
+        )
+        q2 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(2), tc_col, tc_row
+        )
+        q3 = self._load_modelopt_shared_packed_word_for_lane(
+            smem_base, pipe, n_tile, k_tile, Int32(3), tc_col, tc_row
+        )
+        return q0, q1, q2, q3
+
+    @cute.jit
     def _stage_k_tile_async(
         self,
         a_bf16_flat: cute.Tensor,
@@ -2189,10 +2350,20 @@ class W4A16GemmKernel:
                 + Int32(i * self.cta_threads)
                 + tid,
             )
-            cp_async4_shared_global(
-                b_dst,
-                get_ptr_as_int64(b_i32_flat, b_src_int4 * Int32(4)),
-            )
+            if cutlass.const_expr(self.weight_layout == "packed"):
+                cp_async4_shared_global(
+                    b_dst,
+                    get_ptr_as_int64(b_i32_flat, b_src_int4 * Int32(4)),
+                )
+            else:
+                self._stage_b_tile_modelopt_native(
+                    b_i32_flat,
+                    b_dst,
+                    expert_idx,
+                    output_n_tile,
+                    tile_idx,
+                    Int32(i * self.cta_threads) + tid,
+                )
 
         if tid < Int32(self.s_sh_stage):
             s_src_int4 = (
@@ -2767,6 +2938,7 @@ class W4A16FusedMoeKernel:
         fast_math: bool = True,
         swiglu_limit: float | None = None,
         weight_layout: str = "packed",
+        w13_layout: str = "up_gate",
         direct_topk_routes: bool = False,
     ):
         is_gated = validate_activation(activation)
@@ -2775,6 +2947,11 @@ class W4A16FusedMoeKernel:
             raise ValueError("swiglu_limit requires a gated W4A16 activation")
         if weight_layout not in _WEIGHT_LAYOUTS:
             raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+        if weight_layout == "modelopt":
+            if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+                raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        else:
+            w13_layout = "packed"
         fc1_cols = int(intermediate_size) * (2 if is_gated else 1)
         routed_rows = int(size_m) * int(top_k)
         self.size_m = int(size_m)
@@ -2788,12 +2965,22 @@ class W4A16FusedMoeKernel:
         self.has_swiglu_limit = swiglu_limit is not None
         self.swiglu_limit = 0.0 if swiglu_limit is None else swiglu_limit
         self.weight_layout = weight_layout
+        self.w13_layout = w13_layout
         self.apply_router_weight_on_input = bool(apply_router_weight_on_input)
         self.zero_fc2_output = bool(zero_fc2_output)
         self.element_dtype = element_dtype
         self.is_fp16 = element_dtype == "fp16"
         self.fast_math = bool(fast_math)
         self.direct_topk_routes = bool(direct_topk_routes)
+        fc1_source_n_rotation = (
+            int(intermediate_size)
+            if (
+                weight_layout == "modelopt"
+                and w13_layout == "up_gate"
+                and is_gated
+            )
+            else 0
+        )
         self.fc1 = W4A16GemmKernel(
             size_m=size_m,
             size_n=fc1_cols,
@@ -2808,6 +2995,8 @@ class W4A16FusedMoeKernel:
             element_dtype=element_dtype,
             epilogue_activation=None if is_gated else "relu2",
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
+            source_n_rotation=fc1_source_n_rotation,
             single_token_route_fast_path=size_m == 1
             and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
@@ -2825,6 +3014,7 @@ class W4A16FusedMoeKernel:
             max_m_blocks=max_m_blocks,
             element_dtype=element_dtype,
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
             single_token_route_fast_path=size_m == 1
             and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
@@ -3471,6 +3661,7 @@ def compile_w4a16_fused_moe(
     max_shared_mem: int,
     swiglu_limit: float | None = None,
     weight_layout: str = "packed",
+    w13_layout: str = "up_gate",
     direct_topk_routes: bool = False,
 ) -> W4A16FusedMoeCompileResult:
     cutlass_dtype = _cutlass_element_dtype(element_dtype)
@@ -3481,6 +3672,11 @@ def compile_w4a16_fused_moe(
         raise ValueError("swiglu_limit requires a gated W4A16 activation")
     if weight_layout not in _WEIGHT_LAYOUTS:
         raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    if weight_layout == "modelopt":
+        if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    else:
+        w13_layout = "packed"
     direct_topk_routes = bool(direct_topk_routes)
     if direct_topk_routes and (
         int(size_m) > _MAX_DIRECT_TOPK_ROUTE_M
@@ -3554,6 +3750,7 @@ def compile_w4a16_fused_moe(
         bool(fast_math),
         swiglu_limit,
         weight_layout,
+        w13_layout,
         fc1_tile_n,
         fc1_tile_k,
         fc2_tile_n,
@@ -3572,16 +3769,28 @@ def compile_w4a16_fused_moe(
         else int(max_m_blocks) * int(moe_block_size)
     )
     a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
-    w13_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32,
-        (num_experts * (hidden_size // 16) * (fc1_cols // 16 * 32),),
-        assumed_align=16,
-    )
-    w2_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32,
-        (num_experts * (intermediate_size // 16) * (hidden_size // 16 * 32),),
-        assumed_align=16,
-    )
+    if weight_layout == "modelopt":
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8,
+            (num_experts * fc1_cols * (hidden_size // 2),),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8,
+            (num_experts * hidden_size * (intermediate_size // 2),),
+            assumed_align=16,
+        )
+    else:
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (hidden_size // 16) * (fc1_cols // 16 * 32),),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (intermediate_size // 16) * (hidden_size // 16 * 32),),
+            assumed_align=16,
+        )
     fc1_fake = cute.runtime.make_fake_compact_tensor(
         cutlass_dtype,
         (routed_rows * fc1_cols,),
@@ -3678,6 +3887,7 @@ def compile_w4a16_fused_moe(
         fast_math=fast_math,
         swiglu_limit=swiglu_limit,
         weight_layout=weight_layout,
+        w13_layout=w13_layout,
         direct_topk_routes=direct_topk_routes,
     )
     raise_if_kernel_resolution_frozen(
@@ -3726,6 +3936,7 @@ def compile_w4a16_fused_moe(
         max_m_blocks=max_m_blocks,
         blocks_per_sm=kernel.blocks_per_sm,
         weight_layout=weight_layout,
+        w13_layout=w13_layout,
         direct_topk_routes=kernel.direct_topk_routes,
     )
     _FUSED_CACHE[cache_key] = result
@@ -4033,6 +4244,16 @@ def run_w4a16_moe(
     weight_layout = getattr(prepared, "weight_layout", "packed")
     if weight_layout not in _WEIGHT_LAYOUTS:
         raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    w13_layout = getattr(
+        prepared,
+        "w13_layout",
+        "up_gate" if weight_layout == "modelopt" else "packed",
+    )
+    if weight_layout == "modelopt":
+        if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+            raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    else:
+        w13_layout = "packed"
     if topk_weights.dtype != torch.float32:
         raise TypeError("topk_weights must be torch.float32")
     _validate_topk_ids(topk_ids, require_cuda=False, require_contiguous=False)
@@ -4197,6 +4418,7 @@ def run_w4a16_moe(
             max_shared_mem=max_shared_mem,
             swiglu_limit=swiglu_limit,
             weight_layout=weight_layout,
+            w13_layout=w13_layout,
             direct_topk_routes=use_direct_topk_routes,
         )
     else:
@@ -4217,6 +4439,7 @@ def run_w4a16_moe(
             bool(fast_math),
             swiglu_limit,
             weight_layout,
+            w13_layout,
             bool(use_direct_topk_routes),
             block_size_m,
         )
@@ -4232,6 +4455,13 @@ def run_w4a16_moe(
             bool(fused_launch.fast_math),
             fused_launch.swiglu_limit,
             getattr(fused_launch, "weight_layout", "packed"),
+            getattr(
+                fused_launch,
+                "w13_layout",
+                "up_gate"
+                if getattr(fused_launch, "weight_layout", "packed") == "modelopt"
+                else "packed",
+            ),
             bool(getattr(fused_launch, "direct_topk_routes", False)),
             int(fused_launch.moe_block_size),
         )
@@ -4279,8 +4509,12 @@ def run_w4a16_moe(
         device=a_input.device,
         scratch=fc2_c_tmp,
     )
-    w13_arg = prepared.w13.view(torch.int32).view(-1)
-    w2_arg = prepared.w2.view(torch.int32).view(-1)
+    if weight_layout == "modelopt":
+        w13_arg = prepared.w13.view(torch.uint8).view(-1)
+        w2_arg = prepared.w2.view(torch.uint8).view(-1)
+    else:
+        w13_arg = prepared.w13.view(torch.int32).view(-1)
+        w2_arg = prepared.w2.view(torch.int32).view(-1)
     fused.compiled(
         make_ptr(
             _cutlass_element_dtype(element_dtype),

--- a/b12x/moe/fused/w4a16/prepare.py
+++ b/b12x/moe/fused/w4a16/prepare.py
@@ -62,6 +62,10 @@ class W4A16ModelOptWeights:
     params_dtype: torch.dtype
     source_format: str = "modelopt_nvfp4"
     weight_layout: str = "modelopt"
+    micro_w13_scale: torch.Tensor | None = None
+    micro_w13_global_scale: torch.Tensor | None = None
+    micro_w2_scale: torch.Tensor | None = None
+    micro_w2_global_scale: torch.Tensor | None = None
     # Physical order of the two fused FC1 halves in source W13.
     # "up_gate" needs a row rotation before W4A16 SwiGLU; "gate_up" is already
     # in the logical order consumed by the kernel.
@@ -468,17 +472,17 @@ def _prepare_w4a16_packed_weights(
         size_n=hidden_size,
         reuse_input_storage=reuse_input_storage,
     )
-    w13_global_scale = _source_global_scale(
+    native_w13_global_scale = _source_global_scale(
         w13_global_scale,
         source_format=source_format,
     )
-    w2_global_scale = _source_global_scale(
+    native_w2_global_scale = _source_global_scale(
         w2_global_scale,
         source_format=source_format,
     )
     packed_w13_scale, packed_w13_global_scale = _permute_nvfp4_scales(
         w13_scale,
-        w13_global_scale,
+        native_w13_global_scale,
         size_k=hidden_size,
         size_n=w13_rows,
         a_dtype=params_dtype,
@@ -486,7 +490,7 @@ def _prepare_w4a16_packed_weights(
     )
     packed_w2_scale, packed_w2_global_scale = _permute_nvfp4_scales(
         w2_scale,
-        w2_global_scale,
+        native_w2_global_scale,
         size_k=intermediate_size,
         size_n=hidden_size,
         a_dtype=params_dtype,
@@ -598,11 +602,11 @@ def prepare_w4a16_modelopt_native_weights(
         rows=hidden_size,
         cols=intermediate_size,
     )
-    w13_global_scale = _source_global_scale(
+    native_w13_global_scale = _source_global_scale(
         w13_global_scale,
         source_format=source_format,
     )
-    w2_global_scale = _source_global_scale(
+    native_w2_global_scale = _source_global_scale(
         w2_global_scale,
         source_format=source_format,
     )
@@ -616,7 +620,7 @@ def prepare_w4a16_modelopt_native_weights(
     )
     packed_w13_scale, packed_w13_global_scale = _permute_nvfp4_scales(
         w13_scale,
-        w13_global_scale,
+        native_w13_global_scale,
         size_k=hidden_size,
         size_n=w13_rows,
         a_dtype=params_dtype,
@@ -624,7 +628,7 @@ def prepare_w4a16_modelopt_native_weights(
     )
     packed_w2_scale, packed_w2_global_scale = _permute_nvfp4_scales(
         w2_scale,
-        w2_global_scale,
+        native_w2_global_scale,
         size_k=intermediate_size,
         size_n=hidden_size,
         a_dtype=params_dtype,
@@ -644,6 +648,10 @@ def prepare_w4a16_modelopt_native_weights(
         is_gated=is_gated,
         params_dtype=params_dtype,
         source_format=source_format,
+        micro_w13_scale=w13_blockscale.contiguous(),
+        micro_w13_global_scale=native_w13_global_scale.contiguous(),
+        micro_w2_scale=w2_blockscale.contiguous(),
+        micro_w2_global_scale=native_w2_global_scale.contiguous(),
         w13_layout=w13_layout,
     )
 

--- a/b12x/moe/fused/w4a16/prepare.py
+++ b/b12x/moe/fused/w4a16/prepare.py
@@ -19,11 +19,13 @@ from b12x.moe.fused.w4a16.host import (
 _PACKED_TILE_SIZE = 16
 _PACKED_TILE_N_SIZE = 64
 _PACK_FACTOR_4BIT = 8
+_MODEL_OPT_W13_LAYOUTS = {"up_gate", "gate_up"}
 _SOURCE_FORMATS = {
     "modelopt_nvfp4": "modelopt_nvfp4",
     "mxfp4_native": "mxfp4_native",
     "compressed_tensors": "compressed_tensors",
 }
+_MODEL_OPT_NVFP4_FORMATS = {"modelopt_nvfp4"}
 
 
 @dataclass(frozen=True)
@@ -42,6 +44,28 @@ class W4A16PackedWeights:
     params_dtype: torch.dtype
     source_format: str = "modelopt_nvfp4"
     weight_layout: str = "packed"
+
+
+@dataclass(frozen=True)
+class W4A16ModelOptWeights:
+    w13: torch.Tensor
+    w13_scale: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    workspace: torch.Tensor
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    is_gated: bool
+    params_dtype: torch.dtype
+    source_format: str = "modelopt_nvfp4"
+    weight_layout: str = "modelopt"
+    # Physical order of the two fused FC1 halves in source W13.
+    # "up_gate" needs a row rotation before W4A16 SwiGLU; "gate_up" is already
+    # in the logical order consumed by the kernel.
+    w13_layout: str = "up_gate"
 
 
 def _make_workspace(
@@ -385,9 +409,16 @@ def _prepare_w4a16_packed_weights(
     activation: str,
     params_dtype: torch.dtype = torch.bfloat16,
     source_format: str,
+    w13_layout: str = "up_gate",
     reuse_input_storage: bool = False,
 ) -> W4A16PackedWeights:
     source_format = _normalize_source_format(source_format)
+    w13_layout = w13_layout.lower()
+    if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+        raise ValueError(
+            "w13_layout must be one of 'up_gate' or 'gate_up', "
+            f"got {w13_layout!r}"
+        )
     shape = validate_w4a16_packed_inputs(
         w13_fp4,
         w13_global_scale,
@@ -408,7 +439,7 @@ def _prepare_w4a16_packed_weights(
         cols=hidden_size,
     )
     w13_row_rotation = None
-    if is_gated:
+    if is_gated and w13_layout == "up_gate":
         if reuse_input_storage:
             w13_row_rotation = intermediate_size
         else:
@@ -488,6 +519,7 @@ def prepare_w4a16_modelopt_nvfp4_weights(
     *,
     activation: str,
     params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "up_gate",
     reuse_input_storage: bool = False,
 ) -> W4A16PackedWeights:
     """Prepare ModelOpt NVFP4 tensors into the W4A16 packed runtime layout.
@@ -506,7 +538,113 @@ def prepare_w4a16_modelopt_nvfp4_weights(
         activation=activation,
         params_dtype=params_dtype,
         source_format="modelopt_nvfp4",
+        w13_layout=w13_layout,
         reuse_input_storage=reuse_input_storage,
+    )
+
+
+def prepare_w4a16_modelopt_native_weights(
+    w13_fp4: torch.Tensor,
+    w13_blockscale: torch.Tensor,
+    w13_global_scale: torch.Tensor,
+    w2_fp4: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    w2_global_scale: torch.Tensor,
+    *,
+    activation: str,
+    params_dtype: torch.dtype = torch.bfloat16,
+    source_format: str = "modelopt_nvfp4",
+    w13_layout: str = "up_gate",
+) -> W4A16ModelOptWeights:
+    """Prepare W4A16 metadata while keeping ModelOpt FP4 weights native.
+
+    This is the memory-safe path for GLM serving that needs A4 prefill and A16
+    decode in the same process. It keeps the checkpoint FP4 tensors resident
+    instead of materializing a second full W4A16 packed copy.
+    """
+    source_format = _normalize_source_format(source_format)
+    if source_format not in _MODEL_OPT_NVFP4_FORMATS:
+        raise ValueError(
+            "native W4A16 ModelOpt weights require source_format "
+            "'modelopt_nvfp4'"
+        )
+    w13_layout = w13_layout.lower()
+    if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
+        raise ValueError(
+            "w13_layout must be one of 'up_gate' or 'gate_up', "
+            f"got {w13_layout!r}"
+        )
+
+    shape = validate_w4a16_packed_inputs(
+        w13_fp4,
+        w13_global_scale,
+        w2_fp4,
+        w2_global_scale,
+        activation=activation,
+    )
+    num_experts = shape.num_experts
+    hidden_size = shape.hidden_size
+    intermediate_size = shape.intermediate_size
+    w13_rows = shape.w13_rows
+    is_gated = shape.is_gated
+
+    w13_scale = unswizzle_expert_scales(
+        w13_blockscale,
+        rows=w13_rows,
+        cols=hidden_size,
+    )
+    w2_scale = unswizzle_expert_scales(
+        w2_blockscale,
+        rows=hidden_size,
+        cols=intermediate_size,
+    )
+    w13_global_scale = _source_global_scale(
+        w13_global_scale,
+        source_format=source_format,
+    )
+    w2_global_scale = _source_global_scale(
+        w2_global_scale,
+        source_format=source_format,
+    )
+
+    # The W4A16 activation consumes FC1 output in gate/up logical order.
+    # Checkpoint-native ModelOpt GLM tensors are up/gate, while vLLM/FI can
+    # hand over gate/up tensors after its own W13 reorder. Keep that physical
+    # order explicit so source_format never implies a layout transformation.
+    w13_row_rotation = (
+        intermediate_size if is_gated and w13_layout == "up_gate" else None
+    )
+    packed_w13_scale, packed_w13_global_scale = _permute_nvfp4_scales(
+        w13_scale,
+        w13_global_scale,
+        size_k=hidden_size,
+        size_n=w13_rows,
+        a_dtype=params_dtype,
+        row_rotation=w13_row_rotation,
+    )
+    packed_w2_scale, packed_w2_global_scale = _permute_nvfp4_scales(
+        w2_scale,
+        w2_global_scale,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        a_dtype=params_dtype,
+    )
+
+    return W4A16ModelOptWeights(
+        w13=w13_fp4,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=packed_w13_global_scale,
+        w2=w2_fp4,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=packed_w2_global_scale,
+        workspace=_make_workspace(w13_fp4.device, max_blocks_per_sm=4),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        source_format=source_format,
+        w13_layout=w13_layout,
     )
 
 
@@ -612,7 +750,7 @@ def prepare_w4a16_packed_weights(
 
 
 def make_w4a16_packed_buffers(
-    prepared: W4A16PackedWeights,
+    prepared: W4A16PackedWeights | W4A16ModelOptWeights,
     *,
     m: int,
     topk: int,
@@ -632,9 +770,11 @@ def make_w4a16_packed_buffers(
 
 __all__ = [
     "W4A16PackedBuffers",
+    "W4A16ModelOptWeights",
     "W4A16PackedWeights",
     "make_w4a16_packed_buffers",
     "prepare_w4a16_compressed_tensors_weights",
+    "prepare_w4a16_modelopt_native_weights",
     "prepare_w4a16_modelopt_nvfp4_weights",
     "prepare_w4a16_mxfp4_native_weights",
     "prepare_w4a16_packed_weights",

--- a/tests/test_w4a16_e2e.py
+++ b/tests/test_w4a16_e2e.py
@@ -14,6 +14,7 @@ from b12x.moe.fused.w4a16.kernel import (
 )
 from b12x.moe.fused.w4a16.prepare import (
     make_w4a16_packed_buffers as make_w4a16_buffers,
+    prepare_w4a16_modelopt_native_weights,
     prepare_w4a16_modelopt_nvfp4_weights as prepare_w4a16_weights,
 )
 from tests.w4a16_reference import compare_to_reference, moe_reference_w4a16
@@ -285,6 +286,88 @@ def test_w4a16_modelopt_nvfp4_prepare_moe_matches_oracle(
         topk_ids,
         topk_weights,
         activation=activation,
+    )
+    expected = _reference_w4a16(
+        x,
+        *weights,
+        topk_ids,
+        topk_weights,
+        activation=activation,
+    )
+    torch.cuda.synchronize()
+
+    _assert_matches_oracle(actual, expected, activation=activation)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("prepare_native", [False, True])
+@pytest.mark.parametrize("w13_layout", ["up_gate", "gate_up"])
+def test_w4a16_modelopt_nvfp4_explicit_w13_layout_matches_oracle(
+    prepare_native: bool,
+    w13_layout: str,
+) -> None:
+    """W13 physical order is an explicit input, independent of source_format."""
+    torch.manual_seed(20260525 + (1000 if prepare_native else 0))
+    experts, hidden_size, intermediate_size = 8, 128, 128
+    topk, m = 2, 24
+    activation = "silu"
+    weights = _make_weights(
+        experts=experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        activation=activation,
+    )
+    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
+    x = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+    topk_ids = torch.randint(0, experts, (m, topk), device="cuda", dtype=torch.int32)
+    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
+
+    source_w13 = w13
+    source_w13_blockscale = w13_blockscale
+    if w13_layout == "gate_up":
+        half = intermediate_size
+        source_w13 = torch.cat([w13[:, half:], w13[:, :half]], dim=1).contiguous()
+        source_w13_blockscale = torch.cat(
+            [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
+        ).contiguous()
+
+    prepare = prepare_w4a16_modelopt_native_weights if prepare_native else prepare_w4a16_weights
+    kwargs = {"source_format": "modelopt_nvfp4"} if prepare_native else {}
+    prepared = prepare(
+        source_w13,
+        source_w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        activation=activation,
+        params_dtype=x.dtype,
+        w13_layout=w13_layout,
+        **kwargs,
+    )
+    buffers = make_w4a16_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        dtype=x.dtype,
+        device=x.device,
+    )
+    actual = run_w4a16_moe(
+        x,
+        prepared,
+        topk_weights,
+        topk_ids,
+        activation=activation,
+        fast_math=True,
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=buffers.intermediate_cache2,
+        output=buffers.output,
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        expert_offsets=buffers.expert_offsets,
     )
     expected = _reference_w4a16(
         x,

--- a/tests/test_w4a16_packed_format.py
+++ b/tests/test_w4a16_packed_format.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import weakref
+
 import pytest
 import torch
 
 from b12x.cute.fp4 import swizzle_block_scale
+import b12x.integration.tp_moe as tp_moe
 from b12x.integration.tp_moe import (
     prepare_b12x_w4a16_modelopt_nvfp4_weights,
     prepare_b12x_w4a16_packed_weights,
@@ -50,6 +53,31 @@ def _make_case(
         _positive_fp8((experts, hidden_size, intermediate_size // 16))
     )
     return w13, w13_blockscale, w2, w2_blockscale
+
+
+def test_plain_param_cache_revalidates_tensor_identity() -> None:
+    tp_moe._PLAIN_PARAM_CACHE.clear()
+    stale_source = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    requested = torch.tensor([3.0, 4.0], dtype=torch.float32)
+    stale_plain = torch.tensor([9.0, 8.0], dtype=torch.float32)
+    key = (
+        requested.data_ptr(),
+        tuple(requested.shape),
+        tuple(requested.stride()),
+        requested.dtype,
+        requested.dtype,
+        int(requested._version),
+    )
+    tp_moe._PLAIN_PARAM_CACHE[key] = (weakref.ref(stale_source), stale_plain)
+
+    actual = tp_moe._get_plain_cuda_tensor(requested)
+
+    assert actual is not stale_plain
+    assert torch.equal(actual, requested)
+    cached_source, cached_plain = tp_moe._PLAIN_PARAM_CACHE[key]
+    assert cached_source() is requested
+    assert cached_plain is actual
+    tp_moe._PLAIN_PARAM_CACHE.clear()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/test_w4a16_packed_format.py
+++ b/tests/test_w4a16_packed_format.py
@@ -469,6 +469,61 @@ def test_integration_modelopt_nvfp4_preparation_converts_fused_nvfp4_alphas(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_modelopt_nvfp4_gate_up_source_does_not_rotate_gated_w13_twice() -> None:
+    torch.manual_seed(20260524)
+    experts, hidden_size, intermediate_size = 3, 128, 128
+    w13, w13_blockscale, w2, w2_blockscale = _make_case(
+        experts=experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        activation="silu",
+    )
+    w13_global_scale = (torch.rand(experts, device="cuda") * 0.5 + 0.25).to(
+        torch.float32
+    )
+    w2_global_scale = (torch.rand(experts, device="cuda") * 0.5 + 0.25).to(
+        torch.float32
+    )
+
+    half = intermediate_size
+    b12x_w13 = torch.cat([w13[:, half:], w13[:, :half]], dim=1).contiguous()
+    b12x_w13_blockscale = torch.cat(
+        [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
+    ).contiguous()
+
+    expected = prepare_w4a16_weights(
+        w13,
+        w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        activation="silu",
+    )
+    actual = prepare_w4a16_weights(
+        b12x_w13,
+        b12x_w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        activation="silu",
+        w13_layout="gate_up",
+    )
+
+    assert actual.source_format == "modelopt_nvfp4"
+    for name in (
+        "w13",
+        "w13_scale",
+        "w13_global_scale",
+        "w2",
+        "w2_scale",
+        "w2_global_scale",
+    ):
+        assert torch.equal(getattr(actual, name), getattr(expected, name)), name
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 def test_integration_modelopt_nvfp4_preparation_can_reuse_input_storage(
     activation: str,


### PR DESCRIPTION
## Summary

Adds a small-M direct decode path for W4A16 MoE decode in B12X.

The optimized path is selected for small token counts (`M <= 16`) when the request can use direct top-k routing without an `expert_map`. This targets the common single/small-batch decode shape used by GLM-5.1 DCP decode, especially with ModelOpt NVFP4/MXFP8 checkpoints and forced W4A16 decode.

## What changed

- Adds a native small-M direct W4A16 decode kernel path.
- Allows direct top-k routing for `modelopt` W4A16 layout, not only `packed` layout.
- Raises the direct top-k small-M limit to 16.
- Keeps the path enabled by default and provides `B12X_W4A16_SMALL_M_DIRECT=0` as a runtime kill switch.

This branch also includes the split-decode final LSE Triton reduction used in the measured DCP4 setup.

## Validation

Tested on GLM-5.1 MXFP8/NVFP4 mixed checkpoint with vLLM DCP4, B12X MLA sparse attention, B12X MoE backend, and forced W4A16 decode.

Observed decode throughput improvement for DCP4 / no-MTP / A16:

- Before small-M direct path: roughly 43-44 tok/s at concurrency 1.
- After LSE + small-M direct path: roughly 50 tok/s at concurrency 1.
- Concurrency 16 measured around 346 tok/s in the same setup.

Numerical validation was run with the teacher-forced decode KLD harness. The generated-token decisions stayed identical to the BF16 reference in the sampled decode test, while the measured drift stayed in the small BF16-level/noise range seen in repeated runs.

Representative repeated JS values after the patch:

- JS: 0.000006532
- JS: 0.000009363
- JS: 0.000003244

## Notes

The direct path is intentionally constrained to small-M, no `expert_map`, and supported W4A16 layouts. Larger or unsupported shapes continue through the existing general W4A16 path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for W4A16 quantized weight layouts with configurable physical arrangements.
  * Introduced an optimized execution path for specific MoE model configurations.
  * Optional Triton kernel acceleration for performance-critical computations (with automatic PyTorch fallback).

* **Improvements**
  * Enhanced memory cache efficiency through intelligent tensor invalidation.

* **Tests**
  * Added comprehensive tests for weight layout configurations and cache behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukealonso/b12x/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->