### PR TITLE
Add docker/ source-build workflow (build b12x from checkout into the vLLM images)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+*.ncu-rep
+__pycache__
+.pytest_cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+# Build a vLLM serving image with b12x installed from this source checkout.
+#
+# The published voipmonitor/vllm images ship a pinned b12x; this overlays the
+# repo's working tree on top so kernel changes can be tested end-to-end
+# without rebuilding vLLM. b12x kernels are pure-Python CuTe DSL — there is
+# no ahead-of-time compile step; they JIT for the target GPU at engine start
+# (CUTE_DSL_ARCH=sm_120a).
+#
+# Build (from the repo root):
+#   docker build -f docker/Dockerfile -t b12x-dev .
+#
+# Pick a different vLLM base:
+#   docker build -f docker/Dockerfile --build-arg BASE=voipmonitor/vllm:<tag> -t b12x-dev .
+ARG BASE=voipmonitor/vllm:eldritch-enlightenment-v45c1582-b12xf3686b5-pc1441b5-cu132-20260704
+FROM ${BASE}
+
+COPY . /src/b12x
+# --no-deps: torch / cutlass-dsl / tvm-ffi are already pinned in the base
+# image; only the b12x package itself is replaced.
+RUN /opt/venv/bin/pip install --no-deps --force-reinstall /src/b12x \
+    && /opt/venv/bin/python -c "import b12x; print('b12x', b12x.__version__ if hasattr(b12x, '__version__') else 'installed')"
+
+ENV CUTE_DSL_ARCH=sm_120a

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,49 @@
+# Docker: build b12x from source into a vLLM serving image
+
+The published `voipmonitor/vllm` images ship a pinned b12x. This Dockerfile
+overlays the current source checkout on top of one of those images, so kernel
+changes can be tested end-to-end (vLLM serve, CUDA graphs, TP) without
+rebuilding vLLM itself.
+
+## How b12x "builds"
+
+There is no ahead-of-time kernel compilation. b12x is a pure-Python package of
+CuTe DSL kernels (`nvidia-cutlass-dsl`); they are JIT-compiled for the target
+GPU at engine startup via `CUTE_DSL_ARCH=sm_120a`. First engine start after a
+kernel change spends a few extra minutes in JIT. Installing from source is a
+plain pip install:
+
+```bash
+pip install --no-deps --force-reinstall .
+```
+
+(`--no-deps` because the vLLM base image already pins torch / cutlass-dsl /
+tvm-ffi — only the b12x package itself should be replaced.)
+
+## Build
+
+From the repo root:
+
+```bash
+docker build -f docker/Dockerfile -t b12x-dev .
+# or against a different base:
+docker build -f docker/Dockerfile --build-arg BASE=voipmonitor/vllm:<tag> -t b12x-dev .
+```
+
+## Run the test suite
+
+```bash
+docker run --rm --gpus '"device=0"' --ipc=host b12x-dev \
+  bash -c "/opt/venv/bin/pip install -q pytest && /opt/venv/bin/python -m pytest /src/b12x/tests -q"
+```
+
+## Serve a model
+
+The base image's serve scripts and vLLM integration are unchanged — use them
+as documented for the base image, e.g.:
+
+```bash
+docker run --rm --gpus all --ipc=host --network host \
+  -v /path/to/model:/models/<name>:ro \
+  --entrypoint /serve/<serve-script>.sh b12x-dev --port 8001
+```


### PR DESCRIPTION
Adds `docker/Dockerfile` + `docker/README.md`: overlay the current source checkout onto a `voipmonitor/vllm` base image with `pip install --no-deps --force-reinstall`, so kernel changes can be tested end-to-end (vLLM serve, CUDA graphs, TP, or the pytest suite) without rebuilding vLLM. Docs cover the JIT model (no AOT build; `CUTE_DSL_ARCH=sm_120a` at engine start), running tests in the image, and choosing a different base via `--build-arg BASE=`.

Verified: builds against `eldritch-enlightenment-v45c1582` and the source-installed b12x imports cleanly; this is the workflow I used to validate #24 on 4x RTX PRO 6000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for building a development/serving image from the current source.
  * The image can reuse a configurable base image and preserves the existing runtime environment while updating the app package.
  * Sets GPU-targeted runtime settings for kernel compilation at startup.

* **Documentation**
  * Added setup and usage instructions for building, testing, and running the containerized environment.
  * Included guidance for overriding the base image during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->