### PR TITLE
fix(w4a16): admit ultra-wide FC2 tile in forced re-pin validation

### DIFF
--- a/b12x/moe/fused/w4a16/kernel.py
+++ b/b12x/moe/fused/w4a16/kernel.py
@@ -5201,6 +5201,31 @@ def compile_w4a16_fused_moe(
             ("fc1", fc1_cols, hidden_size, fc1_tile_n, fc1_tile_k),
             ("fc2", hidden_size, intermediate_size, fc2_tile_n, fc2_tile_k),
         ):
+            if (
+                name == "fc2"
+                and int(forced_tk) == 32
+                and int(forced_tn) == 512
+                and int(forced_pn) % 512 == 0
+                and int(forced_pk) % 32 == 0
+                and int(forced_tk) % _scale_group_size(scale_format) == 0
+                and _shared_memory_footprint(
+                    cta_m_blocks=_covering_count(moe_block_size, 16),
+                    tile_n=512,
+                    tile_k=32,
+                    scale_format=scale_format,
+                    weight_layout=weight_layout,
+                )
+                <= int(max_shared_mem) - 512
+            ):
+                # The TC-decode FC2 ultra-wide tile (tile_k=32, tile_n=512)
+                # is admitted by the auto selection above via a direct
+                # footprint check because tile_k=32 sits below the generic
+                # tile_k>=64 floor in _candidate_tile_fits. Re-pinning the
+                # selected tiles across the custom-op boundary must admit
+                # the same shape, or every deployment whose SM count fires
+                # the ultra override (e.g. 48-SM GB10) rejects its own
+                # auto-selected config here.
+                continue
             if not _candidate_tile_fits(
                 problem_n=forced_pn,
                 problem_k=forced_pk,


### PR DESCRIPTION
## Summary

The W4A16 TC-decode auto selection can pick the ultra-wide FC2 tile `(tile_k=32, tile_n=512)` (the wave-balance override in `compile_w4a16_fused_moe`), which is admitted via a direct shared-memory footprint check because `tile_k=32` sits below the generic `tile_k>=64` floor in `_candidate_tile_fits` — the override's comment notes this explicitly.

However, when the selected tiles cross the `torch.ops.b12x.w4a16_fused_moe_launch` custom-op boundary, the launch side re-pins them via `force_tile_config`, and that validation path re-checks with the generic `_candidate_tile_fits` — which rejects the exact shape the auto selection just produced:

```
ValueError: force_tile_config fc2 tile (tile_k=32, tile_n=512) does not fit problem N/K=4096/1024 at moe_block_size=8
```

## Why upstream never sees it

The ultra override only fires when its wave-balance gates hold, and those compare FC1/FC2 mn-tile counts against the device SM count (`fc1_mn_after <= sms`, etc.). On 188-SM SM120 parts (RTX PRO 6000) the gates don't fire with typical model dims. On 48-SM GB10 (DGX Spark) they do: DeepSeek-v4-Flash TP2 decode selects the ultra tile and crashes during CUDA graph capture on every boot.

## Fix

Teach the forced re-pin path the same exception the selection path makes: accept fc2 `(tile_k=32, tile_n=512)` under the identical direct footprint check (exact N/K coverage, scale-group alignment, smem fit). No behavior change for any config the generic floor already admits; the tiles still land in the GEMM cache keys as before.

## Testing

- Repro/verify on 2x GB10 (SM121, aarch64): DS4-Flash TP2 with the b12x-a16 backend crashed at graph capture on every boot before the patch; with it, the server boots, serves, and the ultra-tile kernel compiles and runs (currently under a multi-hour benchmark campaign).
- Not reproducible on SM120 hardware (gates never fire there), so no regression path for existing deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for ultra-wide FC2 workloads using specific forced tile configurations.
  * Prevented valid configurations from being incorrectly rejected during fused MoE processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->