### PR TITLE
perf(gemm): 8-35x faster dense MXFP8 input quantizer + SF load reductions

### DIFF
--- a/b12x/gemm/block_fp8_linear.py
+++ b/b12x/gemm/block_fp8_linear.py
@@ -43,6 +43,7 @@ _B12X_TIMING_THRESHOLD_MS = float(
 _SCRATCH_ALIGN_BYTES = 1024
 
 
+
 @dataclass(frozen=True)
 class BlockFP8LinearWeight:
     weight: MXFP8Rows
@@ -664,6 +665,9 @@ def _block_fp8_linear_mxfp8_fused_op(
         c_dtype=_c_dtype_name(source_2d.dtype),
         sf_vec_size=MXFP8_SCALE_VEC_SIZE,
         expected_m=expected_m,
+        # Weight scales come from 128x128 blocks expanded to per-32 rows, so
+        # the four SFB bytes per 128-wide k tile are identical by construction.
+        sfb_k_replicated=True,
         stream=stream_int,
     )[:, :, 0]
 
@@ -792,6 +796,7 @@ def block_fp8_linear_mxfp8(
         sf_vec_size=MXFP8_SCALE_VEC_SIZE,
         out=output_storage,
         expected_m=expected_m,
+        sfb_k_replicated=True,
         stream=stream,
     )[:, :, 0]
     t_gemm = time.perf_counter() if _B12X_TIMING else 0.0

--- a/b12x/gemm/block_fp8_linear.py
+++ b/b12x/gemm/block_fp8_linear.py
@@ -165,6 +165,7 @@ def _quantize_dense_tk_to_tk_kernel(
     scale_rows,
     scale_mma,
     tokens,
+    num_groups_k,
     source_stride_t,
     source_stride_k,
     values_stride_t,
@@ -178,47 +179,72 @@ def _quantize_dense_tk_to_tk_kernel(
     scale_mma_s3,
     scale_mma_s4,
     scale_mma_s5,
-    BLOCK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    GROUPS: tl.constexpr,
+    VEC: tl.constexpr,
 ) -> None:
-    token = tl.program_id(0)
-    chunk = tl.program_id(1)
-    offs = tl.arange(0, BLOCK)
-    k = chunk * BLOCK + offs
+    # Tiled MXFP8 row quantizer: each program covers BLOCK_M tokens x GROUPS
+    # 32-wide scale groups so loads/stores are coalesced across the K dim.
+    # BLOCK_M must divide 32 (or be a multiple of it) so that the swizzled
+    # scale_mma row32/row4/tile_m coordinates stay vectorizable per tile.
+    pid_m = tl.program_id(0)
+    pid_g = tl.program_id(1)
 
-    src = tl.load(source + token * source_stride_t + k * source_stride_k).to(tl.float32)
-    max_abs = tl.max(tl.abs(src), axis=0)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_g = pid_g * GROUPS + tl.arange(0, GROUPS)
+    offs_e = tl.arange(0, VEC)
+    mask_m = offs_m < tokens
+    mask_g = offs_g < num_groups_k
+
+    k = offs_g[:, None] * VEC + offs_e[None, :]
+    mask = mask_m[:, None, None] & mask_g[None, :, None]
+    src = tl.load(
+        source
+        + offs_m[:, None, None] * source_stride_t
+        + k[None, :, :] * source_stride_k,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    max_abs = tl.max(tl.abs(src), axis=2)
     safe = tl.where(max_abs > 0.0, max_abs / 448.0, 1.0)
     scale_exp = tl.minimum(tl.maximum(tl.ceil(tl.log2(safe)), -127.0), 127.0)
     scale = tl.exp2(scale_exp)
     scale_u8 = (scale_exp + 127.0).to(tl.uint8)
 
     tl.store(
-        values + token * values_stride_t + k * values_stride_k,
-        (src / scale).to(tl.float8e4nv),
+        values
+        + offs_m[:, None, None] * values_stride_t
+        + k[None, :, :] * values_stride_k,
+        (src / scale[:, :, None]).to(tl.float8e4nv),
+        mask=mask,
     )
 
+    mask2 = mask_m[:, None] & mask_g[None, :]
     tl.store(
         scale_rows
         + scale_rows_stride_l * 0
-        + token * scale_rows_stride_t
-        + chunk * scale_rows_stride_k,
+        + offs_m[:, None] * scale_rows_stride_t
+        + offs_g[None, :] * scale_rows_stride_k,
         scale_u8,
+        mask=mask2,
     )
 
-    row32 = token % 32
-    row4 = (token // 32) % 4
-    tile_m = token // 128
-    k4 = chunk % 4
-    tile_k = chunk // 4
+    row32 = offs_m % 32
+    row4 = (offs_m // 32) % 4
+    tile_m = offs_m // 128
+    k4 = offs_g % 4
+    tile_k = offs_g // 4
     tl.store(
         scale_mma
-        + row32 * scale_mma_s0
-        + row4 * scale_mma_s1
-        + tile_m * scale_mma_s2
-        + k4 * scale_mma_s3
-        + tile_k * scale_mma_s4
+        + row32[:, None] * scale_mma_s0
+        + row4[:, None] * scale_mma_s1
+        + tile_m[:, None] * scale_mma_s2
+        + k4[None, :] * scale_mma_s3
+        + tile_k[None, :] * scale_mma_s4
         + scale_mma_s5 * 0,
         scale_u8,
+        mask=mask2,
     )
 
 
@@ -504,12 +530,20 @@ def _run_block_fp8_quant_kernel(
     tokens: int,
     in_features: int,
 ) -> None:
-    _quantize_dense_tk_to_tk_kernel[(tokens, in_features // MXFP8_SCALE_VEC_SIZE)](
+    num_groups_k = in_features // MXFP8_SCALE_VEC_SIZE
+    block_m = 32
+    groups = 16
+    grid = (
+        (tokens + block_m - 1) // block_m,
+        (num_groups_k + groups - 1) // groups,
+    )
+    _quantize_dense_tk_to_tk_kernel[grid](
         source_tk,
         out_values,
         out_scale_rows.view(torch.uint8),
         out_scale_mma.view(torch.uint8),
         tokens,
+        num_groups_k,
         source_tk.stride(0),
         source_tk.stride(1),
         out_values.stride(0),
@@ -523,7 +557,9 @@ def _run_block_fp8_quant_kernel(
         out_scale_mma.stride(3),
         out_scale_mma.stride(4),
         out_scale_mma.stride(5),
-        BLOCK=MXFP8_SCALE_VEC_SIZE,
+        BLOCK_M=block_m,
+        GROUPS=groups,
+        VEC=MXFP8_SCALE_VEC_SIZE,
     )
 
 

--- a/b12x/gemm/dense.py
+++ b/b12x/gemm/dense.py
@@ -293,6 +293,7 @@ class DenseGemmKernel:
         use_m1_non_tma_sfa: bool = False,
         load_path: Literal["tma", "cpasync"] = "tma",
         swap_ab: bool = False,
+        sfb_k_reuse: bool = False,
     ):
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
@@ -322,11 +323,17 @@ class DenseGemmKernel:
         self.use_m1_non_tma_sfa = use_m1_non_tma_sfa
         self.load_path = load_path
         self.swap_ab = swap_ab
+        # SFB bytes are k-replicated within a 128-wide k tile (128x128 block
+        # weight scales expanded to per-32): load one byte per stage and feed
+        # every k block from it.
+        self.sfb_k_reuse = sfb_k_reuse
         mma_atom_mn = (self.mma_tile_shape_mnk[0], self.mma_tile_shape_mnk[1])
         if mma_atom_mn in ((16, 64), (16, 128)):
             self.atom_shape = (1, 2, 1)
         elif mma_atom_mn in ((32, 64), (32, 128)):
             self.atom_shape = (2, 2, 1)
+        elif os.getenv("B12X_DENSE_ATOM_24", "0") == "1":
+            self.atom_shape = (2, 4, 1)
         else:
             self.atom_shape = (4, 2, 1)
 
@@ -1302,16 +1309,26 @@ class DenseGemmKernel:
                 tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
                 tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
 
+                # Whole-stage SF copy: scale bytes for all k blocks of the
+                # acquired stage load in one bulk copy (per-k_block SF reloads
+                # dominated the LDS/issue budget at prefill M).
                 cute.copy(
                     smem_tiled_copy_SFA,
-                    tCsSFA_p_filtered[None, None, 0],
-                    tCrSFA_copy_view_filtered[None, None, 0],
+                    tCsSFA_p_filtered,
+                    tCrSFA_copy_view_filtered,
                 )
-                cute.copy(
-                    smem_tiled_copy_SFB,
-                    tCsSFB_p_filtered[None, None, 0],
-                    tCrSFB_copy_view_filtered[None, None, 0],
-                )
+                if cutlass.const_expr(self.sfb_k_reuse):
+                    cute.copy(
+                        smem_tiled_copy_SFB,
+                        tCsSFB_p_filtered[None, None, 0],
+                        tCrSFB_copy_view_filtered[None, None, 0],
+                    )
+                else:
+                    cute.copy(
+                        smem_tiled_copy_SFB,
+                        tCsSFB_p_filtered,
+                        tCrSFB_copy_view_filtered,
+                    )
 
                 for k_tile in range(0, k_tile_iter_cnt - 1, 1, unroll=2):
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -1351,10 +1368,16 @@ class DenseGemmKernel:
                                     WarpField.SFA,
                                     tCrSFA_tile[None, _mt, k_block_idx].iterator,
                                 )
-                                mma_atom.set(
-                                    WarpField.SFB,
-                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                                )
+                                if cutlass.const_expr(self.sfb_k_reuse):
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, 0].iterator,
+                                    )
+                                else:
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                    )
                                 cute.gemm(
                                     mma_atom,
                                     accumulators[None, _mt, _nt],
@@ -1373,20 +1396,31 @@ class DenseGemmKernel:
                             tCrB_copy_view[None, None, k_block_next],
                         )
 
-                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
-                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
-                        cute.copy(
-                            smem_tiled_copy_SFA,
-                            tCsSFA_p_filtered[None, None, k_block_next],
-                            tCrSFA_copy_view_filtered[None, None, k_block_next],
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFB,
-                            tCsSFB_p_filtered[None, None, k_block_next],
-                            tCrSFB_copy_view_filtered[None, None, k_block_next],
-                        )
+                        if k_block_idx == num_k_blocks - 1:
+                            # New stage acquired above: bulk-load its whole SF
+                            # tile once. The current tile's k_block MMAs have
+                            # all consumed their SF registers by this point.
+                            tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
+                            tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
+                            tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
+                            tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+                            cute.copy(
+                                smem_tiled_copy_SFA,
+                                tCsSFA_p_filtered,
+                                tCrSFA_copy_view_filtered,
+                            )
+                            if cutlass.const_expr(self.sfb_k_reuse):
+                                cute.copy(
+                                    smem_tiled_copy_SFB,
+                                    tCsSFB_p_filtered[None, None, 0],
+                                    tCrSFB_copy_view_filtered[None, None, 0],
+                                )
+                            else:
+                                cute.copy(
+                                    smem_tiled_copy_SFB,
+                                    tCsSFB_p_filtered,
+                                    tCrSFB_copy_view_filtered,
+                                )
 
                 # Hoist out last k_tile
                 for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -1409,20 +1443,8 @@ class DenseGemmKernel:
                             tCsB_p[None, None, k_block_next],
                             tCrB_copy_view[None, None, k_block_next],
                         )
-                        tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
-                        tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
-                        cute.copy(
-                            smem_tiled_copy_SFA,
-                            tCsSFA_p_filtered[None, None, k_block_next],
-                            tCrSFA_copy_view_filtered[None, None, k_block_next],
-                        )
-                        cute.copy(
-                            smem_tiled_copy_SFB,
-                            tCsSFB_p_filtered[None, None, k_block_next],
-                            tCrSFB_copy_view_filtered[None, None, k_block_next],
-                        )
+                        # SF registers for the whole stage were bulk-loaded at
+                        # stage acquisition; nothing to reload per k block.
                     # Manual atom unroll: avoids hasAuxTensor address space bug
                     for _mt in range(self.num_m_tiles):
                         for _nt in range(self.num_n_tiles):
@@ -1430,10 +1452,16 @@ class DenseGemmKernel:
                                 WarpField.SFA,
                                 tCrSFA_tile[None, _mt, k_block_idx].iterator,
                             )
-                            mma_atom.set(
-                                WarpField.SFB,
-                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                            )
+                            if cutlass.const_expr(self.sfb_k_reuse):
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, 0].iterator,
+                                )
+                            else:
+                                mma_atom.set(
+                                    WarpField.SFB,
+                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
+                                )
                             cute.gemm(
                                 mma_atom,
                                 accumulators[None, _mt, _nt],
@@ -2397,6 +2425,7 @@ class _DenseGemmLaunch:
         sm_version: str,
         load_path: str,
         swap_ab: bool,
+        sfb_k_reuse: bool,
     ):
         self._n = n
         self._k = k
