### PR TITLE
nvfp4 MLA KV cache + per-layer outer-scale + fp8-RoPE KV-cell (sm120)

### DIFF
--- a/b12x/attention/mla/api.py
+++ b/b12x/attention/mla/api.py
@@ -27,6 +27,8 @@ _MLA_UNIFIED_GLM_Q_HEAD_DIM = 576
 _MLA_SINGLE_PASS_TARGET_Q_ROWS = 2048
 _MLA_SINGLE_PASS_TARGET_TOPK = 2048
 _LN2 = math.log(2.0)
+_KV_FP8_ROPE_ENV = "KV_FP8_ROPE"
+_KV_FP8_ROPE_ENABLED = os.environ.get(_KV_FP8_ROPE_ENV, "0") == "1"
 
 
 if triton is not None and tl is not None:
@@ -134,6 +136,14 @@ def _is_supported_packed_kv_cache_view(
 
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "0").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve_kv_fp8_rope(value: bool | None) -> bool:
+    # Cache layout is a process-lifetime ABI: only the literal operator gate
+    # value "1" enables it; unset and every other value retain the 432-byte ABI.
+    if value is not None:
+        return bool(value)
+    return _KV_FP8_ROPE_ENABLED
 
 
 def _use_sm120_sparse_mla(*, backend: str | None, device: torch.device) -> bool:
