### PR TITLE
[codex] Support strided DS4 packed KV cache

### DIFF
--- a/b12x/attention/indexer/paged.py
+++ b/b12x/attention/indexer/paged.py
@@ -681,6 +681,16 @@ def index_topk_fp8(
             "paged index supertile top-k scratch page-table capacity is too small: "
             f"need={page_table_width}, have={getattr(scratch, 'max_page_table_width', None)}"
         )
+    if (
+        route == "packed_contiguous"
+        and int(index_k_cache.stride(0)) != int(_PAGED_INDEX_CACHE_ROW_BYTES)
+    ):
+        # DS4 packed KV stores each layer as a strided view into a larger
+        # per-block allocation. The packed-contiguous prefill scorer first gathers
+        # a shared supertile into contiguous scratch; that path is only valid for
+        # physically contiguous page rows. The tiled scorer consumes the runtime
+        # cache stride and keeps the vLLM packed-KV layout intact.
+        route = "paged_tiled"
     use_shared_prefill_scorer = route == "packed_contiguous"
     topk_block_k = (
         int(getattr(binding, "prefill_block_k", 0) or getattr(scratch, "prefill_block_k", 0))

--- a/b12x/attention/mla/compressed_api.py
+++ b/b12x/attention/mla/compressed_api.py
@@ -421,8 +421,11 @@ def _compressed_mla_cache_byte_view(cache: torch.Tensor, *, name: str) -> torch.
         )
     if byte_cache.ndim != 2:
         raise ValueError(f"{name} must have shape [pages, page_bytes], got {tuple(cache.shape)}")
-    if not byte_cache.is_contiguous():
-        raise ValueError(f"{name} must be contiguous for compressed MLA")
+    if int(byte_cache.stride(1)) != 1:
+        raise ValueError(
+            f"{name} page payload must be contiguous in the last dimension, "
+            f"got stride {tuple(byte_cache.stride())}"
+        )
     return byte_cache
 
 

--- a/b12x/attention/mla/kernel.py
+++ b/b12x/attention/mla/kernel.py
@@ -1242,6 +1242,37 @@ def _to_cute(x, dtype, align=16, dynamic_layout=False):
     return c
 
 
+def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
+    # Contiguous cache can use the historical flat view. Packed vLLM cache views
+    # are non-contiguous [blocks, page_bytes] tensors whose storage_offset points
+    # at this layer's payload inside a larger packed block. Do not reshape those:
+    # reshape would materialize a contiguous copy and lose the packed layout.
+    return cache.reshape(-1) if cache.is_contiguous() else cache
+
+
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    model_type: int,
+) -> int:
+    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
+
+    if int(model_type) == int(ModelType.GLM_NSA):
+        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    if cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA cache block stride {stride} is smaller than "
+                f"page payload {expected}"
+            )
+        return stride
+    return expected
+
+
 def _topk_bucket(topk: int) -> int:
     """Coarse topk bucket for the compile key (chunks_per_split is the real
     specialization driver; the bucket just keeps the key compact)."""
