### PR TITLE
Fix compressed MLA split contract for MTP graph rows

### DIFF
--- a/b12x/attention/mla/compressed_config.py
+++ b/b12x/attention/mla/compressed_config.py
@@ -6,7 +6,10 @@ from b12x.attention.workspace import SparseMLASplitDecodeConfig
 
 
 _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE = 12
-_COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS = 64
+# vLLM captures MTP decode graphs with rows = requests * (1 + draft tokens).
+# Keep those graph-capacity rows on the decode split contract; switching to the
+# batched split contract at 66+ rows can poison smaller decode graph replays.
+_COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS = 256
 _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE = 64
 _COMPRESSED_MLA_BATCHED_SPLIT_CHUNK_SIZE = 1024
 _COMPRESSED_MLA_SPLIT_MAX_CHUNKS = 256

--- a/tests/test_attention_mla_compressed.py
+++ b/tests/test_attention_mla_compressed.py
@@ -23,6 +23,9 @@ from b12x.attention.mla.compressed_reference import (
     gather_compressed_mla_kv_cache_reference,
     pack_compressed_mla_kv_cache_reference,
 )
+from b12x.attention.mla.compressed_config import (
+    compressed_mla_split_config_for_contract,
+)
 from b12x.integration.mla import (
     clear_mla_caches,
     compressed_mla_decode_forward,
@@ -213,6 +216,24 @@ def test_compressed_mla_page_byte_widths_match_padded_layout() -> None:
 def test_compressed_mla_decode_does_not_pin_flash_tp2_heads_by_default() -> None:
     signature = inspect.signature(compressed_mla_decode_forward)
     assert signature.parameters["expected_num_q_heads"].default is None
+
+
+def test_compressed_mla_mtp_graph_rows_keep_decode_split_contract() -> None:
+    graph_rows_cfg = compressed_mla_split_config_for_contract(
+        rows=192,
+        width=384,
+        max_chunks=6,
+    )
+    larger_prefill_cfg = compressed_mla_split_config_for_contract(
+        rows=257,
+        width=384,
+        max_chunks=6,
+    )
+
+    assert graph_rows_cfg.chunk_size == 64
+    assert graph_rows_cfg.num_chunks == 6
+    assert larger_prefill_cfg.chunk_size == 1024
+    assert larger_prefill_cfg.num_chunks == 1
 
 
 def test_compressed_mla_arena_scratch_uses_contract_q_chunks() -> None:


### PR DESCRIPTION
## Summary

Fixes DS4 DeepSeek-V4-Flash TP4/MTP2 corruption when vLLM captures FULL_AND_PIECEWISE CUDA graphs above 64 MTP rows.

vLLM captures MTP decode graphs with rows equal to `requests * (1 + draft_tokens)`. With `max_num_seqs=64` and MTP2, the capture list can include rows up to 192. The previous compressed MLA split planner switched from the decode split contract to the batched split contract at `rows > 64`. Capturing the first 66-row graph poisoned smaller decode graph replays and produced incoherent/CJK output.

This keeps graph-capacity rows on the decode split contract through 256 rows, covering `max_num_seqs=64` with MTP2/MTP3 while preserving the batched split path for larger prefill rows.

## Changes

- Raise `_COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS` from 64 to 256.
- Add a planner regression asserting:
  - `rows=192,width=384,max_chunks=6` keeps `(chunk_size=64,num_chunks=6)`.
  - `rows=257,width=384,max_chunks=6` falls back to `(chunk_size=1024,num_chunks=1)`.

## Verification

Tested against exact cleaninstall image `voipmonitor/vllm:cu132-vllm00e862f2-b12xad997e2-cleaninstall-20260608` with only patched B12X `compressed_config.py` bind-mounted.

Runtime config:

- DeepSeek-V4-Flash
- TP4, MTP2 probabilistic, `use_local_argmax_reduction=true`
- B12X MLA/MoE/linear
- `FULL_AND_PIECEWISE` CUDA graphs
- explicit capture sizes `[1,2,4,8,16,24,32,40,48,56,64,66,72,80,96,112,128,160,192]`
- `max_num_seqs=64`, `max_num_batched_tokens=4096`, KV fp8

Results:

- Single request `python3 /mnt/test.py --port 5436 --max-tokens 300 --no-overlay`: coherent, 0 CJK, about 333 tok/s generation-only.
- 120s CJK watchdog loop: at least 72 completed 500-token iterations before timeout, all completed iterations reported 0 CJK.
- CC64 sustained decode smoke: `890.4 tok/s` aggregate, avg running `61/64`, per-request `13.9 tok/s`, p50/p90 latency `26.2k/31.1k ms`.

This change does not alter vLLM bindings/workspaces; it only changes the compressed MLA split planning threshold used by B12X.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * New test validates that MTP decode split contracts remain consistent across different graph configurations, ensuring proper chunk sizing and batching behavior.

* **Chores**
  * Increased decode split capacity threshold with added documentation explaining performance constraints to prevent graph replay issues during batched operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->