### PR TITLE
Fix dropped MMA row_slot 1 in decode-graph epilogues for gqa_group_size > 8

### DIFF
--- a/b12x/attention/paged/forward_paged.py
+++ b/b12x/attention/paged/forward_paged.py
@@ -5126,7 +5126,7 @@ class PagedForwardKernel:
 
 
         if const_expr(not self.has_attention_sink_bias):
-            if const_expr(self.single_request_decode_graph or self.single_qtile_decode_graph):
+            if const_expr((self.single_request_decode_graph or self.single_qtile_decode_graph) and self.gqa_group_size <= 8):
                 for mma_q in cutlass.range_constexpr(num_mma_q):
                     if m_frag[mma_q, 0] != -Float32.inf:
                         m_frag[mma_q, 0] = Float32(m_frag[mma_q, 0] * self.softmax_scale_log2)
@@ -5135,7 +5135,7 @@ class PagedForwardKernel:
                     for row_slot in cutlass.range_constexpr(2):
                         if m_frag[mma_q, row_slot] != -Float32.inf:
                             m_frag[mma_q, row_slot] = Float32(m_frag[mma_q, row_slot] * self.softmax_scale_log2)
-        elif const_expr(self.single_request_decode_graph or self.single_qtile_decode_graph):
+        elif const_expr((self.single_request_decode_graph or self.single_qtile_decode_graph) and self.gqa_group_size <= 8):
             for mma_q in cutlass.range_constexpr(num_mma_q):
                 q_head_idx_sink = Int32(kv_head_idx * group_size + row_local_idx[mma_q, 0])
                 _apply_attention_sink_after_lse_scale(
@@ -5204,7 +5204,7 @@ class PagedForwardKernel:
                         sSyncO[warp_kv_idx, packed_row_local, dim_low + 1] = o_frag[0, mma_d, 1]
                         sSyncO[warp_kv_idx, packed_row_local, dim_high + 0] = o_frag[0, mma_d, 4]
                         sSyncO[warp_kv_idx, packed_row_local, dim_high + 1] = o_frag[0, mma_d, 5]
-            elif const_expr(self.single_request_decode_graph or self.single_qtile_decode_graph):
+            elif const_expr((self.single_request_decode_graph or self.single_qtile_decode_graph) and self.gqa_group_size <= 8):
                 for mma_q in cutlass.range_constexpr(num_mma_q):
                     packed_row_local = row_local_idx[mma_q, 0]
                     if row_valid[mma_q, 0] != 0 and lane_pair_base == 0:
@@ -5513,7 +5513,7 @@ class PagedForwardKernel:
                             mLSE[partial_row_idx, q_head_idx] = row_lse
                         else:
                             mLSE[q_head_idx, q_row_idx] = row_lse
-                elif const_expr(self.single_request_decode_graph or self.single_qtile_decode_graph):
+                elif const_expr((self.single_request_decode_graph or self.single_qtile_decode_graph) and self.gqa_group_size <= 8):
                     for mma_q in cutlass.range_constexpr(num_mma_q):
                         packed_row_local = row_local_idx[mma_q, 0]
                         q_head_idx = q_head_idx_frag[mma_q, 0]

--- a/b12x/attention/paged/planner.py
+++ b/b12x/attention/paged/planner.py
@@ -70,7 +70,7 @@ def _merge_backend_supports_split_kv(
     output_dtype: torch.dtype,
     head_dim_vo: int,
 ) -> bool:
-    return output_dtype in (torch.float16, torch.bfloat16, torch.float32) and head_dim_vo == 256
+    return output_dtype in (torch.float16, torch.bfloat16, torch.float32) and head_dim_vo in (128, 256)
 
 
 def _ceil_div(x: int, y: int) -> int:
@@ -869,8 +869,6 @@ def create_paged_plan(
         raise ValueError(f"verify mode requires q_len > 1, got inferred mode {inferred_mode}")
     if force_split_kv is None:
         force_split_kv = mode == "verify" or (msa_block_sparse and mode == "decode")
-    if mode == "decode" and force_split_kv and not msa_block_sparse:
-        raise ValueError("decode plans do not support split-kv")
     if mode == "extend" and force_split_kv:
         raise ValueError("extend plans no longer support split-kv")
     if plan_budget is not None:

--- a/b12x/integration/paged_attention_scratch.py
+++ b/b12x/integration/paged_attention_scratch.py
@@ -1452,6 +1452,7 @@ class B12XPagedAttentionScratchPlan:
         max_cache_page_count: int | None = None,
         fixed_split_size: int = -1,
         window_left: int = -1,
+        force_split_kv: bool = False,
     ) -> "B12XPagedAttentionScratchPlan":
         if not self.caps.use_cuda_graph:
             raise RuntimeError(
@@ -1621,8 +1622,8 @@ class B12XPagedAttentionScratchPlan:
             max_cu_seqlens_q,
             mode="decode",
             fixed_split_size=-1,
-            disable_split_kv=True,
-            force_split_kv=False,
+            disable_split_kv=not force_split_kv,
+            force_split_kv=force_split_kv,
             window_left=int(window_left),
             enable_cuda_graph=True,
             graph_chunk_policy=True,

--- a/tests/test_attention_paged_decode_split_graph.py
+++ b/tests/test_attention_paged_decode_split_graph.py
@@ -1,0 +1,239 @@
+"""Regression tests for force-split dense decode under CUDA graphs.
+
+Covers the gqa_group_size > 8 case (e.g. MiniMax-M3 dense layers: 64 q heads /
+4 KV heads = gqa 16, head_dim 128) where the single-qtile / regularized decode
+graph epilogues previously only stored MMA row_slot 0 (packed rows 0-7),
+dropping q heads 8..group_size-1 of every KV group.
+
+Note the CUDA-graph metadata contract exercised here: with
+copy_runtime_metadata (the default), the copy from the caller's metadata
+tensors into the scratch's static buffers is captured inside the graph, so the
+metadata tensors passed at capture must keep stable addresses across replays —
+callers update their contents in place (this is what a serving engine does with
+persistent buffers).
+"""
+from __future__ import annotations
+
+import torch
+
+from b12x.attention.paged.reference import paged_attention_reference
+from b12x.integration.attention import (
+    B12XPagedAttentionScratchCaps,
+    clear_attention_caches,
+    create_paged_plan,
+    paged_attention_forward,
+    plan_paged_attention_scratch,
+)
+
+from .helpers import require_sm120
+from .paged_attention_helpers import make_paged_inputs
+
+
+class _ForcedSplitDecodeGraphHarness:
+    """Decode-graph harness with split-KV forced on (dense split decode)."""
+
+    def __init__(self, q, k_cache, v_cache):
+        self.q = q
+        self.k_cache = k_cache
+        self.v_cache = v_cache
+        self._scratch_plan = None
+        self._scratch = None
+        self._output = None
+        self._page_table = None
+        self._cache_seqlens = None
+        self._cu_seqlens_q = None
+        self._last_scratch = None
+
+    def prepare(self, page_table, cache_seqlens, cu_seqlens_q):
+        plan = create_paged_plan(
+            self.q,
+            self.k_cache,
+            self.v_cache,
+            page_table,
+            cache_seqlens,
+            cu_seqlens_q,
+            mode="decode",
+            enable_cuda_graph=True,
+            force_split_kv=True,
+        )
+        if self._scratch_plan is None:
+            batch = page_table.shape[0]
+            self._scratch_plan = plan_paged_attention_scratch(
+                B12XPagedAttentionScratchCaps(
+                    device=self.q.device,
+                    mode="decode",
+                    dtype=self.q.dtype,
+                    kv_dtype=self.k_cache.dtype,
+                    num_q_heads=self.q.shape[1],
+                    num_kv_heads=self.k_cache.shape[2],
+                    head_dim_qk=self.q.shape[2],
+                    head_dim_vo=self.v_cache.shape[3],
+                    page_size=self.k_cache.shape[1],
+                    max_total_q=plan.total_q,
+                    max_batch=batch,
+                    max_page_table_width=page_table.shape[1],
+                    # split decode graphs pad work items to the CTA policy
+                    # (~2 CTAs/SM), so size generously rather than from the
+                    # bootstrap plan
+                    max_work_items=max(plan.new_batch_size, 2048),
+                    max_partial_rows=max(plan.total_num_partial_rows, 2048),
+                    num_cache_pages=self.k_cache.shape[0],
+                    use_cuda_graph=True,
+                )
+            )
+            self._scratch = tuple(
+                torch.empty(shape, dtype=dtype, device=self.q.device)
+                for shape, dtype in self._scratch_plan.shapes_and_dtypes()
+            )
+            self._scratch_plan.prepare_decode_graph_replay_state(
+                batch=batch,
+                max_page_table_width=page_table.shape[1],
+                force_split_kv=True,
+            )
+        self._page_table = page_table
+        self._cache_seqlens = cache_seqlens
+        self._cu_seqlens_q = cu_seqlens_q
+        if self._output is not None:
+            self._bind()
+
+    def _bind(self):
+        binding = self._scratch_plan.bind(
+            scratch=self._scratch,
+            q=self.q,
+            k_cache=self.k_cache,
+            v_cache=self.v_cache,
+            output=self._output,
+            page_table=self._page_table,
+            cache_seqlens=self._cache_seqlens,
+            cu_seqlens_q=self._cu_seqlens_q,
+            k_descale=None,
+            v_descale=None,
+        )
+        self._last_scratch = binding.scratch
+        return binding
+
+    def run(self, output):
+        self._output = output
+        return paged_attention_forward(binding=self._bind())
+
+
+def _run_forced_split_decode_graph(
+    *,
+    q_heads: int,
+    kv_heads: int,
+    head_dim: int,
+    cache_seqlens_capture: list[int],
+    cache_seqlens_replay: list[int] | None = None,
+    seed: int = 73,
+) -> None:
+    clear_attention_caches()
+    batch = len(cache_seqlens_capture)
+    max_len = max(cache_seqlens_capture + (cache_seqlens_replay or []))
+    page_size = 64
+    width = max_len // page_size + 2
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1] * batch,
+        cache_seqlens=cache_seqlens_capture,
+        page_size=page_size,
+        seed=seed,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        page_table_width=width,
+        num_pages=4096,
+    )
+    harness = _ForcedSplitDecodeGraphHarness(q, k_cache, v_cache)
+    harness.prepare(page_table, cache_seqlens, cu_seqlens_q)
+    output = torch.empty_like(q)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        harness.run(output)
+
+    ref_out, _ = paged_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, causal=True
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+    assert (output - ref_out).abs().max().item() <= 0.02
+
+    if cache_seqlens_replay is None:
+        return
+
+    q2, k2, v2, pt2, csl2, cu2 = make_paged_inputs(
+        q_seqlens=[1] * batch,
+        cache_seqlens=cache_seqlens_replay,
+        page_size=page_size,
+        seed=seed + 6,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        page_table_width=page_table.shape[1],
+        num_pages=k_cache.shape[0],
+    )
+    # keep metadata tensor addresses stable; update contents in place
+    q.copy_(q2)
+    k_cache.copy_(k2)
+    v_cache.copy_(v2)
+    page_table.copy_(pt2)
+    cache_seqlens.copy_(csl2)
+    cu_seqlens_q.copy_(cu2)
+    harness.prepare(page_table, cache_seqlens, cu_seqlens_q)
+
+    ref_out2, _ = paged_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, causal=True
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+    assert (output - ref_out2).abs().max().item() <= 0.02
+
+
+@torch.inference_mode()
+def test_forced_split_decode_graph_gqa16_head_dim128() -> None:
+    """MiniMax-M3 dense-layer shape: 64 q heads / 4 KV heads / head_dim 128."""
+    require_sm120()
+    _run_forced_split_decode_graph(
+        q_heads=64,
+        kv_heads=4,
+        head_dim=128,
+        cache_seqlens_capture=[4096, 4096, 4096, 4096],
+        cache_seqlens_replay=[512, 1536, 3072, 4096],
+    )
+
+
+@torch.inference_mode()
+def test_forced_split_decode_graph_gqa12_head_dim128() -> None:
+    """gqa 12: second MMA row slot partially occupied."""
+    require_sm120()
+    _run_forced_split_decode_graph(
+        q_heads=48,
+        kv_heads=4,
+        head_dim=128,
+        cache_seqlens_capture=[4096, 4096, 4096, 4096],
+    )
+
+
+@torch.inference_mode()
+def test_forced_split_decode_graph_gqa8_head_dim256() -> None:
+    """gqa 8 / head_dim 256 control (single row slot fast path)."""
+    require_sm120()
+    _run_forced_split_decode_graph(
+        q_heads=8,
+        kv_heads=1,
+        head_dim=256,
+        cache_seqlens_capture=[4096, 4096, 4096, 4096],
+        cache_seqlens_replay=[512, 1536, 3072, 4096],
+    )
+
+
+@torch.inference_mode()
+def test_forced_split_decode_graph_gqa16_head_dim128_batch2() -> None:
+    """batch != 4 exercises the bf16/128 regular-decode merge bdy=3 config."""
+    require_sm120()
+    _run_forced_split_decode_graph(
+        q_heads=64,
+        kv_heads=4,
+        head_dim=128,
+        cache_seqlens_capture=[4096, 2048],
+        cache_seqlens_replay=[1024, 4096],
+    )


