### PR TITLE
tiny-decode: rename tiny_rp -> tiny_decode, enable by default

### DIFF
--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -2413,7 +2413,8 @@ def _plan_core_workspace(
         packed_input_shape = (state_E, max_rows, k // 2)
         packed_input_dtype = torch.uint8
         micro_intermediate_elements = state_E * n
-        if _tiny_rp_enabled() and quant_mode == "w4a8_mx":
+        if quant_mode == "w4a8_mx":
+            # tiny_decode stages fp32 [routed_rows, 2n] gate/up sums here.
             micro_intermediate_elements = max(
                 micro_intermediate_elements, max_rows * 2 * n
             )
@@ -3799,7 +3800,7 @@ def _get_weight_views(
     global _LAST_WEIGHTS
     quant_mode = _normalize_quant_mode(quant_mode)
     if quant_mode == "w4a8_mx" and w1_fp4.dim() != 3:
-        # In-place N256/K128-repacked storage (tiny_rp band): view flat as the
+        # In-place N256/K128-repacked storage (tiny_decode band): view flat as the
         # source-native 3-D shape for pointer plumbing. The prep rotation
         # already normalized the half order -- never flip rp storage in place.
         e_dim = w1_fp4.shape[0]
@@ -4389,7 +4390,7 @@ def _resolve_workspace_layout(
         # W4A8-MX sizes so compacted checkpoints never require a second
         # source-native copy merely to enter the tiny-decode band.
         if normalized_quant_mode == "w4a8_mx":
-            if _tiny_rp_enabled() and _tiny_rp_supports(
+            if _tiny_decode_enabled() and _tiny_decode_supports(
                 num_tokens=num_tokens, k=k, n=n, activation=activation
             ):
                 return "micro", max(1, routed_rows), max(1, routed_rows)
@@ -7931,11 +7932,12 @@ def _launch_compact_micro_flat(
     )
 
 
-def _tiny_rp_enabled() -> bool:
-    return os.environ.get("B12X_W4A8_TINY_RP", "0") == "1"
+def _tiny_decode_enabled() -> bool:
+    # Default on; B12X_W4A8_TINY_DECODE=0 is the kill switch.
+    return os.environ.get("B12X_W4A8_TINY_DECODE", "1") != "0"
 
 
-def _tiny_rp_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
+def _tiny_decode_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
     return (
         num_tokens == 1
         and activation == "silu"
@@ -7946,10 +7948,10 @@ def _tiny_rp_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bo
     )
 
 
-_TINY_RP_KERNEL_CACHE: dict = {}
+_TINY_DECODE_KERNEL_CACHE: dict = {}
 
 
-def _get_tiny_rp_kernel(
+def _get_tiny_decode_kernel(
     weight_E: int,
     m: int,
     k: int,
@@ -7958,14 +7960,14 @@ def _get_tiny_rp_kernel(
     *,
     device: torch.device | None = None,
 ):
-    from b12x.moe.fused.tiny_rp import MoETinyRpKernelBackend
+    from b12x.moe.fused.tiny_decode import MoETinyDecodeKernelBackend
 
     compiled_phases = []
     for phase in (1, 2):
-        kernel = MoETinyRpKernelBackend(compile_time_phase=phase)
+        kernel = MoETinyDecodeKernelBackend(compile_time_phase=phase)
         kernel.configure(m, k, n, num_topk, weight_E, device=device)
-        cache_key = ("tiny_rp",) + kernel.__cache_key__
-        cached = _TINY_RP_KERNEL_CACHE.get(cache_key)
+        cache_key = ("tiny_decode",) + kernel.__cache_key__
+        cached = _TINY_DECODE_KERNEL_CACHE.get(cache_key)
         if cached is not None:
             compiled_phases.append(cached)
             continue
@@ -7989,17 +7991,17 @@ def _get_tiny_rp_kernel(
             dummy(cutlass.BFloat16),
             current_cuda_stream(),
             compile_spec=KernelCompileSpec.from_key(
-                "integration.tp_moe.tiny_rp",
+                "integration.tp_moe.tiny_decode",
                 1,
                 cache_key,
             ),
         )
-        _TINY_RP_KERNEL_CACHE[cache_key] = compiled
+        _TINY_DECODE_KERNEL_CACHE[cache_key] = compiled
         compiled_phases.append(compiled)
     return compiled_phases[0], compiled_phases[1]
 
 
-def _launch_tiny_rp_flat(
+def _launch_tiny_decode_flat(
     *,
     barrier_count: torch.Tensor,
     barrier_epoch: torch.Tensor,
@@ -8018,15 +8020,15 @@ def _launch_tiny_rp_flat(
     n: int,
     num_topk: int,
 ) -> None:
-    from b12x.moe.fused.tiny_rp import MoETinyRpKernelBackend
+    from b12x.moe.fused.tiny_decode import MoETinyDecodeKernelBackend
 
     del barrier_count, barrier_epoch
-    compiled_fc1, compiled_fc2 = _get_tiny_rp_kernel(
+    compiled_fc1, compiled_fc2 = _get_tiny_decode_kernel(
         weight_E, m, k, n, num_topk, device=a.device
     )
     rt = m * num_topk
     inter = micro_intermediate.view(torch.float32).reshape(-1)[: rt * 2 * n]
-    MoETinyRpKernelBackend.launch(
+    MoETinyDecodeKernelBackend.launch(
         compiled_fc1,
         compiled_fc2,
         x=a.reshape(-1),
@@ -8042,10 +8044,10 @@ def _launch_tiny_rp_flat(
 
 
 @torch.library.custom_op(
-    "b12x::tp_moe_tiny_rp_launch",
+    "b12x::tp_moe_tiny_decode_launch",
     mutates_args="unknown",
 )
-def _tp_moe_tiny_rp_launch_op(
+def _tp_moe_tiny_decode_launch_op(
     barrier_count: torch.Tensor,
     barrier_epoch: torch.Tensor,
     micro_intermediate: torch.Tensor,
@@ -8065,7 +8067,7 @@ def _tp_moe_tiny_rp_launch_op(
     volatile_launch_state: bool,
 ) -> None:
     del volatile_launch_state
-    _launch_tiny_rp_flat(
+    _launch_tiny_decode_flat(
         barrier_count=barrier_count,
         barrier_epoch=barrier_epoch,
         micro_intermediate=micro_intermediate,
@@ -8085,8 +8087,8 @@ def _tp_moe_tiny_rp_launch_op(
     )
 
 
-@_tp_moe_tiny_rp_launch_op.register_fake
-def _tp_moe_tiny_rp_launch_fake(
+@_tp_moe_tiny_decode_launch_op.register_fake
+def _tp_moe_tiny_decode_launch_fake(
     barrier_count: torch.Tensor,
     barrier_epoch: torch.Tensor,
     micro_intermediate: torch.Tensor,
@@ -8243,14 +8245,14 @@ def _launch_micro(
     quant_mode = _normalize_quant_mode(quant_mode)
     if quant_mode == "w4a8_mx":
         # The w4a8_mx tiny band reaches the compact family only via the
-        # tiny_rp resolve gate; its weights are N256/K128-repacked, which
-        # direct-micro cannot read.
+        # tiny_decode resolve gate; its weights are N256/K128-repacked,
+        # which direct-micro cannot read.
         if flat_ids.dtype == torch.int32 and flat_ids.is_contiguous():
             launch_ids = flat_ids
         else:
             launch_ids = workspace.compact_topk_ids[: flat_ids.numel()]
             launch_ids.copy_(flat_ids.to(torch.int32))
-        torch.ops.b12x.tp_moe_tiny_rp_launch(
+        torch.ops.b12x.tp_moe_tiny_decode_launch(
             workspace.barrier_count,
             workspace.barrier_epoch,
             workspace.micro_intermediate,

--- a/b12x/moe/fused/tiny_decode.py
+++ b/b12x/moe/fused/tiny_decode.py
@@ -1,4 +1,7 @@
-"""MoETinyRpKernelBackend — rp-native tiny-decode (M<=4) W4A8-MX MoE for SM120.
+"""MoETinyDecodeKernelBackend — tiny-decode (M<=4) W4A8-MX MoE for SM120.
+
+Reads the N256/K128 in-place-REPACKED weight storage (the "rp" layout produced
+by _logical_weight_to_w4a8_rp_inplace) directly.
 
 Consumes the N256/K128 in-place-repacked FP4 weights and e8m0 sfb grids
 directly (inverse mappings verified in tests/test_w4a8_rp_inverse_mapping.py),
@@ -49,7 +52,7 @@ _FC1_KT_PER_TASK = 4
 _FC2_KT_PER_TASK = 2
 
 
-class MoETinyRpKernelBackend:
+class MoETinyDecodeKernelBackend:
     """Tiny-M (decode) W4A8-MX kernel reading the repacked weight layout."""
 
     def __init__(
@@ -60,9 +63,9 @@ class MoETinyRpKernelBackend:
         compile_time_phase: int = 1,
     ):
         if activation != "silu":
-            raise ValueError(f"tiny_rp supports silu only, got {activation!r}")
+            raise ValueError(f"tiny_decode supports silu only, got {activation!r}")
         if int(compile_time_phase) not in (1, 2):
-            raise ValueError(f"unsupported tiny_rp phase {compile_time_phase!r}")
+            raise ValueError(f"unsupported tiny_decode phase {compile_time_phase!r}")
         self.compile_time_phase = int(compile_time_phase)
         self.activation = activation
         self.w13_layout = w13_layout
@@ -82,14 +85,14 @@ class MoETinyRpKernelBackend:
     ) -> None:
         del device
         if k % 256 != 0 or n % 256 != 0:
-            raise ValueError("tiny_rp requires k % 256 == 0 and n % 256 == 0")
+            raise ValueError("tiny_decode requires k % 256 == 0 and n % 256 == 0")
         if m < 1 or m > 4:
-            raise ValueError("tiny_rp supports 1 <= m <= 4")
+            raise ValueError("tiny_decode supports 1 <= m <= 4")
         rt = m * num_topk
         kt13 = k // 128
         kt2 = n // 128
         if kt13 % _FC1_KT_PER_TASK != 0 or kt2 % _FC2_KT_PER_TASK != 0:
-            raise ValueError("tiny_rp k-tile counts not divisible by task sizes")
+            raise ValueError("tiny_decode k-tile counts not divisible by task sizes")
         cfg = dict(
             m=m,
             k=k,


### PR DESCRIPTION
The default-on + rename commit from PR #22 review ("ugh just have it on by default" / "I don't even know wtf RP means") — the squash-merge caught the branch before this landed.

- All public names `tiny_rp` → `tiny_decode` (module, backend class, custom op, helpers); "rp" = the in-place-**repacked** weight storage from `_logical_weight_to_w4a8_rp_inplace`, now spelled out in the module docstring only.
- Default **on**: w4a8_mx M=1 decode uses the kernel out of the box; `B12X_W4A8_TINY_DECODE=0` is the kill switch.
- Verified on your current master (`a611e36`): binding path engages by default (20.6 µs/layer, cos vs fp32 oracle 0.99998) and the kill switch routes dynamic (34.8 µs); full-B12X E2E serve on the merged master: decode cc1 136.3 tok/s (from 131.4 without the kernel), prefill 13,550/13,088/12,102 @8k/64k/128k, 30k coherence clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new tiny-decode path for the W4A8-MX micro backend.
  * Introduced updated launch and kernel handling for this mode, including improved backend selection and caching.
  * Added a new backend name and user-facing validation messages aligned with tiny-decode terminology.

* **Bug Fixes**
  * Updated runtime gating so the tiny-decode path is enabled by default when supported.
  * Preserved existing shape, token, and activation checks while routing to the newer execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->