### PR TITLE
feat(moe): rp-native tiny-decode kernel for w4a8_mx (M=1) — A8 decode reaches A16 parity

### DIFF
--- a/b12x/cute/fp4.py
+++ b/b12x/cute/fp4.py
@@ -1297,6 +1297,54 @@ def red_add_global_release_i32(addr: Int64, val: Int32, *, loc=None, ip=None):
 
 
 @dsl_user_op
+def red_add_global_f32(addr: Int64, val: Float32, *, loc=None, ip=None):
+    """No-return global fp32 add reduction (relaxed device scope)."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Float32(val).ir_value(loc=loc, ip=ip),
+        ],
+        "red.global.add.f32 [$0], $1;",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cvt_bf16x2_to_f16x2(packed: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Convert a u32 holding two bf16 (lo, hi) into an f16x2 u32 (lo, hi)."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(packed).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 blo, bhi, hlo, hhi;
+                .reg .f32 flo, fhi;
+                mov.b32 {blo, bhi}, $1;
+                cvt.f32.bf16 flo, blo;
+                cvt.f32.bf16 fhi, bhi;
+                cvt.rn.f16.f32 hlo, flo;
+                cvt.rn.f16.f32 hhi, fhi;
+                mov.b32 $0, {hlo, hhi};
+            }
+            """,
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
 def red_add_global_bf16x2(addr: Int64, packed: Uint32, *, loc=None, ip=None):
     """No-return global atomic add of a packed bf16x2 value (2 contiguous bf16).
 

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -2413,6 +2413,10 @@ def _plan_core_workspace(
         packed_input_shape = (state_E, max_rows, k // 2)
         packed_input_dtype = torch.uint8
         micro_intermediate_elements = state_E * n
+        if _tiny_rp_enabled() and quant_mode == "w4a8_mx":
+            micro_intermediate_elements = max(
+                micro_intermediate_elements, max_rows * 2 * n
+            )
         if direct_micro_candidate:
             fc2_n_chunks = (n // 2 + 127) // 128
             micro_intermediate_elements = max(
@@ -3794,6 +3798,20 @@ def _get_weight_views(
     """
     global _LAST_WEIGHTS
     quant_mode = _normalize_quant_mode(quant_mode)
