### PR TITLE
[codex] Add GLM sparse MLA prefill HPB8 path

### DIFF
--- a/b12x/attention/mla/decode_math.py
+++ b/b12x/attention/mla/decode_math.py
@@ -309,6 +309,7 @@ def s1_qk_nope_block_scaled(
     kv_smem_stride: cutlass.Constexpr,  # 464
     scale_bytes_per_token: cutlass.Constexpr,  # 8
     scale_format: cutlass.Constexpr = 0,  # ScaleFormat.UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """S1: accumulate Q_nope . K_nope into qk[0..3] via NUM_SCALES*(QUANT_TILE/32)
     block-scaled MMAs (14 DSV4 / 16 GLM).
@@ -357,6 +358,7 @@ def s1_qk_nope_block_scaled(
     sfa_head = gid + (lane & Int32(1)) * Int32(8)
     # sfb candidate row = warp_first_cand + gid (the N-tile base + gid). nt=0.
     sfb_cand = warp_first_cand + gid
+    hi = cutlass.const_expr(valid_hpb > 8)
 
     for blk in cutlass.range_constexpr(num_scales):
         # sfa = exponent byte of the FP32 pow2 Q scale for this (head, blk).
@@ -405,8 +407,9 @@ def s1_qk_nope_block_scaled(
         if cutlass.const_expr(scale_format == 0):
             qk[0] = acc0
             qk[1] = acc1
-            qk[2] = acc2
-            qk[3] = acc3
+            if cutlass.const_expr(hi):
+                qk[2] = acc2
+                qk[3] = acc3
         else:
             # GLM: post-MMA FP32 scale by the per-candidate arbitrary fp32 group
             # scale (legacy _accumulate_scaled_score_frag). c0 -> qk[0]/qk[2];
@@ -420,8 +423,9 @@ def s1_qk_nope_block_scaled(
                 + glm_scale_base + Int32(blk) * Int32(4)))
             qk[0] = qk[0] + acc0 * ks0
             qk[1] = qk[1] + acc1 * ks1
-            qk[2] = qk[2] + acc2 * ks0
-            qk[3] = qk[3] + acc3 * ks1
+            if cutlass.const_expr(hi):
+                qk[2] = qk[2] + acc2 * ks0
+                qk[3] = qk[3] + acc3 * ks1
     return qk
 
 
@@ -437,6 +441,7 @@ def s2_qk_rope_bf16(
     lane: Int32,
     *,
     d_rope: cutlass.Constexpr,        # 64
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """S2: accumulate Q_rope . K_rope into qk[0..3] via D_ROPE/16=4 bf16 MMAs.
 
@@ -450,6 +455,7 @@ def s2_qk_rope_bf16(
     a_col = (lane >> Int32(4)) * Int32(8)
     # Each lane's K-rope entry = warp_first_cand + gid (nt=0).
     entry = warp_first_cand + gid
+    hi = cutlass.const_expr(valid_hpb > 8)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
@@ -467,8 +473,9 @@ def s2_qk_rope_bf16(
         )
         qk[0] = d0
         qk[1] = d1
-        qk[2] = d2
-        qk[3] = d3
+        if cutlass.const_expr(hi):
+            qk[2] = d2
+            qk[3] = d3
     return qk
 
 
@@ -776,6 +783,7 @@ def s6_xv_nope(
     scale_format: cutlass.Constexpr = 0,    # UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
     num_threads: cutlass.Constexpr,  # 256
     barrier_id: cutlass.Constexpr,
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """S6: accumulate W . V_nope into acc_nope[vc*NT+nt][0..3] via PLAIN fp8 MMAs
     (14 DSV4 / 16 GLM = N_V_CHUNKS * NT_PER_WARP_XV * (BI/32)).
@@ -811,6 +819,7 @@ def s6_xv_nope(
     warp_first_cand = warp_id * Int32(8)
     cand_e0 = warp_first_cand + tid * Int32(2)
     cand_e1 = cand_e0 + Int32(1)
+    hi = cutlass.const_expr(valid_hpb > 8)
 
     glm_scale_base = Int32(n_v_chunks) * Int32(v_chunk)  # == D_NOPE (GLM)
 
@@ -830,17 +839,18 @@ def s6_xv_nope(
         vsc0 = _vsc(cand_e0, vc)
         vsc1 = _vsc(cand_e1, vc)
         m0 = fmax_f32(fabs_f32(w_pre[0] * vsc0), fabs_f32(w_pre[1] * vsc1))
-        m1 = fmax_f32(fabs_f32(w_pre[2] * vsc0), fabs_f32(w_pre[3] * vsc1))
         w_head_sc_base = shared_ptr_to_u32(w_head_sc_view.iterator)
         sc0_addr = w_head_sc_base + (Int32(vc) * Int32(hpb) + gid) * Int32(4)
-        sc1_addr = w_head_sc_base + (Int32(vc) * Int32(hpb) + gid + Int32(8)) * Int32(4)
         atomic_max_shared_f32(sc0_addr, m0)
-        atomic_max_shared_f32(sc1_addr, m1)
+        if cutlass.const_expr(hi):
+            m1 = fmax_f32(fabs_f32(w_pre[2] * vsc0), fabs_f32(w_pre[3] * vsc1))
+            sc1_addr = w_head_sc_base + (Int32(vc) * Int32(hpb) + gid + Int32(8)) * Int32(4)
+            atomic_max_shared_f32(sc1_addr, m1)
     cute.arch.barrier(**bar_kw)
 
     # --- (2) normalize w_head_sc -> max(.,1e-10)/FP8_MAX. ---
     i = tid_flat
-    while i < Int32(n_v_chunks * hpb):
+    while i < Int32(n_v_chunks * valid_hpb):
         w_head_sc_view[i] = fmax_f32(w_head_sc_view[i], Float32(1e-10)) * Float32(1.0 / _FP8_MAX)
         i += Int32(num_threads)
     cute.arch.barrier(**bar_kw)
@@ -852,21 +862,23 @@ def s6_xv_nope(
         for vc in cutlass.range_constexpr(n_v_chunks):
             w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
             si0 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
-            si1 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
             vsc0 = _vsc(cand_e0, vc)
             vsc1 = _vsc(cand_e1, vc)
             f00 = _quant_e4m3_byte(w_pre[0] * vsc0 * si0)
             f01 = _quant_e4m3_byte(w_pre[1] * vsc1 * si0)
-            f10 = _quant_e4m3_byte(w_pre[2] * vsc0 * si1)
-            f11 = _quant_e4m3_byte(w_pre[3] * vsc1 * si1)
             st_shared_u8(w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e0, f00.to(cutlass.Uint8))
             st_shared_u8(w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e1, f01.to(cutlass.Uint8))
-            st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0, f10.to(cutlass.Uint8))
-            st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1, f11.to(cutlass.Uint8))
+            if cutlass.const_expr(hi):
+                si1 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+                f10 = _quant_e4m3_byte(w_pre[2] * vsc0 * si1)
+                f11 = _quant_e4m3_byte(w_pre[3] * vsc1 * si1)
+                st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0, f10.to(cutlass.Uint8))
+                st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1, f11.to(cutlass.Uint8))
             cute.arch.barrier(**bar_kw)
 
             sc0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
-            sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+            if cutlass.const_expr(hi):
+                sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
             # A (W) ldmatrix.x4 row/col -- ldmatrix_load_A_fp8 (nt-invariant).
             a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
             a_col = (lane >> Int32(4)) * Int32(16)
@@ -888,8 +900,9 @@ def s6_xv_nope(
                 at = vc * nt_per_warp_xv + nt
                 acc_nope[at][0] = acc_nope[at][0] + xv0 * sc0
                 acc_nope[at][1] = acc_nope[at][1] + xv1 * sc0
-                acc_nope[at][2] = acc_nope[at][2] + xv2 * sc1
-                acc_nope[at][3] = acc_nope[at][3] + xv3 * sc1
+                if cutlass.const_expr(hi):
+                    acc_nope[at][2] = acc_nope[at][2] + xv2 * sc1
+                    acc_nope[at][3] = acc_nope[at][3] + xv3 * sc1
         return acc_nope
 
     # GLM (ARBITRARY_FP32, P10f): 2-pass W (HIGH + LOW e4m3 residual) -> ~7 mantissa
@@ -898,9 +911,10 @@ def s6_xv_nope(
     for vc in cutlass.range_constexpr(n_v_chunks):
         w_fp8_addr = w_fp8_base_addr + Int32(vc & 1) * Int32(hpb * w_fp8_stride)
         si0 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
-        si1 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
         sc0 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid]
-        sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+        if cutlass.const_expr(hi):
+            si1 = Float32(1.0) / w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
+            sc1 = w_head_sc_view[Int32(vc) * Int32(hpb) + gid + Int32(8)]
         vsc0 = _vsc(cand_e0, vc)
         vsc1 = _vsc(cand_e1, vc)
         a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
@@ -908,8 +922,9 @@ def s6_xv_nope(
         # normalized W (= w_pre * V_scale / w_head_sc), the e4m3 quant target.
         wn00 = w_pre[0] * vsc0 * si0
         wn01 = w_pre[1] * vsc1 * si0
-        wn10 = w_pre[2] * vsc0 * si1
-        wn11 = w_pre[3] * vsc1 * si1
+        if cutlass.const_expr(hi):
+            wn10 = w_pre[2] * vsc0 * si1
+            wn11 = w_pre[3] * vsc1 * si1
         # per-nt fp32 accumulators, carried across the W hi/lo passes.
         xv = [[Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
               for _ in range(nt_per_warp_xv)]
@@ -921,17 +936,20 @@ def s6_xv_nope(
                 # LOW residual = e4m3(Wn - dequant(hi_byte)); halves W's quant error.
                 f00 = _quant_e4m3_residual_byte(wn00)
                 f01 = _quant_e4m3_residual_byte(wn01)
-                f10 = _quant_e4m3_residual_byte(wn10)
-                f11 = _quant_e4m3_residual_byte(wn11)
+                if cutlass.const_expr(hi):
+                    f10 = _quant_e4m3_residual_byte(wn10)
+                    f11 = _quant_e4m3_residual_byte(wn11)
             else:
                 f00 = _quant_e4m3_byte(wn00)
                 f01 = _quant_e4m3_byte(wn01)
-                f10 = _quant_e4m3_byte(wn10)
-                f11 = _quant_e4m3_byte(wn11)
+                if cutlass.const_expr(hi):
+                    f10 = _quant_e4m3_byte(wn10)
+                    f11 = _quant_e4m3_byte(wn11)
             st_shared_u8(w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e0, f00.to(cutlass.Uint8))
             st_shared_u8(w_fp8_addr + gid * Int32(w_fp8_stride) + cand_e1, f01.to(cutlass.Uint8))
-            st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0, f10.to(cutlass.Uint8))
-            st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1, f11.to(cutlass.Uint8))
+            if cutlass.const_expr(hi):
+                st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e0, f10.to(cutlass.Uint8))
+                st_shared_u8(w_fp8_addr + (gid + Int32(8)) * Int32(w_fp8_stride) + cand_e1, f11.to(cutlass.Uint8))
             cute.arch.barrier(**bar_kw)
 
             for nt in cutlass.range_constexpr(nt_per_warp_xv):
@@ -957,8 +975,9 @@ def s6_xv_nope(
             at = vc * nt_per_warp_xv + nt
             acc_nope[at][0] = acc_nope[at][0] + xv[nt][0] * sc0
             acc_nope[at][1] = acc_nope[at][1] + xv[nt][1] * sc0
-            acc_nope[at][2] = acc_nope[at][2] + xv[nt][2] * sc1
-            acc_nope[at][3] = acc_nope[at][3] + xv[nt][3] * sc1
+            if cutlass.const_expr(hi):
+                acc_nope[at][2] = acc_nope[at][2] + xv[nt][2] * sc1
+                acc_nope[at][3] = acc_nope[at][3] + xv[nt][3] * sc1
     return acc_nope
 
 

--- a/b12x/attention/mla/prefill.py
+++ b/b12x/attention/mla/prefill.py
@@ -112,9 +112,9 @@ def run_unified_prefill(
 
     num_tokens, heads, _ = q.shape
     hpb = 16
-    if heads % hpb != 0:
-        # VALID_HPB<16 small-TP shards are a separate (decode-landed) feature; until
-        # ported in prefill this is an unsupported shape -> RAISE (not legacy).
+    if heads % hpb != 0 and not (0 < heads < hpb):
+        # VALID_HPB<16 is supported only for the single small-TP shard. Other
+        # non-multiple-of-16 layouts still need an explicit split/tail launcher.
         raise ValueError(
             f"SM120 sparse MLA prefill requires heads divisible by HPB={hpb}, got {heads}"
         )
@@ -199,10 +199,9 @@ def run_unified_prefill(
     # arms (post-MMA fp32 QK scale, raw-V + 2-pass-W XV, no XV-rope) and the
     # 656/528 KV geometry -- all const_expr-selected in the SAME MG kernel. Route
     # GLM prefill OFF the slow per-head-block decode-reuse path onto MG:
-    #   heads == 16        -> MG_N_HG=1 (single-group MG)
+    #   heads <= 16        -> MG_N_HG=1 (single-group MG; heads<16 uses VALID_HPB)
     #   heads % 32 == 0    -> MG_N_HG=2 (32/64/128)
-    # heads == 8 (MG_N_HG=1 + VALID_HPB=8) is a follow-on (the heads%16!=0 entry
-    # guard rejects it before here). topk in {512,1024,2048}.
+    # topk in {512,1024,2048}.
     _mg_glm = (
         _mg_enabled
         and not has_extra
@@ -212,7 +211,7 @@ def run_unified_prefill(
     if _mg_glm and topk in (512, 1024, 2048):
         if heads % (2 * hpb) == 0:
             _glm_n_hg = 2
-        elif heads == hpb:
+        elif heads <= hpb:
             _glm_n_hg = 1
         else:
             _glm_n_hg = 0

--- a/b12x/attention/mla/prefill_mg.py
+++ b/b12x/attention/mla/prefill_mg.py
@@ -200,6 +200,7 @@ def s2_qk_rope_global_mg_dsv4(
     *,
     d_rope: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """Fused DSV4 QK-RoPE.
 
@@ -294,6 +295,7 @@ def s2_qk_rope_regs_mg_glm(
     *,
     d_rope: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """GLM MG QK-RoPE. Mirrors ``s2_qk_rope_regs_mg_dsv4`` (registerized Q-rope A,
     KV-rope B from global) but with the GLM record geometry and the GLM B-operand
@@ -307,6 +309,7 @@ def s2_qk_rope_regs_mg_glm(
     entry = warp_first_cand + gid
     idx = Int32(token_idx_view[entry])
     rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
@@ -315,12 +318,17 @@ def s2_qk_rope_regs_mg_glm(
         b0 = _ld_global_glm_rope_u32(kv_cache_u8, rope_base, ko + tid * Int32(2))
         b1 = _ld_global_glm_rope_u32(kv_cache_u8, rope_base, ko + tid * Int32(2) + Int32(8))
         base = Int32(ks) * Int32(4)
-        qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+        d0, d1, d2, d3 = mma_m16n8k16_f32_bf16(
             qk0[0], qk0[1], qk0[2], qk0[3],
             q_rope_regs0[base + 0], q_rope_regs0[base + 1],
             q_rope_regs0[base + 2], q_rope_regs0[base + 3],
             b0, b1,
         )
+        qk0[0] = d0
+        qk0[1] = d1
+        if cutlass.const_expr(hi0):
+            qk0[2] = d2
+            qk0[3] = d3
         if cutlass.const_expr(n_hg == 2):
             qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
                 qk1[0], qk1[1], qk1[2], qk1[3],
@@ -723,6 +731,7 @@ def s4_online_softmax_mg2(
     barrier_id: cutlass.Constexpr,
     n_acc_tiles: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """S4 online softmax with FlashInfer-style deferred row sums. Every group-1
     statement is gated inline behind ``const_expr(n_hg == 2)`` so the n_hg==2
@@ -730,32 +739,38 @@ def s4_online_softmax_mg2(
     n_hg==1 cleanly elides all qk1/acc1/rope1/gs1/reduce1 work (single HPB head
     group; the cross-warp reduce spans tid_flat < hpb, group 0 only)."""
     two = cutlass.const_expr(n_hg == 2)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
+    reduce_heads = cutlass.const_expr(n_hg * hpb if n_hg == 2 else valid_hpb)
     bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
 
     lm00 = fmax_f32(qk0[0], qk0[1])
-    lm01 = fmax_f32(qk0[2], qk0[3])
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(qk0[2], qk0[3])
     if cutlass.const_expr(two):
         lm10 = fmax_f32(qk1[0], qk1[1])
         lm11 = fmax_f32(qk1[2], qk1[3])
     lm00 = fmax_f32(lm00, cute.arch.shuffle_sync_bfly(lm00, offset=2))
-    lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=2))
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=2))
     if cutlass.const_expr(two):
         lm10 = fmax_f32(lm10, cute.arch.shuffle_sync_bfly(lm10, offset=2))
         lm11 = fmax_f32(lm11, cute.arch.shuffle_sync_bfly(lm11, offset=2))
     lm00 = fmax_f32(lm00, cute.arch.shuffle_sync_bfly(lm00, offset=1))
-    lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=1))
+    if cutlass.const_expr(hi0):
+        lm01 = fmax_f32(lm01, cute.arch.shuffle_sync_bfly(lm01, offset=1))
     if cutlass.const_expr(two):
         lm10 = fmax_f32(lm10, cute.arch.shuffle_sync_bfly(lm10, offset=1))
         lm11 = fmax_f32(lm11, cute.arch.shuffle_sync_bfly(lm11, offset=1))
 
     if tid == Int32(0):
         st_shared_f32(reduce0_max_addr + (warp_id * Int32(hpb) + gid) * Int32(4), lm00)
-        st_shared_f32(
-            reduce0_max_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
-            lm01,
-        )
+        if cutlass.const_expr(hi0):
+            st_shared_f32(
+                reduce0_max_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+                lm01,
+            )
         if cutlass.const_expr(two):
             st_shared_f32(reduce1_max_addr + (warp_id * Int32(hpb) + gid) * Int32(4), lm10)
             st_shared_f32(
@@ -764,9 +779,13 @@ def s4_online_softmax_mg2(
             )
     cute.arch.barrier(**bar_kw)
 
-    if tid_flat < Int32(n_hg * hpb):
-        group = tid_flat // Int32(hpb)
-        h = tid_flat - group * Int32(hpb)
+    if tid_flat < Int32(reduce_heads):
+        if cutlass.const_expr(two):
+            group = tid_flat // Int32(hpb)
+            h = tid_flat - group * Int32(hpb)
+        else:
+            group = Int32(0)
+            h = tid_flat
         rmax = reduce0_max_addr
         if cutlass.const_expr(two):
             if group != Int32(0):
@@ -779,18 +798,21 @@ def s4_online_softmax_mg2(
     cute.arch.barrier(**bar_kw)
 
     blm00 = ld_shared_f32(reduce0_max_addr + gid * Int32(4))
-    blm01 = ld_shared_f32(reduce0_max_addr + (gid + Int32(8)) * Int32(4))
+    if cutlass.const_expr(hi0):
+        blm01 = ld_shared_f32(reduce0_max_addr + (gid + Int32(8)) * Int32(4))
     if cutlass.const_expr(two):
         blm10 = ld_shared_f32(reduce1_max_addr + gid * Int32(4))
         blm11 = ld_shared_f32(reduce1_max_addr + (gid + Int32(8)) * Int32(4))
 
     ngm00 = fmax_f32(gm0[0], blm00)
-    ngm01 = fmax_f32(gm0[1], blm01)
+    if cutlass.const_expr(hi0):
+        ngm01 = fmax_f32(gm0[1], blm01)
     if cutlass.const_expr(two):
         ngm10 = fmax_f32(gm1[0], blm10)
         ngm11 = fmax_f32(gm1[1], blm11)
     alpha00 = _exp2_approx_ftz_f32(gm0[0] - ngm00)
-    alpha01 = _exp2_approx_ftz_f32(gm0[1] - ngm01)
+    if cutlass.const_expr(hi0):
+        alpha01 = _exp2_approx_ftz_f32(gm0[1] - ngm01)
     if cutlass.const_expr(two):
         alpha10 = _exp2_approx_ftz_f32(gm1[0] - ngm10)
         alpha11 = _exp2_approx_ftz_f32(gm1[1] - ngm11)
@@ -798,8 +820,9 @@ def s4_online_softmax_mg2(
     for vc in cutlass.range_constexpr(n_acc_tiles):
         acc0[vc][0] = acc0[vc][0] * alpha00
         acc0[vc][1] = acc0[vc][1] * alpha00
-        acc0[vc][2] = acc0[vc][2] * alpha01
-        acc0[vc][3] = acc0[vc][3] * alpha01
+        if cutlass.const_expr(hi0):
+            acc0[vc][2] = acc0[vc][2] * alpha01
+            acc0[vc][3] = acc0[vc][3] * alpha01
         if cutlass.const_expr(two):
             acc1[vc][0] = acc1[vc][0] * alpha10
             acc1[vc][1] = acc1[vc][1] * alpha10
@@ -807,8 +830,9 @@ def s4_online_softmax_mg2(
             acc1[vc][3] = acc1[vc][3] * alpha11
     rope0[0] = rope0[0] * alpha00
     rope0[1] = rope0[1] * alpha00
-    rope0[2] = rope0[2] * alpha01
-    rope0[3] = rope0[3] * alpha01
+    if cutlass.const_expr(hi0):
+        rope0[2] = rope0[2] * alpha01
+        rope0[3] = rope0[3] * alpha01
     if cutlass.const_expr(two):
         rope1[0] = rope1[0] * alpha10
         rope1[1] = rope1[1] * alpha10
@@ -816,15 +840,20 @@ def s4_online_softmax_mg2(
         rope1[3] = rope1[3] * alpha11
 
     gs0[0] = gs0[0] * alpha00
-    gs0[1] = gs0[1] * alpha01
+    if cutlass.const_expr(hi0):
+        gs0[1] = gs0[1] * alpha01
     if cutlass.const_expr(two):
         gs1[0] = gs1[0] * alpha10
         gs1[1] = gs1[1] * alpha11
 
     p0[0] = _exp2_approx_ftz_f32(qk0[0] - ngm00)
     p0[1] = _exp2_approx_ftz_f32(qk0[1] - ngm00)
-    p0[2] = _exp2_approx_ftz_f32(qk0[2] - ngm01)
-    p0[3] = _exp2_approx_ftz_f32(qk0[3] - ngm01)
+    if cutlass.const_expr(hi0):
+        p0[2] = _exp2_approx_ftz_f32(qk0[2] - ngm01)
+        p0[3] = _exp2_approx_ftz_f32(qk0[3] - ngm01)
+    else:
+        p0[2] = Float32(0.0)
+        p0[3] = Float32(0.0)
     if cutlass.const_expr(two):
         p1[0] = _exp2_approx_ftz_f32(qk1[0] - ngm10)
         p1[1] = _exp2_approx_ftz_f32(qk1[1] - ngm10)
@@ -832,28 +861,33 @@ def s4_online_softmax_mg2(
         p1[3] = _exp2_approx_ftz_f32(qk1[3] - ngm11)
 
     ls00 = p0[0] + p0[1]
-    ls01 = p0[2] + p0[3]
+    if cutlass.const_expr(hi0):
+        ls01 = p0[2] + p0[3]
     if cutlass.const_expr(two):
         ls10 = p1[0] + p1[1]
         ls11 = p1[2] + p1[3]
     ls00 = ls00 + cute.arch.shuffle_sync_bfly(ls00, offset=2)
-    ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=2)
+    if cutlass.const_expr(hi0):
+        ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=2)
     if cutlass.const_expr(two):
         ls10 = ls10 + cute.arch.shuffle_sync_bfly(ls10, offset=2)
         ls11 = ls11 + cute.arch.shuffle_sync_bfly(ls11, offset=2)
     ls00 = ls00 + cute.arch.shuffle_sync_bfly(ls00, offset=1)
-    ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=1)
+    if cutlass.const_expr(hi0):
+        ls01 = ls01 + cute.arch.shuffle_sync_bfly(ls01, offset=1)
     if cutlass.const_expr(two):
         ls10 = ls10 + cute.arch.shuffle_sync_bfly(ls10, offset=1)
         ls11 = ls11 + cute.arch.shuffle_sync_bfly(ls11, offset=1)
 
     gs0[0] = gs0[0] + ls00
-    gs0[1] = gs0[1] + ls01
+    if cutlass.const_expr(hi0):
+        gs0[1] = gs0[1] + ls01
     if cutlass.const_expr(two):
         gs1[0] = gs1[0] + ls10
         gs1[1] = gs1[1] + ls11
     gm0[0] = ngm00
-    gm0[1] = ngm01
+    if cutlass.const_expr(hi0):
+        gm0[1] = ngm01
     if cutlass.const_expr(two):
         gm1[0] = ngm10
         gm1[1] = ngm11
@@ -882,21 +916,25 @@ def s4_finalize_row_sum_mg2(
     num_threads: cutlass.Constexpr,
     barrier_id: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
+    valid_hpb: cutlass.Constexpr = 16,
 ):
     """Final cross-warp row-sum reduction for deferred MG softmax. Group-1
     statements gate inline behind ``const_expr(n_hg == 2)`` (n_hg==2 trace
     unchanged); n_hg==1 reduces only group 0 (tid_flat < hpb)."""
     two = cutlass.const_expr(n_hg == 2)
+    hi0 = cutlass.const_expr(valid_hpb > 8)
+    reduce_heads = cutlass.const_expr(n_hg * hpb if n_hg == 2 else valid_hpb)
     bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
 
     if tid == Int32(0):
         st_shared_f32(reduce0_sum_addr + (warp_id * Int32(hpb) + gid) * Int32(4), gs0[0])
-        st_shared_f32(
-            reduce0_sum_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
-            gs0[1],
-        )
+        if cutlass.const_expr(hi0):
+            st_shared_f32(
+                reduce0_sum_addr + (warp_id * Int32(hpb) + gid + Int32(8)) * Int32(4),
+                gs0[1],
+            )
         if cutlass.const_expr(two):
             st_shared_f32(reduce1_sum_addr + (warp_id * Int32(hpb) + gid) * Int32(4), gs1[0])
             st_shared_f32(
@@ -905,9 +943,13 @@ def s4_finalize_row_sum_mg2(
             )
     cute.arch.barrier(**bar_kw)
 
-    if tid_flat < Int32(n_hg * hpb):
-        group = tid_flat // Int32(hpb)
-        h = tid_flat - group * Int32(hpb)
+    if tid_flat < Int32(reduce_heads):
+        if cutlass.const_expr(two):
+            group = tid_flat // Int32(hpb)
+            h = tid_flat - group * Int32(hpb)
+        else:
+            group = Int32(0)
+            h = tid_flat
         rsum = reduce0_sum_addr
         if cutlass.const_expr(two):
             if group != Int32(0):
@@ -921,7 +963,8 @@ def s4_finalize_row_sum_mg2(
     cute.arch.barrier(**bar_kw)
 
     gs0[0] = ld_shared_f32(reduce0_sum_addr + gid * Int32(4))
-    gs0[1] = ld_shared_f32(reduce0_sum_addr + (gid + Int32(8)) * Int32(4))
+    if cutlass.const_expr(hi0):
+        gs0[1] = ld_shared_f32(reduce0_sum_addr + (gid + Int32(8)) * Int32(4))
     if cutlass.const_expr(two):
         gs1[0] = ld_shared_f32(reduce1_sum_addr + gid * Int32(4))
         gs1[1] = ld_shared_f32(reduce1_sum_addr + (gid + Int32(8)) * Int32(4))
@@ -1201,6 +1244,7 @@ class UnifiedPrefillMGKernel:
         extra_indices_stride0=0,
         row_xor=False,
         head_offset=0,
+        valid_hpb=None,
     ):
         self.traits = traits
         self.layout = layout
@@ -1233,6 +1277,7 @@ class UnifiedPrefillMGKernel:
         self.extra_indices_stride_row = int(extra_indices_stride0)
         self.row_xor = bool(row_xor)
         self.head_offset = int(head_offset)
+        self.valid_hpb = int(valid_hpb) if valid_hpb is not None else int(traits.hpb)
         # MG head-group count (1 for heads==16, 2 for heads % 32 == 0). Derived
         # from the layout (heads_per_cta // hpb) and threaded as a compile-time
         # const so every group-1 op const_expr-elides for n_hg==1.
@@ -1767,7 +1812,7 @@ class UnifiedPrefillMGKernel:
                     q_rope_g0,
                     amax_view,
                     head_base,
-                    Int32(t.hpb),
+                    Int32(self.valid_hpb),
                     tid,
                     d_nope=t.d_nope,
                     d_rope=t.d_rope,
@@ -1996,6 +2041,7 @@ class UnifiedPrefillMGKernel:
                         kv_smem_stride=L.kv_smem_stride,
                         scale_bytes_per_token=8,
                         scale_format=t.scale_format,
+                        valid_hpb=self.valid_hpb,
                     )
                     if cutlass.const_expr(n_hg == 2):
                         qk1 = s1_qk_nope_block_scaled(
@@ -2012,6 +2058,7 @@ class UnifiedPrefillMGKernel:
                             kv_smem_stride=L.kv_smem_stride,
                             scale_bytes_per_token=8,
                             scale_format=t.scale_format,
+                            valid_hpb=t.hpb,
                         )
                     if cutlass.const_expr(is_glm):
                         # GLM QK-RoPE: Q-rope A from preloaded registers, KV-rope B
@@ -2030,6 +2077,7 @@ class UnifiedPrefillMGKernel:
                             rope_stride,
                             d_rope=t.d_rope,
                             n_hg=n_hg,
+                            valid_hpb=self.valid_hpb,
                         )
                     else:
                         # Fused QK-RoPE: KV-RoPE B operand gathered ONCE per CTA tile
@@ -2099,6 +2147,7 @@ class UnifiedPrefillMGKernel:
                     barrier_id=3,
                     n_acc_tiles=n_acc_tiles,
                     n_hg=n_hg,
+                    valid_hpb=self.valid_hpb,
                 )
                 w_pre0 = [p0[0] * wr00, p0[1] * wr00, p0[2] * wr01, p0[3] * wr01]
                 w_pre1 = [p1[0] * wr10, p1[1] * wr10, p1[2] * wr11, p1[3] * wr11]
@@ -2120,7 +2169,7 @@ class UnifiedPrefillMGKernel:
                     # atomicMaxes against uninitialized smem (catastrophic on cold
                     # launch) and later tiles never reset it (stale max bias).
                     i_hs = tid
-                    while i_hs < Int32(n_hg * t.n_v_chunks * t.hpb):
+                    while i_hs < Int32(n_hg * t.n_v_chunks * self.valid_hpb):
                         w_head_sc_view_all[i_hs] = Float32(0.0)
                         i_hs += Int32(self.math_threads)
                     cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
@@ -2146,6 +2195,7 @@ class UnifiedPrefillMGKernel:
                         scale_format=t.scale_format,
                         num_threads=self.math_threads,
                         barrier_id=3,
+                        valid_hpb=self.valid_hpb,
                     )
                     if cutlass.const_expr(n_hg == 2):
                         acc1 = s6_xv_nope(
@@ -2170,6 +2220,7 @@ class UnifiedPrefillMGKernel:
                             scale_format=t.scale_format,
                             num_threads=self.math_threads,
                             barrier_id=3,
+                            valid_hpb=t.hpb,
                         )
                 else:
                     acc0, acc1 = s6_xv_nope_mg_dsv4(
@@ -2314,6 +2365,7 @@ class UnifiedPrefillMGKernel:
                 num_threads=self.math_threads,
                 barrier_id=3,
                 n_hg=n_hg,
+                valid_hpb=self.valid_hpb,
             )
             gsum0_frag[0] = final_sum0[0]
             gsum0_frag[1] = final_sum0[1]
@@ -2360,7 +2412,7 @@ class UnifiedPrefillMGKernel:
                 d_nope=t.d_nope,
                 d_rope=t.d_rope,
                 n_warps=8,
-                valid_hpb=t.hpb,
+                valid_hpb=self.valid_hpb,
                 nt_per_warp_xv=t.nt_per_warp_xv,
                 v_has_rope=t.v_has_rope,
                 epilogue_mode=EPILOGUE_FINAL_BF16,
@@ -2456,6 +2508,7 @@ def _sparse_mla_prefill_mg_flat_launch(
     *,
     active_heads: int | None = None,
     head_offset: int = 0,
+    valid_hpb: int | None = None,
 ) -> None:
     traits = make_unified_traits(int(model_type), compute_mode, int(scale_format))
     layout = make_smem_layout_mg(traits, int(mg_n_hg))
@@ -2466,6 +2519,7 @@ def _sparse_mla_prefill_mg_flat_launch(
     active_heads = int(active_heads)
     head_offset = int(head_offset)
     heads_per_cta = int(layout.heads_per_cta)
+    hpb = int(traits.hpb)
     if active_heads <= 0:
         raise ValueError(f"SM120 sparse MLA MG prefill requires active_heads>0, got {active_heads}")
     if head_offset < 0 or head_offset + active_heads > total_heads:
@@ -2473,12 +2527,19 @@ def _sparse_mla_prefill_mg_flat_launch(
             "SM120 sparse MLA MG prefill head range out of bounds: "
             f"head_offset={head_offset}, active_heads={active_heads}, total_heads={total_heads}"
         )
-    if active_heads % heads_per_cta != 0:
+    if valid_hpb is None:
+        valid_hpb = active_heads if int(mg_n_hg) == 1 and active_heads < heads_per_cta else hpb
+    valid_hpb = int(valid_hpb)
+    if not (1 <= valid_hpb <= hpb):
+        raise ValueError(f"valid_hpb must be in [1, {hpb}], got {valid_hpb}")
+    if active_heads % heads_per_cta != 0 and not (
+        int(mg_n_hg) == 1 and active_heads < heads_per_cta
+    ):
         raise ValueError(
             "SM120 sparse MLA MG prefill active head range must be divisible by "
             f"heads_per_cta={heads_per_cta}; got active_heads={active_heads}"
         )
-    replicate_h = active_heads // heads_per_cta
+    replicate_h = max(1, (active_heads + heads_per_cta - 1) // heads_per_cta)
     # DSV4 dual-cache MG: the union puts tile 0 in the MAIN section, so
     # num_main_tiles MUST be >= 1 (topk==128 => 2). All-extra (num_main_tiles==0)
     # has no extra-prologue arm and is forbidden.
@@ -2507,6 +2568,7 @@ def _sparse_mla_prefill_mg_flat_launch(
         extra_indices_stride0=int(extra_indices_t.stride(0)),
         row_xor=bool(row_xor),
         head_offset=head_offset,
+        valid_hpb=valid_hpb,
     )
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
     base_args = (
@@ -2564,6 +2626,8 @@ def _sparse_mla_prefill_mg_flat_launch(
                 key_field("head_offset", head_offset),
             ]
         )
+    if valid_hpb != hpb:
+        spec_fields.append(key_field("valid_hpb", valid_hpb))
     if has_extra:
         # The dual key_fields are appended ONLY for has_extra so the single-cache
         # compile-spec hash is byte-unchanged (decode/no-extra cache key identical).
@@ -2839,7 +2903,12 @@ def run_unified_prefill_mg(
     # covers a single-group launch, including the 16-head tail of an odd-multiple
     # dual-cache split. The caller picks mg_n_hg and active head range.
     heads_per_cta = int(mg_n_hg) * int(traits.hpb)
-    if active_heads % heads_per_cta != 0:
+    valid_hpb = int(traits.hpb)
+    if int(mg_n_hg) == 1 and active_heads < heads_per_cta:
+        valid_hpb = active_heads
+    if active_heads % heads_per_cta != 0 and not (
+        int(mg_n_hg) == 1 and active_heads < heads_per_cta
+    ):
         raise ValueError(
             f"SM120 sparse MLA MG prefill (mg_n_hg={mg_n_hg}) requires heads divisible "
             f"by {heads_per_cta}, got active_heads={active_heads}"
@@ -2894,7 +2963,7 @@ def run_unified_prefill_mg(
             extra_len_t = extra_topk_length.to(
                 device=device, dtype=torch.int32
             ).contiguous()
-        if active_heads == total_heads and head_offset == 0:
+        if active_heads == total_heads and head_offset == 0 and valid_hpb == int(traits.hpb):
             torch.ops.b12x.sparse_mla_sm120_prefill_mg_dual(
                 q,
                 kv_cache.reshape(-1),
@@ -2952,10 +3021,11 @@ def run_unified_prefill_mg(
                 bool(row_xor),
                 active_heads=active_heads,
                 head_offset=head_offset,
+                valid_hpb=valid_hpb,
             )
         return output, lse_out
 
-    if active_heads == total_heads and head_offset == 0:
+    if active_heads == total_heads and head_offset == 0 and valid_hpb == int(traits.hpb):
         torch.ops.b12x.sparse_mla_sm120_prefill_mg(
             q,
             kv_cache.reshape(-1),
@@ -3005,5 +3075,6 @@ def run_unified_prefill_mg(
             False,  # row_xor
             active_heads=active_heads,
             head_offset=head_offset,
+            valid_hpb=valid_hpb,
         )
     return output, lse_out


### PR DESCRIPTION
## Summary

Adds an HPB8-capable GLM sparse-MLA MG prefill path for high-TP shards with fewer than 16 local heads. The current master already handles odd 16-head multiples, but still rejects `heads < 16`; GLM TP8/DCP1 reaches this case when vLLM avoids padding its prefill query tensor from 8 to 16 heads.

This change:
- allows the single small-head shard (`0 < heads < 16`) to enter the MG prefill path with `mg_n_hg=1`;
- carries `valid_hpb` through the MG launcher/cache key;
- gates GLM S1/S2/S4/S6 work for the invalid upper half when `valid_hpb <= 8`;
- leaves existing `valid_hpb=16` and `mg_n_hg=2` paths unchanged by default.

## Why

Without this, vLLM must pad GLM TP8/DCP1 prefill heads from 8 to 16, allocate/copy a padded Q tensor, and slice the output back. The paired vLLM PR makes that padding opt-in removable; this PR is the B12X kernel-side support needed for it.

Local measurements from the experimental overlay on GLM-5.2 Luke NVFP4 TP8/DCP1/MTP-off/A16 showed 64k prefill improving from about `4724 tok/s` warm baseline to `4877-4927 tok/s` with the deeper HPB8 path (`+3.2%` to `+4.3%`). The remaining limit is that QK/XV tensor-core instructions still use `m16n8` shapes, so this is not a full dedicated 8-head CTA rewrite.

## Validation

- `python3 -m py_compile b12x/attention/mla/decode_math.py b12x/attention/mla/prefill.py b12x/attention/mla/prefill_mg.py`
- Runtime validation was done previously with the same patch as an overlay on GLM-5.2 TP8/DCP1/MTP-off/A16; outputs were coherent and prefill speed improved as above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially active head groups in MLA prefill and decode paths.
  * Improved routing so smaller head layouts can now run without failing validation.

* **Bug Fixes**
  * Corrected handling of head-group processing when only part of a larger group is valid.
  * Reduced unnecessary computation and writes for invalid head slots, improving efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->