@@ -1582,8 +1613,6 @@ def run_unified_decode(
     section). With no extra cache the kernel is compiled with ``has_extra=False``
     so the extra-section code is const_expr-elided (PTX byte-identical).
     """
-    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
-
     has_extra = (
         indexed_k_cache is not None
         or indexed_indices is not None
@@ -1791,33 +1820,33 @@ def run_unified_decode(
         # every (token, head, split) it actually runs.
         mid_lse.fill_(float("-inf"))
 
-    if model_type == ModelType.GLM_NSA:
-        # GLM cache: per-token 656B contiguous record; one paged "block" holds
-        # page_block_size tokens, so the per-block byte stride is pbs*656.
-        stride_kv_block = int(swa_page_size) * _GLM_KV_GMEM_STRIDE
-    else:
-        stride_kv_block = int(compressed_mla_page_nbytes(int(swa_page_size)))
+    stride_kv_block = _cache_block_stride_bytes(
+        swa_k_cache,
+        page_size=int(swa_page_size),
+        model_type=int(model_type),
+    )
 
     # ── EXTRA (indexed) cache views. When there is no extra cache they alias the
     #    main cache / main indices and the kernel's has_extra=False const_expr
     #    elides the extra-section reads -> PTX byte-identical. ──
     if has_extra:
         pbs_extra = int(indexed_page_size)
-        # The extra cache uses the IDENTICAL DSV4 compressed packed byte layout, so
-        # its per-block stride is compressed_mla_page_nbytes(pbs_extra) (same as
-        # the main cache derives from swa_page_size). DSV4-only here.
-        stride_extra_kv_block = int(compressed_mla_page_nbytes(pbs_extra))
-        extra_kv_flat = indexed_k_cache.reshape(-1)
+        stride_extra_kv_block = _cache_block_stride_bytes(
+            indexed_k_cache,
+            page_size=pbs_extra,
+            model_type=int(model_type),
+        )
+        extra_kv_flat = _cache_base_tensor(indexed_k_cache)
         extra_indices_t = indexed_indices.contiguous()
     else:
         pbs_extra = 1
         stride_extra_kv_block = 0
-        extra_kv_flat = swa_k_cache.reshape(-1)  # alias (never read when has_extra=False)
+        extra_kv_flat = _cache_base_tensor(swa_k_cache)  # alias (never read when has_extra=False)
         extra_indices_t = swa_indices            # alias (never read)
 
     output = workspace.output_buffer[:rows, :heads, :d_v]
 
-    kv_flat = swa_k_cache.reshape(-1)
+    kv_flat = _cache_base_tensor(swa_k_cache)
     swa_len_for_op = swa_len_t if swa_len_t is not None else swa_indices
     extra_len_for_op = extra_len_t if extra_len_t is not None else swa_indices
 

--- a/b12x/attention/mla/kernel.py
+++ b/b12x/attention/mla/kernel.py
@@ -1247,7 +1247,18 @@ def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
     # are non-contiguous [blocks, page_bytes] tensors whose storage_offset points
     # at this layer's payload inside a larger packed block. Do not reshape those:
     # reshape would materialize a contiguous copy and lose the packed layout.
-    return cache.reshape(-1) if cache.is_contiguous() else cache
+    if cache.is_contiguous():
+        return cache.reshape(-1)
+    if cache.ndim < 2:
+        return cache
+
+    # Kernels compute raw byte offsets as block * stride_kv_block + in-page byte.
+    # Give Cute a 1-D view over the physical byte span for this layer so
+    # pointer+offset arithmetic stays raw-address based while preserving the
+    # original storage_offset. The explicit stride_kv_block argument still
+    # carries the packed block stride; this view only defines the base pointer.
+    span = (int(cache.shape[0]) - 1) * int(cache.stride(0)) + int(cache.shape[1])
+    return torch.as_strided(cache, size=(span,), stride=(1,))
 
 
 def _cache_block_stride_bytes(

--- a/b12x/attention/mla/prefill.py
+++ b/b12x/attention/mla/prefill.py
@@ -41,6 +41,29 @@ _GLM_HEAD_DIM = 576
 _GLM_KV_GMEM_STRIDE = 656
 
 
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    model_type: ModelType,
+) -> int:
+    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
+
+    if model_type == ModelType.GLM_NSA:
+        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    if cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA cache block stride {stride} is smaller than "
+                f"page payload {expected}"
+            )
+        return stride
+    return expected
+
+
 def run_unified_prefill(
     *,
     q: torch.Tensor,
@@ -97,8 +120,6 @@ def run_unified_prefill(
 
     Returns (O[T, heads, D_V=512] bf16, lse[T, heads] f32 base-2).
     """
-    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
-
     del workspace  # prefill is single-pass; no split/merge workspace needed.
 
     q_head_dim = int(q.shape[-1])