@@ -2417,6 +2446,7 @@ class _DenseGemmLaunch:
         self._policy = policy
         self._load_path = load_path
         self._swap_ab = swap_ab
+        self._sfb_k_reuse = sfb_k_reuse
 
         if not DenseGemmKernel.can_implement(
             ab_dtype,
@@ -2504,6 +2534,7 @@ class _DenseGemmLaunch:
             use_m1_non_tma_sfa=False,
             load_path=self._load_path,
             swap_ab=self._swap_ab,
+            sfb_k_reuse=self._sfb_k_reuse,
         )(
             a_tensor,
             b_tensor,
@@ -2539,6 +2570,7 @@ def _get_compiled_dense_gemm(
     sm_version: str,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
 ) -> Callable:
     def _make_runtime_pointers(
         input_tensors: Optional[List[torch.Tensor]],
@@ -2608,6 +2640,7 @@ def _get_compiled_dense_gemm(
         sm_version=sm_version,
         load_path=load_path,
         swap_ab=swap_ab,
+        sfb_k_reuse=sfb_k_reuse,
     )
     compile_key = (
         n,
@@ -2711,6 +2744,7 @@ def _dense_gemm_launch_flat(
     split_k_atomic_bf16: bool,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
     stream_int: Optional[int],
 ) -> None:
     policy = _DenseGemmPolicy(
@@ -2742,6 +2776,7 @@ def _dense_gemm_launch_flat(
         sm_version="sm_120",
         load_path=load_path,
         swap_ab=swap_ab,
+        sfb_k_reuse=sfb_k_reuse,
     )
     compiled(
         a_tensor_gpu=a_tensor_gpu,
@@ -2788,6 +2823,7 @@ def _dense_gemm_launch_op(
     split_k_atomic_bf16: bool,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
     stream_int: Optional[int],
 ) -> None:
     _dense_gemm_launch_flat(
@@ -2820,6 +2856,7 @@ def _dense_gemm_launch_op(
         split_k_atomic_bf16,
         load_path,
         swap_ab,
+        sfb_k_reuse,
         stream_int,
     )
 
@@ -2855,6 +2892,7 @@ def _dense_gemm_launch_fake(
     split_k_atomic_bf16: bool,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
     stream_int: Optional[int],
 ) -> None:
     return None
@@ -2938,6 +2976,7 @@ def _dense_gemm_launch_functional_op(
     split_k_atomic_bf16: bool,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
     stream_int: Optional[int],
 ) -> torch.Tensor:
     m = int(a_tensor_gpu.shape[0])
@@ -2992,6 +3031,7 @@ def _dense_gemm_launch_functional_op(
         split_k_atomic_bf16,
         load_path,
         swap_ab,
+        sfb_k_reuse,
         stream_int,
     )
     if split_k_output and not split_k_atomic_bf16:
@@ -3030,6 +3070,7 @@ def _dense_gemm_launch_functional_fake(
     split_k_atomic_bf16: bool,
     load_path: str,
     swap_ab: bool,
+    sfb_k_reuse: bool,
     stream_int: Optional[int],
 ) -> torch.Tensor:
     del (
@@ -3058,6 +3099,7 @@ def _dense_gemm_launch_functional_fake(
         split_k_atomic_bf16,
         load_path,
         swap_ab,
+        sfb_k_reuse,
         stream_int,
     )
     return _empty_dense_gemm_output(
@@ -3223,6 +3265,7 @@ def dense_gemm(
     expected_m: Optional[int] = None,
     load_path: Optional[Literal["tma", "cpasync"]] = None,
     swap_ab: Optional[bool] = None,
+    sfb_k_replicated: bool = False,
     stream: object = None,
 ) -> torch.Tensor:
     """Execute dense block-scaled GEMM for one expert-major batch stack.
@@ -3273,6 +3316,9 @@ def dense_gemm(
             swap_ab = default_plan.swap_ab if mma_tiler_mn[1] < 64 else False
     assert load_path is not None
     assert swap_ab is not None
+    # k-reuse relies on SFB being the 128x128-block weight operand; with
+    # swap_ab the smem B slot holds activations, so force it off there.
+    sfb_k_reuse = bool(sfb_k_replicated) and not swap_ab and is_mxfp8
     if alpha_dtype is None:
         alpha_dtype = "float32" if alpha is None else str(alpha.dtype).split(".")[-1]
     policy = _dense_gemm_policy_for(
@@ -3346,6 +3392,7 @@ def dense_gemm(
             policy.split_k_atomic_bf16,
             load_path,
             swap_ab,
+            sfb_k_reuse,
             stream_int,
         )
     split_storage = None
@@ -3415,6 +3462,7 @@ def dense_gemm(
         policy.split_k_atomic_bf16,
         load_path,
         swap_ab,
+        sfb_k_reuse,
         stream_int,
     )
     result = out

--- a/tests/test_w4a8_rp_inverse_mapping.py
+++ b/tests/test_w4a8_rp_inverse_mapping.py
@@ -1,0 +1,110 @@
+"""Verified inverse mappings for the W4A8-MX N256/K128 repacked layout.
+
+The w4a8_mx weight prep repacks logical FP4 weights and e8m0 grids in place
+(`_logical_weight_to_w4a8_rp_inplace`, `_e8m0_scale_to_w4a8_sfb_inplace`).
+Both transforms are pure power-of-two permutations, so a logical
+(row, int32-word) or (row, scale-col) coordinate maps to the repacked buffer
+with a handful of bitfield ops. These are the formulas a tiny-decode kernel
+(micro-class) needs to consume the repacked buffers directly, with zero extra
+weight memory.
+
+Verified bit-exact against the real prep kernels on:
+  - w13 orientation (rows=2n, k_dim=k, row_rotation=n for the w31 gated layout)
+  - w2 orientation  (rows=k,  k_dim=n, no rotation)
+  - both e8m0 grids
+Note: the sfb prep clamps e8m0 bytes >= 249 (2^122+; unreachable for real
+weights), so synthetic inputs must stay below that.
+
+Coalescing caveat for kernel authors: within one logical row, consecutive
+int32 words sit 4 words (16 B) apart in the repacked layout; the 16 B
+rp-contiguous unit covers logical rows {r, r+8, r+16, r+24} at one k-window
+(the n8i mode). A warp that wants full sectors must therefore cover four
+8-apart rows per instruction instead of one row per warp.
+"""
+
+import pytest
+import torch
+
+from b12x.integration.tp_moe import (
+    _e8m0_scale_to_w4a8_sfb_inplace,
+    _logical_weight_to_w4a8_rp_inplace,
+)
+
+
+def rp_word_offset(r: int, w: int, *, rows: int, k_tiles: int, rot: int) -> int:
+    """Logical (row, int32-word) -> flat int32-word offset in the rp buffer."""
+    p = (r - rot) % rows
+    nt, row = p >> 8, p & 255
+    n8c, n8i, r8 = row >> 5, (row >> 3) & 3, row & 7
+    kt, k32, cgrp = w >> 4, (w & 15) >> 2, w & 3
+    idx = n8i | (cgrp << 2) | (r8 << 4) | (n8c << 7) | (k32 << 10)
+    return (nt * k_tiles + kt) * 4096 + idx
+
+
+def sfb_byte_offset(r: int, c: int, *, rows: int, k_tiles: int, rot: int) -> int:
+    """Logical (row, per-32 scale col) -> flat byte offset in the sfb buffer."""
+    p = (r - rot) % rows
+    nt, q = p >> 8, p & 255
+    n32, row8 = q >> 3, q & 7
+    kt, kb = c >> 2, c & 3
+    return kb | (row8 << 2) | (n32 << 5) | ((nt * k_tiles + kt) << 10)
+
+
+@pytest.mark.parametrize(
+    "rows,kdim,rot",
+    [(2048, 4096, 1024), (4096, 1024, 0)],
+    ids=["w13_rotated", "w2"],
+)
+def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
+    torch.manual_seed(0)
+    dev = torch.device("cuda")
+    logical = torch.randint(0, 256, (1, rows, kdim // 2), dtype=torch.uint8, device=dev)
+    qwords = logical.clone().view(torch.int32).reshape(1, rows, kdim // 8)
+    rp = _logical_weight_to_w4a8_rp_inplace(
+        logical.clone(), size_k=kdim, size_n=rows, row_rotation=(rot or None)
+    )
+    rp_flat = rp.reshape(-1).view(torch.int32)
+    k_tiles = kdim // 128
+    rs = torch.randint(0, rows, (4096,))
+    ws = torch.randint(0, kdim // 8, (4096,))
+    offs = torch.tensor(
+        [
+            rp_word_offset(int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot)
+            for r, w in zip(rs, ws)
+        ],
+        device=dev,
+    )
+    assert torch.equal(rp_flat[offs], qwords[0][rs.to(dev), ws.to(dev)])
+
+
+@pytest.mark.parametrize(
+    "rows,kdim,rot",
+    [(2048, 4096, 1024), (4096, 1024, 0)],
+    ids=["w13_rotated", "w2"],
+)
+def test_sfb_grid_inverse(rows: int, kdim: int, rot: int) -> None:
+    torch.manual_seed(0)
+    dev = torch.device("cuda")
+    scale_cols = kdim // 32
+    scale = (
+        torch.arange(rows * scale_cols, dtype=torch.int32, device=dev).reshape(
+            1, rows, scale_cols
+        )
+        % 200
+        + 1
+    ).to(torch.uint8)
+    sfb = _e8m0_scale_to_w4a8_sfb_inplace(
+        scale.clone(), weight_E=1, rows=rows, k_dim=kdim, row_rotation=(rot or None)
+    )
+    sfb_flat = sfb.reshape(-1).view(torch.uint8)
+    k_tiles = kdim // 128
+    rs = torch.randint(0, rows, (4096,))
+    cs = torch.randint(0, scale_cols, (4096,))
+    offs = torch.tensor(
+        [
+            sfb_byte_offset(int(r), int(c), rows=rows, k_tiles=k_tiles, rot=rot)
+            for r, c in zip(rs, cs)
+        ],
+        device=dev,
+    )
+    assert torch.equal(sfb_flat[offs], scale[0][rs.to(dev), cs.to(dev)])


### PR DESCRIPTION
Two changes to the dense MXFP8 linear path, both bit-exact, measured on DSV4-Flash TP2 shapes on RTX PRO 6000 Blackwell (sm_120):

## 1. Tile the dense MXFP8 input quantizer (`a67e5bd`)

`_quantize_dense_tk_to_tk_kernel` launched one CTA per (token, 32-elem group) — ~1.05M CTAs at M=8192/K=4096 — and cost 229 ms per 4-step DS4 TP2 prefill window vs 14 ms for DeepGEMM's per-token-group quant. Retiled to `BLOCK_M=32 x GROUPS=16` per program with masked edges and vectorized stores (incl. the swizzled `scale_mma` layout):

| K (M=8192) | before | after | speedup |
|---|---:|---:|---:|
| 1024 | 122.5 us | 11.9 us | 10.3x |
| 4096 | 483.6 us | 13.7 us | 35.2x |
| 8192 | 965.5 us | 118.1 us | 8.2x |

Bit-exact vs the old kernel and an independent torch reference (values, `scale_rows`, swizzled `scale_mma`), incl. M=1/4/5/33/100/8191 and K=1152.

**E2E: DS4-Flash TP2 A8 full-B12X standalone prefill 12,468/11,971/11,133 → 13,441/12,940/11,948 tok/s @ 8k/64k/128k** (Lucifer CUTLASS parity at 8k, +2.5%/+2.0% above it at 64k/128k). Decode cc1 unchanged (ITL 7.72 ms). 30k-ctx coherence clean.

## 2. Stage-bulk SF copies + k-replicated SFB reuse (`49b453c`)

NCU showed the mainloop issuing 37.7M scalar `LDS` (per-byte SF loads) vs DeepGEMM's 1.3M for the same GEMM. Two bit-exact reductions:
- SF register fragments for the whole acquired pipeline stage load in one bulk copy instead of per-`k_block` slices.
- `sfb_k_replicated` flag (passed by `block_fp8_linear`): 128x128-block weight scales are expanded to per-32 replicas, so the four SFB bytes per 128-wide k tile are identical by construction — load one per stage and feed every k block from it. Guarded off under `swap_ab`. LDS drops to 9.4M.

Honest note: wall-clock is **unchanged** by (2) — SM throughput stays ~73%, which falsifies instruction count as the large-M limiter. Full NCU analysis (speed-of-light, opcode mix, stall profile), the falsified-lever list (tile sweep, tile_k, prefetch, atom_shape, region-illegal SF pre-binding), and a concrete mainloop rewrite spec for reaching DeepGEMM at M>=4096 natively are written up here:

https://github.com/voipmonitor/rtx6kpro/blob/master/optimization/b12x-dense-fp8-gemm-vs-deepgemm.md

## Validation

- `tests/test_gemm_block_fp8_linear.py`, `tests/test_fp8_quant_deepgemm_parity.py`, `tests/test_block_fp8_linear_scratch_bindings.py`, `tests/test_dense_gemm_expected_m.py`: **5 passed, 1 failed** — `test_block_fp8_linear_small_live_m_reuses_prefill_dense_kernel` fails identically on stock `77bd50e` in the same container (pre-existing in this environment, not introduced here).
- Byte-identical GEMM outputs with the flag on vs off on packer-built weights (all four DSV4 TP2 dense shapes, M=8192).
- Served E2E on DSV4-Flash TP2 A8 (B12X_MLA_SPARSE + b12x MoE + b12x linear) for prefill/decode/coherence benches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)