### PR DESCRIPTION
# Fix dropped MMA row_slot 1 in decode-graph epilogues for gqa_group_size > 8

## Summary

Dense (non-MSA) split-KV decode under CUDA graphs produces garbage output whenever `gqa_group_size > 8`. The root cause is in `forward_paged.py`: the `single_request_decode_graph` / `single_qtile_decode_graph` epilogue fast paths only process **MMA row_slot 0** — packed q rows 0-7 of the m16 tile — in four places:

1. LSE scaling after the KV loop
2. attention-sink application
3. the cross-warp smem spill (`sSyncMD`/`sSyncO`)
4. the final merge/store to `mO`/`mLSE`

The generic branches right next to them iterate both row slots (`reg_base = row_slot * 2`). For `gqa_group_size > 8` — e.g. MiniMax-M3's dense full-attention layers: 64 q heads / 4 KV heads = group size 16, head_dim 128 — q heads `8..group_size-1` of every KV group are computed but never stored, so the partial buffers keep stale values and the merged output is garbage. The eager `decode_only` variant handles both slots and is unaffected, which makes the bug graph-only and easy to misattribute to replay-metadata wiring.

**Fix:** gate the four fast paths on `gqa_group_size <= 8` so larger groups fall through to the generic both-slot branches. The row metadata those branches need (`row_local_idx`, `row_valid`, `q_head_idx_frag`, …) is already initialized on the graph variants, so no other changes are needed. gqa ≤ 8 keeps the existing fast path, bit-identical.

