### PR TITLE
Fix W4A8 resident-grid launch beside auxiliary streams

### DIFF
--- a/b12x/moe/fused/dynamic.py
+++ b/b12x/moe/fused/dynamic.py
@@ -2047,6 +2047,12 @@ class MoEDynamicKernelBackend:
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
             cluster=[1, 1, 1],
+            # The phase boundaries below use a software grid barrier.  A
+            # regular launch can admit only part of the grid while auxiliary
+            # stream work occupies the remaining SMs, leaving resident CTAs
+            # spinning and the unscheduled CTAs unable to arrive.  Cooperative
+            # launch makes the all-CTA residency contract explicit.
+            cooperative=True,
             stream=stream,
         )
         if cutlass.const_expr(self.external_materialized_fc1):
@@ -2152,7 +2158,9 @@ class MoEDynamicKernelBackend:
         _, _, gdim_z = cute.arch.grid_dim()
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
-        is_cta_leader = Int32(1) if Int32(tidx) == Int32(0) else Int32(0)
+        # Keep the predicate in DSL IR; a Python conditional would try to
+        # convert the dynamic device value to a host bool during compilation.
+        is_cta_leader = Int32(Int32(tidx) == Int32(0))
 
         if warp_idx == 0:
             cpasync.prefetch_descriptor(tma_a)

--- a/tests/test_w4a8_mx_tp_moe.py
+++ b/tests/test_w4a8_mx_tp_moe.py
@@ -565,6 +565,67 @@ def test_w4a8_mx_dynamic_graph_replay_tracks_routing_updates() -> None:
         assert replay_eager_cos > 0.9999, (round_idx, replay_eager_cos)
 
 
+def test_w4a8_mx_m9_graph_replay_with_aux_stream_work() -> None:
+    """The M=9 two-CTA/SM grid must remain valid beside aux-stream work.
+
+    Dynamic MoE synchronizes all CTAs between routing and compute phases.  At
+    M=9 the W4A8 dispatcher uses the full two-CTA-per-SM resident grid (376
+    CTAs on RTX 6000 Pro Blackwell), which requires a cooperative launch when
+    shared-expert work is active on another stream.
+    """
+    _skip_if_unavailable()
+    from b12x.integration.tp_moe import b12x_moe_fp4, clear_tp_moe_caches
+    from tests.helpers import make_tp_moe_fp4_binding
+
+    clear_tp_moe_caches()
+    device = torch.device("cuda")
+    m = 9
+    weights = _weights(seed=91)
+    prepared = _prepare(weights)
+    x, topk_ids, topk_weights = _routed_inputs(m, 92)
+    output = torch.zeros(m, _K, dtype=torch.bfloat16, device=device)
+    binding = make_tp_moe_fp4_binding(
+        a=x,
+        experts=prepared,
+        topk_weights=topk_weights.contiguous(),
+        topk_ids=topk_ids.contiguous(),
+        output=output,
+        input_scales_static=True,
+        quant_mode="w4a8_mx",
+    )
+
+    def _launch() -> None:
+        b12x_moe_fp4(binding=binding)
+
+    _launch()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+        _launch()
+    torch.cuda.current_stream().wait_stream(capture_stream)
+    torch.cuda.synchronize()
+
+    # Queue enough independent GEMM work to keep the auxiliary stream active
+    # while the graph reaches the resident-grid kernel.
+    aux_stream = torch.cuda.Stream()
+    aux_a = torch.randn(4096, 4096, dtype=torch.bfloat16, device=device)
+    aux_b = torch.randn(4096, 4096, dtype=torch.bfloat16, device=device)
+    aux_out = torch.empty_like(aux_a)
+    output.zero_()
+    with torch.cuda.stream(aux_stream):
+        for _ in range(16):
+            torch.mm(aux_a, aux_b, out=aux_out)
+    graph.replay()
+    torch.cuda.current_stream().wait_stream(aux_stream)
+    torch.cuda.synchronize()
+
+    assert output.isfinite().all()
+    assert output.abs().sum().item() > 0
+
+
 def test_w4a8_mx_dynamic_glm_shard_geometry() -> None:
     """GLM per-rank shard geometry: E=16, K=4096, n=256 (FC1 N=512, FC2
     N=4096 with K=256) through unified dynamic, gated vs the oracle."""


### PR DESCRIPTION
## Root cause

The fused dynamic W4A8 kernel crosses several software resident-grid barriers, but it was launched with an ordinary CUDA kernel launch. At the M=9 boundary the SM120 path selects tile M=16 and a two-CTA-per-SM grid (376 CTAs on RTX 6000 Pro Blackwell). When shared-expert GEMM is active on the vLLM auxiliary stream, only part of that grid can become resident. Those CTAs spin in the grid barrier while unscheduled CTAs cannot arrive, eventually producing an illegal memory access / Xid 31 during FULL CUDA graph capture.

`CUDA_LAUNCH_BLOCKING=1` and disabling the shared-expert stream only masked the race; neither is part of this fix.

## Fix

- launch the dynamic kernel cooperatively so its all-CTA residency assumption is guaranteed by CUDA
- keep the CTA-leader predicate in CuTe DSL IR instead of converting a dynamic device boolean through a Python conditional
- add an M=9 CUDA-graph regression test with concurrent BF16 GEMM work on an auxiliary stream

## Validation

- targeted graph replay test: passed
- new M=9 auxiliary-stream contention test: passed
- exact GLM 5.2 TP6/DCP3/A8/graph64 startup: all PIECEWISE and FULL captures passed, including the formerly deterministic M=9 failure
- 30k-token prefill plus sustained decode replay: passed
- no new NVIDIA Xid after the corrected run

The overlap, MoE backend, quantization mode, grid size, and vLLM stream configuration remain enabled and unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fused MoE kernel reliability during CUDA Graph replay when concurrent GPU work runs on auxiliary streams.
  * Prevented potential synchronization deadlocks at grid-phase boundaries.

* **Tests**
  * Added regression coverage for w4a8 mixed-precision MoE graph replay with concurrent matrix operations.
  * Verified replay results remain finite and non-zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->