@@ -155,12 +176,11 @@ def run_unified_prefill(
         topk_length = topk_length.to(device=device, dtype=torch.int32).contiguous()
 
     if stride_kv_block is None:
-        if model_type == ModelType.GLM_NSA:
-            # GLM cache: per-token 656B contiguous record; a paged "block" holds
-            # page_block_size tokens, so the per-block byte stride is pbs*656.
-            stride_kv_block = int(page_block_size) * _GLM_KV_GMEM_STRIDE
-        else:
-            stride_kv_block = int(compressed_mla_page_nbytes(int(page_block_size)))
+        stride_kv_block = _cache_block_stride_bytes(
+            kv_cache,
+            page_size=int(page_block_size),
+            model_type=model_type,
+        )
 
     q = q.contiguous()
     topk_indices = topk_indices.contiguous()

--- a/b12x/attention/mla/prefill_mg.py
+++ b/b12x/attention/mla/prefill_mg.py
@@ -100,6 +100,33 @@ def _to_cute(x, dtype, align=16, dynamic_layout=False):
     return c
 
 
+def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
+    return cache.reshape(-1) if cache.is_contiguous() else cache
+
+
+def _cache_block_stride_bytes(
+    cache: torch.Tensor,
+    *,
+    page_size: int,
+    is_glm: bool,
+) -> int:
+    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
+
+    if is_glm:
+        expected = int(page_size) * _GLM_IO_STRIDE
+    else:
+        expected = int(compressed_mla_page_nbytes(int(page_size)))
+    if cache.ndim >= 2:
+        stride = int(cache.stride(0)) * int(cache.element_size())
+        if stride < expected:
+            raise ValueError(
+                f"SM120 sparse MLA prefill cache block stride {stride} is "
+                f"smaller than page payload {expected}"
+            )
+        return stride
+    return expected
+
+
 def _topk_bucket(topk: int) -> int:
     return 1 << (max(int(topk), 1) - 1).bit_length()
 
@@ -2765,9 +2792,6 @@ def _sparse_mla_prefill_mg_dual_fake(
     return None
 
 
-_GLM_KV_GMEM_STRIDE = 656
-
-
 def run_unified_prefill_mg(
     *,
     q: torch.Tensor,
@@ -2792,8 +2816,6 @@ def run_unified_prefill_mg(
     active_heads: int | None = None,
     head_offset: int = 0,
 ):
-    from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
-
     model_type = int(model_type)
     is_glm = model_type == ModelType.GLM_NSA
     # DSV4 dual-cache (has_extra) union. all-or-none + DSV4-only (GLM has no extra
@@ -2860,12 +2882,11 @@ def run_unified_prefill_mg(
         attn_sink_t = torch.zeros(1, dtype=torch.float32, device=device)
 
     if stride_kv_block is None:
-        if is_glm:
-            # GLM cache: per-token 656B contiguous record; a paged "block" holds
-            # page_block_size tokens, so the per-block byte stride is pbs*656.
-            stride_kv_block = int(page_block_size) * _GLM_KV_GMEM_STRIDE
-        else:
-            stride_kv_block = int(compressed_mla_page_nbytes(int(page_block_size)))
+        stride_kv_block = _cache_block_stride_bytes(
+            kv_cache,
+            page_size=int(page_block_size),
+            is_glm=bool(is_glm),
+        )
 
     q = q.contiguous()
     topk_indices = topk_indices.contiguous()
@@ -2880,7 +2901,11 @@ def run_unified_prefill_mg(
         # its per-token length. row_xor = (pbs_extra == 2) (FI USE_WFP8_ROW_XOR).
         pbs_extra = int(extra_page_block_size)
         if stride_extra_kv_block is None:
-            stride_extra_kv_block = int(compressed_mla_page_nbytes(pbs_extra))
+            stride_extra_kv_block = _cache_block_stride_bytes(
+                extra_kv_cache,
+                page_size=pbs_extra,
+                is_glm=False,
+            )
         extra_topk = int(extra_indices.shape[1])
         num_extra_tiles = (extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
         num_tiles = num_main_tiles + num_extra_tiles
@@ -2897,13 +2922,13 @@ def run_unified_prefill_mg(
         if active_heads == total_heads and head_offset == 0:
             torch.ops.b12x.sparse_mla_sm120_prefill_mg_dual(
                 q,
-                kv_cache.reshape(-1),
+                _cache_base_tensor(kv_cache),
                 topk_indices,
                 topk_length,
                 attn_sink_t,
                 output,
                 lse_out,
-                extra_kv_cache.reshape(-1),
+                _cache_base_tensor(extra_kv_cache),
                 extra_indices_t,
                 extra_len_t,
                 float(sm_scale),
@@ -2925,13 +2950,13 @@ def run_unified_prefill_mg(
         else:
             _sparse_mla_prefill_mg_flat_launch(
                 q,
-                kv_cache.reshape(-1),
+                _cache_base_tensor(kv_cache),
                 topk_indices,
                 topk_length,
                 attn_sink_t,
                 output,
                 lse_out,
-                extra_kv_cache.reshape(-1),
+                _cache_base_tensor(extra_kv_cache),
                 extra_indices_t,
                 extra_len_t,
                 float(sm_scale),
@@ -2958,7 +2983,7 @@ def run_unified_prefill_mg(
     if active_heads == total_heads and head_offset == 0:
         torch.ops.b12x.sparse_mla_sm120_prefill_mg(
             q,
-            kv_cache.reshape(-1),
+            _cache_base_tensor(kv_cache),
             topk_indices,
             topk_length,
             attn_sink_t,
@@ -2978,13 +3003,13 @@ def run_unified_prefill_mg(
     else:
         _sparse_mla_prefill_mg_flat_launch(
             q,
-            kv_cache.reshape(-1),
+            _cache_base_tensor(kv_cache),
             topk_indices,
             topk_length,
             attn_sink_t,
             output,
             lse_out,
-            kv_cache.reshape(-1),  # extra_kv_flat alias (never read)
+            _cache_base_tensor(kv_cache),  # extra_kv_flat alias (never read)
             topk_indices,          # extra_indices alias (never read)
             topk_length,           # extra_len alias (never read)
             float(sm_scale),

--- a/b12x/attention/mla/prefill_mg.py
+++ b/b12x/attention/mla/prefill_mg.py
@@ -101,7 +101,17 @@ def _to_cute(x, dtype, align=16, dynamic_layout=False):
 
 
 def _cache_base_tensor(cache: torch.Tensor) -> torch.Tensor:
-    return cache.reshape(-1) if cache.is_contiguous() else cache
+    if cache.is_contiguous():
+        return cache.reshape(-1)
+    if cache.ndim < 2:
+        return cache
+
+    # Packed vLLM DS4 cache views are [blocks, page_bytes] with a storage_offset
+    # into a larger per-block allocation. The MG kernels do raw pointer-offset
+    # indexing, so expose the physical byte span for this layer as a 1-D view
+    # and keep the packed block stride in the explicit stride argument.
+    span = (int(cache.shape[0]) - 1) * int(cache.stride(0)) + int(cache.shape[1])
+    return torch.as_strided(cache, size=(span,), stride=(1,))
 
 
 def _cache_block_stride_bytes(


### PR DESCRIPTION
## Summary

Allow SM120 compressed MLA to consume vLLM DeepSeek V4 packed KV cache views without materializing contiguous copies.

The change:
- accepts `[pages, page_bytes]` cache tensors whose last dimension is contiguous even when the page dimension has a larger packed block stride;
- derives the per-block byte stride from `cache.stride(0)` for both decode and prefill paths;
- maps non-contiguous packed views to the physical 1D byte span using `as_strided`, preserving storage offset and avoiding `.reshape(-1)` copies.

This is the B12X-side half of the DS4 packed-KV fix. The matching vLLM adapter PR exposes correctly offset page views for each DS4 cache layer.

## Root Cause

vLLM's DS4 packed-KV layout stores all per-layer cache payloads in a single packed per-block allocation. B12X compressed MLA previously assumed each cache page tensor was contiguous and had an implicit stride equal to the page payload size.

After DS4 KV packing, the layer payload is contiguous inside a page, but page-to-page stride is the packed block stride. Flattening a non-contiguous view with `.reshape(-1)` either materializes a copy or loses the raw address/stride relationship required by the CUDA kernels.

## Validation

Validated with current eldritch vLLM plus the matching vLLM adapter PR on DS4F TP2, MTP off, FP8 KV, B12X attention/MoE/linear, clean image:

`voipmonitor/vllm:eldritch-packedkv-vb923949-b12xf81d898-cu132-20260624`

Functional smoke:
- `/mnt/test.py --port 5627 -L -c 1200`: coherent Python output, CJK=0, generation-only ~`125 tok/s`.

Decode A/B, same image and B12X commit, same GPUs, comparing upstream packed KV vs temporary oldKV layout overlay:

| layout | C1 | C2 | C4 | C8 |
|---|---:|---:|---:|---:|
| packed KV | 119.2 | 190.1 | 305.4 | 448.8 |
| oldKV overlay | 119.8 | 190.7 | 308.0 | 450.3* |

`*` oldKV C8 was marked capacity-limited by the benchmark. Values are aggregate decode tok/s.

GPU 8-9-only PCIe monitor from the same decode run:

| layout | C1 rx/tx MB/s | C2 rx/tx MB/s | C4 rx/tx MB/s | C8 rx/tx MB/s |
|---|---:|---:|---:|---:|
| packed KV | 398/376 | 619/610 | 837/809 | 1284/1292 |
| oldKV overlay | 425/404 | 638/627 | 830/823 | 1089/1071* |

Prefill A/B:

| layout | 8k tok/s | 8k rx/tx MB/s | 64k tok/s | 64k rx/tx MB/s |
|---|---:|---:|---:|---:|
| packed KV | 8,632 | 15191/15982 | 8,151 | 14681/15420 |
| oldKV overlay | 8,748 | 13255/13103 | 8,148 | 15089/14940 |

Interpretation: packed-KV support restores B12X to the oldKV throughput range without reverting vLLM's packed allocation. PCIe numbers are coarse `nvidia-smi dmon` diagnostics and were collected in a helper container that could only see GPUs 8 and 9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache handling for attention decoding and prefill so packed or non-contiguous cache layouts are processed correctly.
  * Added stricter validation for cache layouts and stride sizes, reducing launch-time errors with unsupported tensor shapes.
  * Fixed paged top-k scoring to automatically fall back to a compatible path when the cache layout does not match the packed-contiguous assumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->