+    if quant_mode == "w4a8_mx" and w1_fp4.dim() != 3:
+        # In-place N256/K128-repacked storage (tiny_rp band): view flat as the
+        # source-native 3-D shape for pointer plumbing. The prep rotation
+        # already normalized the half order -- never flip rp storage in place.
+        e_dim = w1_fp4.shape[0]
+        w1_fp4 = w1_fp4.view(torch.uint8).reshape(
+            e_dim, activation_spec.w1_rows(n), k // 2
+        )
+        w2_fp4 = w2_fp4.view(torch.uint8).reshape(e_dim, k, n // 2)
+        w1_blockscale = w1_blockscale.view(torch.uint8).reshape(
+            e_dim, activation_spec.w1_rows(n), k // 32
+        )
+        w2_blockscale = w2_blockscale.view(torch.uint8).reshape(e_dim, k, n // 32)
+        w13_layout = "w13"
     w13_layout = _normalize_w13_layout_for_activation(
         activation_spec.activation,
         w13_layout,
@@ -4371,6 +4389,10 @@ def _resolve_workspace_layout(
         # W4A8-MX sizes so compacted checkpoints never require a second
         # source-native copy merely to enter the tiny-decode band.
         if normalized_quant_mode == "w4a8_mx":
+            if _tiny_rp_enabled() and _tiny_rp_supports(
+                num_tokens=num_tokens, k=k, n=n, activation=activation
+            ):
+                return "micro", max(1, routed_rows), max(1, routed_rows)
             tile_m, _ = _select_dynamic_tile_mn(
                 routed_rows,
                 n,
@@ -7909,6 +7931,183 @@ def _launch_compact_micro_flat(
     )
 
 
+def _tiny_rp_enabled() -> bool:
+    return os.environ.get("B12X_W4A8_TINY_RP", "0") == "1"
+
+
+def _tiny_rp_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
+    return (
+        num_tokens == 1
+        and activation == "silu"
+        and k % 256 == 0
+        and n % 256 == 0
+        and (k // 128) % 4 == 0
+        and (n // 128) % 2 == 0
+    )
+
+
+_TINY_RP_KERNEL_CACHE: dict = {}
+
+
+def _get_tiny_rp_kernel(
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    *,
+    device: torch.device | None = None,
+):
+    from b12x.moe.fused.tiny_rp import MoETinyRpKernelBackend
+
+    compiled_phases = []
+    for phase in (1, 2):
+        kernel = MoETinyRpKernelBackend(compile_time_phase=phase)
+        kernel.configure(m, k, n, num_topk, weight_E, device=device)
+        cache_key = ("tiny_rp",) + kernel.__cache_key__
+        cached = _TINY_RP_KERNEL_CACHE.get(cache_key)
+        if cached is not None:
+            compiled_phases.append(cached)
+            continue
+
+        def dummy(dt):
+            return make_ptr(dt, 16, cute.AddressSpace.gmem, assumed_align=16)
+
+        raise_if_kernel_resolution_frozen(
+            "cute.compile", target=kernel, cache_key=cache_key
+        )
+        compiled = b12x_compile(
+            kernel,
+            dummy(cutlass.BFloat16),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Float32),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Uint8),
+            dummy(cutlass.Int32),
+            dummy(cutlass.Float32),
+            dummy(cutlass.BFloat16),
+            current_cuda_stream(),
+            compile_spec=KernelCompileSpec.from_key(
+                "integration.tp_moe.tiny_rp",
+                1,
+                cache_key,
+            ),
+        )
+        _TINY_RP_KERNEL_CACHE[cache_key] = compiled
+        compiled_phases.append(compiled)
+    return compiled_phases[0], compiled_phases[1]
+
+
+def _launch_tiny_rp_flat(
+    *,
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+) -> None:
+    from b12x.moe.fused.tiny_rp import MoETinyRpKernelBackend
+
+    del barrier_count, barrier_epoch
+    compiled_fc1, compiled_fc2 = _get_tiny_rp_kernel(
+        weight_E, m, k, n, num_topk, device=a.device
+    )
+    rt = m * num_topk
+    inter = micro_intermediate.view(torch.float32).reshape(-1)[: rt * 2 * n]
+    MoETinyRpKernelBackend.launch(
+        compiled_fc1,
+        compiled_fc2,
+        x=a.reshape(-1),
+        w13_rp=w1_storage,
+        sfb13=w1_scale_storage,
+        inter_fp32=inter,
+        w2_rp=w2_storage,
+        sfb2=w2_scale_storage,
+        topk_ids=launch_ids,
+        topk_weights=flat_weights,
+        out=scatter_output.reshape(-1),
+    )
+
+
+@torch.library.custom_op(
+    "b12x::tp_moe_tiny_rp_launch",
+    mutates_args="unknown",
+)
+def _tp_moe_tiny_rp_launch_op(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    volatile_launch_state: bool,
+) -> None:
+    del volatile_launch_state
+    _launch_tiny_rp_flat(
+        barrier_count=barrier_count,
+        barrier_epoch=barrier_epoch,
+        micro_intermediate=micro_intermediate,
+        w1_storage=w1_storage,
+        w1_scale_storage=w1_scale_storage,
+        w2_storage=w2_storage,
+        w2_scale_storage=w2_scale_storage,
+        a=a,
+        launch_ids=launch_ids,
+        flat_weights=flat_weights,
+        scatter_output=scatter_output,
+        weight_E=weight_E,
+        m=m,
+        k=k,
+        n=n,
+        num_topk=num_topk,
+    )
+
+
+@_tp_moe_tiny_rp_launch_op.register_fake
+def _tp_moe_tiny_rp_launch_fake(
+    barrier_count: torch.Tensor,
+    barrier_epoch: torch.Tensor,
+    micro_intermediate: torch.Tensor,
+    w1_storage: torch.Tensor,
+    w1_scale_storage: torch.Tensor,
+    w2_storage: torch.Tensor,
+    w2_scale_storage: torch.Tensor,
+    a: torch.Tensor,
+    launch_ids: torch.Tensor,
+    flat_weights: torch.Tensor,
+    scatter_output: torch.Tensor,
+    weight_E: int,
+    m: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    volatile_launch_state: bool,
+) -> None:
+    return None
+
+
 @torch.library.custom_op(
     "b12x::tp_moe_compact_micro_launch",
     mutates_args="unknown",
@@ -8042,6 +8241,35 @@ def _launch_micro(
 ) -> None:
     del stream, unit_scale_contract
     quant_mode = _normalize_quant_mode(quant_mode)
+    if quant_mode == "w4a8_mx":
+        # The w4a8_mx tiny band reaches the compact family only via the
+        # tiny_rp resolve gate; its weights are N256/K128-repacked, which
+        # direct-micro cannot read.
+        if flat_ids.dtype == torch.int32 and flat_ids.is_contiguous():
+            launch_ids = flat_ids
+        else:
+            launch_ids = workspace.compact_topk_ids[: flat_ids.numel()]
+            launch_ids.copy_(flat_ids.to(torch.int32))
+        torch.ops.b12x.tp_moe_tiny_rp_launch(
+            workspace.barrier_count,
+            workspace.barrier_epoch,
+            workspace.micro_intermediate,
+            weights.w1_storage,
+            weights.w1_scale_storage,
+            weights.w2_storage,
+            weights.w2_scale_storage,
+            a,
+            launch_ids,
+            flat_weights,
+            scatter_output,
+            weight_E,
+            m,
+            k,
+            n,
+            num_topk,
+            workspace.volatile_launch_state,
+        )
+        return
     activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
     micro_cls = activation_spec.micro_kernel_cls
     del routed_rows, topk_ids_dtype

--- a/b12x/moe/fused/tiny_rp.py
+++ b/b12x/moe/fused/tiny_rp.py
@@ -1,0 +1,410 @@
+"""MoETinyRpKernelBackend — rp-native tiny-decode (M<=4) W4A8-MX MoE for SM120.
+
+Consumes the N256/K128 in-place-repacked FP4 weights and e8m0 sfb grids
+directly (inverse mappings verified in tests/test_w4a8_rp_inverse_mapping.py),
+with BF16 activations (no input quantization) and f32 accumulation. Two plain
+(non-cooperative) launches: FC1 dots gate+up rows into an fp32 intermediate,
+FC2 applies SiLU inline and folds router-weighted partials into the bf16
+output via scatter-add. The wrapper zeroes the intermediate and output first;
+there are no grid barriers and no CTA co-residency assumptions, so the
+kernels are safe on busy serving streams.
+
+Thread mapping (256 threads/CTA), the core of the rp coalescing story: one rp
+(nt, kt) tile is 4096 contiguous int32 words whose flat index decomposes as
+``k32<<10 | n8c<<7 | r8<<4 | cgrp<<2 | n8i``. Thread t = (n8c=t>>5, r8=(t>>2)&7,
+cgrp=t&3) issues one 16 B ``ld.global.nc.v4`` per k32 covering n8i=0..3 — four
+8-apart logical rows at one k window — so a warp (fixed n8c) covers a fully
+coalesced 512 B run per k32, and the 4-lane cgrp butterfly folds the k dim.
+
+The prep rotation normalizes both declared w13 layouts to the same rp tile
+order (tiles [0, N/256) hold the "up" rows, [N/256, 2N/256) the "gate" rows of
+the same channels), so FC1 stores inter rows through ``(p + n) % 2n`` and FC2
+reads gate at [0, n), up at [n, 2n) unconditionally.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import Float32
+from cutlass.cutlass_dsl import Int32, Int64
+
+from b12x.cute.utils import current_cuda_stream, make_ptr
+from b12x.cute.fp4 import (
+    cvt_bf16x2_to_f16x2,
+    cvt_e8m0x4_to_f32x4,
+    fp4_dot4_sum_f32acc,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    pack_f32x2_to_f16x2,
+    red_add_global_f32,
+    scatter_add_bf16x2,
+    warp_reduce,
+)
+
+_BLOCK_THREADS = 256
+_FC1_KT_PER_TASK = 4
+_FC2_KT_PER_TASK = 2
+
+
+class MoETinyRpKernelBackend:
+    """Tiny-M (decode) W4A8-MX kernel reading the repacked weight layout."""
+
+    def __init__(
+        self,
+        *,
+        activation: str = "silu",
+        w13_layout: str = "w31",
+        compile_time_phase: int = 1,
+    ):
+        if activation != "silu":
+            raise ValueError(f"tiny_rp supports silu only, got {activation!r}")
+        if int(compile_time_phase) not in (1, 2):
+            raise ValueError(f"unsupported tiny_rp phase {compile_time_phase!r}")
+        self.compile_time_phase = int(compile_time_phase)
+        self.activation = activation
+        self.w13_layout = w13_layout
+        self._cfg_key = None
+        self._c = None
+        self.grid_x = 0
+
+    def configure(
+        self,
+        m: int,
+        k: int,
+        n: int,
+        num_topk: int,
+        weight_E: int,
+        *,
+        device: torch.device | None = None,
+    ) -> None:
+        del device
+        if k % 256 != 0 or n % 256 != 0:
+            raise ValueError("tiny_rp requires k % 256 == 0 and n % 256 == 0")
+        if m < 1 or m > 4:
+            raise ValueError("tiny_rp supports 1 <= m <= 4")
+        rt = m * num_topk
+        kt13 = k // 128
+        kt2 = n // 128
+        if kt13 % _FC1_KT_PER_TASK != 0 or kt2 % _FC2_KT_PER_TASK != 0:
+            raise ValueError("tiny_rp k-tile counts not divisible by task sizes")
+        cfg = dict(
+            m=m,
+            k=k,
+            n=n,
+            two_n=2 * n,
+            num_topk=num_topk,
+            weight_E=weight_E,
+            rt=rt,
+            nt13=(2 * n) // 256,
+            kt13=kt13,
+            fc1_ktg=kt13 // _FC1_KT_PER_TASK,
+            nt2=k // 256,
+            kt2=kt2,
+            fc2_ktg=kt2 // _FC2_KT_PER_TASK,
+            w13_words=(2 * n) * k // 8,
+            w2_words=k * n // 8,
+            sfb13_bytes=(2 * n) * (k // 32),
+            sfb2_bytes=k * (n // 32),
+            fc1_tasks=rt * ((2 * n) // 256) * (kt13 // _FC1_KT_PER_TASK),
+            fc2_tasks=rt * (k // 256) * (kt2 // _FC2_KT_PER_TASK),
+        )
+        self._c = cfg
+        self._cfg_key = tuple(sorted(cfg.items()))
+        self.grid_x = (
+            cfg["fc1_tasks"] if self.compile_time_phase == 1 else cfg["fc2_tasks"]
+        )
+
+    @property
+    def __cache_key__(self):
+        return (
+            self.activation,
+            self.w13_layout,
+            self.compile_time_phase,
+            self._cfg_key,
+            self.grid_x,
+        )
+
+    @cute.jit
+    def _row_block_dot(
+        self,
+        tile_word: Int64,
+        srow: Int64,
+        n8c: Int32,
+        r8: Int32,
+        cgrp: Int32,
+        x0_0: cutlass.Uint32, x1_0: cutlass.Uint32, x2_0: cutlass.Uint32, x3_0: cutlass.Uint32,
+        x0_1: cutlass.Uint32, x1_1: cutlass.Uint32, x2_1: cutlass.Uint32, x3_1: cutlass.Uint32,
+        x0_2: cutlass.Uint32, x1_2: cutlass.Uint32, x2_2: cutlass.Uint32, x3_2: cutlass.Uint32,
+        x0_3: cutlass.Uint32, x1_3: cutlass.Uint32, x2_3: cutlass.Uint32, x3_3: cutlass.Uint32,
+    ):
+        """Dot 4 n8i rows (v=0..3) x 128 k window against packed activations.
+
+        Activation f16x2 quads are per k32 (x*_<k32>). Returns 4 row partials.
+        """
+        word_off = Int64(n8c * Int32(128) + r8 * Int32(16) + cgrp * Int32(4)) * Int64(4)
+        acc = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
+        xq = (
+            (x0_0, x1_0, x2_0, x3_0),
+            (x0_1, x1_1, x2_1, x3_1),
+            (x0_2, x1_2, x2_2, x3_2),
+            (x0_3, x1_3, x2_3, x3_3),
+        )
+        for v in cutlass.range_constexpr(4):
+            sv = ld_global_nc_u32(srow + Int64(v * 32))
+            sk = cvt_e8m0x4_to_f32x4(sv)
+            accv = Float32(0.0)
+            for k32 in cutlass.range_constexpr(4):
+                words = ld_global_nc_v4_u32(tile_word + Int64(k32 * 4096) + word_off)
+                x0, x1, x2, x3 = xq[k32]
+                accv += sk[k32] * fp4_dot4_sum_f32acc(words[v], x0, x1, x2, x3)
+            acc[v] += accv
+        return acc[0], acc[1], acc[2], acc[3]
+
+    @cute.kernel
+    def kernel(
+        self,
+        a_input: cute.Tensor,       # bf16 [m*k]
+        w13: cute.Tensor,           # u8 rp bytes, expert-major
+        sfb13: cute.Tensor,         # u8 sfb bytes, expert-major
+        inter: cute.Tensor,         # f32 [rt * 2n] (pre-zeroed for phase 1)
+        w2: cute.Tensor,            # u8 rp bytes
+        sfb2: cute.Tensor,          # u8 sfb bytes
+        topk_ids: cute.Tensor,      # i32 [rt]
+        topk_weights: cute.Tensor,  # f32 [rt]
+        out: cute.Tensor,           # bf16 [m*k] (pre-zeroed for phase 2)
+    ):
+        c = self._c
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        n8c = tidx // Int32(32)
+        r8 = (tidx // Int32(4)) % Int32(8)
+        cgrp = tidx % Int32(4)
+
+        x_base = get_ptr_as_int64(a_input, Int32(0))
+        w13_base = get_ptr_as_int64(w13, Int32(0))
+        sfb13_base = get_ptr_as_int64(sfb13, Int32(0))
+        inter_base = get_ptr_as_int64(inter, Int32(0))
+        w2_base = get_ptr_as_int64(w2, Int32(0))
+        sfb2_base = get_ptr_as_int64(sfb2, Int32(0))
+        out_base = get_ptr_as_int64(out, Int32(0))
+
+        if cutlass.const_expr(self.compile_time_phase == 1):
+            # ---- FC1: block = (rt, nt13, ktg) ----
+            fc1_per_rt = Int32(c["nt13"] * c["fc1_ktg"])
+            rt_idx = bidx // fc1_per_rt
+            rem = bidx % fc1_per_rt
+            nt = rem // Int32(c["fc1_ktg"])
+            ktg = rem % Int32(c["fc1_ktg"])
+            eid = Int64(Int32(topk_ids[rt_idx]))
+            tok = rt_idx // Int32(c["num_topk"])
+            we_base = w13_base + eid * Int64(c["w13_words"] * 4)
+            se_base = sfb13_base + eid * Int64(c["sfb13_bytes"])
+            xt_base = x_base + Int64(tok) * Int64(c["k"] * 2)
+            srow_base = se_base + Int64(r8 * Int32(4) + n8c * Int32(128))
+
+            acc0 = Float32(0.0)
+            acc1 = Float32(0.0)
+            acc2 = Float32(0.0)
+            acc3 = Float32(0.0)
+            for kt_i in cutlass.range_constexpr(_FC1_KT_PER_TASK):
+                kt = ktg * Int32(_FC1_KT_PER_TASK) + Int32(kt_i)
+                col_tile = nt * Int32(c["kt13"]) + kt
+                tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
+                srow = srow_base + Int64(col_tile) * Int64(1024)
+                xs = []
+                for k32 in cutlass.range_constexpr(4):
+                    ax = xt_base + (
+                        Int64(kt * Int32(128) + cgrp * Int32(8)) + Int64(k32 * 32)
+                    ) * Int64(2)
+                    bq = ld_global_nc_v4_u32(ax)
+                    xs.append(
+                        (
+                            cvt_bf16x2_to_f16x2(bq[0]),
+                            cvt_bf16x2_to_f16x2(bq[1]),
+                            cvt_bf16x2_to_f16x2(bq[2]),
+                            cvt_bf16x2_to_f16x2(bq[3]),
+                        )
+                    )
+                d0, d1, d2, d3 = self._row_block_dot(
+                    tile_word, srow, n8c, r8, cgrp,
+                    xs[0][0], xs[0][1], xs[0][2], xs[0][3],
+                    xs[1][0], xs[1][1], xs[1][2], xs[1][3],
+                    xs[2][0], xs[2][1], xs[2][2], xs[2][3],
+                    xs[3][0], xs[3][1], xs[3][2], xs[3][3],
+                )
+                acc0 += d0
+                acc1 += d1
+                acc2 += d2
+                acc3 += d3
+            acc0 = warp_reduce(acc0, lambda a, b: a + b, width=4)
+            acc1 = warp_reduce(acc1, lambda a, b: a + b, width=4)
+            acc2 = warp_reduce(acc2, lambda a, b: a + b, width=4)
+            acc3 = warp_reduce(acc3, lambda a, b: a + b, width=4)
+            if cgrp == Int32(0):
+                ibase_rt = inter_base + Int64(rt_idx) * Int64(c["two_n"] * 4)
+                accs = (acc0, acc1, acc2, acc3)
+                for v in cutlass.range_constexpr(4):
+                    p = nt * Int32(256) + n8c * Int32(32) + Int32(v * 8) + r8
+                    r_log = p + Int32(c["n"])
+                    if r_log >= Int32(c["two_n"]):
+                        r_log -= Int32(c["two_n"])
+                    red_add_global_f32(ibase_rt + Int64(r_log) * Int64(4), accs[v])
+
+        if cutlass.const_expr(self.compile_time_phase == 2):
+            # ---- FC2: block = (rt, nt2, ktg2) ----
+            fc2_per_rt = Int32(c["nt2"] * c["fc2_ktg"])
+            rt_idx = bidx // fc2_per_rt
+            rem = bidx % fc2_per_rt
+            nt = rem // Int32(c["fc2_ktg"])
+            ktg = rem % Int32(c["fc2_ktg"])
+            eid = Int64(Int32(topk_ids[rt_idx]))
+            tok = rt_idx // Int32(c["num_topk"])
+            rw = Float32(topk_weights[rt_idx])
+            we_base = w2_base + eid * Int64(c["w2_words"] * 4)
+            se_base = sfb2_base + eid * Int64(c["sfb2_bytes"])
+            srow_base = se_base + Int64(r8 * Int32(4) + n8c * Int32(128))
+            ibase = rt_idx * Int32(c["two_n"])
+
+            acc0 = Float32(0.0)
+            acc1 = Float32(0.0)
+            acc2 = Float32(0.0)
+            acc3 = Float32(0.0)
+            for kt_i in cutlass.range_constexpr(_FC2_KT_PER_TASK):
+                kt = ktg * Int32(_FC2_KT_PER_TASK) + Int32(kt_i)
+                col_tile = nt * Int32(c["kt2"]) + kt
+                tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
+                srow = srow_base + Int64(col_tile) * Int64(1024)
+                xs = []
+                for k32 in cutlass.range_constexpr(4):
+                    ich = ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
+                    quads = []
+                    for jp in cutlass.range_constexpr(4):
+                        g0 = Float32(inter[ich + Int32(2 * jp)])
+                        g1 = Float32(inter[ich + Int32(2 * jp + 1)])
+                        u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
+                        u1 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)])
+                        s0 = Float32(1.0) / (
+                            Float32(1.0) + cute.math.exp(-g0, fastmath=False)
+                        )
+                        s1 = Float32(1.0) / (
+                            Float32(1.0) + cute.math.exp(-g1, fastmath=False)
+                        )
+                        a0 = s0 * g0 * u0 * rw
+                        a1 = s1 * g1 * u1 * rw
+                        quads.append(pack_f32x2_to_f16x2(a0, a1))
+                    xs.append((quads[0], quads[1], quads[2], quads[3]))
+                d0, d1, d2, d3 = self._row_block_dot(
+                    tile_word, srow, n8c, r8, cgrp,
+                    xs[0][0], xs[0][1], xs[0][2], xs[0][3],
+                    xs[1][0], xs[1][1], xs[1][2], xs[1][3],
+                    xs[2][0], xs[2][1], xs[2][2], xs[2][3],
+                    xs[3][0], xs[3][1], xs[3][2], xs[3][3],
+                )
+                acc0 += d0
+                acc1 += d1
+                acc2 += d2
+                acc3 += d3
+            acc0 = warp_reduce(acc0, lambda a, b: a + b, width=4)
+            acc1 = warp_reduce(acc1, lambda a, b: a + b, width=4)
+            acc2 = warp_reduce(acc2, lambda a, b: a + b, width=4)
+            acc3 = warp_reduce(acc3, lambda a, b: a + b, width=4)
+            # pair consecutive output rows: partner lane differs in r8 bit0 (lane^4)
+            o0 = cute.arch.shuffle_sync_bfly(acc0, offset=4)
+            o1 = cute.arch.shuffle_sync_bfly(acc1, offset=4)
+            o2 = cute.arch.shuffle_sync_bfly(acc2, offset=4)
+            o3 = cute.arch.shuffle_sync_bfly(acc3, offset=4)
+            if cgrp == Int32(0):
+                if (r8 % Int32(2)) == Int32(0):
+                    ob = out_base + Int64(tok) * Int64(c["k"] * 2)
+                    accs = (acc0, acc1, acc2, acc3)
+                    others = (o0, o1, o2, o3)
+                    for v in cutlass.range_constexpr(4):
+                        p2 = nt * Int32(256) + n8c * Int32(32) + Int32(v * 8) + r8
+                        scatter_add_bf16x2(
+                            ob + Int64(p2) * Int64(2), accs[v], others[v]
+                        )
+
+    @cute.jit
+    def __call__(
+        self,
+        x_ptr: cute.Pointer,
+        w13_ptr: cute.Pointer,
+        sfb13_ptr: cute.Pointer,
+        inter_ptr: cute.Pointer,
+        w2_ptr: cute.Pointer,
+        sfb2_ptr: cute.Pointer,
+        tid_ptr: cute.Pointer,
+        tw_ptr: cute.Pointer,
+        out_ptr: cute.Pointer,
+        stream,
+    ):
+        c = self._c
+        a_input = cute.make_tensor(x_ptr, cute.make_layout(Int32(c["m"] * c["k"])))
+        w13 = cute.make_tensor(
+            w13_ptr, cute.make_layout(Int64(c["weight_E"] * c["w13_words"] * 4))
+        )
+        sfb13 = cute.make_tensor(
+            sfb13_ptr, cute.make_layout(Int64(c["weight_E"] * c["sfb13_bytes"]))
+        )
+        inter = cute.make_tensor(
+            inter_ptr, cute.make_layout(Int32(c["rt"] * c["two_n"]))
+        )
+        w2 = cute.make_tensor(
+            w2_ptr, cute.make_layout(Int64(c["weight_E"] * c["w2_words"] * 4))
+        )
+        sfb2 = cute.make_tensor(
+            sfb2_ptr, cute.make_layout(Int64(c["weight_E"] * c["sfb2_bytes"]))
+        )
+        topk_ids = cute.make_tensor(tid_ptr, cute.make_layout(Int32(c["rt"])))
+        topk_weights = cute.make_tensor(tw_ptr, cute.make_layout(Int32(c["rt"])))
+        out = cute.make_tensor(out_ptr, cute.make_layout(Int32(c["m"] * c["k"])))
+
+        self.kernel(
+            a_input, w13, sfb13, inter, w2, sfb2, topk_ids, topk_weights, out,
+        ).launch(
+            grid=(Int32(self.grid_x), Int32(1), Int32(1)),
+            block=(_BLOCK_THREADS, 1, 1),
+            smem=0,
+            stream=stream,
+        )
+
+    @staticmethod
+    def launch(
+        compiled_fc1,
+        compiled_fc2,
+        *,
+        x: torch.Tensor,
+        w13_rp: torch.Tensor,
+        sfb13: torch.Tensor,
+        inter_fp32: torch.Tensor,
+        w2_rp: torch.Tensor,
+        sfb2: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        out: torch.Tensor,
+    ):
+        def ptr(dt, t, align=16):
+            return make_ptr(
+                dt, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=align
+            )
+
+        inter_fp32.zero_()
+        out.zero_()
+        stream = current_cuda_stream()
+        args = (
+            ptr(cutlass.BFloat16, x),
+            ptr(cutlass.Uint8, w13_rp.view(torch.uint8)),
+            ptr(cutlass.Uint8, sfb13.view(torch.uint8)),
+            ptr(cutlass.Float32, inter_fp32),
+            ptr(cutlass.Uint8, w2_rp.view(torch.uint8)),
+            ptr(cutlass.Uint8, sfb2.view(torch.uint8)),
+            ptr(cutlass.Int32, topk_ids, 4),
+            ptr(cutlass.Float32, topk_weights, 4),
+            ptr(cutlass.BFloat16, out),
+            stream,
+        )
+        compiled_fc1(*args)
+        compiled_fc2(*args)


### PR DESCRIPTION
Per your feedback on the vLLM-side attempt (local-inference-lab/vllm#70): here's the tiny-decode band as a **b12x CuTe DSL kernel integrated into the normal kernel selection** — no vLLM changes needed at all.

## What

`b12x/moe/fused/tiny_rp.py` — `MoETinyRpKernelBackend`, micro-family style, two plain launches:
- **FC1**: gate+up dots into an fp32 intermediate. Thread (n8c, r8, cgrp) issues one 16 B `ld.global.nc.v4` per k32 covering the four 8-apart logical rows of an rp word quad → warps read fully coalesced 512 B runs of the **N256/K128 in-place-repacked storage directly** (inverse mappings from `tests/test_w4a8_rp_inverse_mapping.py`); a 4-lane butterfly folds k.
- **FC2**: inline SiLU from the intermediate, `fp4_dot4` hardware decode (f16-pair math, same numerics class as w4a16), router-weighted `scatter_add_bf16x2` epilogue straight into the bf16 output.

Activations stay **BF16** (no input quantization — at M=1 they're 8 KB; skipping the MXFP8 quant removes work *and* beats the dynamic path's numerics: cos vs fp32 oracle **0.999980** vs 0.9990).

Integration: `_resolve_workspace_layout` routes the w4a8_mx tiny band to the compact family when `B12X_W4A8_TINY_RP=1` (default **off**); `_launch_micro` dispatches to the new kernel; `_get_weight_views` flat-views rp storage (and never re-flips halves in place). Two new fp4 primitives: `red_add_global_f32`, `cvt_bf16x2_to_f16x2`.

## Measured (DS4-Flash TP2 shapes, RTX PRO 6000)

| | µs/layer @ M=1 (full `b12x_moe_fp4` graph) |
|---|---:|
| w4a8_mx dynamic (today) | 37.8 |
| w4a16 fused reference | 22.5 |
| **tiny_rp (this PR)** | **20.6** |

E2E serve (hybrid DG-linear base): decode cc1 **133.7 → 140.2 tok/s**, i.e. **A8 now matches the A16 reference** (140.5, ITL 7.131 vs 7.136 ms) while keeping the A8 prefill advantage (128k prefill unchanged, 12.1k tok/s; 30k coherence clean, CJK 0).

## Notes

- A first single-launch cooperative variant (grid barrier, micro-style) **deadlocked under TP2 serving** — rank-skewed first-use compile broke CTA co-residency while the resident CTAs spun. The landed two-launch form has no co-residency assumptions and no barrier state; it also measured *faster* (20.6 vs 30.8 µs).
- M gate is 1 for now (weights re-read per routed row; the dynamic kernel stays better at M≥2). `configure()` accepts m≤4 for future batched-decode experiments.
- Follow-ups if you want them: fold the two wrapper zeros into the kernels, per-expert FC2 early start, MTP-friendly M=2–4 batching.
- Full working log incl. the Triton prototype journey and falsified variants: https://github.com/voipmonitor/rtx6kpro/blob/master/optimization/b12x-w4a8mx-tiny-decode-kernel.md

Builds on #21 (the verified inverse-mapping test this kernel consumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new tiny MoE execution path for specific small-shape workloads, improving backend flexibility and performance.
  * Expanded low-level numeric support with new packed BF16/FP16 conversion and FP32 reduction handling.
* **Bug Fixes**
  * Improved weight layout handling for certain repacked models to better match expected runtime shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->