### PR TITLE
attention: split GLM odd-16-head MG prefill

### DIFF
--- a/b12x/attention/mla/prefill.py
+++ b/b12x/attention/mla/prefill.py
@@ -235,6 +235,50 @@ def run_unified_prefill(
                 model_type=ModelType.GLM_NSA,
                 scale_format=ScaleFormat.ARBITRARY_FP32,
             )
+        if heads > hpb and heads % (2 * hpb) == hpb:
+            # GLM TP/DCP layouts can produce odd 16-head multiples after virtual
+            # padding, e.g. TP6/DCP3 -> 48 and TP6/DCP6 -> 80. The MG kernel
+            # supports paired 32-head launches and single 16-head launches; run
+            # both over disjoint output/LSE head ranges instead of rejecting.
+            from .prefill_mg import run_unified_prefill_mg
+
+            paired_heads = heads - hpb
+            run_unified_prefill_mg(
+                q=q,
+                kv_cache=kv_cache,
+                topk_indices=topk_indices,
+                sm_scale=sm_scale,
+                page_block_size=page_block_size,
+                topk_length=topk_length,
+                attn_sink=attn_sink,
+                output=output,
+                lse_out=lse_out,
+                stride_kv_block=stride_kv_block,
+                compute_mode=ComputeMode.FP8,
+                mg_n_hg=2,
+                model_type=ModelType.GLM_NSA,
+                scale_format=ScaleFormat.ARBITRARY_FP32,
+                active_heads=paired_heads,
+                head_offset=0,
+            )
+            return run_unified_prefill_mg(
+                q=q,
+                kv_cache=kv_cache,
+                topk_indices=topk_indices,
+                sm_scale=sm_scale,
+                page_block_size=page_block_size,
+                topk_length=topk_length,
+                attn_sink=attn_sink,
+                output=output,
+                lse_out=lse_out,
+                stride_kv_block=stride_kv_block,
+                compute_mode=ComputeMode.FP8,
+                mg_n_hg=1,
+                model_type=ModelType.GLM_NSA,
+                scale_format=ScaleFormat.ARBITRARY_FP32,
+                active_heads=hpb,
+                head_offset=paired_heads,
+            )
     _mg_base = (
         _mg_enabled
         and not has_extra


### PR DESCRIPTION
## Summary

Allow GLM NSA sparse prefill to run B12X MG prefill when the head count is an
odd multiple of 16, e.g. 48 or 80 heads after GLM TP6 virtual padding.

## Problem

The GLM NSA prefill path currently handles the single 16-head case and regular
paired 32-head MG groups, but rejects shapes where:

```text
heads > 16 and heads % 32 == 16
```

That blocks GLM TP6 DCP layouts in vLLM:

- TP6/DCP3 can produce 48 prefill heads.
- TP6/DCP6 can produce 80 prefill heads.

Those are valid GLM layouts after virtual padding, but they do not fit the
existing `heads == 16` or `heads % 32 == 0` dispatch cases.

## Change

For GLM NSA indexed sparse prefill with these odd-16 head counts, dispatch the
existing MG prefill kernel twice over disjoint output/LSE head ranges:

- paired prefix: `heads - 16`, `mg_n_hg=2`, `head_offset=0`
- tail: `16`, `mg_n_hg=1`, `head_offset=heads - 16`

This uses the existing `active_heads` and `head_offset` support in
`run_unified_prefill_mg`; it does not change kernel signatures or introduce a
new scratch/workspace contract.

## Validation

- `python3 -m py_compile b12x/attention/mla/prefill.py`
- Clean Docker image built with this B12X commit:
  `voipmonitor/vllm:glm52-dark-devotion-pr31-tp6odd16-vllm79f154c-b12x1cfc6cf-cu132-20260621`
- GLM-5.2 NVFP4 TP6/DCP6/MTP3 startup succeeds where it previously failed with
  `unsupported shape` for `heads=80`.
- GLM-5.2 NVFP4 TP6/DCP3/MTP3 startup succeeds with `heads=48`.
- Smoke tests on both DCP3 and DCP6 returned coherent output with no CJK or
  duplicated-code pattern in `/mnt/test.py -L` loops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for GLM language models with specific architectural configurations (certain head counts) that previously were unsupported or would fail. These configurations can now be used.
  * Refined kernel dispatch mechanisms to handle a broader range of model parameter combinations that previously encountered limitations or were rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->