### PR TITLE
Handle plain CuTe compile callable with DSL options

### DIFF
--- a/b12x/cute/compiler.py
+++ b/b12x/cute/compiler.py
@@ -1994,7 +1994,17 @@ def compile(
         # Subscript-style DSL compile options (e.g. OptLevel(2): ptxas -O3's
         # scheduler register-starves some scalar-heavy kernels; see the w4a8
         # dynamic MoE recipe).
-        compile_callable = cute.compile[dsl_compile_options]
+        if hasattr(compile_callable, "__getitem__"):
+            compile_callable = compile_callable[dsl_compile_options]
+        else:
+            # Some embedded runtimes expose cutlass.cute.compile as a plain
+            # function instead of the CompileCallable instance installed by the
+            # top-level module import.  Recreate the callable explicitly so DSL
+            # options still take effect instead of crashing or silently falling
+            # back to the default compiler options.
+            from cutlass.base_dsl.compiler import CompileCallable
+
+            compile_callable = CompileCallable(dsl_compile_options)
         kwargs = dict(kwargs)
         kwargs["__dsl_compile_options_key"] = repr(dsl_compile_options)
     memory_cache_key = _compile_memory_cache_key(


### PR DESCRIPTION
## Summary
- keep the existing DSL compile options path for W4A8 dynamic MoE
- handle runtimes where cutlass.cute.compile is exposed as a plain function instead of a CompileCallable instance
- instantiate CompileCallable(dsl_compile_options) explicitly in that case, rather than crashing or dropping the options

## Root Cause
The GLM 5.2 v15 FF image hit TypeError: function object is not subscriptable in b12x/cute/compiler.py when W4A8 dynamic MoE requested OptLevel(2). In the vLLM worker runtime, cutlass.cute.compile can be a plain function, so cute.compile[dsl_compile_options] is not always valid.

## Validation
- runtime overlay benchmark on 8x RTX Pro 6000 Blackwell for /root/models/GLM-5.2-BF16-AMDMXFP4experts, TP8/DCP1/MTP0/A8 force
- before patch: first request killed EngineCore with TypeError at cute.compile[dsl_compile_options]
- after patch: mxfp4-a8-orig completed, decode cc1 88.612 tok/s, prefill 8k 6198 tok/s, prefill 64k 6365 tok/s, KV cache 625344 tokens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation compatibility when DSL options are provided.
  * DSL options are now applied correctly whether the compiler is exposed as a configurable callable or a standard function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->