## Bisection evidence (2x RTX PRO 6000 Blackwell, sm_120a)

Isolated forward+merge vs `paged_attention_reference`, forced-split decode, CUDA graph:

| config | before | after |
|---|---|---|
| gqa 8 (8q/1kv or 32q/4kv), vo 128/256 | max_err 0.00006 | 0.00006 |
| gqa 12 (48q/4kv), vo 128 | **0.248, cos 0.07** | 0.00006 |
| gqa 16 (64q/4kv), vo 128 | **0.394, cos 0.03** | 0.00006 |
| gqa 16, vo 256 | **0.270, cos 0.04** | 0.00006 |
| variable-metadata replay (capture 4096 → replay 512/1536/3072/4096) | garbage | ≤ 0.0005 |

head_dim is not a factor (fails at 256 too); the boundary is exactly gqa > 8 = one MMA row slot.

## Enablement (makes the fixed path reachable & testable)

Stock only ever force-splits decode for MSA plans, so this path was dead code. To exercise it:

- `create_paged_plan`: explicit `force_split_kv=True` on dense decode plans is now accepted (previously `ValueError`). Default heuristic unchanged — no behavior change for existing callers.
- `_merge_backend_supports_split_kv`: accept `head_dim_vo == 128` (the merge kernel is head-dim generic; validated at 128 including the bf16 `bdy=3` config).
- `prepare_decode_graph_replay_state`: new `force_split_kv: bool = False` parameter for the non-MSA capacity plan.