@@ -362,6 +372,7 @@ def sparse_mla_decode_forward(
     nsa_cache_seqlens_int32: torch.Tensor | None = None,
     binding=None,
     sm_scale: float,
+    latent_scale: float = 1.0,
     v_head_dim: int | None = None,
     return_lse: bool = False,
     lse_scale: Literal["base2", "natural"] = "base2",
@@ -369,6 +380,8 @@ def sparse_mla_decode_forward(
     identity_page_table: bool = False,
     backend: str | None = None,
     forced_num_splits: int | None = None,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     q_all, page_table_1, cache_seqlens_int32, nsa_cache_seqlens_int32, workspace = (
         _resolve_sparse_mla_binding(
@@ -390,6 +403,7 @@ def sparse_mla_decode_forward(
         active_token_counts=nsa_cache_seqlens_int32,
         workspace=workspace,
         sm_scale=sm_scale,
+        latent_scale=latent_scale,
         v_head_dim=v_head_dim,
         return_lse=return_lse,
         lse_scale=lse_scale,
@@ -397,6 +411,8 @@ def sparse_mla_decode_forward(
         identity_page_table=identity_page_table,
         backend=backend,
         forced_num_splits=forced_num_splits,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
     )
 
 
@@ -409,10 +425,13 @@ def sparse_mla_extend_forward(
     nsa_cache_seqlens_int32: torch.Tensor | None = None,
     binding=None,
     sm_scale: float,
+    latent_scale: float = 1.0,
     v_head_dim: int | None = None,
     return_lse: bool = False,
     lse_scale: Literal["base2", "natural"] = "base2",
     identity_page_table: bool = False,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     q_all, selected_token_offsets, cache_seqlens_int32, nsa_cache_seqlens_int32, workspace = (
         _resolve_sparse_mla_binding(
@@ -434,10 +453,13 @@ def sparse_mla_extend_forward(
         active_token_counts=nsa_cache_seqlens_int32,
         workspace=workspace,
         sm_scale=sm_scale,
+        latent_scale=latent_scale,
         v_head_dim=v_head_dim,
         return_lse=return_lse,
         lse_scale=lse_scale,
         identity_page_table=identity_page_table,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
     )
 
 
@@ -450,6 +472,7 @@ def _run_sparse_mla(
     active_token_counts: torch.Tensor,
     workspace: object,
     sm_scale: float,
+    latent_scale: float = 1.0,
     v_head_dim: int,
     return_lse: bool = False,
     lse_scale: Literal["base2", "natural"] = "base2",
@@ -457,6 +480,8 @@ def _run_sparse_mla(
     identity_page_table: bool = False,
     backend: str | None = None,
     forced_num_splits: int | None = None,
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if q_all.ndim != 3:
         raise ValueError(f"q_all must be rank-3, got {tuple(q_all.shape)}")
@@ -544,6 +569,34 @@ def _run_sparse_mla(
             f"v_head_dim {v_head_dim} does not match workspace v_head_dim {workspace.v_head_dim}"
         )
     _sm120_route = _use_sm120_sparse_mla(backend=backend, device=q_all.device)
+    # NVFP4 (scale_format=2) selection: explicit kwarg wins; otherwise the
+    # scratch/workspace planned kv_cache_dtype supplies it. None -> inferred
+    # from q_head_dim inside the kernel launchers (fp8 GLM default).
+    scale_format_for_call = (
+        scale_format if scale_format is not None else getattr(workspace, "scale_format", None)
+    )
+    if int(scale_format_for_call or -1) == 2 and fp8_rope is None:
+        # Normal vLLM calls arrive through b12x.integration.mla, whose stable
+        # public signature does not carry this new option. The allocated record
+        # is therefore the authoritative process-lifetime ABI at this boundary;
+        # derive the specialization from it instead of rereading a mutable env.
+        record_bytes = int(kv_cache.shape[-1])
+        if record_bytes not in (368, 432):
+            raise ValueError(
+                "NVFP4 sparse MLA cache record must be 368 or 432 bytes, got "
+                f"{record_bytes}"
+            )
+        fp8_rope_for_call = record_bytes == 368
+    else:
+        fp8_rope_for_call = _resolve_kv_fp8_rope(fp8_rope)
+    if int(scale_format_for_call or -1) == 2:
+        expected_record_bytes = 368 if fp8_rope_for_call else 432
+        if int(kv_cache.shape[-1]) != expected_record_bytes:
+            raise ValueError(
+                "NVFP4 sparse MLA cache record disagrees with KV_FP8_ROPE: "
+                f"got {int(kv_cache.shape[-1])} bytes, expected "
+                f"{expected_record_bytes}"
+            )
     if attn_sink is not None:
         attn_sink = attn_sink.detach()
         if not _sm120_route:
@@ -606,10 +659,13 @@ def _run_sparse_mla(
                 active_token_counts=active_token_counts,
                 workspace=workspace,
                 sm_scale=float(sm_scale),
+                latent_scale=float(latent_scale),
                 v_head_dim=int(v_head_dim),
                 attn_sink=attn_sink,
                 return_lse=return_lse,
                 lse_scale=lse_scale,
+                scale_format=scale_format_for_call,
+                fp8_rope=fp8_rope_for_call,
             )
         from .kernel import run_unified_decode
 
@@ -620,11 +676,14 @@ def _run_sparse_mla(
             swa_topk_lengths=active_token_counts,
             workspace=workspace,
             sm_scale=float(sm_scale),
+            latent_scale=float(latent_scale),
             swa_page_size=int(workspace.page_size),
             attn_sink=attn_sink,
             return_lse=return_lse,
             lse_scale=lse_scale,
             forced_num_splits=forced_num_splits,
+            scale_format_override=scale_format_for_call,
+            fp8_rope_override=fp8_rope_for_call,
         )
     if _is_cuda_graph_capture_active(q_all.device):
         raise RuntimeError(
@@ -661,10 +720,13 @@ def _run_sm120_prefill(
     active_token_counts: torch.Tensor,
     workspace: object,
     sm_scale: float,
+    latent_scale: float,
     v_head_dim: int,
     attn_sink: torch.Tensor | None,
     return_lse: bool,
     lse_scale: Literal["base2", "natural"],
+    scale_format: int | None = None,
+    fp8_rope: bool | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Route a prefill-like call to the active SM120 single-pass prefill."""
     from .kernel import run_unified_prefill
@@ -679,10 +741,13 @@ def _run_sm120_prefill(
         kv_cache=kv_cache,
         topk_indices=selected_indices,
         sm_scale=float(sm_scale),
+        latent_scale=float(latent_scale),
         page_block_size=int(workspace.page_size),
         topk_length=active_token_counts,
         attn_sink=attn_sink,
         output=output,
+        scale_format=scale_format,
+        fp8_rope=fp8_rope,
     )
     if not return_lse:
         return output

--- a/b12x/attention/mla/api.py
+++ b/b12x/attention/mla/api.py
@@ -597,6 +597,10 @@ def _run_sparse_mla(
                 f"got {int(kv_cache.shape[-1])} bytes, expected "
                 f"{expected_record_bytes}"
             )
+        if not _sm120_route:
+            raise NotImplementedError(
+                "NVFP4 sparse MLA requires the active SM120 kernel path"
+            )
     if attn_sink is not None:
         attn_sink = attn_sink.detach()
         if not _sm120_route:

--- a/b12x/attention/mla/decode_math.py
+++ b/b12x/attention/mla/decode_math.py
@@ -57,11 +57,13 @@ from b12x.cute.fp4 import (
     atomic_max_shared_f32,
     byte_perm,
     cvt_f32_to_e4m3,
+    cvt_e4m3_to_f32_via_f16,
     fabs_f32,
     f16x2_to_f32x2,
     fmax_f32,
     fmin_f32,
     fp8_e4m3_to_f32,
+    fp4_decode_2,
     get_ptr_as_int64,
     ld_shared_v4_u32,
     ld_shared_f32,
@@ -71,6 +73,7 @@ from b12x.cute.fp4 import (
     mma_m16n8k16_f32_bf16,
     mma_m16n8k32_f32_e4m3,
     mxfp8_mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
     pow2_ceil_ue8m0,
     rcp_approx_ftz,
     shared_ptr_to_u32,
@@ -248,6 +251,10 @@ def _st_shared_u16(
 # ── DSV4 QK-path compile-time geometry (one CTA, one chunk) ──────────────────
 _FP8_MAX = 448.0
 _FP8_MIN = -448.0
+# NVFP4 MLA latent record geometry inside the staged 288-byte smem row:
+# 256B packed E2M1 data, then 32 E4M3 group-16 scale bytes at offset 256.
+_NVFP4_SCALE_OFFSET = 256
+_NVFP4_SCALE_GROUP = 16
 _NEG_INF = float("-inf")
 # Intra-kernel softmax mask sentinel (FlashInfer decode_dsv4 :443). Large FINITE
 # negative so a fully-invalid warp's (qk - local_max) is 0, not inf - inf = nan.
@@ -381,6 +388,64 @@ def s0_quantize_q_to_smem(
     cute.arch.barrier(**bar_kw)
 
 
+@cute.jit
+def s0_load_q_bf16_to_smem(
+    q_token: cute.Tensor,            # (NUM_HEADS, D_QK) bf16 view for this token
+    q_nope_bf16_base_addr: Int32,    # u32 smem addr of BF16 Q-NoPE
+    q_rope_base_addr: Int32,         # u32 smem addr of q_rope (HPB x q_rope_stride bf16)
+    head_base: Int32,                # first head index of this CTA (h_start)
+    valid_hpb: Int32,                # number of valid heads (<= HPB)
+    tid: Int32,                      # flat thread id in [0, MATH_THREADS)
+    *,
+    d_nope: cutlass.Constexpr,       # 512
+    d_rope: cutlass.Constexpr,       # 64
+    hpb: cutlass.Constexpr,          # 16
+    q_nope_bf16_stride: cutlass.Constexpr,  # D_NOPE + 8
+    q_rope_stride: cutlass.Constexpr,  # D_ROPE plus optional bank-layout pad
+    num_threads: cutlass.Constexpr,  # 256
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+):
+    """S0 (NVFP4): stage Q-NoPE and Q-RoPE as BF16.
+
+    This is the decode-local counterpart to the MG prefill BF16-QK path: no Q
+    FP8 quantization and no Q scale side buffer. Invalid tail heads are zeroed so
+    the regular VALID_HPB-gated epilogue can reuse the same tile geometry.
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+
+    i = tid
+    while i < Int32(hpb * d_nope):
+        h = i // Int32(d_nope)
+        d = i - h * Int32(d_nope)
+        val = Float32(0.0)
+        if h < valid_hpb:
+            val = Float32(q_token[head_base + h, d])
+        st_shared_bf16_from_f32(
+            q_nope_bf16_base_addr
+            + (h * Int32(q_nope_bf16_stride) + d) * Int32(2),
+            val,
+        )
+        i += Int32(num_threads)
+
+    i = tid
+    while i < Int32(hpb * d_rope):
+        h = i // Int32(d_rope)
+        d = i - h * Int32(d_rope)
+        val = Float32(0.0)
+        if h < valid_hpb:
+            val = Float32(q_token[head_base + h, Int32(d_nope) + d])
+        st_shared_bf16_from_f32(
+            _smem_byte(q_rope_base_addr, (h * Int32(q_rope_stride) + d) * Int32(2)),
+            val,
+        )
+        i += Int32(num_threads)
+    cute.arch.barrier(**bar_kw)
+
+
 # =============================================================================
 # S0b -- REMOVED (P10f). The prior GLM K dequant+requant stage forced K/V back
 # through e4m3 to use a UNIT block-scale selector, which DISCARDED the per-group
@@ -404,6 +469,7 @@ def s1_qk_nope_block_scaled(
     kv_sc_base_addr: Int32,         # u32 smem addr of kv_sc[buf] (BI x 8 footer bytes)
     warp_first_cand: Int32,         # first candidate of this warp (warp_id * 8)
     lane: Int32,
+    latent_scale: Float32,
     *,
     num_scales: cutlass.Constexpr,    # 7
     quant_tile: cutlass.Constexpr,    # 64
@@ -438,9 +504,28 @@ def s1_qk_nope_block_scaled(
         scale lives at ``cand*KV_SMEM_STRIDE + D_NOPE + blk*4`` (4B), where
         D_NOPE == NUM_SCALES*QUANT_TILE.
 
-    A (Q) loaded via ldmatrix.x4 (FP8 A 16x32); B (K) via ldmatrix.x2 (FP8 B
-    8x32) -- both with the FLAT FlashInfer ldmatrix addressing.
+      * NVFP4_E4M3: Q-NoPE is already staged as BF16; packed E2M1 K data and
+        E4M3 group-16 scales are dequantized in registers, multiplied by the
+        per-layer outer scale, and fed to the BF16 m16n8k16 MMA. No FP8
+        block-scale selectors are used in this branch.
+
+    A (Q) loaded via ldmatrix.x4 (FP8 A 16x32 for scale_format 0/1, BF16 A
+    16x16 for scale_format 2); B follows the matching FP8 or BF16 path.
     """
+    if cutlass.const_expr(scale_format == 2):
+        return s1_qk_nope_nvfp4_bf16(
+            qk,
+            q_fp8_base_addr,
+            kv_fp8_base_addr,
+            warp_first_cand,
+            lane,
+            latent_scale,
+            num_scales=num_scales,
+            quant_tile=quant_tile,
+            q_nope_bf16_stride=q_nope_stride,
+            kv_smem_stride=kv_smem_stride,
+        )
+
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
     # GLM only: this lane's two candidate columns (c0 -> qk[0]/qk[2],
@@ -528,6 +613,64 @@ def s1_qk_nope_block_scaled(
             if cutlass.const_expr(hi):
                 qk[2] = qk[2] + acc2 * ks0
                 qk[3] = qk[3] + acc3 * ks1
+    return qk
+
+
+@cute.jit
+def s1_qk_nope_nvfp4_bf16(
+    qk,
+    q_nope_bf16_base_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,       # 8 logical 64-dim FP4 K steps
+    quant_tile: cutlass.Constexpr,       # 64
+    q_nope_bf16_stride: cutlass.Constexpr,  # 520 elems
+    kv_smem_stride: cutlass.Constexpr,      # 288 bytes
+):
+    """S1 (NVFP4): BF16 QK-NoPE over in-register dequantized E2M1 K.
+
+    Storage has 32 E4M3 scales per token (group-16). The outer loop keeps the
+    logical FP4 K-step count at 512/64=8, and the inner loop feeds four BF16
+    m16n8k16 MMAs per 64-dim step.
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    kv_gid_row = warp_first_cand + gid
+
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            b0 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            b1 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2) + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a_byte = (
+                a_row * Int32(q_nope_bf16_stride * 2)
+                + (ko + a_col) * Int32(2)
+            )
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_byte(q_nope_bf16_base_addr, a_byte)
+            )
+            qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+                qk[0], qk[1], qk[2], qk[3],
+                a0, a1, a2, a3,
+                b0, b1,
+            )
     return qk
 
 
@@ -698,6 +841,7 @@ def s2_qk_rope_bf16(
     *,
     d_rope: cutlass.Constexpr,        # 64
     valid_hpb: cutlass.Constexpr = 16,
+    fp8_rope: cutlass.Constexpr = False,
 ):
     """S2: accumulate Q_rope . K_rope into qk[0..3] via D_ROPE/16=4 bf16 MMAs.
 
@@ -718,10 +862,26 @@ def s2_qk_rope_bf16(
         # A: Q-rope (bf16) at q_rope + ks*16 (elems), stride D_ROPE elems.
         a_byte = a_row * Int32(d_rope * 2) + (ko + a_col) * Int32(2)
         a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(_smem_byte(q_rope_base_addr, a_byte))
-        # B: per-lane scalar reads of two consecutive bf16 pairs.
-        row_byte = entry * Int32(d_rope * 2) + ko * Int32(2)
-        b0 = _ld_u32(kv_rope_base_addr, row_byte + tid * Int32(2) * Int32(2))
-        b1 = _ld_u32(kv_rope_base_addr, row_byte + (tid * Int32(2) + Int32(8)) * Int32(2))
+        # B: flag-off retains the exact BF16 scalar loads.  Flag-on interprets
+        # the staged 80-byte tail as fp32 scale at +0, pad through +15, then
+        # 64 E4M3 values at +16 and reconstructs each pair to BF16 registers.
+        if cutlass.const_expr(fp8_rope):
+            b0 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr,
+                entry,
+                ko + tid * Int32(2),
+                d_rope=d_rope,
+            )
+            b1 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr,
+                entry,
+                ko + tid * Int32(2) + Int32(8),
+                d_rope=d_rope,
+            )
+        else:
+            row_byte = entry * Int32(d_rope * 2) + ko * Int32(2)
+            b0 = _ld_u32(kv_rope_base_addr, row_byte + tid * Int32(2) * Int32(2))
+            b1 = _ld_u32(kv_rope_base_addr, row_byte + (tid * Int32(2) + Int32(8)) * Int32(2))
         d0, d1, d2, d3 = mma_m16n8k16_f32_bf16(
             qk[0], qk[1], qk[2], qk[3],
             a0, a1, a2, a3,
@@ -912,6 +1072,84 @@ def _ld_u16_zext(base_addr: Int32, byte_off: Int32) -> Uint32:
             asm_dialect=llvm.AsmDialect.AD_ATT,
         )
     )
+
+
+@cute.jit
+def _fp8_rope_pair_bfloat2(
+    kv_rope_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant one E4M3 RoPE pair from the staged 368-byte-record tail."""
+    row_byte = entry * Int32(d_rope * 2)
+    scale = ld_shared_f32(kv_rope_base_addr + row_byte)
+    packed = _ld_u16_zext(
+        kv_rope_base_addr,
+        row_byte + Int32(16) + dim_even,
+    )
+    v0 = cvt_e4m3_to_f32_via_f16(packed & Uint32(0xFF)) * scale
+    v1 = cvt_e4m3_to_f32_via_f16((packed >> Uint32(8)) & Uint32(0xFF)) * scale
+    return pack_f32x2_to_bfloat2(v0, v1)
+
+
+@cute.jit
+def _bf16x2_extract_lane_u16(packed: Uint32, lane: Int32) -> Uint32:
+    sh = (lane & Int32(1)) * Int32(16)
+    return (packed >> sh.to(Uint32)) & Uint32(0xFFFF)
+
+
+@cute.jit
+def _nvfp4_pair_bfloat2(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant E2M1 * inline E4M3 * per-layer outer scale to bf16x2."""
+    data_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + (dim_even // Int32(2)),
+    )
+    vals_h2 = fp4_decode_2(data_byte)
+    v0, v1 = f16x2_to_f32x2(vals_h2)
+    scale_group = dim_even // Int32(_NVFP4_SCALE_GROUP)
+    scale_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride)
+        + Int32(_NVFP4_SCALE_OFFSET)
+        + scale_group,
+    )
+    scale_f = cvt_e4m3_to_f32_via_f16(scale_byte)
+    # This is the single NVFP4 decode dequant point shared by QK and P.V.
+    # Apply s_l before BF16 packing so both MMAs consume the same true-magnitude
+    # latent; the separate BF16 RoPE path never calls this helper.
+    return pack_f32x2_to_bfloat2(
+        (v0 * scale_f) * latent_scale,
+        (v1 * scale_f) * latent_scale,
+    )
+
+
+@cute.jit
+def _nvfp4_scalar_bf16_u16(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    pair = _nvfp4_pair_bfloat2(
+        kv_fp4_base_addr,
+        entry,
+        dim & ~Int32(1),
+        latent_scale,
+        kv_smem_stride=kv_smem_stride,
+    )
+    return _bf16x2_extract_lane_u16(pair, dim & Int32(1))
 
 
 @cute.jit
@@ -1226,6 +1464,150 @@ def s4_online_softmax_glm_h8_swap_ab(
     return p, warp_rescale0, warp_rescale1
 
 
+@cute.jit
+def s4_online_softmax_glm_h8_swap_ab(
+    qk,
+    p,
+    acc_nope,
+    acc_rope,
+    global_max,
+    global_sum,
+    reduce_max_addr: Int32,
+    reduce_sum_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    *,
+    n_acc_tiles: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    rope_tiles_per_warp: cutlass.Constexpr = 0,
+    barrier_threads: cutlass.Constexpr = 0,  # barrier width override (0 -> num_threads)
+):
+    """Online softmax for the swapped 16-candidate x 8-head score tile.
+
+    ``global_{max,sum}[0:2]`` track the head pair ``(2*tid, 2*tid+1)``.
+    PV accumulators instead use the ordinary output-row ownership (head=gid),
+    so the cross-chunk alpha is shuffled from the lane owning that head pair
+    before rescaling the accumulator rows.
+    """
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    head0 = tid * Int32(2)
+    head1 = head0 + Int32(1)
+    _NI = Float32(-1e29)
+
+    local_max0 = fmax_f32(qk[0], qk[2])
+    local_max1 = fmax_f32(qk[1], qk[3])
+    for off in (4, 8, 16):
+        local_max0 = fmax_f32(
+            local_max0, cute.arch.shuffle_sync_bfly(local_max0, offset=off)
+        )
+        local_max1 = fmax_f32(
+            local_max1, cute.arch.shuffle_sync_bfly(local_max1, offset=off)
+        )
+
+    p[0] = _exp2_approx_ftz_f32(qk[0] - local_max0)
+    p[1] = _exp2_approx_ftz_f32(qk[1] - local_max1)
+    p[2] = _exp2_approx_ftz_f32(qk[2] - local_max0)
+    p[3] = _exp2_approx_ftz_f32(qk[3] - local_max1)
+    local_sum0 = p[0] + p[2]
+    local_sum1 = p[1] + p[3]
+    for off in (4, 8, 16):
+        local_sum0 = local_sum0 + cute.arch.shuffle_sync_bfly(
+            local_sum0, offset=off
+        )
+        local_sum1 = local_sum1 + cute.arch.shuffle_sync_bfly(
+            local_sum1, offset=off
+        )
+
+    # Lanes 0..3 (gid==0) own the four head pairs for this warp.
+    if gid == Int32(0):
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + head0) * Int32(4),
+            local_max0,
+        )
+        st_shared_f32(
+            reduce_max_addr + (warp_id * Int32(hpb) + head1) * Int32(4),
+            local_max1,
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + head0) * Int32(4),
+            local_sum0,
+        )
+        st_shared_f32(
+            reduce_sum_addr + (warp_id * Int32(hpb) + head1) * Int32(4),
+            local_sum1,
+        )
+    cute.arch.barrier(**bar_kw)
+
+    if tid_flat < Int32(8):
+        h = tid_flat
+        bmax = Float32(-1e30)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(
+                reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4)
+            )
+            bmax = fmax_f32(bmax, wm)
+        bsum = Float32(0.0)
+        for w in cutlass.range_constexpr(n_warps):
+            wm = ld_shared_f32(
+                reduce_max_addr + (Int32(w) * Int32(hpb) + h) * Int32(4)
+            )
+            ws = ld_shared_f32(
+                reduce_sum_addr + (Int32(w) * Int32(hpb) + h) * Int32(4)
+            )
+            bsum = bsum + ws * _exp2_approx_ftz_f32(wm - bmax)
+        st_shared_f32(reduce_max_addr + h * Int32(4), bmax)
+        st_shared_f32(reduce_sum_addr + h * Int32(4), bsum)
+    cute.arch.barrier(**bar_kw)
+
+    block_max0 = ld_shared_f32(reduce_max_addr + head0 * Int32(4))
+    block_max1 = ld_shared_f32(reduce_max_addr + head1 * Int32(4))
+    block_sum0 = ld_shared_f32(reduce_sum_addr + head0 * Int32(4))
+    block_sum1 = ld_shared_f32(reduce_sum_addr + head1 * Int32(4))
+
+    new_gmax0 = fmax_f32(global_max[0], block_max0)
+    new_gmax1 = fmax_f32(global_max[1], block_max1)
+    alpha0 = Float32(0.0)
+    alpha1 = Float32(0.0)
+    if global_max[0] > _NI:
+        alpha0 = _exp2_approx_ftz_f32(global_max[0] - new_gmax0)
+    if global_max[1] > _NI:
+        alpha1 = _exp2_approx_ftz_f32(global_max[1] - new_gmax1)
+
+    block_rescale0 = _exp2_approx_ftz_f32(block_max0 - new_gmax0)
+    block_rescale1 = _exp2_approx_ftz_f32(block_max1 - new_gmax1)
+    warp_rescale0 = _exp2_approx_ftz_f32(local_max0 - new_gmax0)
+    warp_rescale1 = _exp2_approx_ftz_f32(local_max1 - new_gmax1)
+
+    # Source lanes 0..3 carry alpha for pairs (0,1), (2,3), (4,5), (6,7).
+    pair_lane = gid >> Int32(1)
+    row_alpha0 = cute.arch.shuffle_sync(alpha0, pair_lane)
+    row_alpha1 = cute.arch.shuffle_sync(alpha1, pair_lane)
+    row_alpha = row_alpha0
+    if (gid & Int32(1)) != Int32(0):
+        row_alpha = row_alpha1
+    for at in cutlass.range_constexpr(n_acc_tiles):
+        acc_nope[at][0] = acc_nope[at][0] * row_alpha
+        acc_nope[at][1] = acc_nope[at][1] * row_alpha
+    for rt in cutlass.range_constexpr(rope_tiles_per_warp):
+        acc_rope[rt * 4 + 0] = acc_rope[rt * 4 + 0] * row_alpha
+        acc_rope[rt * 4 + 1] = acc_rope[rt * 4 + 1] * row_alpha
+
+    global_sum[0] = global_sum[0] * alpha0 + block_sum0 * block_rescale0
+    global_sum[1] = global_sum[1] * alpha1 + block_sum1 * block_rescale1
+    global_max[0] = new_gmax0
+    global_max[1] = new_gmax1
+    return p, warp_rescale0, warp_rescale1
+
+
 # =============================================================================
 # S5 -- sm_p_full fill (normalized P -> bf16) + w_head_sc zero-init
 # Port of decode_dsv4 :568-593.
@@ -1280,6 +1662,7 @@ def s6_xv_nope(
     warp_id: Int32,
     lane: Int32,
     tid_flat: Int32,
+    latent_scale: Float32,
     *,
     n_v_chunks: cutlass.Constexpr,   # 7
     v_chunk: cutlass.Constexpr,      # QUANT_TILE = 64
@@ -1295,6 +1678,8 @@ def s6_xv_nope(
     barrier_id: cutlass.Constexpr,
     valid_hpb: cutlass.Constexpr = 16,
     pack_hilo_rows: cutlass.Constexpr = False,
+    sm_p_full_addr: Int32 = None,    # NVFP4 BF16 PV only
+    sm_p_stride: cutlass.Constexpr = 0,  # NVFP4: bf16 elems per sm_p row (0 -> BI)
 ):
     """S6: accumulate W . V_nope into acc_nope[vc*NT+nt][0..3] via PLAIN fp8 MMAs
     (14 DSV4 / 16 GLM = N_V_CHUNKS * NT_PER_WARP_XV * (BI/32)).
@@ -1327,7 +1712,29 @@ def s6_xv_nope(
     both components, preserving the residual-split math while replacing the
     two serial MMAs with one.
     ``nt_per_warp_xv`` (const_expr) tiles each V_CHUNK across N_WARPS*8 columns
-    NT times: GLM's 128-dim V_CHUNK needs NT=2 (8 warps x 8 dims = 64 per nt)."""
+    NT times: GLM's 128-dim V_CHUNK needs NT=2 (8 warps x 8 dims = 64 per nt).
+
+    ``scale_format == NVFP4_E4M3`` (const_expr) bypasses the FP8 W machinery
+    entirely: BF16 probabilities staged in sm_p (``sm_p_full_addr``) are the A
+    operand and V is dequantized in registers from packed E2M1 + E4M3 group-16
+    scales (see ``s6_xv_nope_nvfp4_bf16``)."""
+    if cutlass.const_expr(scale_format == 2):
+        return s6_xv_nope_nvfp4_bf16(
+            acc_nope,
+            sm_p_full_addr,
+            kv_fp8_base_addr,
+            warp_id,
+            lane,
+            latent_scale,
+            n_v_chunks=n_v_chunks,
+            v_chunk=v_chunk,
+            bi=bi,
+            kv_smem_stride=kv_smem_stride,
+            n_warps=n_warps,
+            nt_per_warp_xv=nt_per_warp_xv,
+            sm_p_stride=(sm_p_stride if sm_p_stride else bi),
+        )
+
     bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
@@ -1570,6 +1977,86 @@ def s6_xv_nope(
             if cutlass.const_expr(hi):
                 acc_nope[at][2] = acc_nope[at][2] + xv[nt][2] * sc1
                 acc_nope[at][3] = acc_nope[at][3] + xv[nt][3] * sc1
+    return acc_nope
+
+
+@cute.jit
+def s6_xv_nope_nvfp4_bf16(
+    acc_nope,
+    sm_p_full_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    n_v_chunks: cutlass.Constexpr,      # 8
+    v_chunk: cutlass.Constexpr,         # 64
+    bi: cutlass.Constexpr,              # 64
+    kv_smem_stride: cutlass.Constexpr,  # 288 bytes
+    n_warps: cutlass.Constexpr,         # 8
+    nt_per_warp_xv: cutlass.Constexpr,  # 1
+    sm_p_stride: cutlass.Constexpr = 0,  # bf16 elems per sm_p row (0 -> BI)
+):
+    """S6 (NVFP4): BF16 P.V over in-register dequantized E2M1 V.
+
+    V is the same 512-dim MLA latent as K-NoPE. The BF16 probabilities staged by
+    S5 are used directly as the A operand; each B scalar is dequantized from the
+    packed E2M1 byte and its E4M3 group-16 scale.
+    """
+    p_stride = cutlass.const_expr(sm_p_stride if sm_p_stride else bi)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            dim_base = (
+                Int32(vc) * Int32(v_chunk)
+                + (Int32(nt) * Int32(n_warps) + warp_id) * Int32(8)
+            )
+            col = dim_base + gid
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for ks in cutlass.range_constexpr(bi // 16):
+                k_base = Int32(ks) * Int32(16)
+                a_byte = (a_row * Int32(p_stride) + (k_base + a_col)) * Int32(2)
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+
+                ent0 = k_base + tid * Int32(2)
+                v0 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr, ent0, col, latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v1 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr, ent0 + Int32(1), col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v8 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr, ent0 + Int32(8), col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                v9 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr, ent0 + Int32(9), col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                )
+                b0 = v0 | (v1 << Uint32(16))
+                b1 = v8 | (v9 << Uint32(16))
+                xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(
+                    xv0, xv1, xv2, xv3,
+                    a0, a1, a2, a3,
+                    b0, b1,
+                )
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + xv0
+            acc_nope[at][1] = acc_nope[at][1] + xv1
+            acc_nope[at][2] = acc_nope[at][2] + xv2
+            acc_nope[at][3] = acc_nope[at][3] + xv3
     return acc_nope
 
 

--- a/b12x/attention/mla/io.py
+++ b/b12x/attention/mla/io.py
@@ -70,6 +70,19 @@ _GLM_GMEM_STRIDE = 656
 _GLM_NOPE_SCALE_BYTES = 528  # 512 e4m3 + 16 inline fp32; bulk #1 (-> kv_fp8 row).
 _GLM_ROPE_BYTES = 128        # 64 bf16; bulk #2 (-> kv_rope).
 
+# NVFP4 MLA latent layout: 256B E2M1 NoPE + 32B E4M3 scales + 16B pad + 128B
+# BF16 RoPE. The NoPE+scale+pad region is staged as a 288B row; decode math
+# dequants the E2M1 data and E4M3 group-16 scales in registers.
+_NVFP4_GMEM_STRIDE = 432
+_NVFP4_NOPE_SCALE_BYTES = 288
+_NVFP4_ROPE_BYTES = 128
+_NVFP4_ROPE_SRC = 304
+# GLM-only KV_FP8_ROPE tail.  The latent bytes [0,288) are identical to the
+# stock record; [288,304) holds fp32 scale + 12B zero pad and [304,368) is E4M3.
+_NVFP4_FP8_ROPE_GMEM_STRIDE = 368
+_NVFP4_FP8_ROPE_TAIL_BYTES = 80
+_NVFP4_FP8_ROPE_TAIL_SRC = 288
+
 # IO warp width (one warp = 32 threads; FlashInfer DSV4_IO_THREADS).
 _IO_THREADS = 32
 
@@ -95,6 +108,7 @@ def io_issue_gather(
     scale_bytes_per_token: cutlass.Constexpr,  # 8 (DSV4 footer); unused for GLM
     bulk_tx_bytes: cutlass.Constexpr,      # BI*(448+128)=36864 DSV4 / BI*(528+128)=41984 GLM
     scale_format: cutlass.Constexpr = 0,   # UE8M0_BYTE (0) / ARBITRARY_FP32 (1)
+    fp8_rope: cutlass.Constexpr = False,
     io_threads: cutlass.Constexpr = _IO_THREADS,  # 32 (decode 1 IO warp) / 128 (prefill 4 IO warps)
     packed_glm: cutlass.Constexpr = False,
     packed_dsv4: cutlass.Constexpr = False,
@@ -141,11 +155,24 @@ def io_issue_gather(
 
     # Per-model gmem geometry (const_expr). DSV4: 576B data + grouped 8B footer;
     # GLM: 656B contiguous (528 nope+inline-scales + 128 rope), NO footer.
+    # NVFP4: 432B contiguous (288 nope+E4M3-scales+pad + 128 rope), NO footer.
     if cutlass.const_expr(scale_format == 0):
         _IOS = Int64(_DSV4_IO_STRIDE)          # 576 per-token data stride
         _NOPE = Int32(_DSV4_NOPE_BYTES)        # 448 -> kv_fp8 (e4m3 nope)
         _ROPE = Int32(_DSV4_ROPE_BYTES)        # 128 -> kv_rope
         _ROPE_SRC = Int64(_DSV4_NOPE_BYTES)    # rope follows nope in the record
+    elif cutlass.const_expr(scale_format == 2):
+        _NOPE = Int32(_NVFP4_NOPE_SCALE_BYTES)
+        if cutlass.const_expr(fp8_rope):
+            _IOS = Int64(_NVFP4_FP8_ROPE_GMEM_STRIDE)
+            # Stage scale+pad+FP8 payload contiguously in the existing 128-byte
+            # BF16-rope smem row. decode_math interprets scale at +0 and E4M3 at +16.
+            _ROPE = Int32(_NVFP4_FP8_ROPE_TAIL_BYTES)
+            _ROPE_SRC = Int64(_NVFP4_FP8_ROPE_TAIL_SRC)
+        else:
+            _IOS = Int64(_NVFP4_GMEM_STRIDE)
+            _ROPE = Int32(_NVFP4_ROPE_BYTES)
+            _ROPE_SRC = Int64(_NVFP4_ROPE_SRC)
     else:
         _IOS = Int64(_GLM_GMEM_STRIDE)         # 656 per-token contiguous record
         _NOPE = Int32(_GLM_NOPE_SCALE_BYTES)   # 528 nope+inline-fp32 -> kv_fp8

--- a/b12x/attention/mla/io_mg.py
+++ b/b12x/attention/mla/io_mg.py
@@ -33,6 +33,12 @@ _IO_THREADS = 128
 # issued here.
 _GLM_IO_STRIDE = 656
 _GLM_NOPE_SCALE_BYTES = 528
+# NVFP4 MLA latent record: 256B E2M1 NoPE + 32B E4M3 group-16 scales + 16B pad
+# + 128B BF16 RoPE. The 288B NoPE+scales+pad region bulk-copies into the kv_fp8
+# row; RoPE is read from global/L2 by the math exactly like GLM.
+_NVFP4_IO_STRIDE = 432
+_NVFP4_NOPE_SCALE_BYTES = 288
+_NVFP4_FP8_ROPE_IO_STRIDE = 368
 
 
 @cute.jit
@@ -132,8 +138,10 @@ def io_issue_gather_glm_mg(
     cache_policy: Uint64,
     *,
     bi: cutlass.Constexpr,
-    kv_smem_stride: cutlass.Constexpr,   # 528 (512 nope + 16 inline fp32 scales)
+    kv_smem_stride: cutlass.Constexpr,   # 528 GLM / 288 NVFP4 (smem nope row stride)
     io_threads: cutlass.Constexpr = _IO_THREADS,
+    scale_format: cutlass.Constexpr = 1,
+    fp8_rope: cutlass.Constexpr = False,
 ):
     """Gather one BI=64 GLM prefill tile into MG smem.
 
@@ -143,12 +151,22 @@ def io_issue_gather_glm_mg(
     NO grouped UE8M0 footer (so NO scalar scale gather) and -- like the DSV4 MG
     path -- RoPE is read from global/L2 by the math (NOT staged to smem), so the
     528-stride GLM KV fits the carveout for mg_n_hg==2. Single full mbarrier (the
-    MG convention): the leader arrives + expect_tx over the BI 528B bulks."""
-    _ios = Int64(_GLM_IO_STRIDE)
-    _nope = Int32(_GLM_NOPE_SCALE_BYTES)
+    MG convention): the leader arrives + expect_tx over the BI 528B bulks.
+
+    ``scale_format`` (const_expr): ARBITRARY_FP32 (1, GLM 656B/528B) or
+    NVFP4_E4M3 (2, NVFP4 432B/288B) record geometry."""
+    if cutlass.const_expr(scale_format == 2):
+        if cutlass.const_expr(fp8_rope):
+            _ios = Int64(_NVFP4_FP8_ROPE_IO_STRIDE)
+        else:
+            _ios = Int64(_NVFP4_IO_STRIDE)
+        _nope = Int32(_NVFP4_NOPE_SCALE_BYTES)
+    else:
+        _ios = Int64(_GLM_IO_STRIDE)
+        _nope = Int32(_GLM_NOPE_SCALE_BYTES)
 
     if io_lane == Int32(0):
-        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, Int32(bi * _GLM_NOPE_SCALE_BYTES))
+        cute.arch.mbarrier_arrive_and_expect_tx(full_mbar_ptr, Int32(bi) * _nope)
 
     full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
     eo = Int32(0)

--- a/b12x/attention/mla/kernel.py
+++ b/b12x/attention/mla/kernel.py
@@ -36,6 +36,7 @@ from b12x.cute.compiler import (
 from b12x.cute.fp4 import shared_ptr_to_u32
 
 from .decode_math import (
+    s0_load_q_bf16_to_smem,
     s0_quantize_q_to_smem,
     s1_qk_nope_block_scaled,
     s1_qk_nope_block_scaled_dsv4_h8_swap_ab,
@@ -58,6 +59,7 @@ from .io import io_issue_gather
 from .smem import get_unified_shared_storage_cls, make_smem_layout
 from .traits import (
     ModelType,
+    ScaleFormat,
     infer_model_type,
     make_unified_traits,
 )
@@ -183,13 +185,7 @@ def _dsv4_h16_auto(
     heads: int,
     num_chunks: int,
     h8_num_splits: int,
-    sm_count: int | None = None,
 ) -> bool:
-    # Spark reaches a full H8 launch wave much earlier than the 188-SM tuning
-    # target. Sharing each KV stage across 16 heads wins from B=8 for C4/C128,
-    # while the two-chunk SWA path keeps H8's lower fixed latency.
-    if sm_count is not None and sm_count <= 64 and rows >= 8 and num_chunks > 2:
-        return True
     if num_chunks >= _DSV4_H16_MIN_BW_CHUNKS and rows >= _DSV4_H16_MIN_BW_ROWS:
         return True
     h8_ctas = rows * (heads // 8) * max(1, int(h8_num_splits))
@@ -420,19 +416,18 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,        # (rows, heads, splits, D_V) bf16 partials
         mid_lse: cute.Tensor,        # (rows, heads, splits) f32 base-2 LSE
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         section_len: Int32,          # MAIN per-row valid topk length
         stride_kv_block: Int64,      # MAIN per-block byte stride
         num_tokens: Int32,
         stream: cuda.CUstream,
     ):
-        # SINGLE-CACHE entry: EXACTLY the v1 traced signature (8 data args +
-        # stream). The dispatcher selects this (func=kernel -> __call__) when
-        # has_extra=False so the no-extra DSV4 / GLM trace, mangled name, and the
-        # launched @cute.kernel (self.kernel, 8 params) stay byte-identical to the
-        # pre-P7c kernel: the extra-section args never enter the device entry.
+        # SINGLE-CACHE entry: the deployed eight data args plus the runtime
+        # latent_scale (and stream). The dispatcher selects this (func=kernel ->
+        # __call__) when has_extra=False; extra-section args never enter it.
         self.kernel(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, section_len, stride_kv_block,
+            sm_scale_log2, latent_scale, section_len, stride_kv_block,
         ).launch(
             grid=(num_tokens, self.h_blocks, self.num_splits),
             block=[self.block_threads, 1, 1],
@@ -453,6 +448,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,        # (rows, heads, splits, D_V) bf16 partials
         mid_lse: cute.Tensor,        # (rows, heads, splits) f32 base-2 LSE
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         section_len: Int32,          # MAIN per-row valid topk length
         stride_kv_block: Int64,      # MAIN per-block byte stride
         extra_kv_cache_u8: cute.Tensor,  # flat u8 EXTRA cache (DSV4 dual-cache)
@@ -465,12 +461,12 @@ class UnifiedDecodeKernel:
     ):
         # DUAL-CACHE entry (DSV4 P7c): the dispatcher selects this (func=
         # kernel.call_extra) only when has_extra=True, so its DISTINCT mangled name
-        # never collides with the byte-identical single-cache __call__. It launches
-        # the 13-param @cute.kernel (self.kernel_extra), which shares the body via
+        # never collides with the single-cache __call__. It launches
+        # the 14-param @cute.kernel (self.kernel_extra), which shares the body via
         # _kernel_body(has_extra=True).
         self.kernel_extra(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, section_len, stride_kv_block,
+            sm_scale_log2, latent_scale, section_len, stride_kv_block,
             extra_kv_cache_u8, extra_indices, extra_section_len,
             num_main_chunks, stride_extra_kv_block,
         ).launch(
@@ -489,6 +485,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,        # (rows, heads, splits, D_V) bf16 partials
         mid_lse: cute.Tensor,        # (rows, heads, splits) f32 base-2 LSE
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         topk_length: cute.Tensor,    # (rows,) int32 per-token MAIN valid length
         stride_kv_block: Int64,      # MAIN per-block byte stride
         num_tokens: Int32,
@@ -503,7 +500,7 @@ class UnifiedDecodeKernel:
         # ignores them.
         self.kernel_pertok(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, topk_length, stride_kv_block,
+            sm_scale_log2, latent_scale, topk_length, stride_kv_block,
         ).launch(
             grid=(num_tokens, self.h_blocks, self.num_splits),
             block=[self.block_threads, 1, 1],
@@ -520,6 +517,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         topk_length: cute.Tensor,        # (rows,) int32 per-token MAIN valid length
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
@@ -536,7 +534,7 @@ class UnifiedDecodeKernel:
         # over the MAX topk); per-token clamping zeroes the over-allocated chunks.
         self.kernel_extra_pertok(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, topk_length, stride_kv_block,
+            sm_scale_log2, latent_scale, topk_length, stride_kv_block,
             extra_kv_cache_u8, extra_indices, extra_topk_length,
             num_main_chunks, stride_extra_kv_block,
         ).launch(
@@ -555,6 +553,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         section_len: Int32,
         stride_kv_block: Int64,
     ):
@@ -711,6 +710,7 @@ class UnifiedDecodeKernel:
                     rope_smem_stride=t.d_rope,
                     scale_bytes_per_token=8, bulk_tx_bytes=t.bulk_tx_bytes,
                     scale_format=t.scale_format,
+                    fp8_rope=t.fp8_rope,
                     packed_glm=self.native_glm_h8,
                     packed_dsv4=self.native_dsv4_h8,
                 )
@@ -722,17 +722,27 @@ class UnifiedDecodeKernel:
         else:
             # MATH WARPS (CONSUMER, warps 0-7 = 256 threads).
             n_acc_tiles = int(t.n_v_chunks) * int(t.nt_per_warp_xv)
-            s0_quantize_q_to_smem(
-                q_token, q_fp8_addr, q_sc_view, q_rope_addr, amax_view,
-                head_base, Int32(self.valid_hpb), tid,
-                d_nope=t.d_nope, d_rope=t.d_rope,
-                d_qk=t.d_nope + t.d_rope,
-                quant_tile=t.quant_tile, num_scales=t.num_scales,
-                hpb=(8 if self.native_h8 else t.hpb),
-                q_nope_stride=t.q_nope_stride,
-                q_rope_stride=L.q_rope_stride,
-                num_threads=self.math_threads, barrier_id=2,
-            )
+            if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                s0_load_q_bf16_to_smem(
+                    q_token, q_fp8_addr, q_rope_addr,
+                    head_base, Int32(self.valid_hpb), tid,
+                    d_nope=t.d_nope, d_rope=t.d_rope, hpb=t.hpb,
+                    q_nope_bf16_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads, barrier_id=2,
+                )
+            else:
+                s0_quantize_q_to_smem(
+                    q_token, q_fp8_addr, q_sc_view, q_rope_addr, amax_view,
+                    head_base, Int32(self.valid_hpb), tid,
+                    d_nope=t.d_nope, d_rope=t.d_rope,
+                    d_qk=t.d_nope + t.d_rope,
+                    quant_tile=t.quant_tile, num_scales=t.num_scales,
+                    hpb=(8 if self.native_h8 else t.hpb),
+                    q_nope_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=self.math_threads, barrier_id=2,
+                )
 
             accn_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
             rope_acc_elems = 8 if self.native_dsv4_h8 else 4
@@ -858,7 +868,7 @@ class UnifiedDecodeKernel:
                 else:
                     qk = s1_qk_nope_block_scaled(
                         qk, q_fp8_addr, kv_fp8_b, q_sc_view, kv_sc_b,
-                        warp_first_cand, lane,
+                        warp_first_cand, lane, latent_scale,
                         num_scales=t.num_scales, quant_tile=t.quant_tile,
                         q_nope_stride=t.q_nope_stride,
                         kv_smem_stride=t.kv_smem_stride,
@@ -867,6 +877,7 @@ class UnifiedDecodeKernel:
                     qk = s2_qk_rope_bf16(
                         qk, q_rope_addr, kv_rope_b, warp_first_cand, lane,
                         d_rope=t.d_rope,
+                        fp8_rope=t.fp8_rope,
                     )
                     qk = s3_mask_and_scale(
                         qk, tok_buf_view, warp_first_cand,
@@ -898,6 +909,7 @@ class UnifiedDecodeKernel:
                     acc_nope = s6_xv_nope(
                         w_pre, acc_nope, kv_fp8_b, kv_sc_b,
                         w_head_sc_view, w_fp8_addr, warp_id, lane, tid,
+                        latent_scale,
                         n_v_chunks=t.n_v_chunks, v_chunk=t.quant_tile,
                         hpb=t.hpb, bi=t.bi,
                         kv_smem_stride=t.kv_smem_stride,
@@ -906,6 +918,8 @@ class UnifiedDecodeKernel:
                         nt_per_warp_xv=t.nt_per_warp_xv,
                         scale_format=t.scale_format,
                         num_threads=self.math_threads, barrier_id=3,
+                        sm_p_full_addr=sm_p_full_addr,
+                        sm_p_stride=L.sm_p_full_stride,
                     )
 
                 # S6b (XV-RoPE) is DSV4-only (V_HAS_ROPE). const_expr-elided for GLM.
@@ -1006,6 +1020,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         section_len: Int32,
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
@@ -1014,11 +1029,11 @@ class UnifiedDecodeKernel:
         num_main_chunks: Int32,
         stride_extra_kv_block: Int64,
     ):
-        # DUAL-CACHE @cute.kernel: 13 device params; threads the real extra-section
+        # DUAL-CACHE @cute.kernel: 14 device params; threads the real extra-section
         # args into the shared body (has_extra=True).
         self._kernel_body(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, section_len, stride_kv_block,
+            sm_scale_log2, latent_scale, section_len, stride_kv_block,
             extra_kv_cache_u8, extra_indices, extra_section_len,
             num_main_chunks, stride_extra_kv_block,
             swa_indices, extra_indices,  # length tensors unused (per_token_len=False)
@@ -1034,6 +1049,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         topk_length: cute.Tensor,
         stride_kv_block: Int64,
     ):
@@ -1045,7 +1061,7 @@ class UnifiedDecodeKernel:
         # swa_indices (never read when has_extra=False).
         self._kernel_body(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, Int32(0), stride_kv_block,
+            sm_scale_log2, latent_scale, Int32(0), stride_kv_block,
             kv_cache_u8, swa_indices, Int32(0),
             Int32(0), stride_kv_block,
             topk_length, swa_indices,
@@ -1061,6 +1077,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         topk_length: cute.Tensor,
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
@@ -1075,7 +1092,7 @@ class UnifiedDecodeKernel:
         # a scalar; per-token clamping masks the over-allocated chunks.
         self._kernel_body(
             q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
-            sm_scale_log2, Int32(0), stride_kv_block,
+            sm_scale_log2, latent_scale, Int32(0), stride_kv_block,
             extra_kv_cache_u8, extra_indices, Int32(0),
             num_main_chunks, stride_extra_kv_block,
             topk_length, extra_topk_length,
@@ -1091,6 +1108,7 @@ class UnifiedDecodeKernel:
         mid_out: cute.Tensor,
         mid_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         section_len: Int32,
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
@@ -1328,6 +1346,7 @@ class UnifiedDecodeKernel:
                     rope_smem_stride=t.d_rope,
                     scale_bytes_per_token=8, bulk_tx_bytes=t.bulk_tx_bytes,
                     scale_format=t.scale_format,
+                    fp8_rope=t.fp8_rope,
                     packed_glm=self.native_glm_h8,
                     packed_dsv4=self.native_dsv4_h8 or self.native_dsv4_h16,
                 )
@@ -1442,21 +1461,34 @@ class UnifiedDecodeKernel:
                     cute.make_layout(int(L.w_head_sc_bytes // 4)),
                 )
 
-            s0_quantize_q_to_smem(
-                q_token, q_fp8_stage, q_sc_stage_view, q_rope_stage,
-                amax_stage_view,
-                head_base_stage,
-                Int32(8 if self.native_dsv4_h16 else self.valid_hpb),
-                tid_sel,
-                d_nope=t.d_nope, d_rope=t.d_rope,
-                d_qk=t.d_nope + t.d_rope,
-                quant_tile=t.quant_tile, num_scales=t.num_scales,
-                hpb=(8 if (self.native_h8 or self.native_dsv4_h16) else t.hpb),
-                q_nope_stride=t.q_nope_stride,
-                q_rope_stride=L.q_rope_stride,
-                num_threads=nt_stage, barrier_id=2,
-                barrier_threads=bt_stage,
-            )
+            if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                s0_load_q_bf16_to_smem(
+                    q_token, q_fp8_stage, q_rope_stage,
+                    head_base_stage,
+                    Int32(self.valid_hpb),
+                    tid_sel,
+                    d_nope=t.d_nope, d_rope=t.d_rope, hpb=t.hpb,
+                    q_nope_bf16_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=nt_stage, barrier_id=2,
+                    barrier_threads=bt_stage,
+                )
+            else:
+                s0_quantize_q_to_smem(
+                    q_token, q_fp8_stage, q_sc_stage_view, q_rope_stage,
+                    amax_stage_view,
+                    head_base_stage,
+                    Int32(8 if self.native_dsv4_h16 else self.valid_hpb),
+                    tid_sel,
+                    d_nope=t.d_nope, d_rope=t.d_rope,
+                    d_qk=t.d_nope + t.d_rope,
+                    quant_tile=t.quant_tile, num_scales=t.num_scales,
+                    hpb=(8 if (self.native_h8 or self.native_dsv4_h16) else t.hpb),
+                    q_nope_stride=t.q_nope_stride,
+                    q_rope_stride=L.q_rope_stride,
+                    num_threads=nt_stage, barrier_id=2,
+                    barrier_threads=bt_stage,
+                )
 
             accn_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
             rope_acc_elems = 8 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 4
@@ -1600,7 +1632,7 @@ class UnifiedDecodeKernel:
                 else:
                     qk = s1_qk_nope_block_scaled(
                         qk, q_fp8_addr, kv_fp8_b, q_sc_view, kv_sc_b,
-                        warp_first_cand, lane,
+                        warp_first_cand, lane, latent_scale,
                         num_scales=t.num_scales, quant_tile=t.quant_tile,
                         q_nope_stride=t.q_nope_stride,
                         kv_smem_stride=t.kv_smem_stride,
@@ -1609,6 +1641,7 @@ class UnifiedDecodeKernel:
                     qk = s2_qk_rope_bf16(
                         qk, q_rope_addr, kv_rope_b, warp_first_cand, lane,
                         d_rope=t.d_rope,
+                        fp8_rope=t.fp8_rope,
                     )
 
                     # Per-chunk section dispatch for the S3 mask: compare the
@@ -1661,6 +1694,7 @@ class UnifiedDecodeKernel:
                     acc_nope = s6_xv_nope(
                         w_pre, acc_nope, kv_fp8_b, kv_sc_b,
                         w_head_sc_view, w_fp8_addr, warp_id, lane, tid,
+                        latent_scale,
                         n_v_chunks=t.n_v_chunks, v_chunk=t.quant_tile,
                         hpb=t.hpb, bi=t.bi,
                         kv_smem_stride=t.kv_smem_stride,
@@ -1669,6 +1703,8 @@ class UnifiedDecodeKernel:
                         nt_per_warp_xv=t.nt_per_warp_xv,
                         scale_format=t.scale_format,
                         num_threads=self.math_threads, barrier_id=3,
+                        sm_p_full_addr=sm_p_full_addr,
+                        sm_p_stride=L.sm_p_full_stride,
                     )
 
                 # S6b (XV-RoPE) is DSV4-only (V_HAS_ROPE). const_expr-elided for GLM.
@@ -1803,11 +1839,15 @@ def _cache_block_stride_bytes(
     *,
     page_size: int,
     model_type: int,
+    record_bytes: int | None = None,
 ) -> int:
     from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
 
     if int(model_type) == int(ModelType.GLM_NSA):
-        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+        expected = int(page_size) * rec
     else:
         expected = int(compressed_mla_page_nbytes(int(page_size)))
     # Contiguous inputs are flattened before launch, so their original rank is
@@ -1842,9 +1882,11 @@ def _sparse_mla_decode_grid_flat_launch(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     model_type: int,
     compute_mode: int,
     scale_format: int,
+    fp8_rope: bool,
     swa_page_size: int,
     topk: int,
     extra_topk: int,
@@ -1870,6 +1912,8 @@ def _sparse_mla_decode_grid_flat_launch(
         and int(grid_h_blocks) == 1
         and int(head_block_offset) == 0
         and not bool(has_extra)
+        # NVFP4 records are validated on the generic HPB=16 arm only.
+        and int(scale_format) != int(ScaleFormat.NVFP4_E4M3)
         and _env_glm_h8_native_enabled()
     )
     native_dsv4_h8 = bool(
@@ -1891,6 +1935,7 @@ def _sparse_mla_decode_grid_flat_launch(
         int(model_type),
         int(compute_mode),
         int(scale_format),
+        fp8_rope=bool(fp8_rope),
     )
     if native_h8:
         # Four warps cover 4*16 candidates in swapped QK.  PV keeps the same
@@ -1921,6 +1966,7 @@ def _sparse_mla_decode_grid_flat_launch(
             _to_cute(mid_out, cutlass.BFloat16, align=16, dynamic_layout=True),
             _to_cute(mid_lse, cutlass.Float32, align=4, dynamic_layout=True),
             Float32(float(sm_scale) * LOG2_E),
+            Float32(float(latent_scale)),
             _to_cute(swa_len_t, cutlass.Int32, align=4, dynamic_layout=True),
             Int64(stride_kv_block),
         )
@@ -1944,6 +1990,7 @@ def _sparse_mla_decode_grid_flat_launch(
             _to_cute(mid_out, cutlass.BFloat16, align=16, dynamic_layout=True),
             _to_cute(mid_lse, cutlass.Float32, align=4, dynamic_layout=True),
             Float32(float(sm_scale) * LOG2_E),
+            Float32(float(latent_scale)),
             Int32(topk),
             Int64(stride_kv_block),
         )
@@ -1989,6 +2036,7 @@ def _sparse_mla_decode_grid_flat_launch(
         key_field("model_type", traits.model_type),
         key_field("compute_mode", traits.compute_mode),
         key_field("scale_format", traits.scale_format),
+        key_field("fp8_rope", int(traits.fp8_rope)),
         key_field("num_heads", heads),
         key_field("hpb", hpb),
         key_field("valid_hpb", int(valid_hpb)),
@@ -2061,7 +2109,10 @@ def _sparse_mla_decode_grid_flat_launch(
             )
     compile_spec = KernelCompileSpec.from_fields(
         "attention.mla.sm120.decode",
-        15,
+        # v17 adds the runtime FP8-RoPE record format specialization.  The
+        # explicit cache key does not hash source, so this ABI bump rejects
+        # cubins compiled for the 432-byte BF16-RoPE record.
+        17,
         *spec_fields,
     )
     if per_token_len:
@@ -2091,9 +2142,11 @@ def _sparse_mla_decode_grid_op(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     model_type: int,
     compute_mode: int,
     scale_format: int,
+    fp8_rope: bool,
     swa_page_size: int,
     topk: int,
     extra_topk: int,
@@ -2120,9 +2173,11 @@ def _sparse_mla_decode_grid_op(
         extra_indices_t,
         extra_len_t,
         sm_scale,
+        latent_scale,
         model_type,
         compute_mode,
         scale_format,
+        fp8_rope,
         swa_page_size,
         topk,
         extra_topk,
@@ -2152,9 +2207,11 @@ def _sparse_mla_decode_grid_fake(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     model_type: int,
     compute_mode: int,
     scale_format: int,
+    fp8_rope: bool,
     swa_page_size: int,
     topk: int,
     extra_topk: int,
@@ -2181,6 +2238,7 @@ def run_unified_decode(
     swa_topk_lengths: torch.Tensor,
     workspace,
     sm_scale: float,
+    latent_scale: float = 1.0,
     swa_page_size: int,
     indexed_k_cache: torch.Tensor | None = None,
     indexed_indices: torch.Tensor | None = None,
@@ -2192,6 +2250,8 @@ def run_unified_decode(
     lse_scale: str = "base2",
     forced_num_splits: int | None = None,
     out: torch.Tensor | None = None,
+    scale_format_override: int | None = None,
+    fp8_rope_override: bool | None = None,
 ):
     """Active SM120 sparse-MLA decode: kernel (split-K partials) + merge.
 
@@ -2295,7 +2355,14 @@ def run_unified_decode(
     h_blocks = h_blocks_full + (1 if rem_heads else 0)
 
     model_type, compute_mode, scale_format = infer_model_type(q_head_dim, swa_k_cache.dtype)
-    traits = make_unified_traits(model_type, compute_mode, scale_format)
+    if scale_format_override is not None:
+        scale_format = int(scale_format_override)
+    traits = make_unified_traits(
+        model_type,
+        compute_mode,
+        scale_format,
+        fp8_rope=fp8_rope_override,
+    )
     d_v = int(traits.d_v)  # output O dim (512 for both; V == nope for GLM)
 
     topk = int(swa_indices.shape[1])
@@ -2333,11 +2400,7 @@ def run_unified_decode(
             extra_topk=extra_topk,
         )
         native_dsv4_h16 = _dsv4_h16_auto(
-            rows=rows,
-            heads=heads,
-            num_chunks=_nc8,
-            h8_num_splits=_ns8,
-            sm_count=sm_count,
+            rows=rows, heads=heads, num_chunks=_nc8, h8_num_splits=_ns8
         )
     else:
         native_dsv4_h16 = bool(h16_allowed and h16_mode)
@@ -2429,6 +2492,9 @@ def run_unified_decode(
         int(model_type) == int(ModelType.GLM_NSA)
         and int(heads) == 8
         and not has_extra
+        # NVFP4 records (432B, packed E2M1+E4M3) are validated on the generic
+        # HPB=16 arm only; the packed-656B H8 staging would misread them.
+        and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3)
         and _env_glm_h8_native_enabled()
     )
     native_h8 = native_glm_h8 or native_dsv4_h8
@@ -2452,6 +2518,8 @@ def run_unified_decode(
                 else int(traits.kv_smem_stride)
             )
         ),
+        kv_gmem_stride=int(traits.kv_gmem_stride),
+        fp8_rope=bool(traits.fp8_rope),
         qk_candidates_per_warp=(16 if (native_h8 or native_dsv4_h16) else 8),
         qk_swap_ab=native_h8 or native_dsv4_h16,
         topk=int(topk),
@@ -2486,6 +2554,7 @@ def run_unified_decode(
         swa_k_cache,
         page_size=int(swa_page_size),
         model_type=int(model_type),
+        record_bytes=int(traits.kv_gmem_stride),
     )
 
     # ── EXTRA (indexed) cache views. When there is no extra cache they alias the
@@ -2542,9 +2611,11 @@ def run_unified_decode(
             extra_indices_t,
             extra_len_for_op,
             float(sm_scale),
+            float(latent_scale),
             int(model_type),
-            int(compute_mode),
-            int(scale_format),
+            int(traits.compute_mode),
+            int(traits.scale_format),
+            bool(traits.fp8_rope),
             int(swa_page_size),
             int(topk),
             int(extra_topk),

--- a/b12x/attention/mla/prefill.py
+++ b/b12x/attention/mla/prefill.py
@@ -45,11 +45,15 @@ def _cache_block_stride_bytes(
     *,
     page_size: int,
     model_type: ModelType,
+    record_bytes: int | None = None,
 ) -> int:
     from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
 
     if model_type == ModelType.GLM_NSA:
-        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+        expected = int(page_size) * rec
     else:
         expected = int(compressed_mla_page_nbytes(int(page_size)))
     # Contiguous inputs are flattened before launch, so their original rank is
@@ -109,6 +113,9 @@ def run_unified_prefill(
     extra_page_block_size: int | None = None,
     stride_extra_kv_block: int | None = None,
     workspace=None,
+    scale_format: int | None = None,
+    latent_scale: float = 1.0,
+    fp8_rope: bool | None = None,
 ):
     """Unified SM120 sparse-MLA single-pass prefill -> BF16 O + base-2 LSE.
 
@@ -142,6 +149,7 @@ def run_unified_prefill(
       extra_kv_cache / extra_indices / extra_topk_length / extra_page_block_size:
                     DSV4 dual-cache EXTRA pool (all-or-none; partial trio RAISEs).
       stride_extra_kv_block: EXTRA per-block byte stride (derived when omitted).
+      latent_scale: per-layer outer scale for the reconstructed NVFP4 latent.
       workspace:    unused (prefill is single-pass, no split/merge workspace);
                     accepted for launcher-signature symmetry.
 
@@ -168,8 +176,26 @@ def run_unified_prefill(
             f"SM120 sparse MLA prefill requires heads divisible by {hpb // 2}, got {heads}"
         )
 
-    model_type, compute_mode, scale_format = infer_model_type(q_head_dim, kv_cache.dtype)
-    traits = make_unified_traits(model_type, compute_mode, scale_format)
+    model_type, compute_mode, inferred_scale_format = infer_model_type(
+        q_head_dim, kv_cache.dtype
+    )
+    if scale_format is None:
+        scale_format = inferred_scale_format
+    else:
+        scale_format = int(scale_format)
+        if q_head_dim == _GLM_HEAD_DIM and scale_format == ScaleFormat.NVFP4_E4M3:
+            # NVFP4 GLM-family prefill runs the BF16-QK MG arm (native E2M1
+            # dequant + BF16 MMA); FP8 compute would misread the 432B record.
+            compute_mode = ComputeMode.BF16
+        elif scale_format != inferred_scale_format:
+            raise ValueError(
+                "SM120 sparse MLA prefill scale_format does not match q_head_dim: "
+                f"q_head_dim={q_head_dim}, inferred={int(inferred_scale_format)}, "
+                f"override={int(scale_format)}"
+            )
+    traits = make_unified_traits(
+        model_type, compute_mode, scale_format, fp8_rope=fp8_rope
+    )
     d_v = int(traits.d_v)
 
     # ── DSV4 dual-cache: validate the extra trio (all-or-none) and that it is DSV4. ──
@@ -208,6 +234,7 @@ def run_unified_prefill(
             kv_cache,
             page_size=int(page_block_size),
             model_type=model_type,
+            record_bytes=int(traits.kv_gmem_stride),
         )
 
     q = q.contiguous()
@@ -239,6 +266,7 @@ def run_unified_prefill(
                 kv_cache=kv_cache,
                 topk_indices=topk_indices,
                 sm_scale=sm_scale,
+                latent_scale=latent_scale,
                 page_block_size=page_block_size,
                 topk_length=topk_length,
                 attn_sink=attn_sink,
@@ -249,6 +277,7 @@ def run_unified_prefill(
                 mg_n_hg=mg_n_hg,
                 model_type=model_type,
                 scale_format=scale_format,
+                fp8_rope=bool(traits.fp8_rope),
             )
             if extra_kv_cache is not None:
                 kwargs.update(
@@ -306,6 +335,22 @@ def run_unified_prefill(
             model_type=ModelType.GLM_NSA,
             scale_format=ScaleFormat.ARBITRARY_FP32,
         )
+    # ── NVFP4 (E2M1 + E4M3 group-16, GLM-family) MG gate ───────────────────────
+    # Same MG head-group structure as GLM; the math arms are the BF16-QK path
+    # with native in-register E2M1/E4M3 dequant (the same math as the validated
+    # NVFP4 decode). topk==128 additionally routes here (BF16-QK shape).
+    _mg_nvfp4 = (
+        _mg_enabled
+        and not has_extra
+        and model_type == ModelType.GLM_NSA
+        and scale_format == ScaleFormat.NVFP4_E4M3
+    )
+    if _mg_nvfp4 and topk in (128, 512, 1024, 2048):
+        return _run_partitioned_mg(
+            compute_mode=ComputeMode.BF16,
+            model_type=ModelType.GLM_NSA,
+            scale_format=ScaleFormat.NVFP4_E4M3,
+        )
     _mg_base = (
         _mg_enabled
         and not has_extra
@@ -360,5 +405,7 @@ def run_unified_prefill(
         "DSV4 single-cache topk in {512, 1024, 2048} (FP8) or 128 "
         "(BF16-QK, heads%8==0); "
         "DSV4 dual-cache topk==128 with heads%8==0 and pbs_extra in {2, 64}; "
-        "GLM_NSA topk in {512, 1024, 2048}. No decode-reuse fallback."
+        "GLM_NSA topk in {512, 1024, 2048}; "
+        "NVFP4 (GLM-family, scale_format=2) topk in {128, 512, 1024, 2048}. "
+        "No decode-reuse fallback."
     )

--- a/b12x/attention/mla/prefill_mg.py
+++ b/b12x/attention/mla/prefill_mg.py
@@ -26,12 +26,16 @@ from b12x.cute.fp4 import (
     atomic_max_shared_f32_offset,
     byte_perm,
     create_l2_evict_first_policy,
+    cvt_e4m3_to_f32_via_f16,
     dequant_kv_e4m3_pair_to_bf16x2,
+    f16x2_to_f32x2,
     fmax_f32,
     fmin_f32,
+    fp4_decode_2,
     get_ptr_as_int64,
     ld_global_b16,
     ld_global_nc_u32,
+    ld_global_v4_f32,
     ld_shared_f32_offset,
     ld_shared_u16_offset,
     ld_shared_u8_offset,
@@ -39,6 +43,7 @@ from b12x.cute.fp4 import (
     ldmatrix_m8n8x4_b16,
     mma_m16n8k16_f32_bf16,
     mma_m16n8k32_f32_e4m3,
+    pack_f32x2_to_bfloat2,
     quantize_scaled_store_shared_v2_e4m3,
     rcp_approx_ftz,
     shared_ptr_to_u32,
@@ -80,6 +85,62 @@ _DSV4_ROPE_GMEM_OFFSET = 448
 # 4*4 inline-scale bytes). MG reads it from global/L2 (no smem staging).
 _GLM_IO_STRIDE = 656
 _GLM_ROPE_GMEM_OFFSET = 528
+# NVFP4 MLA latent record: 256B packed E2M1 NoPE + 32B E4M3 group-16 scales +
+# 16B pad + 128B bf16 rope == 432B. RoPE byte offset within the record == 304.
+# Inside the staged 288B smem row the scale bytes sit at offset 256.
+_NVFP4_IO_STRIDE = 432
+_NVFP4_ROPE_GMEM_OFFSET = 304
+_NVFP4_FP8_ROPE_IO_STRIDE = 368
+_NVFP4_FP8_ROPE_SCALE_OFFSET = 288
+_NVFP4_SCALE_OFFSET = 256
+_NVFP4_SCALE_GROUP = 16
+
+
+@cute.jit
+def _ld_global_index_i32(index_base_ptr: Int64, entry: Int32) -> Int32:
+    """Load one selected-token index directly from the tile's global row."""
+    return Int32(
+        ld_global_nc_u32(index_base_ptr + entry.to(Int64) * Int64(4))
+    )
+
+
+@cute.jit
+def s3_mask_and_scale_global(
+    qk,
+    index_base_ptr: Int64,
+    warp_first_cand: Int32,
+    split_cand_start: Int32,
+    split_cand_end: Int32,
+    section_len: Int32,
+    sm_scale_log2: Float32,
+    lane: Int32,
+):
+    """FI-shaped S3: validate candidates from the global selected-index row."""
+    tid = lane & Int32(3)
+    c0 = warp_first_cand + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    abs_c0 = c0 + split_cand_start
+    abs_c1 = c1 + split_cand_start
+
+    idx0 = Int32(-1)
+    if abs_c0 < section_len:
+        idx0 = _ld_global_index_i32(index_base_ptr, c0)
+    idx1 = Int32(-1)
+    if abs_c1 < section_len:
+        idx1 = _ld_global_index_i32(index_base_ptr, c1)
+
+    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+        qk[0] = Float32(-1.0e30)
+        qk[2] = Float32(-1.0e30)
+    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+        qk[1] = Float32(-1.0e30)
+        qk[3] = Float32(-1.0e30)
+
+    qk[0] = qk[0] * sm_scale_log2
+    qk[1] = qk[1] * sm_scale_log2
+    qk[2] = qk[2] * sm_scale_log2
+    qk[3] = qk[3] * sm_scale_log2
+    return qk
 
 
 @cute.jit
@@ -178,11 +239,15 @@ def _cache_block_stride_bytes(
     *,
     page_size: int,
     is_glm: bool,
+    record_bytes: int | None = None,
 ) -> int:
     from b12x.attention.mla.compressed_reference import compressed_mla_page_nbytes
 
     if is_glm:
-        expected = int(page_size) * _GLM_IO_STRIDE
+        # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
+        # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
+        rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
+        expected = int(page_size) * rec
     else:
         expected = int(compressed_mla_page_nbytes(int(page_size)))
     # Contiguous inputs are flattened before launch, so their original rank is
@@ -374,6 +439,29 @@ def _glm_rope_base_off(idx: Int32, page_block_size: Int32, stride_kv_block: Int6
 
 
 @cute.jit
+def _nvfp4_rope_base_off(
+    idx: Int32,
+    page_block_size: Int32,
+    stride_kv_block: Int64,
+    *,
+    fp8_rope: cutlass.Constexpr = False,
+) -> Int64:
+    if idx < Int32(0):
+        idx = Int32(0)
+    block_idx = idx // page_block_size
+    local_idx = idx - block_idx * page_block_size
+    if cutlass.const_expr(fp8_rope):
+        record_stride = Int64(_NVFP4_FP8_ROPE_IO_STRIDE)
+    else:
+        record_stride = Int64(_NVFP4_IO_STRIDE)
+    return (
+        Int64(block_idx) * stride_kv_block
+        + Int64(local_idx) * record_stride
+        + Int64(_NVFP4_ROPE_GMEM_OFFSET)
+    )
+
+
+@cute.jit
 def _ld_global_glm_rope_u32(
     kv_cache_u8: cute.Tensor,
     rope_base: Int64,
@@ -382,6 +470,22 @@ def _ld_global_glm_rope_u32(
     """Load two consecutive bf16 rope elems (one u32) from global at rope_base +
     elem*2 bytes. ``elem`` is even (the lane reads bf16 pairs)."""
     return ld_global_nc_u32(get_ptr_as_int64(kv_cache_u8, rope_base + Int64(elem) * Int64(2)))
+
+
+@cute.jit
+def _ld_global_nvfp4_fp8_rope_bfloat2(
+    kv_cache_u8: cute.Tensor,
+    rope_base: Int64,
+    elem_even: Int32,
+    scale: Float32,
+) -> Uint32:
+    """Load/dequant two adjacent E4M3 post-RoPE values to packed BF16."""
+    pair = ld_global_b16(
+        get_ptr_as_int64(kv_cache_u8, rope_base + Int64(elem_even))
+    )
+    v0 = cvt_e4m3_to_f32_via_f16(pair & Uint32(0xFF)) * scale
+    v1 = cvt_e4m3_to_f32_via_f16((pair >> Uint32(8)) & Uint32(0xFF)) * scale
+    return pack_f32x2_to_bfloat2(v0, v1)
 
 
 @cute.jit
@@ -400,6 +504,8 @@ def s2_qk_rope_regs_mg_glm(
     d_rope: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
     valid_hpb: cutlass.Constexpr = 16,
+    scale_format: cutlass.Constexpr = 1,
+    fp8_rope: cutlass.Constexpr = False,
 ):
     """GLM MG QK-RoPE. Mirrors ``s2_qk_rope_regs_mg_dsv4`` (registerized Q-rope A,
     KV-rope B from global) but with the GLM record geometry and the GLM B-operand
@@ -407,20 +513,60 @@ def s2_qk_rope_regs_mg_glm(
     ``warp_first_cand + gid`` (NOT the DSV4 nt/tid layout), and b0/b1 are two
     consecutive bf16 rope-pairs of THAT one entry's rope row. The B operand
     depends only on the candidate token + rope chunk, so it is gathered once and
-    reused across both head groups (n_hg==2)."""
+    reused across both head groups (n_hg==2).
+
+    ``scale_format`` (const_expr) selects the record geometry: ARBITRARY_FP32
+    (1, 656B record, rope at 528) or NVFP4_E4M3 (2, 432B record, rope at 304).
+    The rope payload itself is BF16 in BOTH formats -- bit-identical loads."""
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
     entry = warp_first_cand + gid
     idx = _ld_global_index_i32(index_base_ptr, entry)
-    rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block)
+    if cutlass.const_expr(scale_format == 2):
+        rope_base = _nvfp4_rope_base_off(
+            idx,
+            page_block_size,
+            stride_kv_block,
+            fp8_rope=fp8_rope,
+        )
+    else:
+        rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block)
     hi0 = cutlass.const_expr(valid_hpb > 8)
+
+    if cutlass.const_expr(scale_format == 2 and fp8_rope):
+        rope_scale, _, _, _ = ld_global_v4_f32(
+            get_ptr_as_int64(
+                kv_cache_u8,
+                rope_base
+                + Int64(
+                    _NVFP4_FP8_ROPE_SCALE_OFFSET - _NVFP4_ROPE_GMEM_OFFSET
+                ),
+            )
+        )
+    else:
+        rope_scale = Float32(1.0)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
         # decode_math.s2_qk_rope_bf16 B packing: b0 = rope[ko + tid*2 .. +1],
         # b1 = rope[ko + tid*2 + 8 .. +9] of this entry's rope row.
-        b0 = _ld_global_glm_rope_u32(kv_cache_u8, rope_base, ko + tid * Int32(2))
-        b1 = _ld_global_glm_rope_u32(kv_cache_u8, rope_base, ko + tid * Int32(2) + Int32(8))
+        if cutlass.const_expr(scale_format == 2 and fp8_rope):
+            b0 = _ld_global_nvfp4_fp8_rope_bfloat2(
+                kv_cache_u8, rope_base, ko + tid * Int32(2), rope_scale
+            )
+            b1 = _ld_global_nvfp4_fp8_rope_bfloat2(
+                kv_cache_u8,
+                rope_base,
+                ko + tid * Int32(2) + Int32(8),
+                rope_scale,
+            )
+        else:
+            b0 = _ld_global_glm_rope_u32(
+                kv_cache_u8, rope_base, ko + tid * Int32(2)
+            )
+            b1 = _ld_global_glm_rope_u32(
+                kv_cache_u8, rope_base, ko + tid * Int32(2) + Int32(8)
+            )
         base = Int32(ks) * Int32(4)
         d0, d1, d2, d3 = mma_m16n8k16_f32_bf16(
             qk0[0], qk0[1], qk0[2], qk0[3],
@@ -700,6 +846,168 @@ def s1_qk_nope_bf16_mg2(
                     qk1[0], qk1[1], qk1[2], qk1[3], a10, a11, a12, a13, b0, b1
                 )
     return qk0, qk1
+
+
+@cute.jit
+def _nvfp4_pair_bfloat2_mg(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim_even: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+) -> Uint32:
+    """Dequant E2M1 * inline E4M3 * per-layer outer scale to bf16x2."""
+    data_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride) + (dim_even // Int32(2)),
+    )
+    vals_h2 = fp4_decode_2(data_byte)
+    v0, v1 = f16x2_to_f32x2(vals_h2)
+    scale_group = dim_even // Int32(_NVFP4_SCALE_GROUP)
+    scale_byte = _ld_u8_zext(
+        kv_fp4_base_addr,
+        entry * Int32(kv_smem_stride)
+        + Int32(_NVFP4_SCALE_OFFSET)
+        + scale_group,
+    )
+    scale_f = cvt_e4m3_to_f32_via_f16(scale_byte)
+    # Prefill QK has its own MG B-operand loader.  Restore s_l here, before
+    # BF16 packing/MMA, to match decode QK and the shared decode P.V helper.
+    return pack_f32x2_to_bfloat2(
+        (v0 * scale_f) * latent_scale,
+        (v1 * scale_f) * latent_scale,
+    )
+
+
+@cute.jit
+def s1_qk_nope_nvfp4_bf16_mg2(
+    qk0,
+    qk1,
+    q_nope_bf16_g0_addr: Int32,
+    q_nope_bf16_g1_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,
+    quant_tile: cutlass.Constexpr,
+    q_nope_bf16_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """S1 (NVFP4): MG BF16 QK-NoPE with native E2M1/E4M3 in-register dequant.
+
+    Same MMA packing as ``s1_qk_nope_bf16_mg2`` but the K/B operand comes from
+    the packed 288-byte NVFP4 row (256B E2M1 + 32B E4M3 group-16 scales); the
+    same math path as the validated NVFP4 decode ``s1_qk_nope_nvfp4_bf16``."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    kv_gid_row = warp_first_cand + gid
+
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            b0 = _nvfp4_pair_bfloat2_mg(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            b1 = _nvfp4_pair_bfloat2_mg(
+                kv_fp4_base_addr,
+                kv_gid_row,
+                ko + tid * Int32(2) + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a_byte = (
+                a_row * Int32(q_nope_bf16_stride * 2)
+                + (ko + a_col) * Int32(2)
+            )
+            a00, a01, a02, a03 = ldmatrix_m8n8x4_b16(
+                _smem_byte(q_nope_bf16_g0_addr, a_byte)
+            )
+            qk0[0], qk0[1], qk0[2], qk0[3] = mma_m16n8k16_f32_bf16(
+                qk0[0], qk0[1], qk0[2], qk0[3], a00, a01, a02, a03, b0, b1
+            )
+            if cutlass.const_expr(n_hg == 2):
+                a10, a11, a12, a13 = ldmatrix_m8n8x4_b16(
+                    _smem_byte(q_nope_bf16_g1_addr, a_byte)
+                )
+                qk1[0], qk1[1], qk1[2], qk1[3] = mma_m16n8k16_f32_bf16(
+                    qk1[0], qk1[1], qk1[2], qk1[3], a10, a11, a12, a13, b0, b1
+                )
+    return qk0, qk1
+
+
+@cute.jit
+def s5_fill_sm_p_full_mg2_nvfp4(
+    w_pre0,
+    w_pre1,
+    weight_smem_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    *,
+    bi: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    n_hg: cutlass.Constexpr = 2,
+):
+    """Stage MG per-warp BF16 probabilities for the NVFP4 BF16 P.V.
+
+    Reuses the dead W_FP8 region exactly like ``s6b_xv_rope_global_mg_dsv4``:
+    the NVFP4 arm never writes FP8 W, so after S4 the region is free. A leading
+    barrier orders the PREVIOUS tile's P readers before this tile's stores; the
+    caller barriers again after this returns, before the S6 ldmatrix reads."""
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    warp_first_cand = warp_id * Int32(8)
+    c0 = warp_first_cand + tid * Int32(2)
+    c1 = c0 + Int32(1)
+    group_stride = Int32(sm_p_stride * hpb * 2)
+    sm_p_g0_addr = weight_smem_addr
+    sm_p_g1_addr = weight_smem_addr + group_stride
+
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + c0) * Int32(2), w_pre0[0]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + (gid * Int32(sm_p_stride) + c1) * Int32(2), w_pre0[1]
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c0) * Int32(2),
+        w_pre0[2],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_g0_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c1) * Int32(2),
+        w_pre0[3],
+    )
+    if cutlass.const_expr(n_hg == 2):
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + c0) * Int32(2),
+            w_pre1[0],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + (gid * Int32(sm_p_stride) + c1) * Int32(2),
+            w_pre1[1],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c0) * Int32(2),
+            w_pre1[2],
+        )
+        st_shared_bf16_from_f32(
+            sm_p_g1_addr + ((gid + Int32(8)) * Int32(sm_p_stride) + c1) * Int32(2),
+            w_pre1[3],
+        )
+    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=num_threads)
 
 
 @cute.jit
@@ -1743,7 +2051,7 @@ class UnifiedPrefillMGKernel:
         self.has_sink = bool(has_sink)
         self.topk = int(topk)
         # DSV4 dual-cache (has_extra) prefill onto MG. All default to current
-        # behavior so the single-cache __call__/kernel trace is byte-identical:
+        # behavior apart from the shared outer-scale runtime scalar:
         # has_extra=False const_expr-elides every extra-section arm in _body,
         # row_xor=False keeps the s6_xv_nope_mg_dsv4 address arithmetic textually
         # unchanged. The union spans num_main_tiles main chunks (gathered from the
@@ -1776,6 +2084,7 @@ class UnifiedPrefillMGKernel:
         output: cute.Tensor,
         out_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         stride_kv_block: Int64,
         num_tokens: Int32,
         stream: cuda.CUstream,
@@ -1789,6 +2098,7 @@ class UnifiedPrefillMGKernel:
             output,
             out_lse,
             sm_scale_log2,
+            latent_scale,
             stride_kv_block,
         ).launch(
             grid=(num_tokens * Int32(self.replicate_h), 1, 1),
@@ -1814,6 +2124,7 @@ class UnifiedPrefillMGKernel:
         output: cute.Tensor,         # (T, heads, D_V) bf16
         out_lse: cute.Tensor,        # (T, heads) f32 base-2 LSE
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         stride_kv_block: Int64,      # MAIN per-block byte stride
         extra_kv_cache_u8: cute.Tensor,  # flat u8 EXTRA cache (DSV4 dual-cache)
         extra_indices: cute.Tensor,      # (T, extra_topk) int32
@@ -1824,8 +2135,8 @@ class UnifiedPrefillMGKernel:
     ):
         # DUAL-CACHE entry (DSV4 dual-cache prefill onto MG): the dispatcher selects
         # this (entry=kernel.call_dual) only when has_extra=True, so its DISTINCT
-        # mangled name never collides with the byte-identical single-cache __call__.
-        # Launches the 13-param @cute.kernel (self.kernel_dual), which shares the
+        # mangled name never collides with the single-cache __call__.
+        # Launches the 14-param @cute.kernel (self.kernel_dual), which shares the
         # body via _body(has_extra=True, row_xor=self.row_xor). The extra device
         # args are appended AFTER stride_kv_block in the order:
         # extra_kv_cache_u8, extra_indices, extra_topk_length, stride_extra_kv_block.
@@ -1838,6 +2149,7 @@ class UnifiedPrefillMGKernel:
             output,
             out_lse,
             sm_scale_log2,
+            latent_scale,
             stride_kv_block,
             extra_kv_cache_u8,
             extra_indices,
@@ -1861,9 +2173,10 @@ class UnifiedPrefillMGKernel:
         output: cute.Tensor,
         out_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         stride_kv_block: Int64,
     ):
-        # SINGLE-CACHE @cute.kernel (9 device params): the byte-identical DSV4-main /
+        # SINGLE-CACHE @cute.kernel (10 device params): the DSV4-main /
         # DSV4-BF16 / GLM MG prefill path. Threads dummy extra args (aliased to the
         # main tensors) into the shared body with has_extra=False so the
         # extra-section code is fully const_expr-elided.
@@ -1876,6 +2189,7 @@ class UnifiedPrefillMGKernel:
             output,
             out_lse,
             sm_scale_log2,
+            latent_scale,
             stride_kv_block,
             kv_cache_u8,
             indices,
@@ -1896,13 +2210,14 @@ class UnifiedPrefillMGKernel:
         output: cute.Tensor,
         out_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
         extra_indices: cute.Tensor,
         extra_topk_length: cute.Tensor,
         stride_extra_kv_block: Int64,
     ):
-        # DUAL-CACHE @cute.kernel (13 device params): threads the real extra-section
+        # DUAL-CACHE @cute.kernel (14 device params): threads the real extra-section
         # args into the shared body (has_extra=True, row_xor=self.row_xor).
         self._body(
             q_all,
@@ -1913,6 +2228,7 @@ class UnifiedPrefillMGKernel:
             output,
             out_lse,
             sm_scale_log2,
+            latent_scale,
             stride_kv_block,
             extra_kv_cache_u8,
             extra_indices,
@@ -1933,6 +2249,7 @@ class UnifiedPrefillMGKernel:
         output: cute.Tensor,
         out_lse: cute.Tensor,
         sm_scale_log2: Float32,
+        latent_scale: Float32,
         stride_kv_block: Int64,
         extra_kv_cache_u8: cute.Tensor,
         extra_indices: cute.Tensor,
@@ -1966,6 +2283,11 @@ class UnifiedPrefillMGKernel:
         # Q-rope registerized (aliased onto W_FP8). DSV4 is the scale_format==0 /
         # has_extra arm and is byte-identical.
         is_glm = cutlass.const_expr(t.model_type == ModelType.GLM_NSA)
+        # NVFP4 (E2M1 + E4M3 group-16) GLM-family arm: BF16-QK with native
+        # in-register dequant, BF16 P.V staged in the dead W_FP8 region, and
+        # the 432B/288B record geometry. is_glm stays true for NVFP4 so the
+        # shared GLM staging (io gather / kv_sc absence / q_rope alias) applies.
+        is_nvfp4 = cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3)
         q_head_dim = cutlass.const_expr(_GLM_HEAD_DIM if is_glm else _DSV4_HEAD_DIM)
         # Compile-time head-group count: 1 (heads==16) or 2 (heads % 32 == 0). All
         # group-1 work below const_expr-elides when n_hg==1 (single-group MG).
@@ -2145,6 +2467,8 @@ class UnifiedPrefillMGKernel:
                         bi=t.bi,
                         kv_smem_stride=L.kv_smem_stride,
                         io_threads=_PREFILL_IO_THREADS,
+                        scale_format=t.scale_format,
+                        fp8_rope=t.fp8_rope,
                     )
                 else:
                     io_issue_gather_dsv4_nope(
@@ -2241,6 +2565,8 @@ class UnifiedPrefillMGKernel:
                                 bi=t.bi,
                                 kv_smem_stride=L.kv_smem_stride,
                                 io_threads=_PREFILL_IO_THREADS,
+                                scale_format=t.scale_format,
+                                fp8_rope=t.fp8_rope,
                             )
                         else:
                             io_issue_gather_dsv4_nope(
@@ -2287,7 +2613,30 @@ class UnifiedPrefillMGKernel:
                     n_hg=n_hg,
                     valid_hpb=self.valid_hpb,
                 )
-                if cutlass.const_expr(not reload_bf16_qrope):
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 QK-RoPE uses the GLM B-operand packing, so keep the
+                    # Q-rope A operands as the GLM-style register ARRAYS (not
+                    # the DSV4 scalar snapshot). W_FP8 is then free for the
+                    # BF16 P staging in S5/S6.
+                    q_rope_regs0 = preload_q_rope_regs_mg(
+                        q_rope_g0,
+                        lane,
+                        d_rope=t.d_rope,
+                        q_rope_stride=L.q_rope_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        q_rope_regs1 = preload_q_rope_regs_mg(
+                            q_rope_g1,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                        )
+                    else:
+                        q_rope_regs1 = q_rope_regs0  # never read when n_hg==1.
+                    cute.arch.barrier(
+                        barrier_id=2, number_of_threads=self.math_threads
+                    )
+                elif cutlass.const_expr(not reload_bf16_qrope):
                     (
                         q000, q001, q002, q003,
                         q010, q011, q012, q013,
@@ -2474,7 +2823,44 @@ class UnifiedPrefillMGKernel:
                 gs1 = [gsum1_frag[0], gsum1_frag[1]]
                 qk1 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
 
-                if cutlass.const_expr(bf16_qk):
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 QK: native E2M1+E4M3 in-register dequant feeding the
+                    # BF16 MMA -- the same math path as the validated NVFP4
+                    # decode. QK-RoPE reads the record's BF16 rope from global
+                    # via the GLM helper with the 432B/304-offset geometry.
+                    qk0, qk1 = s1_qk_nope_nvfp4_bf16_mg2(
+                        qk0,
+                        qk1,
+                        q_nope_bf16_g0,
+                        q_nope_bf16_g1,
+                        kv_fp8_b,
+                        warp_first_cand,
+                        lane,
+                        latent_scale,
+                        num_scales=t.num_scales,
+                        quant_tile=t.quant_tile,
+                        q_nope_bf16_stride=L.q_nope_bf16_stride,
+                        kv_smem_stride=L.kv_smem_stride,
+                        n_hg=n_hg,
+                    )
+                    qk0, qk1 = s2_qk_rope_regs_mg_glm(
+                        qk0,
+                        qk1,
+                        q_rope_regs0,
+                        q_rope_regs1,
+                        rope_cache,
+                        index_base_ptr,
+                        warp_first_cand,
+                        lane,
+                        rope_pbs,
+                        rope_stride,
+                        d_rope=t.d_rope,
+                        n_hg=n_hg,
+                        valid_hpb=self.valid_hpb,
+                        scale_format=t.scale_format,
+                        fp8_rope=t.fp8_rope,
+                    )
+                elif cutlass.const_expr(bf16_qk):
                     if cutlass.const_expr(reload_bf16_qrope):
                         # Tile 0 consumes the S0 copy. S6 overwrites the aliased
                         # W_FP8 scratch, so restore only the 4 KiB Q-RoPE slice
@@ -2572,6 +2958,7 @@ class UnifiedPrefillMGKernel:
                         kv_sc_b,
                         warp_first_cand,
                         lane,
+                        latent_scale,
                         num_scales=t.num_scales,
                         quant_tile=t.quant_tile,
                         q_nope_stride=t.q_nope_stride,
@@ -2589,6 +2976,7 @@ class UnifiedPrefillMGKernel:
                             kv_sc_b,
                             warp_first_cand,
                             lane,
+                            latent_scale,
                             num_scales=t.num_scales,
                             quant_tile=t.quant_tile,
                             q_nope_stride=t.q_nope_stride,
@@ -2615,6 +3003,8 @@ class UnifiedPrefillMGKernel:
                             d_rope=t.d_rope,
                             n_hg=n_hg,
                             valid_hpb=self.valid_hpb,
+                            scale_format=t.scale_format,
+                            fp8_rope=t.fp8_rope,
                         )
                     else:
                         # Fused QK-RoPE: KV-RoPE B operand gathered ONCE per CTA tile
@@ -2694,7 +3084,81 @@ class UnifiedPrefillMGKernel:
                 w_pre0 = [p0[0] * wr00, p0[1] * wr00, p0[2] * wr01, p0[3] * wr01]
                 w_pre1 = [p1[0] * wr10, p1[1] * wr10, p1[2] * wr11, p1[3] * wr11]
 
-                if cutlass.const_expr(is_glm):
+                if cutlass.const_expr(is_nvfp4):
+                    # NVFP4 XV-NoPE: BF16 P.V with native E2M1+E4M3 V dequant
+                    # (decode s6_xv_nope scale_format==2 branch). The BF16 P
+                    # tiles are staged into the dead W_FP8 region (per-group
+                    # base + sm_p_full_stride rows), exactly like the DSV4
+                    # XV-RoPE weight staging. No FP8 W quant, no w_head_sc.
+                    s5_fill_sm_p_full_mg2_nvfp4(
+                        w_pre0,
+                        w_pre1,
+                        w_fp8_addr,
+                        warp_id,
+                        lane,
+                        bi=t.bi,
+                        hpb=t.hpb,
+                        sm_p_stride=L.sm_p_full_stride,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        n_hg=n_hg,
+                    )
+                    sm_p_g0 = w_fp8_addr
+                    sm_p_g1 = w_fp8_addr + Int32(L.sm_p_full_stride * t.hpb * 2)
+                    acc0 = s6_xv_nope(
+                        w_pre0,
+                        acc0,
+                        kv_fp8_b,
+                        kv_sc_b,
+                        w_head_sc_g0,
+                        glm_w_fp8_g0,
+                        warp_id,
+                        lane,
+                        tid,
+                        latent_scale,
+                        n_v_chunks=t.n_v_chunks,
+                        v_chunk=t.quant_tile,
+                        hpb=t.hpb,
+                        bi=t.bi,
+                        kv_smem_stride=L.kv_smem_stride,
+                        w_fp8_stride=t.bi + 16,
+                        n_warps=8,
+                        scale_bytes_per_token=8,
+                        nt_per_warp_xv=t.nt_per_warp_xv,
+                        scale_format=t.scale_format,
+                        num_threads=self.math_threads,
+                        barrier_id=3,
+                        sm_p_full_addr=sm_p_g0,
+                        sm_p_stride=L.sm_p_full_stride,
+                    )
+                    if cutlass.const_expr(n_hg == 2):
+                        acc1 = s6_xv_nope(
+                            w_pre1,
+                            acc1,
+                            kv_fp8_b,
+                            kv_sc_b,
+                            w_head_sc_g1,
+                            glm_w_fp8_g1,
+                            warp_id,
+                            lane,
+                            tid,
+                            latent_scale,
+                            n_v_chunks=t.n_v_chunks,
+                            v_chunk=t.quant_tile,
+                            hpb=t.hpb,
+                            bi=t.bi,
+                            kv_smem_stride=L.kv_smem_stride,
+                            w_fp8_stride=t.bi + 16,
+                            n_warps=8,
+                            scale_bytes_per_token=8,
+                            nt_per_warp_xv=t.nt_per_warp_xv,
+                            scale_format=t.scale_format,
+                            num_threads=self.math_threads,
+                            barrier_id=3,
+                            sm_p_full_addr=sm_p_g1,
+                            sm_p_stride=L.sm_p_full_stride,
+                        )
+                elif cutlass.const_expr(is_glm):
                     # GLM XV-NoPE: the per-group decode s6_xv_nope (raw-e4m3 V +
                     # per-(cand,vc) inline fp32 group scale + 2-pass W HIGH+LOW
                     # residual). V scales + V B operands come from the SHARED kv_fp8
@@ -2737,6 +3201,7 @@ class UnifiedPrefillMGKernel:
                         warp_id,
                         lane,
                         tid,
+                        latent_scale,
                         n_v_chunks=t.n_v_chunks,
                         v_chunk=t.quant_tile,
                         hpb=t.hpb,
@@ -2763,6 +3228,7 @@ class UnifiedPrefillMGKernel:
                             warp_id,
                             lane,
                             tid,
+                            latent_scale,
                             n_v_chunks=t.n_v_chunks,
                             v_chunk=t.quant_tile,
                             hpb=t.hpb,
@@ -3100,6 +3566,7 @@ def _sparse_mla_prefill_mg_flat_launch(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     page_block_size: int,
     topk: int,
     num_tiles: int,
@@ -3109,6 +3576,7 @@ def _sparse_mla_prefill_mg_flat_launch(
     mg_n_hg: int,
     model_type: int,
     scale_format: int,
+    fp8_rope: bool,
     has_extra: bool,
     extra_topk: int,
     num_main_tiles: int,
@@ -3119,7 +3587,9 @@ def _sparse_mla_prefill_mg_flat_launch(
     active_heads: int | None = None,
     head_offset: int = 0,
 ) -> None:
-    traits = make_unified_traits(int(model_type), compute_mode, int(scale_format))
+    traits = make_unified_traits(
+        int(model_type), compute_mode, int(scale_format), fp8_rope=bool(fp8_rope)
+    )
     layout = make_smem_layout_mg(traits, int(mg_n_hg))
     q_head_dim = int(q.shape[2])
     total_heads = int(q.shape[1])
@@ -3196,6 +3666,7 @@ def _sparse_mla_prefill_mg_flat_launch(
         _to_cute(output, cutlass.BFloat16, align=16, dynamic_layout=True),
         _to_cute(lse_out, cutlass.Float32, align=4, dynamic_layout=True),
         Float32(float(sm_scale) * LOG2_E),
+        Float32(float(latent_scale)),
         Int64(stride_kv_block),
     )
     if has_extra:
@@ -3215,6 +3686,7 @@ def _sparse_mla_prefill_mg_flat_launch(
         key_field("model_type", int(model_type)),
         key_field("compute_mode", int(compute_mode)),
         key_field("scale_format", int(scale_format)),
+        key_field("fp8_rope", int(traits.fp8_rope)),
         key_field("num_heads", total_heads),
         key_field("heads_per_cta", heads_per_cta),
         key_field("mg_n_hg", int(mg_n_hg)),
@@ -3246,7 +3718,8 @@ def _sparse_mla_prefill_mg_flat_launch(
         )
     if has_extra:
         # The dual key_fields are appended ONLY for has_extra so the single-cache
-        # compile-spec hash is byte-unchanged (decode/no-extra cache key identical).
+        # shape key remains free of dual-only fields. The explicit v2 version
+        # below deliberately invalidates the old device ABI.
         spec_fields.extend(
             [
                 key_field("has_extra", int(has_extra)),
@@ -3263,7 +3736,9 @@ def _sparse_mla_prefill_mg_flat_launch(
         )
     compile_spec = KernelCompileSpec.from_fields(
         "attention.mla.sm120.prefill_mg",
-        1,
+        # v3 adds the FP8-RoPE record specialization/read path. The explicit
+        # cache key does not hash source, so do not reuse v2 KLD-only cubins.
+        3,
         *spec_fields,
     )
     entry = kernel.call_dual if has_extra else kernel
@@ -3283,6 +3758,7 @@ def _sparse_mla_prefill_mg_op(
     output: torch.Tensor,
     lse_out: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     page_block_size: int,
     topk: int,
     num_tiles: int,
@@ -3292,11 +3768,11 @@ def _sparse_mla_prefill_mg_op(
     mg_n_hg: int,
     model_type: int,
     scale_format: int,
+    fp8_rope: bool,
 ) -> None:
-    # SINGLE-CACHE op (DSV4 main / DSV4-BF16 / GLM MG). Byte-identical: passes
-    # has_extra=False with the extra device args aliased to the main tensors (never
-    # read under const_expr(has_extra=False)). Op signature is UNCHANGED so the
-    # no-extra cache key and all existing callers are untouched.
+    # SINGLE-CACHE op (DSV4 main / DSV4-BF16 / GLM MG). It carries the new
+    # latent_scale runtime scalar and passes has_extra=False with extra device
+    # args aliased to the main tensors (never read under const_expr(False)).
     _sparse_mla_prefill_mg_flat_launch(
         q,
         kv_flat,
@@ -3309,6 +3785,7 @@ def _sparse_mla_prefill_mg_op(
         topk_indices,   # extra_indices alias (never read)
         topk_length,    # extra_len alias (never read)
         sm_scale,
+        latent_scale,
         page_block_size,
         topk,
         num_tiles,
@@ -3318,6 +3795,7 @@ def _sparse_mla_prefill_mg_op(
         mg_n_hg,
         model_type,
         scale_format,
+        fp8_rope,
         False,  # has_extra
         0,      # extra_topk
         0,      # num_main_tiles
@@ -3337,6 +3815,7 @@ def _sparse_mla_prefill_mg_fake(
     output: torch.Tensor,
     lse_out: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     page_block_size: int,
     topk: int,
     num_tiles: int,
@@ -3346,6 +3825,7 @@ def _sparse_mla_prefill_mg_fake(
     mg_n_hg: int,
     model_type: int,
     scale_format: int,
+    fp8_rope: bool,
 ) -> None:
     return None
 
@@ -3366,6 +3846,7 @@ def _sparse_mla_prefill_mg_dual_op(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     page_block_size: int,
     topk: int,
     num_tiles: int,
@@ -3381,9 +3862,9 @@ def _sparse_mla_prefill_mg_dual_op(
     stride_extra_kv_block: int,
     row_xor: bool,
 ) -> None:
-    # DUAL-CACHE op (DSV4 has_extra union -> MG). SEPARATE op from the single-cache
-    # one so the no-extra op signature / cache key stays byte-identical. has_extra
-    # is implicitly True.
+    # DUAL-CACHE op (DSV4 has_extra union -> MG). Separate from the single-cache
+    # op; both carry the same outer-scale runtime scalar. has_extra is implicitly
+    # True here.
     _sparse_mla_prefill_mg_flat_launch(
         q,
         kv_flat,
@@ -3396,6 +3877,7 @@ def _sparse_mla_prefill_mg_dual_op(
         extra_indices_t,
         extra_len_t,
         sm_scale,
+        latent_scale,
         page_block_size,
         topk,
         num_tiles,
@@ -3405,6 +3887,7 @@ def _sparse_mla_prefill_mg_dual_op(
         mg_n_hg,
         model_type,
         scale_format,
+        False,  # fp8_rope (dual cache is DSV4-only)
         True,  # has_extra
         extra_topk,
         num_main_tiles,
@@ -3427,6 +3910,7 @@ def _sparse_mla_prefill_mg_dual_fake(
     extra_indices_t: torch.Tensor,
     extra_len_t: torch.Tensor,
     sm_scale: float,
+    latent_scale: float,
     page_block_size: int,
     topk: int,
     num_tiles: int,
@@ -3461,6 +3945,8 @@ def run_unified_prefill_mg(
     mg_n_hg: int = 2,
     model_type: int = ModelType.DSV4,
     scale_format: int | None = None,
+    latent_scale: float = 1.0,
+    fp8_rope: bool | None = None,
     extra_kv_cache: torch.Tensor | None = None,
     extra_indices: torch.Tensor | None = None,
     extra_topk_length: torch.Tensor | None = None,
@@ -3509,7 +3995,9 @@ def run_unified_prefill_mg(
             "SM120 sparse MLA MG prefill head range out of bounds: "
             f"head_offset={head_offset}, active_heads={active_heads}, total_heads={total_heads}"
         )
-    traits = make_unified_traits(model_type, int(compute_mode), scale_format)
+    traits = make_unified_traits(
+        model_type, int(compute_mode), scale_format, fp8_rope=fp8_rope
+    )
     # heads_per_cta = mg_n_hg * HPB. mg_n_hg==2 covers paired head groups; mg_n_hg==1
     # covers a single-group launch, including 16-head tails and the heads==8
     # valid_hpb shard. The caller picks mg_n_hg and active head range.
@@ -3542,6 +4030,7 @@ def run_unified_prefill_mg(
             kv_cache,
             page_size=int(page_block_size),
             is_glm=bool(is_glm),
+            record_bytes=int(traits.kv_gmem_stride),
         )
 
     q = q.contiguous()
@@ -3588,6 +4077,7 @@ def run_unified_prefill_mg(
                 extra_indices_t,
                 extra_len_t,
                 float(sm_scale),
+                float(latent_scale),
                 int(page_block_size),
                 int(topk),
                 int(num_tiles),
@@ -3616,6 +4106,7 @@ def run_unified_prefill_mg(
                 extra_indices_t,
                 extra_len_t,
                 float(sm_scale),
+                float(latent_scale),
                 int(page_block_size),
                 int(topk),
                 int(num_tiles),
@@ -3625,6 +4116,7 @@ def run_unified_prefill_mg(
                 int(mg_n_hg),
                 model_type,
                 scale_format,
+                False,  # fp8_rope (dual cache is DSV4-only)
                 True,  # has_extra
                 int(extra_topk),
                 int(num_main_tiles),
@@ -3646,6 +4138,7 @@ def run_unified_prefill_mg(
             output,
             lse_out,
             float(sm_scale),
+            float(latent_scale),
             int(page_block_size),
             int(topk),
             int(num_main_tiles),
@@ -3655,6 +4148,7 @@ def run_unified_prefill_mg(
             int(mg_n_hg),
             model_type,
             scale_format,
+            bool(traits.fp8_rope),
         )
     else:
         _sparse_mla_prefill_mg_flat_launch(
@@ -3669,6 +4163,7 @@ def run_unified_prefill_mg(
             topk_indices,          # extra_indices alias (never read)
             topk_length,           # extra_len alias (never read)
             float(sm_scale),
+            float(latent_scale),
             int(page_block_size),
             int(topk),
             int(num_main_tiles),
@@ -3678,6 +4173,7 @@ def run_unified_prefill_mg(
             int(mg_n_hg),
             model_type,
             scale_format,
+            bool(traits.fp8_rope),
             False,  # has_extra
             0,      # extra_topk
             0,      # num_main_tiles

--- a/b12x/attention/mla/traits.py
+++ b/b12x/attention/mla/traits.py
@@ -12,6 +12,16 @@ are DROPPED per `.sm120port/scope_decisions.md`.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
+
+
+KV_FP8_ROPE_ENV = "KV_FP8_ROPE"
+KV_FP8_ROPE_ENABLED = os.environ.get(KV_FP8_ROPE_ENV, "0") == "1"
+
+
+def kv_fp8_rope_enabled() -> bool:
+    """Return the strict runtime gate for the GLM NVFP4 RoPE sub-record."""
+    return KV_FP8_ROPE_ENABLED
 
 
 # ---------------------------------------------------------------------------
@@ -31,6 +41,7 @@ class ComputeMode:
 class ScaleFormat:
     UE8M0_BYTE = 0  # DSV4: power-of-2 exponent bytes in an 8B footer.
     ARBITRARY_FP32 = 1  # GLM: arbitrary FP32 inline scales (reference.py).
+    NVFP4_E4M3 = 2  # GLM/DS MLA latent: E2M1 data + E4M3 group-16 scales.
 
 
 @dataclass(frozen=True)
@@ -62,12 +73,17 @@ class UnifiedMLATraits:
     bulk_tx_bytes: int
     v_has_rope: bool
     has_extra_cache: bool
+    fp8_rope: bool
+    rope_gmem_offset: int
+    rope_payload_bytes: int
+    rope_scale_offset: int
 
 
 def make_unified_traits(
     model_type: int,
     compute_mode: int,
     scale_format: int,
+    fp8_rope: bool | None = None,
 ) -> UnifiedMLATraits:
     """Build the trait bundle for one specialization tuple.
 
@@ -75,6 +91,11 @@ def make_unified_traits(
     ``ValueError`` for the dropped DSV3.2 / POW2_FP32 combinations and for any
     (model, scale_format) mismatch.
     """
+    # Resolve the process-wide cache ABI once per traits construction.  The gate
+    # is deliberately orthogonal to ScaleFormat.NVFP4_E4M3 so the latent's E2M1
+    # data, E4M3 group scales, and outer-scale reconstruction remain unchanged.
+    fp8_rope_requested = kv_fp8_rope_enabled() if fp8_rope is None else bool(fp8_rope)
+
     # BF16 compute_mode is deferred (both decode targets are FP8) but the enum
     # value is accepted so the const_expr branch can exist; FP8 is the only
     # validated path today.
@@ -109,12 +130,50 @@ def make_unified_traits(
             bulk_tx_bytes=36864,  # 64*(448+128); footer excluded (16-align caveat)
             v_has_rope=True,
             has_extra_cache=True,  # DSV4 dual-cache only
+            fp8_rope=False,
+            rope_gmem_offset=448,
+            rope_payload_bytes=128,
+            rope_scale_offset=-1,
         )
 
     if model_type == ModelType.GLM_NSA:
+        if scale_format == ScaleFormat.NVFP4_E4M3:
+            # NVFP4 MLA latent cache: 256B packed E2M1 NoPE + 32B E4M3
+            # group-16 scales + 16B pad + 128B BF16 RoPE. Decode stages Q-NoPE
+            # as BF16 and dequants FP4 K/V in-register for BF16 QK/PV MMAs.
+            use_fp8_rope = fp8_rope_requested
+            return UnifiedMLATraits(
+                model_type=ModelType.GLM_NSA,
+                compute_mode=ComputeMode.BF16,
+                scale_format=ScaleFormat.NVFP4_E4M3,
+                d_nope=512,
+                d_rope=64,
+                d_v=512,
+                quant_tile=64,
+                num_scales=8,  # logical FP4 steps; storage has 32 group-16 scales
+                n_v_chunks=8,
+                nt_per_warp_xv=1,
+                kv_gmem_stride=368 if use_fp8_rope else 432,
+                kv_smem_stride=288,
+                q_nope_stride=520,  # BF16 Q-NoPE smem stride: D_NOPE + 8 elems.
+                bi=64,
+                hpb=16,
+                block_threads=288,
+                math_threads=256,
+                # Decode stages the unchanged 288-byte latent plus either the
+                # 128-byte BF16 rope or the aligned 80-byte scale/pad/FP8 tail.
+                bulk_tx_bytes=23552 if use_fp8_rope else 26624,
+                v_has_rope=False,
+                has_extra_cache=False,
+                fp8_rope=use_fp8_rope,
+                rope_gmem_offset=304,
+                rope_payload_bytes=64 if use_fp8_rope else 128,
+                rope_scale_offset=288 if use_fp8_rope else -1,
+            )
         if scale_format != ScaleFormat.ARBITRARY_FP32:
             raise ValueError(
-                "GLM_NSA requires ScaleFormat.ARBITRARY_FP32 (inline); "
+                "GLM_NSA requires ScaleFormat.ARBITRARY_FP32 (inline) or "
+                "ScaleFormat.NVFP4_E4M3; "
                 f"got scale_format={scale_format!r}"
             )
         # GLM_NSA column of verified_traits.md (ARBITRARY_FP32, V_HAS_ROPE=false).
@@ -139,6 +198,10 @@ def make_unified_traits(
             bulk_tx_bytes=41984,  # 64*(528+128)
             v_has_rope=False,
             has_extra_cache=False,
+            fp8_rope=False,
+            rope_gmem_offset=528,
+            rope_payload_bytes=128,
+            rope_scale_offset=-1,
         )
 
     raise ValueError(


### PR DESCRIPTION
## nvfp4 MLA KV cache + per-layer outer-scale + fp8-RoPE KV-cell (sm120)

Adds a 4-bit NVFP4 MLA KV cache path to the b12x MLA kernels, plus two quality/efficiency
refinements, all validated on GLM-5.2 (4x RTX PRO 6000 Blackwell, TP4/DCP4):

- **nvfp4_ds_mla record** (432 B/token): 512-D latent as NVFP4 (E2M1 + E4M3 g16 scales) instead of
  fp8 — ~1.5x the context pool vs fp8_ds_mla.
- **Per-layer outer-scale** (`scale_format==2`): in-kernel `s_l` restore on read; recovers latent
  quantization loss (teacher-forced KLD 0.184 -> 0.152).
- **fp8-RoPE KV-cell**: store the decoupled RoPE key as fp8-e4m3 + amax; record 432 -> 368 B
  (+15.8% pool, genuine 1M single-request). 64K needle retrieval 15/15 = 15/15, KL below noise.

Companion vLLM plumbing: local-inference-lab/vllm#95.

### ⚠️ Merge note (draft)
This is 3-way merged from the fork-point `5af873a` onto current `master`. The nvfp4/fp8-rope
additions overlap `master`'s post-`5af873a` MLA changes in ~48 spots (decode_math/kernel/prefill/
prefill_mg), which were resolved toward preserving the feature. **Those resolutions need a careful
review against your recent MLA work** — flagging so we can reconcile any infra changes I may have
shadowed. Opening as draft for exactly that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 precision support for sparse MLA decode and prefill workloads.
  * Added configurable latent scaling and scale-format options for improved flexibility across supported configurations.
  * Added optional FP8 RoPE handling, including an environment-based process-wide toggle.
  * Extended decoding and prefill APIs to accept the new configuration options.
* **Bug Fixes**
  * Improved cache-layout validation and routing for NVFP4 and FP8 RoPE combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->