### PR TITLE
MoE W4A16: parallelize the prefill route-packer count+prefix (~+4.7% prefill)

### DIFF
--- a/b12x/moe/fused/w4a16/route_pack.py
+++ b/b12x/moe/fused/w4a16/route_pack.py
@@ -20,6 +20,65 @@ _SMALL_PREFIX_MAX_ROUTE_BLOCKS = 128
 _SMALL_PREFIX_MAX_EXPERT_BLOCK_PRODUCT = 65536
 
 
+_FAST_COUNT_BLOCK_T = 1024
+
+
+@triton.jit
+def _w4a16_route_count_kernel(
+    topk_ids,
+    expert_map,
+    counts,
+    live_numel,
+    NUM_EXPERTS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    """Parallel atomic histogram of routes per (mapped) expert.
+
+    Multi-program replacement for the single-CTA count loop in
+    ``_pack_topk_routes_prefix_kernel`` -- same expert-id resolution as the
+    sort kernel (expert_map aware). Writes ``counts[NUM_EXPERTS]``."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_T + tl.arange(0, BLOCK_T)
+    raw_ids = tl.load(topk_ids + offsets, mask=offsets < live_numel, other=-1).to(
+        tl.int32
+    )
+    valid = (offsets < live_numel) & (raw_ids >= 0) & (raw_ids < NUM_EXPERTS)
+    ids = raw_ids
+    if HAS_EXPERT_MAP:
+        safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+        ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(tl.int32)
+        valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+    tl.atomic_add(counts + ids, 1, sem="relaxed", mask=valid)
+
+
+@triton.jit
+def _w4a16_route_prefix_from_counts_kernel(
+    counts,
+    packed_route_count,
+    expert_offsets,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Tiny over-experts block-padded prefix from precomputed counts.
+
+    Emits exactly the ``expert_offsets`` / ``packed_route_count`` contract of
+    ``_pack_topk_routes_prefix_kernel`` (clean block-padded prefix; the sort
+    kernel later advances expert_offsets in place)."""
+    experts = tl.arange(0, BLOCK_E)
+    mask = experts < NUM_EXPERTS
+    counts_v = tl.load(counts + experts, mask=mask, other=0)
+    padded = ((counts_v + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+    padded = tl.where(mask, padded, 0)
+    inclusive = tl.cumsum(padded, axis=0)
+    prefix = inclusive - padded
+    total = tl.sum(padded, axis=0)
+    tl.store(expert_offsets + experts, prefix, mask=mask)
+    tl.store(expert_offsets + NUM_EXPERTS, total)
+    tl.store(packed_route_count, total)
+
+
 def _next_power_of_2(x: int) -> int:
     return 1 << (int(x) - 1).bit_length()
 
@@ -347,20 +406,51 @@ def pack_topk_routes_by_expert(
                 triton.cdiv(max_route_blocks, _POST_PREFIX_BLOCK_T),
             ),
         )
-        _pack_topk_routes_prefix_kernel[(1,)](
-            topk_ids,
-            expert_map_tensor,
-            packed_route_count,
-            expert_offsets,
-            numel,
-            NUMEL_CAPACITY=numel_capacity,
-            BLOCK_SIZE=int(block_size),
-            NUM_EXPERTS=int(num_experts),
-            HAS_EXPERT_MAP=expert_map is not None,
-            BLOCK_E=block_e,
-            BLOCK_T=_COUNT_BLOCK_T,
-            num_warps=8,
-        )
+        if not torch.cuda.is_current_stream_capturing():
+            # FAST (eager prefill): parallel atomic count + tiny over-experts
+            # block-padded prefix, replacing the single-CTA count+prefix
+            # (~7-31x measured at prefill). Only the large path (routes > 4096,
+            # i.e. > 512 tokens) reaches here, and cudagraph capture is bounded
+            # to <=128 tokens (the small-prefix path), so this scratch alloc is
+            # never captured. The slow single-CTA kernel stays as the defensive
+            # captured-path fallback below.
+            expert_counts = torch.zeros(
+                int(num_experts), dtype=torch.int32, device=topk_ids.device
+            )
+            _w4a16_route_count_kernel[(triton.cdiv(numel, _FAST_COUNT_BLOCK_T),)](
+                topk_ids,
+                expert_map_tensor,
+                expert_counts,
+                numel,
+                NUM_EXPERTS=int(num_experts),
+                HAS_EXPERT_MAP=expert_map is not None,
+                BLOCK_T=_FAST_COUNT_BLOCK_T,
+                num_warps=4,
+            )
+            _w4a16_route_prefix_from_counts_kernel[(1,)](
+                expert_counts,
+                packed_route_count,
+                expert_offsets,
+                BLOCK_SIZE=int(block_size),
+                NUM_EXPERTS=int(num_experts),
+                BLOCK_E=block_e,
+                num_warps=4,
+            )
+        else:
+            _pack_topk_routes_prefix_kernel[(1,)](
+                topk_ids,
+                expert_map_tensor,
+                packed_route_count,
+                expert_offsets,
+                numel,
+                NUMEL_CAPACITY=numel_capacity,
+                BLOCK_SIZE=int(block_size),
+                NUM_EXPERTS=int(num_experts),
+                HAS_EXPERT_MAP=expert_map is not None,
+                BLOCK_E=block_e,
+                BLOCK_T=_COUNT_BLOCK_T,
+                num_warps=8,
+            )
         _pack_topk_routes_post_prefix_kernel[post_prefix_grid](
             packed_route_indices,
             block_expert_ids,


### PR DESCRIPTION
# MoE W4A16: parallelize the prefill route-packer count+prefix (~+4.7% prefill)

## Summary

The W4A16 fused-MoE route packer (`b12x/moe/fused/w4a16/route_pack.py`) builds the
per-expert block-padded offsets with a **single-CTA** kernel that loops over the entire
`topk_ids` buffer to count routes, then computes the prefix. At prefill shapes this one
block is a serial bottleneck - it scales with token count while running on one SM.

This patch adds a **parallel atomic histogram** (`_w4a16_route_count_kernel`, one program
per `BLOCK_T=1024` routes) feeding a **tiny over-experts prefix**
(`_w4a16_route_prefix_from_counts_kernel`, one program over the experts), used on the
eager prefill path. The single-CTA kernel is kept unchanged as the CUDA-graph-capture
fallback. The packing contract is **bit-identical**, so model outputs are unchanged.

- **Route-pack microbench:** ~6.8x @ m=2048, ~31x @ m=8192 vs the single-CTA path.
- **End-to-end:** **+4.7% prefill throughput** on GLM-5.2-NVFP4 (2830 -> 2963 tok/s),
  accuracy-neutral.

## Motivation

A torch-profiler trace of GLM-5.2-NVFP4 prefill (TP=8, DCP=4, 8xRTX PRO 6000 / SM120)
showed the route-pack count+prefix as a serial, single-block step on the critical path -
~8% of per-GPU prefill work at an 8192-token chunk. The count loop is an embarrassingly
parallel histogram; collapsing it into one CTA leaves the GPU idle. The fix parallelizes
the count and reduces the prefix to a small over-experts pass.

## What changed

`b12x/moe/fused/w4a16/route_pack.py` (additive - no existing kernel modified):

1. **`_w4a16_route_count_kernel`** - parallel atomic histogram of routes per (mapped)
   expert. Same expert-id resolution as the sort kernel (`expert_map`-aware, identical
   validity masks). Grid = `cdiv(numel, 1024)`. Writes `counts[NUM_EXPERTS]`.
2. **`_w4a16_route_prefix_from_counts_kernel`** - single-program block-padded prefix over
   experts from the precomputed counts. Emits exactly the existing
   `expert_offsets` / `packed_route_count` contract (block-padded prefix; the sort kernel
   still advances `expert_offsets` in place afterward).
3. **Dispatch** in `pack_topk_routes_by_expert` (large-shape branch only): when
   `not torch.cuda.is_current_stream_capturing()`, run count->prefix; otherwise fall back
   to the original `_pack_topk_routes_prefix_kernel`.

Unchanged: the small-prefix decode path, the sort kernel, the post-prefix kernel, the
workspace/contract, and the public API.

## Why it's safe

- **Bit-identical packing.** The two kernels reproduce the same `expert_offsets`,
  `packed_route_count`, and (via the unchanged sort/post-prefix kernels) the same
  `packed_route_indices` / `block_expert_ids`. Packing is a permutation; identical packing
  => identical MoE output. No numerics change.
- **CUDA-graph capture is untouched.** The fast path is gated behind
  `not torch.cuda.is_current_stream_capturing()`. It also allocates a small
  `expert_counts` scratch tensor, which is illegal mid-capture - but capture only ever hits
  the *small-prefix* path (cudagraph capture is bounded to <=128 tokens), and the large
  branch's defensive `else` keeps the original single-CTA kernel for any captured call.
  So no allocation occurs under capture.
- **Reachability.** Only the large path (packed routes > 4096, i.e. > 512 tokens) reaches
  the new code; decode-sized calls keep using the unchanged fused small-prefix kernel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized W4A16 Mixture of Experts route packing with faster prefix path computation.

* **Bug Fixes**
  * Improved compatibility with CUDA graph capture in expert routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->