### PR TITLE
attention: use 64-bit offsets in fused paged indexer

### DIFF
--- a/b12x/attention/indexer/fused_indexer.py
+++ b/b12x/attention/indexer/fused_indexer.py
@@ -27,7 +27,7 @@ import cutlass
 import cutlass.cute as cute
 import cuda.bindings.driver as cuda
 import torch
-from cutlass import Float32, Int32, Uint32
+from cutlass import Float32, Int32, Int64, Uint32
 from cutlass.cute.runtime import from_dlpack
 
 from b12x.cute.compiler import (
@@ -192,7 +192,7 @@ def _load_flat_k_tile_wide(
 def _load_permute_k_page_g2s(
     k_quant_bytes: cute.Tensor,  # [pages, 64, 128] uint8 (16B-aligned base)
     page_id: Int32,
-    page_stride_bytes: Int32,  # dim-0 byte stride; 8192 for contiguous K, 8448 for
+    page_stride_bytes: Int64,  # dim-0 byte stride; 8192 for contiguous K, 8448 for
                                # the packed paged cache (64*128 quant + 64*4 scales / page)
     k_perm_base_addr: Int32,
     tx: Int32,
@@ -207,7 +207,7 @@ def _load_permute_k_page_g2s(
     stride is 8448, not the contiguous 8192) — using a hardcoded stride reads the
     wrong page for the packed layout. It stays 16B-aligned (8448 = 16*528).
     """
-    page_elem_base = page_id * page_stride_bytes
+    page_elem_base = Int64(page_id) * page_stride_bytes
     linear = tx
     total = Int32(_PAGE_SIZE * (_INDEX_HEAD_DIM // 16))
     while linear < total:
@@ -215,7 +215,9 @@ def _load_permute_k_page_g2s(
         vec_idx = linear - row * Int32(_INDEX_HEAD_DIM // 16)
         g_addr = get_ptr_as_int64(
             k_quant_bytes,
-            page_elem_base + row * Int32(_INDEX_HEAD_DIM) + vec_idx * Int32(16),
+            page_elem_base
+            + Int64(row) * Int64(_INDEX_HEAD_DIM)
+            + Int64(vec_idx) * Int64(16),
         )
         v0, v1, v2, v3 = ld_global_v4_u32(g_addr)
         dst_addr = _smem_addr_from_b128_offset(
@@ -1148,7 +1150,7 @@ class SparseNSAFusedIndexerKernel:
                 if cutlass.const_expr(self.kv_layout == KV_LAYOUT_PAGED):
                     # Fused g2s load + permute (no linear staging, no repack pass).
                     _load_permute_k_page_g2s(
-                        k_quant_bytes, page_id, Int32(self.k_quant_page_stride),
+                        k_quant_bytes, page_id, Int64(self.k_quant_page_stride),
                         k_page_perm_base_addr, tx, Int32(_RADIX_THREADS),
                     )
                     scale_idx = tx


### PR DESCRIPTION
## Summary

Fix the paged fused sparse-indexer K loader to compute packed-KV page byte offsets in 64-bit arithmetic.

The current fused paged path computes:

```python
page_elem_base = page_id * page_stride_bytes
```

with both operands in `Int32`. For packed KV layouts and high physical page IDs, this overflows before the offset is passed to `get_ptr_as_int64()`.

## Root Cause

I dumped the exact vLLM tensors from a failing DeepSeek-V4-Flash B12X fused paged-indexer call and replayed the kernel standalone.

Failing runtime metadata:

- `k_quant_page_stride = 1,039,680` bytes
- max physical `page_id = 7024`
- `live_pages = 251`
- `topk = 512`
- `ctas_per_group = 188`
- `merge_threshold = 43996`

The page byte offset becomes:

```text
7024 * 1,039,680 = 7,302,712,320 bytes
```

which exceeds `2^32`. The maximum safe page id for that stride is `4131`.

This also explains why `4096` looked safe while `8192` could fail:

```text
4096 * 1,039,680 = 4,258,529,280  # barely below 2^32
8192 * 1,039,680 = 8,517,058,560  # overflows 32-bit byte offset
```

## Change

Only the page byte offset arithmetic in `_load_permute_k_page_g2s()` is widened:

- import `Int64`
- accept `page_stride_bytes` as `Int64`
- compute `page_elem_base = Int64(page_id) * page_stride_bytes`
- cast row/vector byte increments to `Int64`
- pass `Int64(self.k_quant_page_stride)` from the callsite

No routing workaround, no workspace/arena changes, and no vLLM binding changes.

## Validation

Exact-tensor replay from the same dumped vLLM call:

- original kernel + exact packed-stride dump: `CUDA_ERROR_ILLEGAL_ADDRESS`
- original kernel + sorted page table: still fails
- original kernel + contiguous low page IDs: passes
- patched kernel + exact packed-stride dump: passes

Full vLLM repro with fused paged indexer enabled also completed the 64k prompt path after this fix.

The important diagnostic is that sorting the page table does not help, while remapping to low contiguous page IDs does. So the bug is not page-table ordering; it is 32-bit byte-offset overflow for packed paged KV with high physical page IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the stability of the fused indexer’s paged loading path by using larger integer precision for address and stride calculations.
  * This helps prevent incorrect memory offset calculations when handling larger page layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->