### PR TITLE
moe(w4a16): preserve preplanned tile geometry across launch op

### DIFF
--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -6986,6 +6986,19 @@ def run_w4a16_moe(
                 f"planned={actual_fused + (int(fused_launch.max_m_blocks),)}"
             )
         fused = fused_launch
+    if weight_layout == "nf3_2p1":
+        prepared_tiles = (
+            int(getattr(prepared, "fc1_tile_n", 0)),
+            int(getattr(prepared, "fc2_tile_n", 0)),
+        )
+        compiled_tiles = (int(fused.fc1_tile_n), int(fused.fc2_tile_n))
+        if prepared_tiles != compiled_tiles:
+            raise RuntimeError(
+                "prepared NF3 packing geometry does not match the compiled "
+                "W4A16 launch: "
+                f"prepared_fc1_fc2_tile_n={prepared_tiles}, "
+                f"compiled_fc1_fc2_tile_n={compiled_tiles}"
+            )
     capacity_m = int(fused.size_m)
     capacity_routed_rows = capacity_m * topk
     if intermediate_cache13_flat.numel() < capacity_routed_rows * max(fc1_cols, hidden_size):

--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import os
 from dataclasses import dataclass, replace
 from typing import NamedTuple
@@ -5846,6 +5845,10 @@ def _w4a16_fused_moe_launch_flat(
     weight_layout: str,
     scale_format: str,
     w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
     direct_topk_routes: bool,
     tc_decode_fused_sum: bool,
     collect_activation_amax: bool,
@@ -5882,6 +5885,10 @@ def _w4a16_fused_moe_launch_flat(
         direct_topk_routes=bool(direct_topk_routes),
         tc_decode_fused_sum=bool(tc_decode_fused_sum),
         collect_activation_amax=collect_activation_amax,
+        # The custom-op boundary cannot carry the compiled launch object. Re-pin
+        # its selected geometry so tile-specific packs (notably NF3) resolve the
+        # identical cache entry instead of silently recompiling with auto tiles.
+        force_tile_config=(fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n),
     )
     fused.compiled(
         make_ptr(
@@ -6021,6 +6028,10 @@ def _w4a16_fused_moe_launch_op(
     weight_layout: str,
     scale_format: str,
     w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
     direct_topk_routes: bool,
     tc_decode_fused_sum: bool,
     stream_int: int,
@@ -6067,6 +6078,10 @@ def _w4a16_fused_moe_launch_op(
         weight_layout=weight_layout,
         scale_format=scale_format,
         w13_layout=w13_layout,
+        fc1_tile_k=fc1_tile_k,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        fc2_tile_n=fc2_tile_n,
         direct_topk_routes=direct_topk_routes,
         tc_decode_fused_sum=tc_decode_fused_sum,
         collect_activation_amax=False,
@@ -6115,6 +6130,10 @@ def _w4a16_fused_moe_launch_fake(
     weight_layout: str,
     scale_format: str,
     w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
     direct_topk_routes: bool,
     tc_decode_fused_sum: bool,
     stream_int: int,
@@ -6168,6 +6187,10 @@ def _w4a16_fused_moe_calibrated_launch_op(
     weight_layout: str,
     scale_format: str,
     w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
     stream_int: int,
 ) -> None:
     _w4a16_fused_moe_launch_flat(
@@ -6212,6 +6235,10 @@ def _w4a16_fused_moe_calibrated_launch_op(
         weight_layout=weight_layout,
         scale_format=scale_format,
         w13_layout=w13_layout,
+        fc1_tile_k=fc1_tile_k,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        fc2_tile_n=fc2_tile_n,
         direct_topk_routes=False,
         tc_decode_fused_sum=False,
         collect_activation_amax=True,
@@ -6262,6 +6289,10 @@ def _w4a16_fused_moe_calibrated_launch_fake(
     weight_layout: str,
     scale_format: str,
     w13_layout: str,
+    fc1_tile_k: int,
+    fc1_tile_n: int,
+    fc2_tile_k: int,
+    fc2_tile_n: int,
     stream_int: int,
 ) -> None:
     return None
@@ -7048,6 +7079,10 @@ def run_w4a16_moe(
         weight_layout,
         scale_format,
         w13_layout,
+        int(fused.fc1_tile_k),
+        int(fused.fc1_tile_n),
+        int(fused.fc2_tile_k),
+        int(fused.fc2_tile_n),
     )
     if collect_activation_amax:
         assert activation_amax is not None

--- a/tests/test_launch_custom_ops.py
+++ b/tests/test_launch_custom_ops.py
@@ -447,6 +447,10 @@ def test_w4a16_moe_launch_ops_have_fake_dispatch() -> None:
             "modelopt",
             "e8m0_k32",
             "w13",
+            64,
+            128,
+            64,
+            128,
             False,
             False,
             0,
@@ -494,6 +498,10 @@ def test_w4a16_moe_launch_ops_have_fake_dispatch() -> None:
             "modelopt",
             "e8m0_k32",
             "w13",
+            64,
+            128,
+            64,
+            128,
             0,
         )
 

--- a/tests/test_w4a16_nf3.py
+++ b/tests/test_w4a16_nf3.py
@@ -95,7 +95,11 @@ def _build_problem(m: int, seed: int = 0):
         0, 8, (num_experts, w13_rows, hidden), dtype=torch.int32, device=_DEVICE
     )
     w2_codes = torch.randint(
-        0, 8, (num_experts, hidden, intermediate_size), dtype=torch.int32, device=_DEVICE
+        0,
+        8,
+        (num_experts, hidden, intermediate_size),
+        dtype=torch.int32,
+        device=_DEVICE,
     )
     w13_scale = _round_to_e4m3_scale(
         0.01 + 0.24 * torch.rand(num_experts, w13_rows, hidden // 32, device=_DEVICE)
@@ -241,3 +245,121 @@ def _run_case(m: int, *, tc_decode: bool) -> None:
 )
 def test_nf3_matches_dequant_reference(m: int, tc_decode: bool) -> None:
     _run_case(m, tc_decode=tc_decode)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_nf3_tc_decode_production_shape_with_tier_mask() -> None:
+    """Cover the GLM-5.2 TP4 hybrid contract used by the vLLM integration.
+
+    The serving path compiles one m=8 launch at pinned 256-wide tiles, reuses
+    it at m=1, and maps routes belonging to the other precision tier to -1.
+    """
+    torch.manual_seed(20260714)
+    m, capacity_m = 1, 8
+    num_experts, topk = 4, 8
+    hidden, intermediate = 6144, 512
+    w13_rows = 2 * intermediate
+
+    w13_codes = torch.randint(
+        0,
+        8,
+        (num_experts, w13_rows, hidden),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w2_codes = torch.randint(
+        0,
+        8,
+        (num_experts, hidden, intermediate),
+        dtype=torch.int32,
+        device=_DEVICE,
+    )
+    w13_scale = _round_to_e4m3_scale(
+        0.01 + 0.24 * torch.rand(num_experts, w13_rows, hidden // 32, device=_DEVICE)
+    )
+    w2_scale = _round_to_e4m3_scale(
+        0.01
+        + 0.24 * torch.rand(num_experts, hidden, intermediate // 32, device=_DEVICE)
+    )
+    x = (torch.randn(m, hidden, device=_DEVICE) * 0.1).to(_DTYPE)
+    topk_ids = torch.tensor(
+        [[0, -1, 1, -1, 2, -1, 3, -1]], dtype=torch.int32, device=_DEVICE
+    )
+    topk_weights = torch.softmax(torch.randn(m, topk, device=_DEVICE), dim=-1)
+
+    sms, max_shared_mem = _device_limits()
+    fused = compile_w4a16_fused_moe(
+        size_m=capacity_m,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        num_experts=num_experts,
+        top_k=topk,
+        activation="silu",
+        apply_router_weight_on_input=False,
+        zero_fc2_output=False,
+        moe_block_size=8,
+        max_m_blocks=capacity_m * topk,
+        element_dtype="bf16",
+        fast_math=True,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        weight_layout="nf3_2p1",
+        scale_format="e4m3_k32",
+        w13_layout="w13",
+        direct_topk_routes=True,
+        tc_decode_fused_sum=True,
+        force_tile_config=(64, 256, 64, 256),
+    )
+    prepared = prepare_nf3_moe_weights(
+        w13_codes,
+        w13_scale,
+        w2_codes,
+        w2_scale,
+        activation="silu",
+        fc1_tile_n=256,
+        fc2_tile_n=256,
+        params_dtype=_DTYPE,
+    )
+    buffers = make_w4a16_packed_buffers(
+        prepared,
+        m=capacity_m,
+        topk=topk,
+        dtype=_DTYPE,
+        device=_DEVICE,
+    )
+    out = run_w4a16_moe(
+        x,
+        prepared,
+        topk_weights,
+        topk_ids,
+        activation="silu",
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=buffers.intermediate_cache2,
+        output=buffers.output[:m],
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        fused_launch=fused,
+    )
+    torch.cuda.synchronize()
+
+    w13_deq = _dequant(w13_codes, w13_scale)
+    w2_deq = _dequant(w2_codes, w2_scale)
+    ref = torch.zeros((m, hidden), dtype=torch.float32, device=_DEVICE)
+    x_f = x.float()
+    for route in range(topk):
+        expert = int(topk_ids[0, route])
+        if expert < 0:
+            continue
+        fc1 = x_f[0] @ w13_deq[expert].float().T
+        gate, up = fc1[:intermediate], fc1[intermediate:]
+        act = (gate * torch.sigmoid(gate)).to(_DTYPE) * up.to(_DTYPE)
+        ref[0] += float(topk_weights[0, route]) * (
+            act.float() @ w2_deq[expert].float().T
+        )
+
+    denom = ref.abs().amax().clamp(min=1e-6)
+    rel = (out.float() - ref).abs().amax() / denom
+    assert rel < 2e-2, f"production-shape NF3 TC decode rel err {float(rel):.4f}"

--- a/tests/test_w4a16_nf3.py
+++ b/tests/test_w4a16_nf3.py
@@ -14,6 +14,8 @@ back off the compile result, and packs with exactly those. The same
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 import torch
 
@@ -363,3 +365,22 @@ def test_nf3_tc_decode_production_shape_with_tier_mask() -> None:
     denom = ref.abs().amax().clamp(min=1e-6)
     rel = (out.float() - ref).abs().amax() / denom
     assert rel < 2e-2, f"production-shape NF3 TC decode rel err {float(rel):.4f}"
+
+    mismatched = replace(prepared, fc1_tile_n=128)
+    with pytest.raises(RuntimeError, match="NF3 packing geometry"):
+        run_w4a16_moe(
+            x,
+            mismatched,
+            topk_weights,
+            topk_ids,
+            activation="silu",
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=buffers.intermediate_cache2,
+            output=buffers.output[:m],
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            fused_launch=fused,
+        )


### PR DESCRIPTION
## Problem

`run_w4a16_moe()` receives a precompiled launch whose weight packing may be tile-specific, especially for `nf3_2p1`. The Torch custom-op boundary cannot carry that compiled object. Reconstructing the launch with automatic tile selection can choose different FC1/FC2 tiles for the runtime M shape, silently selecting a different cache entry than the one used to pack the weights.

## Fix

Thread the four selected tile dimensions through the custom-op and fake-op schemas and pass them back as `force_tile_config` when resolving the compiled launch. This preserves the exact preplanned geometry for normal and calibrated launches.

Also remove a stale unused `math` import already exposed by current-master lint.

## Validation

- Rebased directly on B12X master `115926e`
- Production-shape GLM-5.2 TP4 NF3 TC-decode test with tier-masked routes: passed on SM120
- W4A16 custom-op fake-dispatch schema test: passed
- `ruff check` on all changed files
- `ruff format --check` on changed tests
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fused MoE execution by carrying the selected kernel tile configuration through the custom-op launch path, including NF3 workloads.
  * Added runtime validation to catch packing-geometry mismatches for NF3.

* **Tests**
  * Added a CUDA-only test covering “production shape” NF3 behavior with tier-masked experts.
  * Updated custom-op dispatch tests to match the expanded launch arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->