### PR TITLE
moe(tiny_decode): support odd FC2 K-tile counts (n % 128 shards)

### DIFF
--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8015,13 +8015,14 @@ def _tiny_decode_enabled() -> bool:
 
 
 def _tiny_decode_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
+    # n needs whole 128-column rp tiles only; odd tile counts (e.g. n=384
+    # from GLM 2048/TP6 padded shards) run FC2 with one K tile per task.
     return (
         1 <= num_tokens <= 4
         and activation == "silu"
         and k % 256 == 0
-        and n % 256 == 0
+        and n % 128 == 0
         and (k // 128) % 4 == 0
-        and (n // 128) % 2 == 0
     )
 
 

--- a/b12x/moe/fused/tiny_decode.py
+++ b/b12x/moe/fused/tiny_decode.py
@@ -84,15 +84,24 @@ class MoETinyDecodeKernelBackend:
         device: torch.device | None = None,
     ) -> None:
         del device
-        if k % 256 != 0 or n % 256 != 0:
-            raise ValueError("tiny_decode requires k % 256 == 0 and n % 256 == 0")
+        # The rp tile grid needs whole 256-row tiles on each GEMM's N dim:
+        # FC1 tiles 2n rows (so n % 128 suffices) and FC2 tiles k rows.
+        if k % 256 != 0 or (2 * n) % 256 != 0:
+            raise ValueError("tiny_decode requires k % 256 == 0 and n % 128 == 0")
         if m < 1 or m > 4:
             raise ValueError("tiny_decode supports 1 <= m <= 4")
         rt = m * num_topk
         kt13 = k // 128
         kt2 = n // 128
-        if kt13 % _FC1_KT_PER_TASK != 0 or kt2 % _FC2_KT_PER_TASK != 0:
+        if kt13 % _FC1_KT_PER_TASK != 0:
             raise ValueError("tiny_decode k-tile counts not divisible by task sizes")
+        # FC2 walks the intermediate dim in per-task groups of K tiles. Odd
+        # tile counts (e.g. n=384 -> 3 tiles from GLM 2048/TP6 padded shards)
+        # drop to one tile per task; partials are scatter-added, so the task
+        # split does not change results.
+        fc2_kt_per_task = (
+            _FC2_KT_PER_TASK if kt2 % _FC2_KT_PER_TASK == 0 else 1
+        )
         cfg = dict(
             m=m,
             k=k,
@@ -106,13 +115,14 @@ class MoETinyDecodeKernelBackend:
             fc1_ktg=kt13 // _FC1_KT_PER_TASK,
             nt2=k // 256,
             kt2=kt2,
-            fc2_ktg=kt2 // _FC2_KT_PER_TASK,
+            fc2_kt_per_task=fc2_kt_per_task,
+            fc2_ktg=kt2 // fc2_kt_per_task,
             w13_words=(2 * n) * k // 8,
             w2_words=k * n // 8,
             sfb13_bytes=(2 * n) * (k // 32),
             sfb2_bytes=k * (n // 32),
             fc1_tasks=rt * ((2 * n) // 256) * (kt13 // _FC1_KT_PER_TASK),
-            fc2_tasks=rt * (k // 256) * (kt2 // _FC2_KT_PER_TASK),
+            fc2_tasks=rt * (k // 256) * (kt2 // fc2_kt_per_task),
         )
         self._c = cfg
         self._cfg_key = tuple(sorted(cfg.items()))
@@ -275,8 +285,8 @@ class MoETinyDecodeKernelBackend:
             acc1 = Float32(0.0)
             acc2 = Float32(0.0)
             acc3 = Float32(0.0)
-            for kt_i in cutlass.range_constexpr(_FC2_KT_PER_TASK):
-                kt = ktg * Int32(_FC2_KT_PER_TASK) + Int32(kt_i)
+            for kt_i in cutlass.range_constexpr(c["fc2_kt_per_task"]):
+                kt = ktg * Int32(c["fc2_kt_per_task"]) + Int32(kt_i)
                 col_tile = nt * Int32(c["kt2"]) + kt
                 tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
                 srow = srow_base + Int64(col_tile) * Int64(1024)

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -249,12 +249,14 @@ def test_w4a8_mx_w31_layout_flip() -> None:
 
 
 @pytest.mark.parametrize("m", [1, 2, 4])
-def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
+# n=384 covers odd rp K-tile counts on FC2 (GLM-5.2 2048/TP6 padded shards).
+@pytest.mark.parametrize("n", [_N, 384])
+def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:
     _skip_if_unavailable()
     from b12x.integration import plan_b12x_fp4_moe_weights, tp_moe
     from b12x.moe.fused.reference import moe_reference_w4a16_fp4_e8m0_k32
 
-    weights = _weights()
+    weights = _weights(n=n)
     weight_plan = plan_b12x_fp4_moe_weights(
         quant_modes="w4a8_mx",
         source_format="fp4_e8m0_k32",
@@ -262,7 +264,7 @@ def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
         params_dtype=torch.bfloat16,
         num_experts=_E,
         hidden_size=_K,
-        intermediate_size=_N,
+        intermediate_size=n,
     )
     plan = tp_moe.plan_tp_moe_execution(
         num_tokens=m,
@@ -286,11 +288,11 @@ def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
         topk_weights,
         _E,
         _K,
-        _N,
+        n,
         activation="silu",
         w13_layout="w13",
     )
-    prepared = _prepare(weights)
+    prepared = _prepare(weights, n=n)
     out = _run(m, prepared)
     n_out = out.float().norm().item()
     assert n_out > 0.01, f"w4a8_mx tiny output near-zero (norm={n_out})"

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -175,11 +175,12 @@ def _run(
     return out
 
 
-def test_w4a8_mx_dynamic_matches_oracle() -> None:
+@pytest.mark.parametrize("n", [_N, 384])
+def test_w4a8_mx_dynamic_matches_oracle(n: int) -> None:
     _skip_if_unavailable()
     from b12x.moe.fused.reference import moe_reference_w4a8_mx
 
-    weights = _weights()
+    weights = _weights(n=n)
     m = 16
     x, topk_ids, topk_weights = _routed_inputs(m, 33)
     ref = moe_reference_w4a8_mx(
@@ -196,10 +197,10 @@ def test_w4a8_mx_dynamic_matches_oracle() -> None:
         topk_weights,
         _E,
         _K,
-        _N,
+        n,
         activation="silu",
     )
-    prepared = _prepare(weights)
+    prepared = _prepare(weights, n=n)
     out = _run(m, prepared)
     n_out = out.float().norm().item()
     assert n_out > 0.01, f"w4a8_mx output near-zero (norm={n_out})"
@@ -248,7 +249,7 @@ def test_w4a8_mx_w31_layout_flip() -> None:
         )
 
 
-@pytest.mark.parametrize("m", [1, 2, 4])
+@pytest.mark.parametrize("m", [1, 2, 3, 4])
 # n=384 covers odd rp K-tile counts on FC2 (GLM-5.2 2048/TP6 padded shards).
 @pytest.mark.parametrize("n", [_N, 384])
 def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:


### PR DESCRIPTION
## Problem

`tiny_decode` (the M≤4 W4A8-MX decode kernel) requires `n % 256 == 0` and `(n // 128) % 2 == 0`, so padded GLM-5.2 TP6 expert shards (`moe_intermediate 2048/6` → 384 = 3×128, produced by the vLLM-side QMMA padding fix in [vllm#80](https://github.com/local-inference-lab/vllm/pull/80)) never take the tiny path — M≤4 A8 decode falls back to the dynamic QMMA kernels, costing ~13% decode vs A16 at TP6.

## Fix

Structurally the rp tile grid only needs whole 256-row tiles per GEMM **N** dim (FC1 tiles `2n` rows, so `n % 128` suffices; FC2's N dim is `k`). The only real 256 dependency was FC2's fixed two-K-tiles-per-task grouping (`_FC2_KT_PER_TASK = 2`).

- Make the FC2 K-tiles-per-task a `configure()`-time value: **2 when the tile count is even** (unchanged behavior, unchanged compiled kernels for every existing shape — the value is part of the cfg/cache key), **1 when odd**. FC2 partials are scatter-added, so the finer task split cannot change results.
- Relax `configure()` validation and `_tiny_decode_supports` to `n % 128 == 0`.

## Tests

Parametrized `test_w4a8_mx_small_band_matches_fp32_oracle` over `n ∈ {1024, 384}`: the 384 cases assert the planner selects the micro path and match the fp32 reference — 6/6 pass (m ∈ {1,2,4}).

## E2E

GLM-5.2-BF16-AMDMXFP4experts, TP6/DCP1, force-A8 + online MXFP8 dense overlay, shards padded 352→384:

| | A8 before | **A8 + this fix** | A16 |
|---|---:|---:|---:|
| decode c0 | 72.2 | **83.0** | 79.2 |
| decode c3000 | 71.2 | **81.4** | 77.9 |
| prefill 8k / 64k | 4,770 / 5,225 | 4,864 / 5,219 (unchanged) | 4,643 / 4,816 |

A8 goes from the slowest to the fastest TP6 mode on both axes; outputs coherent (0 CJK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded tiny-decode and MoE kernel eligibility by relaxing intermediate/FC geometry constraints and FC2 tiling rules.
  * Improved support for more intermediate-size shapes in small-band execution.

* **Bug Fixes**
  * Relaxed overly strict divisibility requirements that could incorrectly reject valid configurations.
  * Updated FC2 phase scheduling so task work partitioning adapts to the computed configuration.

* **Tests**
  * Enhanced oracle-matching coverage by running reference comparisons across multiple `n` values (in addition to existing `m` coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->