Motivation: at long context, dense decode without split-KV runs one CTA per (request × KV head) — for M3 at 1M tokens that is 3 dense layers scanning the whole cache with 8 of ~376 CTA slots occupied. Force-split decode parallelizes this; with this fix it is numerically correct under graph replay.

## Tests

`tests/test_attention_paged_decode_split_graph.py`: forced-split decode graph capture+replay at gqa 16/12/8, head_dim 128/256, variable-metadata replays (with address-stable metadata updates per the `copy_runtime_metadata` capture contract), and a batch=2 case for the bf16/128 merge `bdy=3` config. All pass on sm_120a; `tests/test_attention_cuda_graphs.py` + `tests/test_attention_paged_merge.py` results are identical before/after this change.

### Note on pre-existing test failures (separate issue)

On RTX PRO 6000 (188 SMs), 3 tests in `test_attention_cuda_graphs.py` already fail at HEAD (`7bfc945`) with `paged plan needs 376 block-valid entries, scratch capacity is 4`: the decode-graph capacity plan pads work items to the CTA policy (2/SM → 376, hardware-dependent) while the test harness sizes `max_work_items` from the bootstrap plan. Untouched by this PR; happy to follow up separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for forced split KV during decode, including CUDA graph replay.
  * Expanded compatibility for a wider range of attention head sizes in supported configurations.

* **Bug Fixes**
  * Fixed decode behavior for larger GQA group sizes by using the more general processing path when needed.
  * Improved consistency and correctness when replaying captured graphs with updated inputs.

* **Tests**
  * Added regression coverage for forced split KV decode across multiple GQA and head-dimension combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->