### PR TITLE
moe: native 32-aligned expert shards for w4a8_mx and native-E8M0 w4a16

### DIFF
--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -2980,11 +2980,17 @@ def _as_e8m0_k32_grid(
             f"got {scales.dtype}"
         )
     grid = scales.view(torch.uint8)
-    expected = (int(grid.shape[0]), rows, k_dim // 32)
-    if grid.dim() != 3 or tuple(grid.shape) != expected:
+    # Already-prepared ceil-tiled sfb views arrive with padded extents
+    # (rows to 256-tiles, K to 128-tiles); logical grids arrive unpadded.
+    rows_pad = -(-rows // 256) * 256
+    cols = k_dim // 32
+    cols_pad = (-(-k_dim // 128) * 128) // 32
+    expected = (int(grid.shape[0]), rows, cols)
+    expected_pad = (int(grid.shape[0]), rows_pad, cols_pad)
+    if grid.dim() != 3 or tuple(grid.shape) not in (expected, expected_pad):
         raise ValueError(
-            f"{name} must be [E, rows, K//32] = {expected} for w4a8_mx, "
-            f"got {tuple(grid.shape)}"
+            f"{name} must be [E, rows, K//32] = {expected} (or the ceil-tiled "
+            f"{expected_pad}) for w4a8_mx, got {tuple(grid.shape)}"
         )
     return grid.contiguous()
 
@@ -2992,23 +2998,26 @@ def _as_e8m0_k32_grid(
 def _w4a8_rp_shape(size_n: int, size_k: int) -> tuple[int, int, int, int, int, int]:
     size_n = int(size_n)
     size_k = int(size_k)
-    if size_n % 256 != 0 or size_k % 128 != 0:
+    if size_n % 8 != 0 or size_k % 32 != 0:
         raise ValueError(
-            "W4A8 weight repack requires N multiple of 256 and K "
-            f"multiple of 128; got N={size_n}, K={size_k}"
+            "W4A8 weight repack requires N multiple of 8 and K "
+            f"multiple of 32; got N={size_n}, K={size_k}"
         )
-    return (size_n // 256, size_k // 128, 4, 8, 32, 4)
+    # Ceil-tiled: shards that 256/128 tiles don't divide (e.g. 2048/TP6 = 352)
+    # store zero-filled tail tiles so the fixed 4096-word tile addressing
+    # stays uniform; kernels bound their reads by the logical sizes.
+    return (-(-size_n // 256), -(-size_k // 128), 4, 8, 32, 4)
 
 
 def _w4a8_sfb_shape(size_n: int, size_k: int) -> tuple[int, int, int, int]:
     size_n = int(size_n)
     size_k = int(size_k)
-    if size_n % 256 != 0 or size_k % 128 != 0:
+    if size_n % 8 != 0 or size_k % 32 != 0:
         raise ValueError(
-            "W4A8 scale repack requires N multiple of 256 and K "
-            f"multiple of 128; got N={size_n}, K={size_k}"
+            "W4A8 scale repack requires N multiple of 8 and K "
+            f"multiple of 32; got N={size_n}, K={size_k}"
         )
-    return (size_n // 256, size_k // 128, 32, 8)
+    return (-(-size_n // 256), -(-size_k // 128), 32, 8)
 
 
 def _w4a16_packed_weight_shape(size_k: int, size_n: int) -> tuple[int, int]:
@@ -3106,10 +3115,21 @@ def _qweight_to_w4a8_rp_kernel(
     k32 = tmp >> 3
 
     row = n8c * 32 + n8i * 8 + r8
-    src_row = nt * 256 + row + row_rotation
+    dst_row = nt * 256 + row
+    src_row = dst_row + row_rotation
     src_row = tl.where(src_row >= rows, src_row - rows, src_row)
     src_col = kt * 16 + k32 * 4 + cgrp
-    values = tl.load(q + expert * q_expert_stride + src_row * q_cols + src_col)
+    # Tail tiles: positions past the logical N/K read as zero (FP4 zero rows
+    # and columns), keeping the fixed 4096-word tile addressing uniform.
+    in_bounds = (dst_row < rows) & (src_col < q_cols)
+    src_row = tl.where(in_bounds, src_row, 0)
+    src_col = tl.where(in_bounds, src_col, 0)
+    values = tl.load(
+        q + expert * q_expert_stride + src_row * q_cols + src_col,
+        mask=mask & in_bounds,
+        other=0,
+    )
+    values = tl.where(in_bounds, values, 0)
     dst_base = expert * dst_expert_stride + (nt * k_tiles_128 + kt) * 4096
     tl.store(dst + dst_base + idx, values, mask=mask)
 
@@ -3171,8 +3191,8 @@ def _grid_to_w4a8_sfb_kernel(
     pid = tl.program_id(0)
     idx = pid * BLOCK + tl.arange(0, BLOCK)
     mask = idx < total_elements
-    expert = idx // (rows * scale_cols)
-    local = idx - expert * (rows * scale_cols)
+    expert = idx // dst_expert_stride
+    local = idx - expert * dst_expert_stride
 
     kb = local & 3
     tmp = local >> 2
@@ -3183,10 +3203,21 @@ def _grid_to_w4a8_sfb_kernel(
     kt = tmp % k_tiles_128
     nt = tmp // k_tiles_128
 
-    row = nt * 256 + n32 * 8 + row8 + row_rotation
+    dst_row = nt * 256 + n32 * 8 + row8
+    row = dst_row + row_rotation
     row = tl.where(row >= rows, row - rows, row)
     col = kt * 4 + kb
-    values = tl.load(grid + expert * grid_expert_stride + row * scale_cols + col)
+    # Tail tiles: scale bytes past the logical grid are zero (2^-127 scale on
+    # already-zero FP4 weights).
+    in_bounds = (dst_row < rows) & (col < scale_cols)
+    row = tl.where(in_bounds, row, 0)
+    col = tl.where(in_bounds, col, 0)
+    values = tl.load(
+        grid + expert * grid_expert_stride + row * scale_cols + col,
+        mask=mask & in_bounds,
+        other=0,
+    )
+    values = tl.where(in_bounds, values, 0)
     tl.store(dst + expert * dst_expert_stride + local, values, mask=mask)
 
 
@@ -3347,6 +3378,10 @@ def _logical_weight_to_w4a8_rp_inplace(
             f"got {weight.dtype} {tuple(weight.shape)}"
         )
     rp_shape = _w4a8_rp_shape(size_n, size_k)
+    n_tiles = -(-size_n // 256)
+    k_tiles = -(-size_k // 128)
+    rp_words = _tensor_numel(rp_shape)
+    has_tail = rp_words != size_n * (size_k // 8)
     if weight.is_cuda:
         weight_E = int(weight.shape[0])
         q_cols = size_k // 8
@@ -3358,24 +3393,38 @@ def _logical_weight_to_w4a8_rp_inplace(
         block = 1024
         row_rot = 0 if row_rotation is None else int(row_rotation)
         weight_i32 = weight.view(torch.int32)
-        dst_expert_stride = _tensor_numel(rp_shape)
+        # Ceil-tiled tails don't fit the source storage; write a fresh
+        # destination and read the (never-aliased) source directly.
+        out_i32 = (
+            torch.empty(
+                (weight_E, rp_words), dtype=torch.int32, device=weight.device
+            )
+            if has_tail
+            else None
+        )
+        dst_expert_stride = rp_words
         blocks_per_tile = triton.cdiv(4096, block)
         for e0 in range(0, weight_E, chunk):
             e1 = min(weight_E, e0 + chunk)
-            q_scratch = torch.empty(
-                (e1 - e0, size_n, q_cols),
-                dtype=torch.int32,
-                device=weight.device,
-            )
-            q_scratch.copy_(weight_i32[e0:e1].reshape(e1 - e0, size_n, q_cols))
-            total_programs = (e1 - e0) * (size_n // 256) * (size_k // 128)
+            if has_tail:
+                q_chunk = weight_i32[e0:e1].reshape(e1 - e0, size_n, q_cols)
+                dst_chunk = out_i32[e0:e1]
+            else:
+                q_chunk = torch.empty(
+                    (e1 - e0, size_n, q_cols),
+                    dtype=torch.int32,
+                    device=weight.device,
+                )
+                q_chunk.copy_(weight_i32[e0:e1].reshape(e1 - e0, size_n, q_cols))
+                dst_chunk = weight_i32[e0:e1]
+            total_programs = (e1 - e0) * n_tiles * k_tiles
             total_programs *= blocks_per_tile
             _qweight_to_w4a8_rp_kernel[(total_programs,)](
-                q_scratch,
-                weight_i32[e0:e1],
+                q_chunk,
+                dst_chunk,
                 total_programs,
-                size_n // 256,
-                size_k // 128,
+                n_tiles,
+                k_tiles,
                 q_cols,
                 size_n,
                 size_n * q_cols,
@@ -3384,8 +3433,14 @@ def _logical_weight_to_w4a8_rp_inplace(
                 BLOCK=block,
                 num_warps=4,
             )
-        return weight_i32.view(weight_E, *rp_shape)
+        base = out_i32 if has_tail else weight_i32
+        return base.view(weight_E, *rp_shape)
 
+    if has_tail:
+        raise NotImplementedError(
+            "ceil-tiled W4A8 repack tails are CUDA-only; move the weights to "
+            f"a CUDA device (N={size_n}, K={size_k})"
+        )
     q_scratch = torch.empty(
         (size_n, size_k // 8),
         dtype=torch.int32,
@@ -3601,6 +3656,10 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
         k_dim=k_dim,
     )
     sfb_shape = _w4a8_sfb_shape(rows, k_dim)
+    n_tiles = -(-rows // 256)
+    k_tiles = -(-k_dim // 128)
+    sfb_bytes = _tensor_numel(sfb_shape) * 4
+    has_tail = sfb_bytes != rows * (k_dim // 32)
     if scale.is_cuda:
         scale_cols = k_dim // 32
         rows_pad = rows if is_logical else int(scale_u8.shape[2])
@@ -3618,6 +3677,14 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
         row_rot = 0 if row_rotation is None else int(row_rotation)
         total_per_expert = rows * scale_cols
         source_stride = rows * scale_cols if is_logical else scale_cols * rows_pad
+        # Ceil-tiled tails don't fit the source storage in place.
+        out_u8 = (
+            torch.empty(
+                (weight_E, sfb_bytes), dtype=torch.uint8, device=scale.device
+            )
+            if has_tail
+            else None
+        )
         for e0 in range(0, weight_E, chunk):
             e1 = min(weight_E, e0 + chunk)
             chunk_experts = e1 - e0
@@ -3640,22 +3707,30 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
                 BLOCK=block,
                 num_warps=4,
             )
-            _grid_to_w4a8_sfb_kernel[(triton.cdiv(total, block),)](
+            dst_chunk = out_u8[e0:e1] if has_tail else scale_u8[e0:e1]
+            total_sfb = chunk_experts * sfb_bytes
+            _grid_to_w4a8_sfb_kernel[(triton.cdiv(total_sfb, block),)](
                 grid_scratch,
-                scale_u8[e0:e1],
-                total,
+                dst_chunk,
+                total_sfb,
                 rows,
                 scale_cols,
-                rows // 256,
-                k_dim // 128,
+                n_tiles,
+                k_tiles,
                 total_per_expert,
-                total_per_expert,
+                sfb_bytes,
                 row_rot,
                 BLOCK=block,
                 num_warps=4,
             )
-        return scale_u8.view(torch.int32).view(weight_E, *sfb_shape)
+        base = out_u8 if has_tail else scale_u8
+        return base.view(torch.int32).view(weight_E, *sfb_shape)
 
+    if has_tail:
+        raise NotImplementedError(
+            "ceil-tiled W4A8 scale tails are CUDA-only; move the scales to "
+            f"a CUDA device (rows={rows}, K={k_dim})"
+        )
     grid_scratch = torch.empty(
         (rows, scale_cols),
         dtype=torch.uint8,
@@ -3817,14 +3892,17 @@ def _get_weight_views(
         # source-native 3-D shape for pointer plumbing. The prep rotation
         # already normalized the half order -- never flip rp storage in place.
         e_dim = w1_fp4.shape[0]
-        w1_fp4 = w1_fp4.view(torch.uint8).reshape(
-            e_dim, activation_spec.w1_rows(n), k // 2
-        )
-        w2_fp4 = w2_fp4.view(torch.uint8).reshape(e_dim, k, n // 2)
+        # Ceil-tiled storage views back as ceil-row/col 3-D shapes (equal to
+        # the logical shapes when the tiles divide exactly); consumers use rp
+        # tile addressing from the base pointer, never these extents.
+        w1_rows_pad = -(-activation_spec.w1_rows(n) // 256) * 256
+        n_pad = -(-n // 128) * 128
+        w1_fp4 = w1_fp4.view(torch.uint8).reshape(e_dim, w1_rows_pad, k // 2)
+        w2_fp4 = w2_fp4.view(torch.uint8).reshape(e_dim, k, n_pad // 2)
         w1_blockscale = w1_blockscale.view(torch.uint8).reshape(
-            e_dim, activation_spec.w1_rows(n), k // 32
+            e_dim, w1_rows_pad, k // 32
         )
-        w2_blockscale = w2_blockscale.view(torch.uint8).reshape(e_dim, k, n // 32)
+        w2_blockscale = w2_blockscale.view(torch.uint8).reshape(e_dim, k, n_pad // 32)
         w13_layout = "w13"
     w13_layout = _normalize_w13_layout_for_activation(
         activation_spec.activation,
@@ -8015,13 +8093,14 @@ def _tiny_decode_enabled() -> bool:
 
 
 def _tiny_decode_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
-    # n needs whole 128-column rp tiles only; odd tile counts (e.g. n=384
-    # from GLM 2048/TP6 padded shards) run FC2 with one K tile per task.
+    # The rp storage is ceil-tiled with zero-filled tails, and the tiny FC2
+    # bounds its intermediate loads by the logical n, so any 32-aligned shard
+    # works (e.g. 352 from GLM 2048/TP6, 192 from DS4-Pro 3072/TP16).
     return (
         1 <= num_tokens <= 4
         and activation == "silu"
         and k % 256 == 0
-        and n % 128 == 0
+        and n % 32 == 0
         and (k // 128) % 4 == 0
     )
 

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8015,13 +8015,14 @@ def _tiny_decode_enabled() -> bool:
 
 
 def _tiny_decode_supports(*, num_tokens: int, k: int, n: int, activation: str) -> bool:
+    # n needs whole 128-column rp tiles only; odd tile counts (e.g. n=384
+    # from GLM 2048/TP6 padded shards) run FC2 with one K tile per task.
     return (
         1 <= num_tokens <= 4
         and activation == "silu"
         and k % 256 == 0
-        and n % 256 == 0
+        and n % 128 == 0
         and (k // 128) % 4 == 0
-        and (n // 128) % 2 == 0
     )
 
 

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -1439,11 +1439,10 @@ def _w4a8_dynamic_dense_candidate(
         _normalize_quant_mode(quant_mode) == "w4a8_mx"
         and activation == "silu"
         and k % 256 == 0
-        # The dynamic gated FC1 pairs the up/gate halves per 128-row
-        # tile, so the half boundary must sit on a tile edge; ceil-tiled
-        # tail shards (352/192) stay on tiny (m<=4) until the pairing
-        # learns mid-tile splits.
-        and n % 128 == 0
+        # Half-aligned ceil-tiled rp storage keeps the up/gate halves on
+        # 128-row tile boundaries, so the per-tile pairing works for any
+        # 32-aligned shard (352 = 2048/TP6, 192 = 3072/TP16).
+        and n % 32 == 0
         and _select_dynamic_tile_mn(
             routed_rows,
             n,
@@ -1593,11 +1592,10 @@ def _w4a8_dynamic_materialized_enabled(
     m1_candidate = bool(
         int(num_tokens) == 1
         and k % 256 == 0
-        # The dynamic gated FC1 pairs the up/gate halves per 128-row
-        # tile, so the half boundary must sit on a tile edge; ceil-tiled
-        # tail shards (352/192) stay on tiny (m<=4) until the pairing
-        # learns mid-tile splits.
-        and n % 128 == 0
+        # Half-aligned ceil-tiled rp storage keeps the up/gate halves on
+        # 128-row tile boundaries, so the per-tile pairing works for any
+        # 32-aligned shard (352 = 2048/TP6, 192 = 3072/TP16).
+        and n % 32 == 0
         and _w4a8_dynamic_direct_candidate(
             quant_mode=quant_mode,
             activation=activation,
@@ -3099,6 +3097,8 @@ def _qweight_to_w4a8_rp_kernel(
     q_expert_stride: tl.constexpr,
     dst_expert_stride: tl.constexpr,
     row_rotation: tl.constexpr,
+    half_rows: tl.constexpr,
+    half_rows_pad: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -3124,12 +3124,34 @@ def _qweight_to_w4a8_rp_kernel(
 
     row = n8c * 32 + n8i * 8 + r8
     dst_row = nt * 256 + row
-    src_row = dst_row + row_rotation
-    src_row = tl.where(src_row >= rows, src_row - rows, src_row)
     src_col = kt * 16 + k32 * 4 + cgrp
-    # Tail tiles: positions past the logical N/K read as zero (FP4 zero rows
-    # and columns), keeping the fixed 4096-word tile addressing uniform.
-    in_bounds = (dst_row < rows) & (src_col < q_cols)
+    if half_rows_pad > 0:
+        # Gated W13 with a ceil-tiled half: dst rows [0, half_pad) hold the
+        # up half, [half_pad, 2*half_pad) the gate half, each zero-padded to
+        # a 128-row boundary so the dynamic kernel's per-128-tile up/gate
+        # pairing stays aligned. `row_rotation` here is the SOURCE row of the
+        # up half (n for w31 sources, 0 for w13); the other half starts at
+        # (rotation + half) % (2*half).
+        is_gate = dst_row >= half_rows_pad
+        half_dst = dst_row - tl.where(is_gate, half_rows_pad, 0)
+        half_src_base = row_rotation + tl.where(is_gate, half_rows, 0)
+        half_src_base = tl.where(
+            half_src_base >= 2 * half_rows,
+            half_src_base - 2 * half_rows,
+            half_src_base,
+        )
+        src_row = half_src_base + half_dst
+        in_bounds = (
+            (dst_row < 2 * half_rows_pad)
+            & (half_dst < half_rows)
+            & (src_col < q_cols)
+        )
+    else:
+        src_row = dst_row + row_rotation
+        src_row = tl.where(src_row >= rows, src_row - rows, src_row)
+        # Tail tiles: positions past the logical N/K read as zero (FP4 zero
+        # rows and columns), keeping the fixed tile addressing uniform.
+        in_bounds = (dst_row < rows) & (src_col < q_cols)
     src_row = tl.where(in_bounds, src_row, 0)
     src_col = tl.where(in_bounds, src_col, 0)
     values = tl.load(
@@ -3194,6 +3216,8 @@ def _grid_to_w4a8_sfb_kernel(
     grid_expert_stride: tl.constexpr,
     dst_expert_stride: tl.constexpr,
     row_rotation: tl.constexpr,
+    half_rows: tl.constexpr,
+    half_rows_pad: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -3212,12 +3236,30 @@ def _grid_to_w4a8_sfb_kernel(
     nt = tmp // k_tiles_128
 
     dst_row = nt * 256 + n32 * 8 + row8
-    row = dst_row + row_rotation
-    row = tl.where(row >= rows, row - rows, row)
     col = kt * 4 + kb
-    # Tail tiles: scale bytes past the logical grid are zero (2^-127 scale on
-    # already-zero FP4 weights).
-    in_bounds = (dst_row < rows) & (col < scale_cols)
+    if half_rows_pad > 0:
+        # Same half-aligned mapping as the weight repack (see
+        # _qweight_to_w4a8_rp_kernel).
+        is_gate = dst_row >= half_rows_pad
+        half_dst = dst_row - tl.where(is_gate, half_rows_pad, 0)
+        half_src_base = row_rotation + tl.where(is_gate, half_rows, 0)
+        half_src_base = tl.where(
+            half_src_base >= 2 * half_rows,
+            half_src_base - 2 * half_rows,
+            half_src_base,
+        )
+        row = half_src_base + half_dst
+        in_bounds = (
+            (dst_row < 2 * half_rows_pad)
+            & (half_dst < half_rows)
+            & (col < scale_cols)
+        )
+    else:
+        row = dst_row + row_rotation
+        row = tl.where(row >= rows, row - rows, row)
+        # Tail tiles: scale bytes past the logical grid are zero (2^-127
+        # scale on already-zero FP4 weights).
+        in_bounds = (dst_row < rows) & (col < scale_cols)
     row = tl.where(in_bounds, row, 0)
     col = tl.where(in_bounds, col, 0)
     values = tl.load(
@@ -3374,6 +3416,7 @@ def _logical_weight_to_w4a8_rp_inplace(
     size_k: int,
     size_n: int,
     row_rotation: int | None = None,
+    gated_half_rows: int | None = None,
 ) -> torch.Tensor:
     size_k = int(size_k)
     size_n = int(size_n)
@@ -3390,6 +3433,17 @@ def _logical_weight_to_w4a8_rp_inplace(
     k_tiles = -(-size_k // 128)
     rp_words = _tensor_numel(rp_shape)
     has_tail = rp_words != size_n * (size_k // 8)
+    # Gated W13 tails place each half's zero rows at a 128-row boundary so
+    # the dynamic kernel's per-tile up/gate pairing stays aligned. The
+    # interpretation of row_rotation shifts to "source row of the up half"
+    # (numerically identical for the aligned case).
+    half_rows = 0
+    half_rows_pad = 0
+    if has_tail and gated_half_rows is not None:
+        half_rows = int(gated_half_rows)
+        half_rows_pad = -(-half_rows // 128) * 128
+        assert 2 * half_rows == size_n, (half_rows, size_n)
+        assert 2 * half_rows_pad == n_tiles * 256, (half_rows_pad, n_tiles)
     if weight.is_cuda:
         weight_E = int(weight.shape[0])
         q_cols = size_k // 8
@@ -3438,6 +3492,8 @@ def _logical_weight_to_w4a8_rp_inplace(
                 size_n * q_cols,
                 dst_expert_stride,
                 row_rot,
+                half_rows,
+                half_rows_pad,
                 BLOCK=block,
                 num_warps=4,
             )
@@ -3651,6 +3707,7 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
     rows: int,
     k_dim: int,
     row_rotation: int | None = None,
+    gated_half_rows: int | None = None,
 ) -> torch.Tensor:
     weight_E = int(weight_E)
     rows = int(rows)
@@ -3668,6 +3725,12 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
     k_tiles = -(-k_dim // 128)
     sfb_bytes = _tensor_numel(sfb_shape) * 4
     has_tail = sfb_bytes != rows * (k_dim // 32)
+    half_rows = 0
+    half_rows_pad = 0
+    if has_tail and gated_half_rows is not None:
+        half_rows = int(gated_half_rows)
+        half_rows_pad = -(-half_rows // 128) * 128
+        assert 2 * half_rows == rows, (half_rows, rows)
     if scale.is_cuda:
         scale_cols = k_dim // 32
         rows_pad = rows if is_logical else int(scale_u8.shape[2])
@@ -3728,6 +3791,8 @@ def _e8m0_scale_to_w4a8_sfb_inplace(
                 total_per_expert,
                 sfb_bytes,
                 row_rot,
+                half_rows,
+                half_rows_pad,
                 BLOCK=block,
                 num_warps=4,
             )
@@ -4146,14 +4211,14 @@ def _prepare_w4a8_from_e8m0_source(
     _as_e8m0_k32_grid(w1_blockscale, w1_rows, k, name="w1_blockscale")
     _as_e8m0_k32_grid(w2_blockscale, k, n, name="w2_blockscale")
 
-    row_rotation = (
-        n if w13_layout == "w31" and is_gated_moe_activation(activation) else None
-    )
+    is_gated = is_gated_moe_activation(activation)
+    row_rotation = n if w13_layout == "w31" and is_gated else None
     w13_rp = _logical_weight_to_w4a8_rp_inplace(
         w1_fp4,
         size_k=k,
         size_n=w1_rows,
         row_rotation=row_rotation,
+        gated_half_rows=n if is_gated else None,
     )
     w2_rp = _logical_weight_to_w4a8_rp_inplace(
         w2_fp4,
@@ -4166,6 +4231,7 @@ def _prepare_w4a8_from_e8m0_source(
         rows=w1_rows,
         k_dim=k,
         row_rotation=row_rotation,
+        gated_half_rows=n if is_gated else None,
     )
     w2_sfb = _e8m0_scale_to_w4a8_sfb_inplace(
         w2_blockscale,
@@ -7425,6 +7491,14 @@ def _launch_dynamic_flat(
     volatile_launch_state: bool,
 ) -> None:
     quant_mode = _normalize_quant_mode(quant_mode)
+    if w4a8_repacked and int(n) % 128 != 0:
+        # Half-aligned ceil-tiled rp/sfb storage is byte-identical to the
+        # storage of zero-padded n_pad weights, and the dynamic kernel has no
+        # external tensor with an n extent (output is [m, k]); launching at
+        # n_pad therefore computes the exact result — the padded FC1 columns
+        # are silu(0)*0 = 0 and w2's padded K rows are zero. tiny_decode
+        # keeps the logical-n bounds for the decode band.
+        n = -(-int(n) // 128) * 128
     decode_regime = bool(
         w4a8_repacked
         and _w4a8_dynamic_decode_candidate(

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -1439,6 +1439,10 @@ def _w4a8_dynamic_dense_candidate(
         _normalize_quant_mode(quant_mode) == "w4a8_mx"
         and activation == "silu"
         and k % 256 == 0
+        # The dynamic gated FC1 pairs the up/gate halves per 128-row
+        # tile, so the half boundary must sit on a tile edge; ceil-tiled
+        # tail shards (352/192) stay on tiny (m<=4) until the pairing
+        # learns mid-tile splits.
         and n % 128 == 0
         and _select_dynamic_tile_mn(
             routed_rows,
@@ -1589,6 +1593,10 @@ def _w4a8_dynamic_materialized_enabled(
     m1_candidate = bool(
         int(num_tokens) == 1
         and k % 256 == 0
+        # The dynamic gated FC1 pairs the up/gate halves per 128-row
+        # tile, so the half boundary must sit on a tile edge; ceil-tiled
+        # tail shards (352/192) stay on tiny (m<=4) until the pairing
+        # learns mid-tile splits.
         and n % 128 == 0
         and _w4a8_dynamic_direct_candidate(
             quant_mode=quant_mode,

--- a/b12x/moe/execution.py
+++ b/b12x/moe/execution.py
@@ -604,10 +604,13 @@ def plan_moe_weight_preparation(
         if spec.quant_mode == "w4a8_mx":
             if spec.activation != "silu":
                 raise ValueError("W4A8-MX preparation currently requires silu")
-            if hidden_size % 256 != 0 or intermediate_size % 128 != 0:
+            # The rp storage ceil-tiles partial 256/128 tiles (zero-filled),
+            # so 32-aligned shards (352 = 2048/TP6, 192 = 3072/TP16) prepare
+            # fine; consumers bound their reads by the logical sizes.
+            if hidden_size % 256 != 0 or intermediate_size % 32 != 0:
                 raise ValueError(
                     "W4A8-MX QMMA layout requires hidden_size % 256 == 0 and "
-                    "intermediate_size % 128 == 0"
+                    "intermediate_size % 32 == 0"
                 )
             transforms.add(WeightPreparationTransform.W4A8_QMMA)
             weight_layouts.add(PreparedWeightLayout.QMMA_REPACKED)

--- a/b12x/moe/execution.py
+++ b/b12x/moe/execution.py
@@ -616,10 +616,17 @@ def plan_moe_weight_preparation(
         if spec.quant_mode == "w4a16":
             layout = requested_w4a16_layout
             if layout is None:
+                # The packed MMA kernels only have tile configs for
+                # 128-aligned intermediate shards; the native path already
+                # supports compact sub-32 tails (see
+                # test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid),
+                # so route every non-128-aligned e8m0 shard through it
+                # instead of failing at kernel-config time (e.g. 2048/TP6 =
+                # 352, 3072/TP16 = 192).
                 layout = (
                     PreparedWeightLayout.SOURCE_NATIVE
                     if source_format == "modelopt_nvfp4"
-                    or (source_format == "fp4_e8m0_k32" and intermediate_size % 32 != 0)
+                    or (source_format == "fp4_e8m0_k32" and intermediate_size % 128 != 0)
                     else PreparedWeightLayout.MMA_PACKED
                 )
             if (

--- a/b12x/moe/fused/dynamic.py
+++ b/b12x/moe/fused/dynamic.py
@@ -1967,9 +1967,15 @@ class MoEDynamicKernelBackend:
                 n_int + Int32(self.tile_shape_mnk[1]) - Int32(1)
             ) // Int32(self.tile_shape_mnk[1])
         else:
-            gate_tile_cnt = Int32(b_w13.shape[0]) // Int32(self.tile_shape_mnk[1])
+            # Same ceil as the swap_ab branch: gate_tile_cnt is also the w2
+            # rp K-tile stride, so a floored count misaddresses every tile
+            # past nt=0 on non-128-aligned shards (e.g. 352).
+            n_int = Int32(b_w13.shape[0])
             if self.is_gated:
-                gate_tile_cnt = gate_tile_cnt // Int32(2)
+                n_int = n_int // Int32(2)
+            gate_tile_cnt = (
+                n_int + Int32(self.tile_shape_mnk[1]) - Int32(1)
+            ) // Int32(self.tile_shape_mnk[1])
         launch_params = DynamicLaunchParams(row_counts, gate_tile_cnt)
         if cutlass.const_expr(self.is_w4a8):
             assert sfb_w13_mx is not None and sfb_down_mx is not None, (

--- a/b12x/moe/fused/tiny_decode.py
+++ b/b12x/moe/fused/tiny_decode.py
@@ -84,15 +84,18 @@ class MoETinyDecodeKernelBackend:
         device: torch.device | None = None,
     ) -> None:
         del device
-        # The rp tile grid needs whole 256-row tiles on each GEMM's N dim:
-        # FC1 tiles 2n rows (so n % 128 suffices) and FC2 tiles k rows.
-        if k % 256 != 0 or (2 * n) % 256 != 0:
-            raise ValueError("tiny_decode requires k % 256 == 0 and n % 128 == 0")
+        # Weights arrive in the ceil-tiled rp layout: partial 256-row / 128-col
+        # tiles are stored zero-filled, so any n % 32 shard works. FC1's
+        # zero rows contribute exact +0.0 through the rotated scatter-add;
+        # FC2 bounds its intermediate loads by k2_tail_g32 (see the kernel).
+        if k % 256 != 0 or n % 32 != 0:
+            raise ValueError("tiny_decode requires k % 256 == 0 and n % 32 == 0")
         if m < 1 or m > 4:
             raise ValueError("tiny_decode supports 1 <= m <= 4")
         rt = m * num_topk
         kt13 = k // 128
-        kt2 = n // 128
+        kt2 = -(-n // 128)
+        nt13 = -(-(2 * n) // 256)
         if kt13 % _FC1_KT_PER_TASK != 0:
             raise ValueError("tiny_decode k-tile counts not divisible by task sizes")
         # FC2 walks the intermediate dim in per-task groups of K tiles. Odd
@@ -110,18 +113,22 @@ class MoETinyDecodeKernelBackend:
             num_topk=num_topk,
             weight_E=weight_E,
             rt=rt,
-            nt13=(2 * n) // 256,
+            nt13=nt13,
             kt13=kt13,
             fc1_ktg=kt13 // _FC1_KT_PER_TASK,
             nt2=k // 256,
             kt2=kt2,
+            # Index of the partial FC2 K tile (== kt2 when none) and how many
+            # 32-value groups of it are logically valid.
+            kt2_full=n // 128,
+            k2_tail_g32=(n % 128) // 32,
             fc2_kt_per_task=fc2_kt_per_task,
             fc2_ktg=kt2 // fc2_kt_per_task,
-            w13_words=(2 * n) * k // 8,
-            w2_words=k * n // 8,
-            sfb13_bytes=(2 * n) * (k // 32),
-            sfb2_bytes=k * (n // 32),
-            fc1_tasks=rt * ((2 * n) // 256) * (kt13 // _FC1_KT_PER_TASK),
+            w13_words=nt13 * kt13 * 4096,
+            w2_words=(k // 256) * kt2 * 4096,
+            sfb13_bytes=nt13 * kt13 * 1024,
+            sfb2_bytes=(k // 256) * kt2 * 1024,
+            fc1_tasks=rt * nt13 * (kt13 // _FC1_KT_PER_TASK),
             fc2_tasks=rt * (k // 256) * (kt2 // fc2_kt_per_task),
         )
         self._c = cfg
@@ -291,24 +298,53 @@ class MoETinyDecodeKernelBackend:
                 tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
                 srow = srow_base + Int64(col_tile) * Int64(1024)
                 xs = []
-                for k32 in cutlass.range_constexpr(4):
-                    ich = ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
-                    quads = []
-                    for jp in cutlass.range_constexpr(4):
-                        g0 = Float32(inter[ich + Int32(2 * jp)])
-                        g1 = Float32(inter[ich + Int32(2 * jp + 1)])
-                        u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
-                        u1 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)])
-                        s0 = Float32(1.0) / (
-                            Float32(1.0) + cute.math.exp(-g0, fastmath=False)
-                        )
-                        s1 = Float32(1.0) / (
-                            Float32(1.0) + cute.math.exp(-g1, fastmath=False)
-                        )
-                        a0 = s0 * g0 * u0 * rw
-                        a1 = s1 * g1 * u1 * rw
-                        quads.append(pack_f32x2_to_f16x2(a0, a1))
-                    xs.append((quads[0], quads[1], quads[2], quads[3]))
+                if cutlass.const_expr(c["k2_tail_g32"] > 0):
+                    # Ceil-tiled FC2 K tail: 32-groups past the logical n get
+                    # zero activations (their rp weights/scales are zero-filled
+                    # too), which also keeps the intermediate loads in bounds.
+                    kt_valid_g32 = Int32(4)
+                    if kt == Int32(c["kt2_full"]):
+                        kt_valid_g32 = Int32(c["k2_tail_g32"])
+                    for k32 in cutlass.range_constexpr(4):
+                        ich = ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
+                        quads = []
+                        for jp in cutlass.range_constexpr(4):
+                            a0 = Float32(0.0)
+                            a1 = Float32(0.0)
+                            if Int32(k32) < kt_valid_g32:
+                                g0 = Float32(inter[ich + Int32(2 * jp)])
+                                g1 = Float32(inter[ich + Int32(2 * jp + 1)])
+                                u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
+                                u1 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)])
+                                s0 = Float32(1.0) / (
+                                    Float32(1.0) + cute.math.exp(-g0, fastmath=False)
+                                )
+                                s1 = Float32(1.0) / (
+                                    Float32(1.0) + cute.math.exp(-g1, fastmath=False)
+                                )
+                                a0 = s0 * g0 * u0 * rw
+                                a1 = s1 * g1 * u1 * rw
+                            quads.append(pack_f32x2_to_f16x2(a0, a1))
+                        xs.append((quads[0], quads[1], quads[2], quads[3]))
+                else:
+                    for k32 in cutlass.range_constexpr(4):
+                        ich = ibase + kt * Int32(128) + cgrp * Int32(8) + Int32(k32 * 32)
+                        quads = []
+                        for jp in cutlass.range_constexpr(4):
+                            g0 = Float32(inter[ich + Int32(2 * jp)])
+                            g1 = Float32(inter[ich + Int32(2 * jp + 1)])
+                            u0 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp)])
+                            u1 = Float32(inter[ich + Int32(c["n"]) + Int32(2 * jp + 1)])
+                            s0 = Float32(1.0) / (
+                                Float32(1.0) + cute.math.exp(-g0, fastmath=False)
+                            )
+                            s1 = Float32(1.0) / (
+                                Float32(1.0) + cute.math.exp(-g1, fastmath=False)
+                            )
+                            a0 = s0 * g0 * u0 * rw
+                            a1 = s1 * g1 * u1 * rw
+                            quads.append(pack_f32x2_to_f16x2(a0, a1))
+                        xs.append((quads[0], quads[1], quads[2], quads[3]))
                 d0, d1, d2, d3 = self._row_block_dot(
                     tile_word, srow, n8c, r8, cgrp,
                     xs[0][0], xs[0][1], xs[0][2], xs[0][3],

--- a/b12x/moe/fused/tiny_decode.py
+++ b/b12x/moe/fused/tiny_decode.py
@@ -84,15 +84,24 @@ class MoETinyDecodeKernelBackend:
         device: torch.device | None = None,
     ) -> None:
         del device
-        if k % 256 != 0 or n % 256 != 0:
-            raise ValueError("tiny_decode requires k % 256 == 0 and n % 256 == 0")
+        # The rp tile grid needs whole 256-row tiles on each GEMM's N dim:
+        # FC1 tiles 2n rows (so n % 128 suffices) and FC2 tiles k rows.
+        if k % 256 != 0 or (2 * n) % 256 != 0:
+            raise ValueError("tiny_decode requires k % 256 == 0 and n % 128 == 0")
         if m < 1 or m > 4:
             raise ValueError("tiny_decode supports 1 <= m <= 4")
         rt = m * num_topk
         kt13 = k // 128
         kt2 = n // 128
-        if kt13 % _FC1_KT_PER_TASK != 0 or kt2 % _FC2_KT_PER_TASK != 0:
+        if kt13 % _FC1_KT_PER_TASK != 0:
             raise ValueError("tiny_decode k-tile counts not divisible by task sizes")
+        # FC2 walks the intermediate dim in per-task groups of K tiles. Odd
+        # tile counts (e.g. n=384 -> 3 tiles from GLM 2048/TP6 padded shards)
+        # drop to one tile per task; partials are scatter-added, so the task
+        # split does not change results.
+        fc2_kt_per_task = (
+            _FC2_KT_PER_TASK if kt2 % _FC2_KT_PER_TASK == 0 else 1
+        )
         cfg = dict(
             m=m,
             k=k,
@@ -106,13 +115,14 @@ class MoETinyDecodeKernelBackend:
             fc1_ktg=kt13 // _FC1_KT_PER_TASK,
             nt2=k // 256,
             kt2=kt2,
-            fc2_ktg=kt2 // _FC2_KT_PER_TASK,
+            fc2_kt_per_task=fc2_kt_per_task,
+            fc2_ktg=kt2 // fc2_kt_per_task,
             w13_words=(2 * n) * k // 8,
             w2_words=k * n // 8,
             sfb13_bytes=(2 * n) * (k // 32),
             sfb2_bytes=k * (n // 32),
             fc1_tasks=rt * ((2 * n) // 256) * (kt13 // _FC1_KT_PER_TASK),
-            fc2_tasks=rt * (k // 256) * (kt2 // _FC2_KT_PER_TASK),
+            fc2_tasks=rt * (k // 256) * (kt2 // fc2_kt_per_task),
         )
         self._c = cfg
         self._cfg_key = tuple(sorted(cfg.items()))
@@ -275,8 +285,8 @@ class MoETinyDecodeKernelBackend:
             acc1 = Float32(0.0)
             acc2 = Float32(0.0)
             acc3 = Float32(0.0)
-            for kt_i in cutlass.range_constexpr(_FC2_KT_PER_TASK):
-                kt = ktg * Int32(_FC2_KT_PER_TASK) + Int32(kt_i)
+            for kt_i in cutlass.range_constexpr(c["fc2_kt_per_task"]):
+                kt = ktg * Int32(c["fc2_kt_per_task"]) + Int32(kt_i)
                 col_tile = nt * Int32(c["kt2"]) + kt
                 tile_word = we_base + Int64(col_tile) * Int64(4096 * 4)
                 srow = srow_base + Int64(col_tile) * Int64(1024)

--- a/b12x/moe/fused/tiny_decode.py
+++ b/b12x/moe/fused/tiny_decode.py
@@ -122,6 +122,9 @@ class MoETinyDecodeKernelBackend:
             # 32-value groups of it are logically valid.
             kt2_full=n // 128,
             k2_tail_g32=(n % 128) // 32,
+            # Half-aligned rp storage: each gated half is zero-padded to a
+            # 128-row boundary (up at [0, n_pad128), gate at [n_pad128, ...)).
+            n_pad128=kt2 * 128,
             fc2_kt_per_task=fc2_kt_per_task,
             fc2_ktg=kt2 // fc2_kt_per_task,
             w13_words=nt13 * kt13 * 4096,
@@ -268,10 +271,29 @@ class MoETinyDecodeKernelBackend:
                 accs = (acc0, acc1, acc2, acc3)
                 for v in cutlass.range_constexpr(4):
                     p = nt * Int32(256) + n8c * Int32(32) + Int32(v * 8) + r8
-                    r_log = p + Int32(c["n"])
-                    if r_log >= Int32(c["two_n"]):
-                        r_log -= Int32(c["two_n"])
-                    red_add_global_f32(ibase_rt + Int64(r_log) * Int64(4), accs[v])
+                    if cutlass.const_expr(c["k2_tail_g32"] > 0):
+                        # Half-aligned tail storage: up rows at
+                        # [0, n_pad128), gate rows at [n_pad128, 2*n_pad128),
+                        # each half zero-padded past the logical n. Skip the
+                        # dead rows' stores (their accs are exact zeros, but
+                        # the mapped inter rows would go out of bounds).
+                        is_gate = p >= Int32(c["n_pad128"])
+                        half_dst = p
+                        r_log = p + Int32(c["n"])
+                        if is_gate:
+                            half_dst = p - Int32(c["n_pad128"])
+                            r_log = half_dst
+                        if half_dst < Int32(c["n"]):
+                            red_add_global_f32(
+                                ibase_rt + Int64(r_log) * Int64(4), accs[v]
+                            )
+                    else:
+                        r_log = p + Int32(c["n"])
+                        if r_log >= Int32(c["two_n"]):
+                            r_log -= Int32(c["two_n"])
+                        red_add_global_f32(
+                            ibase_rt + Int64(r_log) * Int64(4), accs[v]
+                        )
 
         if cutlass.const_expr(self.compile_time_phase == 2):
             # ---- FC2: block = (rt, nt2, ktg2) ----

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -4784,10 +4784,15 @@ def compile_w4a16_fused_moe(
         )
     fc1_cols = int(intermediate_size) * (2 if is_gated else 1)
     routed_rows = int(size_m) * int(top_k)
+    # Logical K/N tails are needed for every shard the tile table can't
+    # divide, not just sub-32 ones: 2048/TP6 = 352 and 3072/TP16 = 192 are
+    # 32-aligned yet have no dividing tile_k/tile_n. %32 shards are the
+    # ceil-scale-grid subset of the same machinery (%32 != 0 implies
+    # %128 != 0).
     allow_native_logical_tail = (
         weight_layout == "modelopt"
         and scale_format == "e8m0_k32"
-        and int(intermediate_size) % 32 != 0
+        and int(intermediate_size) % 128 != 0
     )
     fc1_tile_k, fc1_tile_n, fc1_cta_threads, _ = _select_tile_config(
         problem_m=size_m,

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -507,16 +507,18 @@ class _W4A16SmallMDirectKernel(MoEMicroKernelBackend):
         num_experts: int,
         scale_format: str = "e4m3_k16",
     ) -> bool:
-        # E8M0 reads the shared packed scale grid. Both block axes must be /32,
-        # and the FC2 chunking (256 intermediate values per chunk, see
-        # fc2_n_chunks) must cover the intermediate exactly: on a logical tail
-        # (e.g. 352 or 384 per-rank shards) the padded chunk region indexes
-        # scale columns past the e8m0 grid. The e4m3_k16 path masks this fine;
-        # e8m0 does not — route those shards to the fused kernels instead.
+        # E8M0 reads the shared packed scale grid. Both block axes must be /32.
+        # The FC2 chunking (256 intermediate values per chunk, fc2_n_chunks)
+        # masks a tail inside a single chunk correctly (I=128 oracle-covered),
+        # but multi-chunk shards with a partial last chunk (352, 384) index
+        # scale columns past the e8m0 grid and corrupt decode outputs — the
+        # e4m3_k16 path masks this fine; e8m0 must cover multi-chunk exactly.
         if scale_format == "e8m0_k32":
+            fc2_n_chunks = ((int(intermediate_size) // 2) + 127) // 128
             scale_block_ok = (
                 int(hidden_size) % 32 == 0
-                and int(intermediate_size) % 256 == 0
+                and int(intermediate_size) % 32 == 0
+                and (fc2_n_chunks == 1 or int(intermediate_size) % 256 == 0)
             )
         else:
             scale_block_ok = True

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -507,11 +507,16 @@ class _W4A16SmallMDirectKernel(MoEMicroKernelBackend):
         num_experts: int,
         scale_format: str = "e4m3_k16",
     ) -> bool:
-        # E8M0 reads the shared packed scale grid. Both block axes must be /32.
+        # E8M0 reads the shared packed scale grid. Both block axes must be /32,
+        # and the FC2 chunking (256 intermediate values per chunk, see
+        # fc2_n_chunks) must cover the intermediate exactly: on a logical tail
+        # (e.g. 352 or 384 per-rank shards) the padded chunk region indexes
+        # scale columns past the e8m0 grid. The e4m3_k16 path masks this fine;
+        # e8m0 does not — route those shards to the fused kernels instead.
         if scale_format == "e8m0_k32":
             scale_block_ok = (
                 int(hidden_size) % 32 == 0
-                and int(intermediate_size) % 32 == 0
+                and int(intermediate_size) % 256 == 0
             )
         else:
             scale_block_ok = True

--- a/tests/test_moe_execution_model.py
+++ b/tests/test_moe_execution_model.py
@@ -308,3 +308,22 @@ def test_planner_rejects_two_incompatible_repacks() -> None:
 
 def test_storage_policy_has_no_keep_both_state() -> None:
     assert "keep_both" not in {policy.value for policy in WeightStoragePolicy}
+
+
+def test_non_128_aligned_e8m0_w4a16_shards_stay_source_native() -> None:
+    """2048/TP6 = 352 and 3072/TP16 = 192 have no packed tile configs; the
+    planner must route them through the native layout instead of failing at
+    kernel-config time. 128-aligned shards keep the packed fast path."""
+    for shard in (352, 192):
+        plan = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=shard)
+        assert WeightPreparationTransform.W4A16_NATIVE in plan.transforms
+        assert (
+            plan.required_weight_layout("w4a16")
+            is PreparedWeightLayout.SOURCE_NATIVE
+        )
+
+    aligned = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=256)
+    assert WeightPreparationTransform.W4A16_PACKED in aligned.transforms
+    assert (
+        aligned.required_weight_layout("w4a16") is PreparedWeightLayout.MMA_PACKED
+    )

--- a/tests/test_w4a16_e2e.py
+++ b/tests/test_w4a16_e2e.py
@@ -573,17 +573,27 @@ def test_w4a16_e8m0_native_large_m_uses_main_gemm(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("activation", ["silu", "relu2"])
+@pytest.mark.parametrize(
+    ("activation", "intermediate_size"),
+    [
+        ("silu", 312),
+        ("relu2", 112),
+        # 32-aligned but not 128-aligned: no dividing tile config, so the
+        # same logical-tail path must engage (2048/TP6 = 352, 3072/TP16 = 192).
+        ("silu", 352),
+        ("relu2", 192),
+    ],
+)
 def test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid(
     activation: str,
+    intermediate_size: int,
 ) -> None:
     """Native E8M0 supports compact FC2 K tails without padding I to 32."""
     experts, hidden_size = 4, 128
-    intermediate_size = 312 if activation == "silu" else 112
     rows = intermediate_size * (2 if activation == "silu" else 1)
     topk, m = 2, 24
     assert intermediate_size % 8 == 0
-    assert intermediate_size % 32 != 0
+    assert intermediate_size % 128 != 0
     torch.manual_seed(20260610)
     w13 = torch.randint(
         0, 256, (experts, rows, hidden_size // 2), dtype=torch.uint8, device="cuda"

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -182,7 +182,7 @@ def _run(
     return out
 
 
-@pytest.mark.parametrize("n", [_N, 384, 352, 192])
+@pytest.mark.parametrize("n", [_N, 384, 352, 192, 320])
 def test_w4a8_mx_dynamic_matches_oracle(n: int) -> None:
     _skip_if_unavailable()
     from b12x.moe.fused.reference import moe_reference_w4a8_mx
@@ -257,9 +257,9 @@ def test_w4a8_mx_w31_layout_flip() -> None:
 
 
 @pytest.mark.parametrize("m", [1, 2, 3, 4])
-# n=384 covers odd rp K-tile counts on FC2; 352/192 cover ceil-tiled tails
-# (GLM-5.2 2048/TP6 and DS4-Pro 3072/TP16 native shards).
-@pytest.mark.parametrize("n", [_N, 384, 352, 192])
+# n=384 covers odd rp K-tile counts on FC2; 352/192/320 cover ceil-tiled
+# tails (GLM-5.2 2048/TP6, DS4-Pro 3072/TP16 and 3072/TP10 native shards).
+@pytest.mark.parametrize("n", [_N, 384, 352, 192, 320])
 def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:
     _skip_if_unavailable()
     from b12x.integration import plan_b12x_fp4_moe_weights, tp_moe

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -137,7 +137,14 @@ def _prepare(weights: dict, *, n: int = _N, w13_layout: str = "w13"):
             runtime.w2_sfb,
         )
     )
-    assert runtime_ptrs == source_ptrs
+    # Aligned shards repack in place; ceil-tiled tails (n % 128 != 0 for w2,
+    # (2n) % 256 != 0 for w13) can't fit the source storage and get fresh
+    # allocations instead.
+    has_tail = n % 128 != 0 or (2 * n) % 256 != 0
+    if has_tail:
+        assert runtime_ptrs != source_ptrs
+    else:
+        assert runtime_ptrs == source_ptrs
     return prepared
 
 
@@ -250,8 +257,9 @@ def test_w4a8_mx_w31_layout_flip() -> None:
 
 
 @pytest.mark.parametrize("m", [1, 2, 3, 4])
-# n=384 covers odd rp K-tile counts on FC2 (GLM-5.2 2048/TP6 padded shards).
-@pytest.mark.parametrize("n", [_N, 384])
+# n=384 covers odd rp K-tile counts on FC2; 352/192 cover ceil-tiled tails
+# (GLM-5.2 2048/TP6 and DS4-Pro 3072/TP16 native shards).
+@pytest.mark.parametrize("n", [_N, 384, 352, 192])
 def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:
     _skip_if_unavailable()
     from b12x.integration import plan_b12x_fp4_moe_weights, tp_moe

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -249,12 +249,14 @@ def test_w4a8_mx_w31_layout_flip() -> None:
 
 
 @pytest.mark.parametrize("m", [1, 2, 4])
-def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
+# n=384 covers odd rp K-tile counts on FC2 (GLM-5.2 2048/TP6 padded shards).
+@pytest.mark.parametrize("n", [_N, 384])
+def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:
     _skip_if_unavailable()
     from b12x.integration import plan_b12x_fp4_moe_weights, tp_moe
     from b12x.moe.fused.reference import moe_reference_w4a16_fp4_e8m0_k32
 
-    weights = _weights()
+    weights = _weights(n=n)
     weight_plan = plan_b12x_fp4_moe_weights(
         quant_modes="w4a8_mx",
         source_format="fp4_e8m0_k32",
@@ -262,7 +264,7 @@ def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
         params_dtype=torch.bfloat16,
         num_experts=_E,
         hidden_size=_K,
-        intermediate_size=_N,
+        intermediate_size=n,
     )
     plan = tp_moe.plan_tp_moe_execution(
         num_tokens=m,
@@ -286,11 +288,11 @@ def test_w4a8_mx_small_band_matches_fp32_oracle(m: int) -> None:
         topk_weights,
         _E,
         _K,
-        _N,
+        n,
         activation="silu",
         w13_layout="w13",
     )
-    prepared = _prepare(weights)
+    prepared = _prepare(weights, n=n)
     out = _run(m, prepared)
     n_out = out.float().norm().item()
     assert n_out > 0.01, f"w4a8_mx tiny output near-zero (norm={n_out})"

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -182,7 +182,7 @@ def _run(
     return out
 
 
-@pytest.mark.parametrize("n", [_N, 384])
+@pytest.mark.parametrize("n", [_N, 384, 352, 192])
 def test_w4a8_mx_dynamic_matches_oracle(n: int) -> None:
     _skip_if_unavailable()
     from b12x.moe.fused.reference import moe_reference_w4a8_mx

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -175,11 +175,12 @@ def _run(
     return out
 
 
-def test_w4a8_mx_dynamic_matches_oracle() -> None:
+@pytest.mark.parametrize("n", [_N, 384])
+def test_w4a8_mx_dynamic_matches_oracle(n: int) -> None:
     _skip_if_unavailable()
     from b12x.moe.fused.reference import moe_reference_w4a8_mx
 
-    weights = _weights()
+    weights = _weights(n=n)
     m = 16
     x, topk_ids, topk_weights = _routed_inputs(m, 33)
     ref = moe_reference_w4a8_mx(
@@ -196,10 +197,10 @@ def test_w4a8_mx_dynamic_matches_oracle() -> None:
         topk_weights,
         _E,
         _K,
-        _N,
+        n,
         activation="silu",
     )
-    prepared = _prepare(weights)
+    prepared = _prepare(weights, n=n)
     out = _run(m, prepared)
     n_out = out.float().norm().item()
     assert n_out > 0.01, f"w4a8_mx output near-zero (norm={n_out})"
@@ -248,7 +249,7 @@ def test_w4a8_mx_w31_layout_flip() -> None:
         )
 
 
-@pytest.mark.parametrize("m", [1, 2, 4])
+@pytest.mark.parametrize("m", [1, 2, 3, 4])
 # n=384 covers odd rp K-tile counts on FC2 (GLM-5.2 2048/TP6 padded shards).
 @pytest.mark.parametrize("n", [_N, 384])
 def test_w4a8_mx_small_band_matches_fp32_oracle(m: int, n: int) -> None:

--- a/tests/test_w4a8_rp_inverse_mapping.py
+++ b/tests/test_w4a8_rp_inverse_mapping.py
@@ -52,8 +52,16 @@ def sfb_byte_offset(r: int, c: int, *, rows: int, k_tiles: int, rot: int) -> int
 
 @pytest.mark.parametrize(
     "rows,kdim,rot",
-    [(2048, 4096, 1024), (4096, 1024, 0)],
-    ids=["w13_rotated", "w2"],
+    [
+        (2048, 4096, 1024),
+        (4096, 1024, 0),
+        # ceil-tiled tails (2048/TP6 = 352): w13 = 704 rows rotated by 352,
+        # w2 = K tail (352 = 2x128 + 96)
+        (704, 4096, 352),
+        (4096, 352, 0),
+        (352, 352, 0),
+    ],
+    ids=["w13_rotated", "w2", "w13_n_tail", "w2_k_tail", "both_tails"],
 )
 def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
     torch.manual_seed(0)
@@ -64,7 +72,7 @@ def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
         logical.clone(), size_k=kdim, size_n=rows, row_rotation=(rot or None)
     )
     rp_flat = rp.reshape(-1).view(torch.int32)
-    k_tiles = kdim // 128
+    k_tiles = -(-kdim // 128)
     rs = torch.randint(0, rows, (4096,))
     ws = torch.randint(0, kdim // 8, (4096,))
     offs = torch.tensor(
@@ -75,12 +83,33 @@ def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
         device=dev,
     )
     assert torch.equal(rp_flat[offs], qwords[0][rs.to(dev), ws.to(dev)])
+    n_tiles = -(-rows // 256)
+    if n_tiles * 256 != rows or k_tiles * 128 != kdim:
+        # every rp word not addressed by a logical (row, word) must be zero
+        seen = torch.zeros(n_tiles * k_tiles * 4096, dtype=torch.bool, device=dev)
+        all_r = torch.arange(rows).repeat_interleave(kdim // 8)
+        all_w = torch.arange(kdim // 8).repeat(rows)
+        all_offs = torch.tensor(
+            [
+                rp_word_offset(int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot)
+                for r, w in zip(all_r, all_w)
+            ],
+            device=dev,
+        )
+        seen[all_offs] = True
+        assert (rp_flat[~seen] == 0).all()
 
 
 @pytest.mark.parametrize(
     "rows,kdim,rot",
-    [(2048, 4096, 1024), (4096, 1024, 0)],
-    ids=["w13_rotated", "w2"],
+    [
+        (2048, 4096, 1024),
+        (4096, 1024, 0),
+        (704, 4096, 352),
+        (4096, 352, 0),
+        (352, 352, 0),
+    ],
+    ids=["w13_rotated", "w2", "w13_n_tail", "w2_k_tail", "both_tails"],
 )
 def test_sfb_grid_inverse(rows: int, kdim: int, rot: int) -> None:
     torch.manual_seed(0)
@@ -97,7 +126,7 @@ def test_sfb_grid_inverse(rows: int, kdim: int, rot: int) -> None:
         scale.clone(), weight_E=1, rows=rows, k_dim=kdim, row_rotation=(rot or None)
     )
     sfb_flat = sfb.reshape(-1).view(torch.uint8)
-    k_tiles = kdim // 128
+    k_tiles = -(-kdim // 128)
     rs = torch.randint(0, rows, (4096,))
     cs = torch.randint(0, scale_cols, (4096,))
     offs = torch.tensor(

--- a/tests/test_w4a8_rp_inverse_mapping.py
+++ b/tests/test_w4a8_rp_inverse_mapping.py
@@ -31,9 +31,22 @@ from b12x.integration.tp_moe import (
 )
 
 
-def rp_word_offset(r: int, w: int, *, rows: int, k_tiles: int, rot: int) -> int:
+def rp_word_offset(
+    r: int,
+    w: int,
+    *,
+    rows: int,
+    k_tiles: int,
+    rot: int,
+    half: int = 0,
+) -> int:
     """Logical (row, int32-word) -> flat int32-word offset in the rp buffer."""
-    p = (r - rot) % rows
+    if half:
+        half_pad = -(-half // 128) * 128
+        rel = (r - rot) % rows
+        p = rel if rel < half else half_pad + (rel - half)
+    else:
+        p = (r - rot) % rows
     nt, row = p >> 8, p & 255
     n8c, n8i, r8 = row >> 5, (row >> 3) & 3, row & 7
     kt, k32, cgrp = w >> 4, (w & 15) >> 2, w & 3
@@ -51,25 +64,32 @@ def sfb_byte_offset(r: int, c: int, *, rows: int, k_tiles: int, rot: int) -> int
 
 
 @pytest.mark.parametrize(
-    "rows,kdim,rot",
+    "rows,kdim,rot,half",
     [
-        (2048, 4096, 1024),
-        (4096, 1024, 0),
+        (2048, 4096, 1024, 0),
+        (4096, 1024, 0, 0),
         # ceil-tiled tails (2048/TP6 = 352): w13 = 704 rows rotated by 352,
         # w2 = K tail (352 = 2x128 + 96)
-        (704, 4096, 352),
-        (4096, 352, 0),
-        (352, 352, 0),
+        (704, 4096, 352, 0),
+        (4096, 352, 0, 0),
+        (352, 352, 0, 0),
+        # gated half-aligned tail layout (the serving w13 path)
+        (704, 4096, 352, 352),
     ],
-    ids=["w13_rotated", "w2", "w13_n_tail", "w2_k_tail", "both_tails"],
+    ids=["w13_rotated", "w2", "w13_n_tail", "w2_k_tail", "both_tails",
+         "w13_half_tail"],
 )
-def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
+def test_rp_weight_inverse(rows: int, kdim: int, rot: int, half: int) -> None:
     torch.manual_seed(0)
     dev = torch.device("cuda")
     logical = torch.randint(0, 256, (1, rows, kdim // 2), dtype=torch.uint8, device=dev)
     qwords = logical.clone().view(torch.int32).reshape(1, rows, kdim // 8)
     rp = _logical_weight_to_w4a8_rp_inplace(
-        logical.clone(), size_k=kdim, size_n=rows, row_rotation=(rot or None)
+        logical.clone(),
+        size_k=kdim,
+        size_n=rows,
+        row_rotation=(rot or None),
+        gated_half_rows=(half or None),
     )
     rp_flat = rp.reshape(-1).view(torch.int32)
     k_tiles = -(-kdim // 128)
@@ -77,7 +97,9 @@ def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
     ws = torch.randint(0, kdim // 8, (4096,))
     offs = torch.tensor(
         [
-            rp_word_offset(int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot)
+            rp_word_offset(
+                int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot, half=half
+            )
             for r, w in zip(rs, ws)
         ],
         device=dev,
@@ -91,7 +113,9 @@ def test_rp_weight_inverse(rows: int, kdim: int, rot: int) -> None:
         all_w = torch.arange(kdim // 8).repeat(rows)
         all_offs = torch.tensor(
             [
-                rp_word_offset(int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot)
+                rp_word_offset(
+                    int(r), int(w), rows=rows, k_tiles=k_tiles, rot=rot, half=half
+                )
                 for r, w in zip(all_r, all_w)
             ],
             device=dev,


### PR DESCRIPTION
Replaces the padding approach you rejected in local-inference-lab/vllm#80: no checkpoint mutation, no fabricated 128-column shards. GLM-5.2 2048/TP6 = 352 and DS4-Pro 3072/TP16 = 192 per-rank shards now run natively in both w4a8_mx and w4a16; vLLM needs no change.

## How

- **Ceil-tiled rp/sfb storage**: shards the N256/K128 tiles don't divide store zero-filled tail tiles (fresh allocation when in-place can't fit; the repack/grid Triton kernels bound their reads by the logical sizes). Fixed 4096-word tile addressing stays uniform; aligned shards keep the in-place path bit-for-bit.
- **Half-aligned gated halves**: the dynamic gated FC1 pairs up/gate per 128-row tile, so each half now sits on its own 128-row boundary (up at `[0, n_pad128)`, gate at `[n_pad128, ...)`), zero rows at the end of each half. Same byte count; for tile-aligned shards the mapping degenerates to the existing rotation semantics exactly.
- **Dynamic launch**: that storage is byte-identical to zero-padded `n_pad` weights and the kernel has no external tensor with an n extent, so the launch substitutes `n_pad` and computes the exact result (padded FC1 columns are `silu(0)*0 = 0`, w2's padded K rows are zero). Also mirrored your swap_ab ceil of `gate_tile_cnt` into the plain branch — it doubles as the w2 rp K-tile stride, so the floored count misaddressed every tile past nt=0.
- **tiny_decode**: accepts `n % 32`, bounds the partial FC2 K tile's intermediate loads by `k2_tail_g32`, FC1 store maps the half-aligned rows; kernel time at 352 measures within 2% of the padded-384 shape on GLM decode shapes.
- **w4a16 native**: the automatic layout policy routes non-128-aligned e8m0 shards through SOURCE_NATIVE (your logical-tail machinery handles them; the %32 condition was a subset), and `allow_native_logical_tail` widens the same way.

## Two pre-existing bugs found on the way

1. **e8m0 small-M direct silently corrupts multi-chunk tails**: the direct micro kernel chunks FC2 by 256 intermediate values; on shards the chunks don't cover exactly (352/384) the padded chunk region indexes e8m0 scale columns past the grid — decode output is garbage with no error (e4m3_k16 masks this correctly, which is why NVFP4 direct decode works at 352). Gated precisely: single-chunk tails stay direct (I=128 class is oracle-covered on master), multi-chunk partial coverage routes to the fused path.
2. **Duplicate expert ids inside one token's top-k corrupt the fused logical-tail path** (m=1, ids=[e,e]: cos 0.33 vs expected; aligned shards handle it exactly). Real routers emit distinct ids per token, so serving is unaffected — documented, not fixed here.

## Verification

- fp32 oracle: dynamic n ∈ {1024, 384, 352, 192} (m=16) and the tiny band n ∈ {1024, 384, 352, 192} × m ∈ {1..4}, all through the full serving prepare path.
- rp/sfb inverse-mapping tests extended with tail shapes, the half-aligned layout, and zero-fill assertions over every non-logical word.
- Suite parity vs master: the same 9 pre-existing test_w4a8_dynamic_kernel failures on both sides (test/kernel signature skew on master, e.g. `rows_padded`), 147 pass here incl. 26 new parametrizations; `test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes[relu2]` newly passes.
- E2E GLM-5.2 TP6, AMD MXFP4 checkpoint, online MXFP8 dense, DCP1, zero checkpoint padding:
  - **A8: decode c0 84.1 / c3000 82.7 tok/s, 30k-ctx TTFT 3.27 s, 0 CJK** (the padded experiment measured 83.0/81.4).
  - A16 native: 67.9/67.0, 0 CJK, KV 436,608 (+29% KV vs packed — no second weight copy).

## Notes

- First two commits are #26 (this builds on the odd-tile-count support); merging #26 first rebases this clean, or merging this closes #26.
- Known follow-ups, not blocking: a dot3 tail variant in tiny (skip the dead k32 group's weight fetches, ~+3-4% decode) and true masked tails in the dynamic kernel (drops the +9% padded-region compute on large-M, your swap_ab direction applied to w4a8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded W4A8 and W4A16 MoE support for non-128-aligned shard sizes with refined tail handling.
  * Broadened eligibility for W4A8 dense/materialized paths and tiny-decode kernel shapes.

* **Bug Fixes**
  * Corrected tile-counting and kernel launch behavior for partial final gate tiles and non-multiple-of-128 sizes.
  * Improved repacking/mapping for W4A8 tail and gated-half layouts to prevent mismatches and out-of-bounds stores.

* **Tests**
  * Added/updated unit and end-to-end tests to validate layout selection, tail behavior, aliasing, and inverse mappings across more configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->