### PR TITLE
moe(w4a16): NF3 3-bit weight layout — mixed-precision MoE serving (NVFP4 + NF3)

### DIFF
--- a/b12x/cute/fp4.py
+++ b/b12x/cute/fp4.py
@@ -5522,3 +5522,129 @@ def compute_y_and_max_abs_f32(
         max_abs = fmax_f32(max_abs, fabs_f32(y_f32[i]))
 
     return y_f32, max_abs
+
+
+# ---------------------------------------------------------------------------
+# NF3 (3-bit NormalFloat codebook) dequant for the W4A16 "nf3_2p1" layout.
+#
+# Input per call: 8 codes in 2+1 split-plane form — lo16 (8 x 2-bit fields,
+# code j bits 1:0 at bits 2j+1:2j) and hi8 (8 x 1-bit, code j bit 2 at bit j)
+# — plus the 8-entry bf16 codebook as 4 u32 pools (lo/hi bytes of entries
+# 0..3 and 4..7).  Output: 4 packed bf16x2 fragments in the SAME element
+# order as packed_dequant_e2m1x4 pairs: o0=(v0,v1) o1=(v2,v3) o2=(v4,v5)
+# o3=(v6,v7).
+#
+# Selector build is the carry-safe shift ladder (NOT a multiply spread — the
+# 0x249 multiply trick carries between lanes).  prmt pool selectors are the
+# 3-bit codes themselves; bit 3 of every selector nibble stays 0 so prmt
+# byte-select mode is used, never sign-replicate.
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def packed_dequant_nf3x8_to_bfloat2x4(
+    lo16: Uint32,
+    hi8: Uint32,
+    cb_lo01: Uint32,
+    cb_lo23: Uint32,
+    cb_hi01: Uint32,
+    cb_hi23: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """NF3 codebook dequant: 8 3-bit codes -> 4 bf16x2 fragments."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [
+            Uint32(lo16).ir_value(loc=loc, ip=ip),
+            Uint32(hi8).ir_value(loc=loc, ip=ip),
+            Uint32(cb_lo01).ir_value(loc=loc, ip=ip),
+            Uint32(cb_lo23).ir_value(loc=loc, ip=ip),
+            Uint32(cb_hi01).ir_value(loc=loc, ip=ip),
+            Uint32(cb_hi23).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .b32 la, lb, ha, hb, t, u, s2, s1, selA, selB;
+            .reg .b32 loA, hiA, loB, hiB;
+
+            and.b32 la, $4, 0xFF;
+            shr.u32 lb, $4, 8;
+            and.b32 lb, lb, 0xFF;
+            and.b32 ha, $5, 0xF;
+            shr.u32 hb, $5, 4;
+            and.b32 hb, hb, 0xF;
+
+            shl.b32 t, la, 4;
+            or.b32 t, t, la;
+            and.b32 t, t, 0x0F0F;
+            shl.b32 s2, t, 2;
+            or.b32 s2, s2, t;
+            and.b32 s2, s2, 0x3333;
+            shl.b32 u, ha, 6;
+            or.b32 u, u, ha;
+            and.b32 u, u, 0x0303;
+            shl.b32 s1, u, 3;
+            or.b32 s1, s1, u;
+            and.b32 s1, s1, 0x1111;
+            shl.b32 s1, s1, 2;
+            or.b32 selA, s2, s1;
+
+            shl.b32 t, lb, 4;
+            or.b32 t, t, lb;
+            and.b32 t, t, 0x0F0F;
+            shl.b32 s2, t, 2;
+            or.b32 s2, s2, t;
+            and.b32 s2, s2, 0x3333;
+            shl.b32 u, hb, 6;
+            or.b32 u, u, hb;
+            and.b32 u, u, 0x0303;
+            shl.b32 s1, u, 3;
+            or.b32 s1, s1, u;
+            and.b32 s1, s1, 0x1111;
+            shl.b32 s1, s1, 2;
+            or.b32 selB, s2, s1;
+
+            prmt.b32 loA, $6, $7, selA;
+            prmt.b32 hiA, $8, $9, selA;
+            prmt.b32 $0, loA, hiA, 0x5140;
+            prmt.b32 $1, loA, hiA, 0x7362;
+            prmt.b32 loB, $6, $7, selB;
+            prmt.b32 hiB, $8, $9, selB;
+            prmt.b32 $2, loB, hiB, 0x5140;
+            prmt.b32 $3, loB, hiB, 0x7362;
+        }
+        """,
+        "=r,=r,=r,=r,r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    o0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    o1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    o2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    o3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(o0), Uint32(o1), Uint32(o2), Uint32(o3)
+
+
+def nf3_codebook_pools(codebook) -> tuple:
+    """Host-side: 8 floats -> (cb_lo01, cb_lo23, cb_hi01, cb_hi23) u32 prmt pools.
+
+    Entry i's bf16 bytes: lo byte -> pool byte i of (cb_lo01|cb_lo23),
+    hi byte -> same slot of (cb_hi01|cb_hi23).  Pool pair {a,b} is prmt's
+    8-byte space indexed 0..7 by the 3-bit code.
+    """
+    import struct
+
+    assert len(codebook) == 8
+    lo = [0, 0]
+    hi = [0, 0]
+    for i, v in enumerate(codebook):
+        (f32_bits,) = struct.unpack("<I", struct.pack("<f", float(v)))
+        # round-to-nearest-even f32 -> bf16
+        bf16 = (f32_bits + 0x7FFF + ((f32_bits >> 16) & 1)) >> 16
+        reg, slot = divmod(i, 4)
+        lo[reg] |= (bf16 & 0xFF) << (8 * slot)
+        hi[reg] |= ((bf16 >> 8) & 0xFF) << (8 * slot)
+    return lo[0], lo[1], hi[0], hi[1]

--- a/b12x/moe/fused/w4a16/host.py
+++ b/b12x/moe/fused/w4a16/host.py
@@ -97,6 +97,70 @@ def validate_w4a16_packed_inputs(
     )
 
 
+def validate_nf3_moe_inputs(
+    w13_codes: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_codes: torch.Tensor,
+    w2_scale: torch.Tensor,
+    *,
+    activation: str,
+) -> W4A16PackedShape:
+    """Validate NF3 ("nf3_2p1") code/scale inputs to the packer.
+
+    Codes are integer tensors of values 0..7 in kernel-native output order:
+        w13_codes [E, 2*I, hidden]  w2_codes [E, hidden, I]
+    Scales are per-K/32-group ``t_s`` floats:
+        w13_scale [E, 2*I, hidden//32]  w2_scale [E, hidden, I//32]
+    The NF3 runtime contract requires K % 32 == 0 and N % 64 == 0 for both
+    GEMMs (the scale byte encoding and the 64-N tile packing).
+    """
+    is_gated = validate_activation(activation)
+    _int_dtypes = (torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
+    if w13_codes.dtype not in _int_dtypes or w2_codes.dtype not in _int_dtypes:
+        raise TypeError("NF3 codes must be integer tensors of values 0..7")
+
+    num_experts = int(w2_codes.shape[0])
+    hidden_size = int(w2_codes.shape[1])
+    intermediate_size = int(w2_codes.shape[2])
+    w13_rows = intermediate_size * (2 if is_gated else 1)
+    if tuple(w13_codes.shape) != (num_experts, w13_rows, hidden_size):
+        raise ValueError(
+            f"expected w13_codes shape {(num_experts, w13_rows, hidden_size)}, "
+            f"got {tuple(w13_codes.shape)}"
+        )
+    if tuple(w2_codes.shape) != (num_experts, hidden_size, intermediate_size):
+        raise ValueError(
+            f"expected w2_codes shape {(num_experts, hidden_size, intermediate_size)}, "
+            f"got {tuple(w2_codes.shape)}"
+        )
+    for name, size_k, size_n in (
+        ("w13", hidden_size, w13_rows),
+        ("w2", intermediate_size, hidden_size),
+    ):
+        if int(size_k) % 32 != 0:
+            raise ValueError(f"NF3 {name} requires K % 32 == 0, got {size_k}")
+        if int(size_n) % 64 != 0:
+            raise ValueError(f"NF3 {name} requires N % 64 == 0, got {size_n}")
+    if tuple(w13_scale.shape) != (num_experts, w13_rows, hidden_size // 32):
+        raise ValueError(
+            f"expected w13_scale shape {(num_experts, w13_rows, hidden_size // 32)}, "
+            f"got {tuple(w13_scale.shape)}"
+        )
+    if tuple(w2_scale.shape) != (num_experts, hidden_size, intermediate_size // 32):
+        raise ValueError(
+            "expected w2_scale shape "
+            f"{(num_experts, hidden_size, intermediate_size // 32)}, "
+            f"got {tuple(w2_scale.shape)}"
+        )
+    return W4A16PackedShape(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w13_rows=w13_rows,
+        is_gated=is_gated,
+    )
+
+
 def unswizzle_block_scale(
     swizzled_scale: torch.Tensor, rows: int, cols_blocks: int
 ) -> torch.Tensor:
@@ -319,5 +383,6 @@ __all__ = [
     "unswizzle_block_scale",
     "unswizzle_expert_scales",
     "validate_activation",
+    "validate_nf3_moe_inputs",
     "validate_w4a16_packed_inputs",
 ]

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -49,6 +49,8 @@ from b12x.cute.fp4 import (
     packed_dequant_e4m3x4_to_half2x2,
     packed_dequant_e8m0x4_to_bfloat2x2,
     packed_dequant_e8m0x4_to_half2x2,
+    packed_dequant_nf3x8_to_bfloat2x4,
+    nf3_codebook_pools,
     pack_f32x2_to_bfloat2,
     pack_f32x2_to_f16x2,
     red_add_global_bf16x2,
@@ -98,11 +100,16 @@ _STAGES = 4
 _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT = 64
 _DEVICE_MAX_REG_BYTES = 255 * 1024
 _DEFAULT_MAX_SHARED_MEM = 101_376
-_WEIGHT_LAYOUTS = {"packed", "modelopt"}
+_WEIGHT_LAYOUTS = {"packed", "modelopt", "nf3_2p1"}
 _MODEL_OPT_W13_LAYOUTS = {"w13", "w31"}
+# NF3 codebook: 8 bf16 codepoints for the 3-bit ("nf3_2p1") weight layout. The
+# device dequant reads these as prmt pools (see nf3_codebook_pools); the host
+# injects the 4 pool words as compile-time constants into the GEMM.
+_NF3_CODEBOOK = (-1.0, -0.6047, -0.3563, -0.1275, 0.1275, 0.3563, 0.6047, 1.0)
 _SCALE_FORMATS = {
     "e4m3_k16": "e4m3_k16",
     "e8m0_k32": "e8m0_k32",
+    "e4m3_k32": "e4m3_k32",
 }
 _E8M0_K32_FP16_GLOBAL_COMPENSATION = float(2.0**7)
 _E8M0_K32_BF16_GLOBAL_COMPENSATION = float(2.0**119)
@@ -610,6 +617,15 @@ class W4A16GemmKernel:
         else:
             w13_layout = "packed"
             source_n_rotation = 0
+        if weight_layout == "nf3_2p1":
+            if scale_format != "e4m3_k32":
+                raise ValueError(
+                    "nf3_2p1 W4A16 weights require scale_format='e4m3_k32'"
+                )
+            if element_dtype != "bf16":
+                raise ValueError(
+                    "nf3_2p1 W4A16 weights are bf16-activation only (v1)"
+                )
         if epilogue_activation not in (None, "relu2"):
             raise ValueError(
                 "W4A16 GEMM epilogue activation currently supports only relu2"
@@ -652,6 +668,12 @@ class W4A16GemmKernel:
                 raise ValueError(
                     "E8M0 K/32 W4A16 scales require size_k/tile_k multiples of 32"
                 )
+            if scale_format == "e4m3_k32" and (
+                size_k % 32 != 0 or tile_k % 32 != 0
+            ):
+                raise ValueError(
+                    "E4M3 K/32 W4A16 scales require size_k/tile_k multiples of 32"
+                )
         if moe_block_size not in _ALLOWED_ROUTED_SIZES:
             raise ValueError(f"unsupported moe_block_size {moe_block_size}")
         if moe_block_size != 8 and moe_block_size % 16 != 0:
@@ -675,8 +697,23 @@ class W4A16GemmKernel:
         self.is_fp16 = element_dtype == "fp16"
         self.epilogue_relu2 = epilogue_activation == "relu2"
         self.weight_layout = weight_layout
+        self.weight_layout_nf3 = weight_layout == "nf3_2p1"
         self.scale_format = scale_format
         self.scale_format_e8m0_k32 = scale_format == "e8m0_k32"
+        # k32 scale cadence (two K16 rows share one scale group). Shared by the
+        # native E8M0 K/32 path and the NF3 e4m3-style K/32 path; the scale
+        # DECODE stays keyed on scale_format_e8m0_k32 (e4m3_k32 uses the e4m3
+        # decode arm, its 2**116 compensation lives in the global_scale tensor).
+        self.scale_k32 = scale_format in ("e8m0_k32", "e4m3_k32")
+        # NF3 codebook prmt pools (host-computed compile-time constants injected
+        # into the device dequant). Only consumed by the nf3_2p1 path; cheap to
+        # compute unconditionally.
+        (
+            self._nf3_cb0,
+            self._nf3_cb1,
+            self._nf3_cb2,
+            self._nf3_cb3,
+        ) = nf3_codebook_pools(_NF3_CODEBOOK)
         self.scale_group_size = int(scale_group_size)
         self.scale_k_groups = _covering_count(self.size_k, self.scale_group_size)
         self.n_tiles = _covering_count(self.size_n, self.tile_n)
@@ -744,10 +781,28 @@ class W4A16GemmKernel:
         self.b_sh_stride_threads = self.b_sh_stride
         self.b_sh_stage = self.b_sh_stride * self.cta_k_blocks
         self.b_sh_wr_iters = self.b_sh_stage // self.cta_threads
+        # NF3 ("nf3_2p1") stages 12-byte triples per 32-code unit instead of the
+        # 16-byte int4 unit; the per-thread unit count is unchanged, only the
+        # bytes-per-unit and the 16-byte cp.async chunk count differ.
+        self.b_unit_bytes = 12 if self.weight_layout_nf3 else 16
+        self.b_sh_stage_bytes = self.b_sh_stage * self.b_unit_bytes
+        if self.weight_layout_nf3:
+            if self.b_sh_stage_bytes % 16 != 0:
+                raise ValueError(
+                    "nf3_2p1 B stage bytes must be a multiple of 16; "
+                    f"got {self.b_sh_stage_bytes}"
+                )
+            self.b_sh_chunks = self.b_sh_stage_bytes // 16
+            self.b_sh_wr_iters_nf3 = _covering_count(
+                self.b_sh_chunks, self.cta_threads
+            )
+        else:
+            self.b_sh_chunks = self.b_sh_stage
+            self.b_sh_wr_iters_nf3 = self.b_sh_wr_iters
 
         self.s_sh_stride = 16 * self.cta_n_blocks // 16
         self.s_tb_groups = (
-            self.cta_k_blocks // 2 if scale_format == "e8m0_k32" else self.cta_k_blocks
+            self.cta_k_blocks // 2 if self.scale_k32 else self.cta_k_blocks
         )
         self.s_sh_stage = self.s_tb_groups * self.s_sh_stride
         self.tb_n_warps = self.cta_n_blocks // 4
@@ -763,7 +818,11 @@ class W4A16GemmKernel:
         self.sh_topk_off = sh_block_route_indices + sh_rd_block_route_indices
 
         sh_red_size = (2 * self.cta_n_blocks + 1) * 16 * self.cta_m_blocks
-        sh_b_size = _STAGES * self.b_sh_stage
+        # B region size in int4 (16-byte) units. NF3 units are 12 bytes, so the
+        # region is 0.75x; round the total up to a 16-byte multiple so the
+        # following SMEM regions keep their 16-byte alignment (exact for all
+        # supported tiles since b_sh_stage is a multiple of 4).
+        sh_b_size = _covering_count(_STAGES * self.b_sh_stage_bytes, 16)
         sh_size_min = min(sh_red_size, sh_b_size)
         sh_size_max = max(sh_red_size, sh_b_size)
         sh_bias_size = self.cta_n_blocks * 16 // 8
@@ -1447,8 +1506,10 @@ class W4A16GemmKernel:
         a_gl_stride = Int32(self.size_k // 8)
         b_gl_stride = Int32(16 * self.size_n // (_PACK_FACTOR * 4))
         s_gl_stride = Int32(self.scale_n_groups)
-        if cutlass.const_expr(self.scale_format_e8m0_k32):
-            if cutlass.const_expr(self.has_logical_tail):
+        if cutlass.const_expr(self.scale_k32):
+            if cutlass.const_expr(
+                self.scale_format_e8m0_k32 and self.has_logical_tail
+            ):
                 scales_expert_stride = Int32(self.scale_k_groups * self.scale_n_groups)
             else:
                 scales_expert_stride = Int32((self.size_n * self.size_k) // (32 * 16))
@@ -1876,8 +1937,22 @@ class W4A16GemmKernel:
                         )
 
                         for jj in cutlass.range_constexpr(4):
-                            q, s = self._select_b_scale_register(jj, b_scale_cur)
-                            self._scaled_dequant_b_fragment(b_frag, q, s)
+                            if cutlass.const_expr(self.weight_layout_nf3):
+                                # NF3 triple: lo16 = half (jj % 2) of word
+                                # (jj // 2); hi8 = byte jj of the hi word; scale
+                                # register is the same per-jj lane as packed.
+                                lo_w = b_scale_cur[0, jj // 2]
+                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(0xFFFF)
+                                hi8 = (b_scale_cur[0, 2] >> Uint32(8 * jj)) & Uint32(
+                                    0xFF
+                                )
+                                s = b_scale_cur[1, jj]
+                                self._scaled_dequant_b_fragment_nf3(
+                                    b_frag, lo16, hi8, s
+                                )
+                            else:
+                                q, s = self._select_b_scale_register(jj, b_scale_cur)
+                                self._scaled_dequant_b_fragment(b_frag, q, s)
                             if cutlass.const_expr(uses_m_block_8):
                                 self._mma_accumulate_m8(
                                     acc,
@@ -2295,6 +2370,29 @@ class W4A16GemmKernel:
                 pipe,
                 kk,
             )
+        elif cutlass.const_expr(self.weight_layout_nf3):
+            # NF3-MAPPING-V1: the thread's 32-code unit index within the pipe's
+            # B region equals the stock staged-unit index (algebraically
+            # identical to b_sh_stride*kk + b_sh_rd): cur_group_id is the K16 row
+            # within the tile, (tid % b_sh_stride) is the N-pair. Each unit is a
+            # 12-byte (lo0, lo1, hi) triple; three scalar u32 loads over stride-3
+            # words are bank-conflict free (gcd(3, 32) == 1). q3 is unused.
+            nf3_warp_id = tid // Int32(32)
+            nf3_warp_row = nf3_warp_id // Int32(self.tb_n_warps)
+            nf3_group = Int32(self.b_sh_wr_iters) * nf3_warp_row + kk
+            nf3_unit = nf3_group * Int32(self.b_sh_stride) + (
+                tid % Int32(self.b_sh_stride)
+            )
+            b_addr = (
+                smem_base
+                + Int32(self.sh_b_off * 16)
+                + pipe * Int32(self.b_sh_stage_bytes)
+                + nf3_unit * Int32(12)
+            )
+            q0 = ld_shared_u32(b_addr)
+            q1 = ld_shared_u32(b_addr + Int32(4))
+            q2 = ld_shared_u32(b_addr + Int32(8))
+            q3 = Uint32(0)
         else:
             b_addr = self._int4_addr(
                 smem_base,
@@ -2308,7 +2406,7 @@ class W4A16GemmKernel:
         warp_id = tid // Int32(32)
         warp_row = warp_id // Int32(self.tb_n_warps)
         cur_group_id = Int32(self.b_sh_wr_iters) * warp_row + kk
-        if cutlass.const_expr(self.scale_format_e8m0_k32):
+        if cutlass.const_expr(self.scale_k32):
             scale_group_id = cur_group_id // Int32(2)
         else:
             scale_group_id = cur_group_id
@@ -2442,6 +2540,30 @@ class W4A16GemmKernel:
         frag[0, 1] = b0_1
         frag[1, 0] = b1_0
         frag[1, 1] = b1_1
+
+    @cute.jit
+    def _scaled_dequant_b_fragment_nf3(
+        self, frag: cute.Tensor, lo16: Uint32, hi8: Uint32, s: Uint32
+    ):
+        # NF3: 8 3-bit codes (2 lo-bits in lo16, 1 hi-bit in hi8) -> 4 bf16x2
+        # codebook fragments, in the SAME element order the packed path uses:
+        # o0=(cb[c0],cb[c1]) -> frag[0,0], o1 -> frag[0,1], o2 -> frag[1,0],
+        # o3 -> frag[1,1]. frag[0,*] takes the N-col-0 scale lane, frag[1,*] the
+        # N-col-1 lane (identical broadcast to _scaled_dequant_b_fragment).
+        o0, o1, o2, o3 = packed_dequant_nf3x8_to_bfloat2x4(
+            lo16,
+            hi8,
+            Uint32(self._nf3_cb0),
+            Uint32(self._nf3_cb1),
+            Uint32(self._nf3_cb2),
+            Uint32(self._nf3_cb3),
+        )
+        s_lane0 = bfloat2_broadcast_lane(s, Int32(0))
+        s_lane1 = bfloat2_broadcast_lane(s, Int32(1))
+        frag[0, 0] = self._elem2_mul(o0, s_lane0)
+        frag[0, 1] = self._elem2_mul(o1, s_lane0)
+        frag[1, 0] = self._elem2_mul(o2, s_lane1)
+        frag[1, 1] = self._elem2_mul(o3, s_lane1)
 
     @cute.jit
     def _mma_accumulate_m8(
@@ -2740,7 +2862,40 @@ class W4A16GemmKernel:
                     (row < block_valid_rows).to(Int32),
                 )
 
-        for i in cutlass.range_constexpr(self.b_sh_wr_iters):
+        if cutlass.const_expr(self.weight_layout_nf3):
+            # NF3 flat-span staging: the packer lays the per-(expert,
+            # output_n_tile, k-stage) B block out as ONE contiguous 12-byte-triple
+            # span (n_tile-major, then K16-row, then N-pair), so we copy it
+            # verbatim as 16-byte cp.async chunks. SMEM byte X of the pipe's B
+            # region == global byte X of the span, so the register read (unit*12)
+            # indexes it directly. b_gl_rd_base is unused on this path.
+            nf3_units_per_expert = (self.size_n * self.size_k) // 32
+            nf3_ntile_stride = (self.size_k // 16) * (self.tile_n // 2)
+            nf3_span_base_unit = (
+                Int32(nf3_units_per_expert) * expert_idx
+                + Int32(nf3_ntile_stride) * output_n_tile
+                + tile_idx * Int32(self.cta_k_blocks * self.b_sh_stride)
+            )
+            for i in cutlass.range_constexpr(self.b_sh_wr_iters_nf3):
+                nf3_chunk = Int32(i * self.cta_threads) + tid
+                b_dst = (
+                    smem_base
+                    + Int32(self.sh_b_off * 16)
+                    + pipe * Int32(self.b_sh_stage_bytes)
+                    + nf3_chunk * Int32(16)
+                )
+                # int32-element index of the chunk's first word:
+                # (span_base_unit*12 + chunk*16) / 4 = span_base_unit*3 + chunk*4.
+                b_src_i32 = nf3_span_base_unit * Int32(3) + nf3_chunk * Int32(4)
+                cp_async4_shared_global_pred(
+                    b_dst,
+                    get_ptr_as_int64(b_i32_flat, b_src_i32),
+                    (nf3_chunk < Int32(self.b_sh_chunks)).to(Int32),
+                )
+
+        for i in cutlass.range_constexpr(
+            0 if self.weight_layout_nf3 else self.b_sh_wr_iters
+        ):
             b_src_int4 = (
                 b_gl_rd_base
                 + tile_idx * Int32(self.cta_k_blocks) * b_gl_stride
@@ -3525,6 +3680,7 @@ class W4A16FusedMoeKernel:
         w13_layout: str = "w13",
         direct_topk_routes: bool = False,
         tc_decode_fused_sum: bool = False,
+        tc_zero_output: bool = True,
         collect_activation_amax: bool = False,
     ):
         activation = normalize_moe_activation(activation)
@@ -3544,6 +3700,10 @@ class W4A16FusedMoeKernel:
         else:
             w13_layout = "packed"
         self.tc_decode_fused_sum = bool(tc_decode_fused_sum)
+        # When two TC-decode launches share one pre-zeroed output (the NF3 hybrid
+        # runs an NVFP4 launch then an NF3 launch into the same tensor), only the
+        # first must zero it. Default True preserves single-launch behavior.
+        self.tc_zero_output = bool(tc_zero_output)
         self.collect_activation_amax = bool(collect_activation_amax)
         if self.collect_activation_amax and bool(direct_topk_routes):
             raise ValueError("activation amax collection requires route-packed W4A16")
@@ -3662,6 +3822,7 @@ class W4A16FusedMoeKernel:
             self.element_dtype,
             self.fast_math,
             self.direct_topk_routes,
+            self.tc_zero_output,
             self.collect_activation_amax,
             self.fc1.__cache_key__,
             self.fc2.__cache_key__,
@@ -3819,13 +3980,17 @@ class W4A16FusedMoeKernel:
             # (top_k routes atomically summed into the SAME token row), so the
             # zero span is active_m*hidden_size -- NOT the per-route
             # active_m*top_k*hidden_size of _zero_fc2_output.
-            zidx = cta * Int32(self.cta_threads) + tid
-            zstride = grid_x * Int32(self.cta_threads)
-            ztotal = active_m * Int32(self.hidden_size)
-            zzero = self._cast_elem(cutlass.Float32(0.0))
-            while zidx < ztotal:
-                fc2_bf16_flat[zidx] = zzero
-                zidx += zstride
+            # tc_zero_output=False skips the zero (a paired earlier launch has
+            # already zeroed the shared output); the grid barrier below is
+            # unconditional so ordering is preserved either way.
+            if cutlass.const_expr(self.tc_zero_output):
+                zidx = cta * Int32(self.cta_threads) + tid
+                zstride = grid_x * Int32(self.cta_threads)
+                ztotal = active_m * Int32(self.hidden_size)
+                zzero = self._cast_elem(cutlass.Float32(0.0))
+                while zidx < ztotal:
+                    fc2_bf16_flat[zidx] = zzero
+                    zidx += zstride
 
         if cutlass.const_expr(self.activation_is_gated):
             self.fc1._run_persistent_gemm(
@@ -4336,13 +4501,17 @@ def _normalize_scale_format(scale_format: str) -> str:
         return _SCALE_FORMATS[scale_format.lower()]
     except KeyError as exc:
         raise ValueError(
-            "scale_format must be one of 'e4m3_k16' or 'e8m0_k32', "
+            "scale_format must be one of 'e4m3_k16', 'e8m0_k32', or 'e4m3_k32', "
             f"got {scale_format!r}"
         ) from exc
 
 
 def _scale_group_size(scale_format: str) -> int:
-    return 32 if _normalize_scale_format(scale_format) == "e8m0_k32" else 16
+    return (
+        32
+        if _normalize_scale_format(scale_format) in ("e8m0_k32", "e4m3_k32")
+        else 16
+    )
 
 
 def _scale_fake_int32_elements(
@@ -4750,6 +4919,7 @@ def compile_w4a16_fused_moe(
     direct_topk_routes: bool = False,
     tc_decode_fused_sum: bool = False,
     collect_activation_amax: bool = False,
+    force_tile_config: tuple[int, int, int, int] | None = None,
 ) -> W4A16FusedMoeCompileResult:
     scale_format = _normalize_scale_format(scale_format)
     cutlass_dtype = _cutlass_element_dtype(element_dtype)
@@ -4783,7 +4953,7 @@ def compile_w4a16_fused_moe(
     )
     if direct_topk_routes and (
         int(size_m) > direct_topk_m_cap
-        or weight_layout != "packed"
+        or weight_layout not in ("packed", "nf3_2p1")
         or bool(zero_fc2_output)
     ):
         raise ValueError(
@@ -4977,6 +5147,44 @@ def compile_w4a16_fused_moe(
             fc2_tile_n = 512
             fc2_tile_k = ultra_fc2_tile_k
             fc2_cta_threads = 256
+    if force_tile_config is not None:
+        # Explicit (fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n) pin. The
+        # NF3 ("nf3_2p1") flat-span weight layout is packed for a specific CTA
+        # N-tile, so hybrid deployments pin ONE tile config across every m
+        # regime instead of the m-dependent auto selection (and TC-decode
+        # wide-N overrides) above. Overrides whatever was selected; the tiles
+        # land in the GEMM cache keys, so no cache collision is possible.
+        fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (
+            int(v) for v in force_tile_config
+        )
+        fc1_cta_threads = (fc1_tile_n * fc1_tile_k) // 64
+        fc2_cta_threads = (fc2_tile_n * fc2_tile_k) // 64
+        if fc1_cta_threads != fc2_cta_threads:
+            raise ValueError(
+                "force_tile_config FC1/FC2 thread counts must match, got "
+                f"{fc1_cta_threads} vs {fc2_cta_threads}"
+            )
+        for name, forced_pn, forced_pk, forced_tn, forced_tk in (
+            ("fc1", fc1_cols, hidden_size, fc1_tile_n, fc1_tile_k),
+            ("fc2", hidden_size, intermediate_size, fc2_tile_n, fc2_tile_k),
+        ):
+            if not _candidate_tile_fits(
+                problem_n=forced_pn,
+                problem_k=forced_pk,
+                cta_m_blocks=_covering_count(moe_block_size, 16),
+                tile_n=forced_tn,
+                tile_k=forced_tk,
+                cta_threads=fc1_cta_threads,
+                max_shared_mem=int(max_shared_mem) - 512,
+                scale_format=scale_format,
+                allow_logical_tail=allow_native_logical_tail,
+            ):
+                raise ValueError(
+                    f"force_tile_config {name} tile "
+                    f"(tile_k={forced_tk}, tile_n={forced_tn}) does not fit "
+                    f"problem N/K={forced_pn}/{forced_pk} at "
+                    f"moe_block_size={moe_block_size}"
+                )
     kernel = W4A16FusedMoeKernel(
         size_m=size_m,
         hidden_size=hidden_size,
@@ -5071,6 +5279,18 @@ def compile_w4a16_fused_moe(
         w2_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Uint8,
             (num_experts * hidden_size * (intermediate_size // 2),),
+            assumed_align=16,
+        )
+    elif weight_layout == "nf3_2p1":
+        # NF3: int32, 3 words per 32-code unit; (size_n // 2) units per K16 row.
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (hidden_size // 16) * (fc1_cols // 2) * 3,),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (num_experts * (intermediate_size // 16) * (hidden_size // 2) * 3,),
             assumed_align=16,
         )
     else:
@@ -6476,7 +6696,7 @@ def run_w4a16_moe(
     use_tc_decode = bool(
         (not collect_activation_amax)
         and (fused_launch is None or preplanned_tc_decode)
-        and weight_layout == "packed"
+        and weight_layout in ("packed", "nf3_2p1")
         and expert_map is None
         and is_gated
         and element_dtype == "bf16"
@@ -6491,7 +6711,7 @@ def run_w4a16_moe(
     direct_topk_eligible = (
         (not collect_activation_amax)
         and (m <= _MAX_DIRECT_TOPK_ROUTE_M or use_tc_decode)
-        and weight_layout == "packed"
+        and weight_layout in ("packed", "nf3_2p1")
         and expert_map is None
     )
     use_direct_topk_routes = bool(

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -161,6 +161,14 @@ _W4A16_REGS_SM121 = {
     (128, 4, 4, 8, False): 255,
     (128, 4, 8, 4, False): 255,
 }
+# Layout overlay: the nf3_2p1 dequant inner loop (codebook prmt pools, 12B
+# staged triples) allocates fewer registers than the packed e2m1 loop.
+# Measured from ncu on SM120 JIT output at the production hybrid tile config;
+# unmeasured specializations fall back to the packed table (a conservative
+# upper bound).
+_W4A16_REGS_SM121_NF3 = {
+    (256, 4, 16, 4, False): 238,
+}
 _SMALL_BATCH_TILE_CONFIGS = (
     (128, 128, 256),
     (64, 128, 128),
@@ -209,6 +217,7 @@ def _w4a16_num_regs(
     cta_n_blocks: int,
     cta_k_blocks: int,
     uses_m_block_8: bool,
+    weight_layout: str = "packed",
 ) -> int:
     key = (
         int(cta_threads),
@@ -217,6 +226,10 @@ def _w4a16_num_regs(
         int(cta_k_blocks),
         bool(uses_m_block_8),
     )
+    if weight_layout == "nf3_2p1":
+        hit = _W4A16_REGS_SM121_NF3.get(key)
+        if hit is not None:
+            return hit
     try:
         return _W4A16_REGS_SM121[key]
     except KeyError as exc:
@@ -231,6 +244,7 @@ def _shared_memory_footprint(
     tile_n: int,
     tile_k: int,
     scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
 ) -> int:
     cta_m = int(cta_m_blocks) * 16
     cta_n = int(tile_n)
@@ -238,6 +252,10 @@ def _shared_memory_footprint(
     sh_block_meta_size = cta_m * 16
     sh_a_size = _STAGES * (cta_m * cta_k) * 2
     sh_b_size = _STAGES * (cta_k * cta_n // _PACK_FACTOR) * 4
+    if weight_layout == "nf3_2p1":
+        # NF3 stages 12-byte triples per 32-code unit instead of 16-byte int4
+        # units (see b_unit_bytes) -- 3/4 of the packed B stage footprint.
+        sh_b_size = sh_b_size * 3 // 4
     sh_red_size = cta_m * (cta_n + 8) * 2
     sh_bias_size = cta_n * 2
     tmp_size = min(sh_b_size, sh_red_size) + sh_bias_size
@@ -261,6 +279,7 @@ def _determine_blocks_per_sm(
     sms: int,
     max_shared_mem: int,
     scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
 ) -> int:
     num_regs = _w4a16_num_regs(
         cta_threads=cta_threads,
@@ -268,6 +287,7 @@ def _determine_blocks_per_sm(
         cta_n_blocks=tile_n // 16,
         cta_k_blocks=tile_k // 16,
         uses_m_block_8=uses_m_block_8,
+        weight_layout=weight_layout,
     )
     register_bytes = max(num_regs, 1) * int(cta_threads) * 4
     smem_bytes = _shared_memory_footprint(
@@ -275,6 +295,7 @@ def _determine_blocks_per_sm(
         tile_n=tile_n,
         tile_k=tile_k,
         scale_format=scale_format,
+        weight_layout=weight_layout,
     )
     blocks_per_sm_limit = min(
         _DEVICE_MAX_REG_BYTES // register_bytes,
@@ -312,6 +333,7 @@ def _candidate_tile_fits(
     cta_threads: int,
     max_shared_mem: int,
     scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
     allow_logical_tail: bool = False,
 ) -> bool:
     if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
@@ -340,6 +362,7 @@ def _candidate_tile_fits(
         tile_n=tile_n,
         tile_k=tile_k,
         scale_format=scale_format,
+        weight_layout=weight_layout,
     )
     return smem_bytes <= int(max_shared_mem)
 
@@ -355,6 +378,7 @@ def _select_tile_config(
     max_shared_mem: int,
     required_cta_threads: int | None = None,
     scale_format: str = "e4m3_k16",
+    weight_layout: str = "packed",
     allow_logical_tail: bool = False,
 ) -> tuple[int, int, int, int]:
     cta_m_blocks = _covering_count(moe_block_size, 16)
@@ -378,6 +402,7 @@ def _select_tile_config(
             cta_threads=cta_threads,
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
+            weight_layout=weight_layout,
             allow_logical_tail=allow_logical_tail,
         ):
             continue
@@ -398,6 +423,7 @@ def _select_tile_config(
             sms=sms,
             max_shared_mem=max_shared_mem,
             scale_format=scale_format,
+            weight_layout=weight_layout,
         )
         if blocks_per_sm_limit > best_blocks_per_sm:
             best_blocks_per_sm = blocks_per_sm_limit
@@ -764,6 +790,7 @@ class W4A16GemmKernel:
             sms=self.sms,
             max_shared_mem=max_shared_mem,
             scale_format=scale_format,
+            weight_layout=weight_layout,
         )
 
         # W4A16 shared-memory geometry, in int4 units unless noted.
@@ -4980,6 +5007,7 @@ def compile_w4a16_fused_moe(
         sms=sms,
         max_shared_mem=max_shared_mem,
         scale_format=scale_format,
+        weight_layout=weight_layout,
         allow_logical_tail=allow_native_logical_tail,
     )
     fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
@@ -4991,6 +5019,7 @@ def compile_w4a16_fused_moe(
         sms=sms,
         max_shared_mem=max_shared_mem,
         scale_format=scale_format,
+        weight_layout=weight_layout,
         allow_logical_tail=allow_native_logical_tail,
     )
     if fc1_cta_threads != fc2_cta_threads:
@@ -5005,6 +5034,7 @@ def compile_w4a16_fused_moe(
             max_shared_mem=max_shared_mem,
             required_cta_threads=common_cta_threads,
             scale_format=scale_format,
+            weight_layout=weight_layout,
             allow_logical_tail=allow_native_logical_tail,
         )
         fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
@@ -5017,6 +5047,7 @@ def compile_w4a16_fused_moe(
             max_shared_mem=max_shared_mem,
             required_cta_threads=common_cta_threads,
             scale_format=scale_format,
+            weight_layout=weight_layout,
             allow_logical_tail=allow_native_logical_tail,
         )
         if fc1_cta_threads != fc2_cta_threads:
@@ -5065,6 +5096,7 @@ def compile_w4a16_fused_moe(
             cta_threads=256,
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
+            weight_layout=weight_layout,
         ):
             fc1_tile_n = 256
             fc1_tile_k = wide_fc1_tile_k
@@ -5095,6 +5127,7 @@ def compile_w4a16_fused_moe(
             cta_threads=256,
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
+            weight_layout=weight_layout,
         ):
             fc2_tile_n = 256
             fc2_tile_k = wide_fc2_tile_k
@@ -5139,6 +5172,7 @@ def compile_w4a16_fused_moe(
             tile_n=512,
             tile_k=ultra_fc2_tile_k,
             scale_format=scale_format,
+            weight_layout=weight_layout,
         )
         if (
             int(intermediate_size) % ultra_fc2_tile_k == 0
@@ -5177,6 +5211,7 @@ def compile_w4a16_fused_moe(
                 cta_threads=fc1_cta_threads,
                 max_shared_mem=int(max_shared_mem) - 512,
                 scale_format=scale_format,
+                weight_layout=weight_layout,
                 allow_logical_tail=allow_native_logical_tail,
             ):
                 raise ValueError(

--- a/b12x/moe/fused/w4a16/prepare.py
+++ b/b12x/moe/fused/w4a16/prepare.py
@@ -11,6 +11,7 @@ from b12x.moe.fused.w4a16.host import (
     W4A16PackedBuffers,
     make_w4a16_packed_buffers as _make_w4a16_packed_buffers,
     unswizzle_expert_scales,
+    validate_nf3_moe_inputs,
     validate_w4a16_packed_inputs,
 )
 
@@ -37,6 +38,13 @@ _W13_LAYOUTS = {
     "gate_up": "w31",
 }
 _MODEL_OPT_NVFP4_FORMATS = {"modelopt_nvfp4"}
+# NF3 ("nf3_2p1") 3-bit codebook. Must match kernel._NF3_CODEBOOK. The scale
+# convention (see NF3_KERNEL_MODSPEC.md): weights decode to the FULL-precision
+# bf16 codebook value, the K/32 scale byte encodes t_s * 2**-4 (e4m3-style,
+# E4=0 arm), and the per-tensor global_scale carries the matching 2**116.
+_NF3_CODEBOOK = (-1.0, -0.6047, -0.3563, -0.1275, 0.1275, 0.3563, 0.6047, 1.0)
+_NF3_SCALE_GLOBAL = 2.0**116
+_NF3_SCALE_FLOOR = 2.0 ** -10  # f16(t_s*2^-4) must stay f16-NORMAL (>=2^-14) -> t_s >= 2^-10; real early-layer scales dip below the old 2^-7
 
 
 @dataclass(frozen=True)
@@ -84,6 +92,39 @@ class W4A16ModelOptWeights:
     # == "up_gate" physical) needs a row rotation before W4A16 SwiGLU; "w31"
     # (== "gate_up") is already in the kernel-native order.
     w13_layout: str = "w13"
+
+
+@dataclass(frozen=True)
+class PreparedNF3MoeWeights:
+    """Runtime NF3 ("nf3_2p1") hybrid-expert W4A16 weights.
+
+    Mirrors W4A16PackedWeights so run_w4a16_moe consumes it identically. The
+    packed planes are int32 (3 words per 32-code unit); the K/32 scales are
+    e4m3-style bytes viewed uint8; the global scales carry the 2**116 the NF3
+    scale convention defers out of the codebook. fc1_tile_n / fc2_tile_n record
+    the CTA N-tile the flat-span packing was built for -- the kernel MUST be
+    compiled/launched with the SAME tile_n (read them back from the compiled
+    W4A16FusedMoeCompileResult).
+    """
+
+    w13: torch.Tensor
+    w13_scale: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2: torch.Tensor
+    w2_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    workspace: torch.Tensor
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    is_gated: bool
+    params_dtype: torch.dtype
+    fc1_tile_n: int
+    fc2_tile_n: int
+    source_format: str = "nf3_2p1"
+    w13_layout: str = "packed"
+    weight_layout: str = "nf3_2p1"
+    scale_format: str = "e4m3_k32"
 
 
 def _make_workspace(
@@ -617,6 +658,179 @@ def _permute_nvfp4_scales(
     return packed_scales, packed_global.contiguous()
 
 
+# ---------------------------------------------------------------------------
+# NF3 ("nf3_2p1") packing.
+#
+# The kernel's B operand is a stream of 32-code "units" (2 N-columns x 16 K),
+# each a 12-byte (lo0, lo1, hi) triple. The GEMM reads unit index
+#   unit = cur_group_id * (tile_n // 2) + (tid % (tile_n // 2))
+# from the pipe's B SMEM region (see kernel._load_b_scale_registers,
+# NF3-MAPPING-V1) which -- verified algebraically -- equals the stock staged
+# unit index; cur_group_id is the K16 row within the CTA-K tile, (tid %
+# (tile_n // 2)) is the N-pair. The flat-span staging copies the packer's
+# global bytes verbatim, so the packer must place, at global unit
+#   I = nt*(K/16)*(tile_n/2) + R*(tile_n/2) + p          (n_tile-major)
+# the codes for CTA N-tile nt, K16-row-global R, N-pair p. The 4 jj words in
+# the triple correspond to the stock 4-u32 group; per jj the 8 codes decode
+# (packed_dequant_nf3x8_to_bfloat2x4) to fragments
+#   frag[0,0]=(cb[c0],cb[c1]) frag[0,1]=(cb[c2],cb[c3])
+#   frag[1,0]=(cb[c4],cb[c5]) frag[1,1]=(cb[c6],cb[c7])
+# which must equal the stock fragment identity for this thread/jj:
+#   frag[0,0]=(C1@K0,   C1@K0+1)  frag[0,1]=(C1@K0+8, C1@K0+9)
+#   frag[1,0]=(C2@K0,   C2@K0+1)  frag[1,1]=(C2@K0+8, C2@K0+9)
+# where, from _repack_4bit_no_perm composed with the read mapping,
+#   wru = p + (tile_n/2)*nt ; n_tile_64 = wru // 32 ; th_id = wru % 32
+#   tc_col = th_id // 4 ; tc_row = (th_id % 4) * 2
+#   C1 = n_tile_64*64 + jj*16 + tc_col ; C2 = C1 + 8 ; K0 = R*16 + tc_row
+# => code order [c0..c7] =
+#   [ (C1,K0),(C1,K0+1),(C1,K0+8),(C1,K0+9),
+#     (C2,K0),(C2,K0+1),(C2,K0+8),(C2,K0+9) ].
+# This whole chain is asserted by _nf3_pack_selftest against an independent
+# torch simulation of the kernel read+dequant.
+# ---------------------------------------------------------------------------
+
+
+def _nf3_check_shapes(size_k: int, size_n: int, tile_n: int) -> None:
+    if int(size_k) % 32 != 0:
+        raise ValueError(f"NF3 requires K % 32 == 0, got {size_k}")
+    if int(size_n) % 64 != 0:
+        raise ValueError(f"NF3 requires N % 64 == 0, got {size_n}")
+    if int(tile_n) % 16 != 0 or int(tile_n) < 64:
+        raise ValueError(f"NF3 tile_n must be a multiple of 16 and >= 64, got {tile_n}")
+    if int(size_n) % int(tile_n) != 0:
+        raise ValueError(f"NF3 requires N ({size_n}) divisible by tile_n ({tile_n})")
+
+
+def _nf3_code_gather_index(
+    size_k: int, size_n: int, tile_n: int, device: torch.device
+) -> torch.Tensor:
+    """[units, 4, 8] flat indices into a contiguous [N, K] code tensor.
+
+    Entry [I, jj, v] is the (C * size_k + K) index of the v-th code (NF3 order)
+    of triple word jj at global unit I. Built from the exact _repack /
+    read-mapping math documented above so the packer and the kernel agree.
+    """
+    _nf3_check_shapes(size_k, size_n, tile_n)
+    npairs = int(tile_n) // 2
+    k16 = int(size_k) // 16
+    units = k16 * (int(size_n) // 2)
+    ntile_units = k16 * npairs
+    idx_i = torch.arange(units, device=device, dtype=torch.long)
+    nt = idx_i // ntile_units
+    within = idx_i % ntile_units
+    R = within // npairs
+    p = within % npairs
+    wru = p + npairs * nt
+    n_tile_64 = wru // 32
+    th_id = wru % 32
+    tc_col = th_id // 4
+    tc_row = (th_id % 4) * 2
+    jj = torch.arange(4, device=device, dtype=torch.long)
+    col1 = jj[None, :] * 16 + tc_col[:, None]  # [units, 4]
+    col2 = col1 + 8
+    C1 = n_tile_64[:, None] * 64 + col1  # [units, 4]
+    C2 = n_tile_64[:, None] * 64 + col2
+    K0 = (R * 16 + tc_row)[:, None]  # [units, 1]
+    k_off = torch.tensor([0, 1, 8, 9], device=device, dtype=torch.long)
+    idx = torch.empty((units, 4, 8), device=device, dtype=torch.long)
+    for t in range(4):
+        idx[:, :, t] = C1 * int(size_k) + (K0 + k_off[t])
+        idx[:, :, 4 + t] = C2 * int(size_k) + (K0 + k_off[t])
+    return idx
+
+
+def _nf3_pack_codes(
+    codes_nk: torch.Tensor, *, size_k: int, size_n: int, tile_n: int
+) -> torch.Tensor:
+    """Pack one expert's [N, K] codes (0..7) into int32 [units*3] NF3 planes."""
+    if tuple(codes_nk.shape) != (int(size_n), int(size_k)):
+        raise ValueError(
+            f"expected codes shape {(int(size_n), int(size_k))}, "
+            f"got {tuple(codes_nk.shape)}"
+        )
+    device = codes_nk.device
+    flat = codes_nk.reshape(-1).to(torch.int64)
+    if bool((flat < 0).any()) or bool((flat > 7).any()):
+        raise ValueError("NF3 codes must be integers in [0, 7]")
+    idx = _nf3_code_gather_index(size_k, size_n, tile_n, device)  # [units,4,8]
+    g = flat[idx.reshape(-1)].reshape(idx.shape)  # [units,4,8]
+    sh_lo = (torch.arange(4, device=device, dtype=torch.int64) * 2).view(1, 1, 4)
+    sh_hi = torch.arange(4, device=device, dtype=torch.int64).view(1, 1, 4)
+    la = ((g[:, :, 0:4] & 3) << sh_lo).sum(-1)  # [units,4]
+    lb = ((g[:, :, 4:8] & 3) << sh_lo).sum(-1)
+    lo16 = la | (lb << 8)
+    ha = (((g[:, :, 0:4] >> 2) & 1) << sh_hi).sum(-1)
+    hb = (((g[:, :, 4:8] >> 2) & 1) << sh_hi).sum(-1)
+    hi8 = ha | (hb << 4)
+    lo0 = lo16[:, 0] | (lo16[:, 1] << 16)
+    lo1 = lo16[:, 2] | (lo16[:, 3] << 16)
+    hi = hi8[:, 0] | (hi8[:, 1] << 8) | (hi8[:, 2] << 16) | (hi8[:, 3] << 24)
+    words = torch.stack([lo0, lo1, hi], dim=1).reshape(-1)  # int64 in [0, 2**32)
+    words = torch.where(words >= 2**31, words - 2**32, words)
+    return words.to(torch.int32).contiguous()
+
+
+def _process_nf3_packed_scales(packed_scales: torch.Tensor) -> torch.Tensor:
+    """[rows, N] float t_s -> [rows, N] uint8 e4m3-style byte = highbyte(f16(t_s*2**-4)<<1)."""
+    packed_scales = packed_scales.to(torch.float16)
+    packed_scales = packed_scales.view(-1, 4)[:, [0, 2, 1, 3]].view(
+        packed_scales.size(0),
+        -1,
+    )
+    packed_scales = (packed_scales.float() * (2.0**-4)).to(torch.float16)
+    packed_scales = packed_scales.view(torch.int16) << 1
+    packed_scales = packed_scales.view(torch.uint8)
+    return packed_scales[:, 1::2].contiguous()
+
+
+def _nf3_pack_scales(
+    t_s: torch.Tensor, *, size_k: int, size_n: int
+) -> torch.Tensor:
+    """Pack one expert's [N, K//32] scales into uint8 [K//32, N] (permuted)."""
+    if tuple(t_s.shape) != (int(size_n), int(size_k) // 32):
+        raise ValueError(
+            f"expected scale shape {(int(size_n), int(size_k) // 32)}, "
+            f"got {tuple(t_s.shape)}"
+        )
+    t_s = t_s.to(torch.float32)
+    # zero scales (whole group exactly zero in the checkpoint) MUST stay zero:
+    # stored byte 0 decodes to exact +0.0. Flooring them to _NF3_SCALE_FLOOR
+    # injects noise into all-zero groups (real early-layer experts have many)
+    # -> compounding early-layer error -> prompt-dependent degeneration.
+    zero_mask = t_s == 0
+    t_s = t_s.clamp(min=_NF3_SCALE_FLOOR)
+    t_s[zero_mask] = 0.0
+    if bool((t_s >= 32.0).any()):
+        raise ValueError("NF3 scales must be < 32 for the e4m3 K/32 encoding")
+    permuted = _permute_packed_scales(
+        t_s.T.contiguous(),
+        size_k=size_k,
+        size_n=size_n,
+        group_size=32,
+    )  # [K//32, N] float
+    return _process_nf3_packed_scales(permuted)
+
+
+def _nf3_pack_code_experts(
+    codes: torch.Tensor, *, size_k: int, size_n: int, tile_n: int
+) -> torch.Tensor:
+    packed = [
+        _nf3_pack_codes(codes[e], size_k=size_k, size_n=size_n, tile_n=tile_n)
+        for e in range(int(codes.shape[0]))
+    ]
+    return torch.stack(packed, dim=0).contiguous()
+
+
+def _nf3_pack_scale_experts(
+    t_s: torch.Tensor, *, size_k: int, size_n: int
+) -> torch.Tensor:
+    packed = [
+        _nf3_pack_scales(t_s[e], size_k=size_k, size_n=size_n)
+        for e in range(int(t_s.shape[0]))
+    ]
+    return torch.stack(packed, dim=0).contiguous()
+
+
 def _prepare_w4a16_packed_weights(
     w13_fp4: torch.Tensor,
     w13_blockscale: torch.Tensor,
@@ -1146,11 +1360,194 @@ def make_w4a16_packed_buffers(
     )
 
 
+def prepare_nf3_moe_weights(
+    w13_codes: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_codes: torch.Tensor,
+    w2_scale: torch.Tensor,
+    *,
+    activation: str,
+    fc1_tile_n: int,
+    fc2_tile_n: int,
+    params_dtype: torch.dtype = torch.bfloat16,
+) -> PreparedNF3MoeWeights:
+    """Pack NF3 codes/scales into the runtime "nf3_2p1" W4A16 layout.
+
+    Inputs are per-expert integer codes (0..7) in kernel-native output order
+    (gate/up already resolved for FC1) and per-group float scales ``t_s``:
+        w13_codes [E, 2*I, hidden]   w13_scale [E, 2*I, hidden//32]
+        w2_codes  [E, hidden, I]     w2_scale  [E, hidden, I//32]
+    ``fc1_tile_n`` / ``fc2_tile_n`` MUST equal the CTA N-tiles the kernel will
+    use (read them from the compiled W4A16FusedMoeCompileResult) -- the
+    flat-span layout is tile_n specific.
+    """
+    if params_dtype != torch.bfloat16:
+        raise ValueError("nf3_2p1 W4A16 weights are bf16-only for v1")
+    shape = validate_nf3_moe_inputs(
+        w13_codes,
+        w13_scale,
+        w2_codes,
+        w2_scale,
+        activation=activation,
+    )
+    device = w13_codes.device
+    packed_w13 = _nf3_pack_code_experts(
+        w13_codes, size_k=shape.hidden_size, size_n=shape.w13_rows, tile_n=fc1_tile_n
+    )
+    packed_w2 = _nf3_pack_code_experts(
+        w2_codes,
+        size_k=shape.intermediate_size,
+        size_n=shape.hidden_size,
+        tile_n=fc2_tile_n,
+    )
+    packed_w13_scale = _nf3_pack_scale_experts(
+        w13_scale, size_k=shape.hidden_size, size_n=shape.w13_rows
+    )
+    packed_w2_scale = _nf3_pack_scale_experts(
+        w2_scale, size_k=shape.intermediate_size, size_n=shape.hidden_size
+    )
+    global_scale = torch.full(
+        (shape.num_experts,), _NF3_SCALE_GLOBAL, dtype=torch.float32, device=device
+    )
+    return PreparedNF3MoeWeights(
+        w13=packed_w13,
+        w13_scale=packed_w13_scale,
+        w13_global_scale=global_scale,
+        w2=packed_w2,
+        w2_scale=packed_w2_scale,
+        w2_global_scale=global_scale.clone(),
+        workspace=_make_workspace(device, max_blocks_per_sm=4),
+        hidden_size=shape.hidden_size,
+        intermediate_size=shape.intermediate_size,
+        num_experts=shape.num_experts,
+        is_gated=shape.is_gated,
+        params_dtype=params_dtype,
+        fc1_tile_n=int(fc1_tile_n),
+        fc2_tile_n=int(fc2_tile_n),
+    )
+
+
+def _nf3_pack_selftest() -> None:
+    """Prove the packer matches the kernel's read+dequant chain (torch/CPU).
+
+    Packs random codes, then INDEPENDENTLY simulates the kernel's flat-span
+    staging + register read (unit = cur_group_id*(tile_n//2) + tid%(tile_n//2))
+    + packed_dequant_nf3x8 fragment placement in pure torch, and asserts the
+    reconstructed dequantized matrix equals codebook[codes] at every (N, K).
+    """
+    codebook = _NF3_CODEBOOK
+
+    def simulate(packed, size_k, size_n, tile_n, tile_k):
+        cta_threads = tile_n * tile_k // 64
+        b_sh_stride = tile_n // 2
+        cta_k_blocks = tile_k // 16
+        b_sh_stage = b_sh_stride * cta_k_blocks
+        b_sh_wr_iters = b_sh_stage // cta_threads
+        tb_n_warps = tile_n // 64
+        b_chunks = b_sh_stage * 12 // 16
+        wr_iters_nf3 = (b_chunks + cta_threads - 1) // cta_threads
+        ntile_stride = (size_k // 16) * (tile_n // 2)
+        n_tiles = size_n // tile_n
+        k_tiles = size_k // tile_k
+        packed = packed.tolist()
+        w = [[None] * size_n for _ in range(size_k)]
+
+        def u32(x):
+            return x & 0xFFFFFFFF
+
+        for nt in range(n_tiles):
+            for tile_idx in range(k_tiles):
+                span_base_unit = (
+                    nt * ntile_stride + tile_idx * cta_k_blocks * b_sh_stride
+                )
+                smem = {}
+                for i in range(wr_iters_nf3):
+                    for tid in range(cta_threads):
+                        c = i * cta_threads + tid
+                        if c >= b_chunks:
+                            continue
+                        for word in range(4):
+                            smem[c * 4 + word] = u32(
+                                packed[span_base_unit * 3 + c * 4 + word]
+                            )
+                for tid in range(cta_threads):
+                    warp_row = (tid // 32) // tb_n_warps
+                    for kk in range(b_sh_wr_iters):
+                        cur = b_sh_wr_iters * warp_row + kk
+                        unit = cur * b_sh_stride + (tid % b_sh_stride)
+                        lo0 = smem[unit * 3 + 0]
+                        lo1 = smem[unit * 3 + 1]
+                        hi = smem[unit * 3 + 2]
+                        R = tile_idx * cta_k_blocks + cur
+                        p = tid % b_sh_stride
+                        for jj in range(4):
+                            lo_w = lo0 if (jj // 2) == 0 else lo1
+                            lo16 = (lo_w >> (16 * (jj % 2))) & 0xFFFF
+                            hi8 = (hi >> (8 * jj)) & 0xFF
+                            la = lo16 & 0xFF
+                            lb = (lo16 >> 8) & 0xFF
+                            ha = hi8 & 0xF
+                            hb = (hi8 >> 4) & 0xF
+
+                            def code(byte2, nib1, j):
+                                return ((byte2 >> (2 * j)) & 3) | (
+                                    ((nib1 >> j) & 1) << 2
+                                )
+
+                            cds = [code(la, ha, j) for j in range(4)] + [
+                                code(lb, hb, j) for j in range(4)
+                            ]
+                            wru = p + (tile_n // 2) * nt
+                            n64 = wru // 32
+                            th = wru % 32
+                            tc_col = th // 4
+                            tc_row = (th % 4) * 2
+                            col1 = jj * 16 + tc_col
+                            c1 = n64 * 64 + col1
+                            c2 = c1 + 8
+                            k0 = R * 16 + tc_row
+                            w[k0 + 0][c1] = codebook[cds[0]]
+                            w[k0 + 1][c1] = codebook[cds[1]]
+                            w[k0 + 8][c1] = codebook[cds[2]]
+                            w[k0 + 9][c1] = codebook[cds[3]]
+                            w[k0 + 0][c2] = codebook[cds[4]]
+                            w[k0 + 1][c2] = codebook[cds[5]]
+                            w[k0 + 8][c2] = codebook[cds[6]]
+                            w[k0 + 9][c2] = codebook[cds[7]]
+        return w
+
+    torch.manual_seed(0)
+    cases = [
+        (256, 128, 128, 128),
+        (256, 128, 128, 64),
+        (64, 256, 256, 64),
+        (512, 256, 256, 64),
+    ]
+    for size_k, size_n, tile_n, tile_k in cases:
+        codes = torch.randint(0, 8, (size_n, size_k), dtype=torch.int64)
+        packed = _nf3_pack_codes(
+            codes, size_k=size_k, size_n=size_n, tile_n=tile_n
+        )
+        w = simulate(packed, size_k, size_n, tile_n, tile_k)
+        for k in range(size_k):
+            for n in range(size_n):
+                expect = _NF3_CODEBOOK[int(codes[n, k])]
+                got = w[k][n]
+                assert got is not None, f"unfilled ({k},{n}) for {(size_k, size_n, tile_n, tile_k)}"
+                assert abs(got - expect) < 1e-9, (
+                    f"mismatch at ({k},{n}) for {(size_k, size_n, tile_n, tile_k)}: "
+                    f"{got} != {expect}"
+                )
+    print("nf3 pack self-test PASSED")
+
+
 __all__ = [
+    "PreparedNF3MoeWeights",
     "W4A16PackedBuffers",
     "W4A16ModelOptWeights",
     "W4A16PackedWeights",
     "make_w4a16_packed_buffers",
+    "prepare_nf3_moe_weights",
     "prepare_w4a16_compressed_tensors_weights",
     "prepare_w4a16_e8m0_native_weights",
     "prepare_w4a16_fp4_e8m0_k32_weights",


### PR DESCRIPTION
## What

A new `weight_layout="nf3_2p1"` (+ `scale_format="e4m3_k32"`) for the fused W4A16 MoE path: a 3-bit normal-float weight format that serves alongside packed NVFP4 through the same kernel machinery. Two preplanned launches per MoE layer (one per precision tier) share one route geometry and one `topk_sum`, both CUDA-graph-safe.

Motivation: instead of pruning experts to fit big MoE models, keep **all** experts and quantize the low-saliency tail to 3 bits. GLM-5.2 753B with all 256 experts/layer fits and serves on 4× 96 GB SM120 this way (top-64 experts NVFP4, 192-expert tail NF3), and has been our production configuration since 2026-07-05.

Four files, kernel-side only: `b12x/moe/fused/w4a16/{kernel,prepare,host}.py` + `b12x/cute/fp4.py`. The serving integration (runtime graft, checkpoint build/GPTQ pipeline, tests, proven configs) lives out-of-tree: [MadeBy561/b12x@nf3-hybrid-full](https://github.com/MadeBy561/b12x/tree/nf3-hybrid-full/nf3-hybrid), checkpoint at [madeby561/GLM-5.2-NVFP4-NF3-Hybrid](https://huggingface.co/madeby561/GLM-5.2-NVFP4-NF3-Hybrid).

## Kernel design

- **Staging**: NF3 packs 32 codes into a 12-byte (lo0, lo1, hi) triple; B-tile staging is byte-parameterized flat copy (12 B/unit vs 16 B int4), same cp.async machinery.
- **Fragment reads**: three scalar u32 loads over stride-3 words — bank-conflict-free (gcd(3, 32) = 1).
- **Dequant**: `prmt`-LUT over codebook pools; the 8-level codebook enters as a kernel parameter, not a constant — learned per-tensor codebooks are free later.
- **Scales**: `e4m3_k32` group-32 decode on the existing scale pipeline (2^-116 convention; compensation folded into the f32 global scale — zero new kernel scale math).
- **`tc_zero_output` const_expr flag**: lets a second TC-decode launch accumulate into a shared output without re-zeroing (the two-tier decode path).
- **Planner accuracy** (second commit): `weight_layout`-aware register table (NF3 measures 238 regs at the production tile config on SM120 ncu output vs the packed table's 255) and B-stage footprint (12 B/32-code = ×3/4). Verified inert at production tiles — planning truth for future tile/occupancy decisions on NF3 shapes.

## What is not touched

`packed` / `modelopt` planning and codegen are byte-identical — every new parameter defaults to prior behavior.

## Receipts (GLM-5.2 753B all-256-expert hybrid, 4× RTX PRO 6000 Max-Q, TP4/DCP4)

- **GPQA-Diamond 176/198 (88.89 %)** — statistically tied with full precision (89.52 % FP8 / 89.39 % all-NVFP4 at 435 GB, same harness).
- KLD vs the official-FP8 reference (fixed 2,047-position corpus, identical rig for every number): 0.126 per-token mean (same-rig anchors: 435 GB all-NVFP4 0.060, 340 GB UD-IQ4_XS 0.087).
- Kernel fidelity vs a Triton oracle: argmax 100 %, logit MAE 0.019 (same-server A/B).
- ncu at production tiles: zero register spills.
- Serving: pool 422,656 tokens @ 262k max-len, prefill 1.65–1.72k tok/s, decode 92–104 tok/s single-stream (MTP5).

## Testing

Pack/unpack, scale-convention, and kernel-probe tests live with the out-of-tree harness (GPU tests). The suite re-run against this exact branch is queued for our next free serving window — results will be posted in this thread before we ask for merge. Production serving on the rebased kernel code is continuous.