### PR TITLE
fix(mla): guard compact KV cache writer bounds

### DIFF
--- a/b12x/attention/mla/kv_cache.py
+++ b/b12x/attention/mla/kv_cache.py
@@ -157,6 +157,7 @@ class ConcatAndCacheNvfp4MlaFp8RopeKernel:
         k_pe_stride: Int32,  # k_pe.stride(0), elements
         block_stride: Int64,  # kv_cache.stride(0), bytes
         entry_stride: Int32,  # kv_cache.stride(1), bytes
+        slot_capacity: Int32,
         num_tokens: Int32,
         stream: cuda.CUstream,
     ):
@@ -169,6 +170,7 @@ class ConcatAndCacheNvfp4MlaFp8RopeKernel:
             k_pe_stride,
             block_stride,
             entry_stride,
+            slot_capacity,
         ).launch(
             grid=(num_tokens, 1, 1),
             block=[_THREADS, 1, 1],
@@ -186,6 +188,7 @@ class ConcatAndCacheNvfp4MlaFp8RopeKernel:
         k_pe_stride: Int32,
         block_stride: Int64,
         entry_stride: Int32,
+        slot_capacity: Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         token_idx, _, _ = cute.arch.block_idx()
@@ -193,9 +196,9 @@ class ConcatAndCacheNvfp4MlaFp8RopeKernel:
         token = Int32(token_idx)
 
         slot = Int64(slot_mapping[token])
-        if slot >= Int64(0):
-            # Slot capacity is host-asserted < 2^31, so the block/offset
-            # split runs in Int32 (the byte offset below is Int64).
+        if (slot >= Int64(0)) & (slot < slot_capacity.to(Int64)):
+            # Capacity is host-asserted in (0, 2^31), so the block/offset
+            # split is safe in Int32 after the Int64 bounds check.
             slot32 = slot.to(Int32)
             block_idx = slot32 // Int32(self.block_size)
             block_off = slot32 % Int32(self.block_size)
@@ -329,18 +332,20 @@ def _concat_and_cache_nvfp4_mla_fp8_rope_flat_launch(
     if num_tokens == 0:
         return
     block_size = int(kv_cache.shape[1])
+    slot_capacity = int(kv_cache.shape[0]) * block_size
     is_bf16 = kv_c.dtype == torch.bfloat16
     kernel = _build_concat_and_cache_nvfp4_mla_fp8_rope_kernel(block_size, is_bf16)
 
     args = (
         _to_kernel_tensor(kv_c, assumed_align=4, leading_dim=1),
-        _to_kernel_tensor(k_pe, assumed_align=2, leading_dim=1),
+        _to_kernel_tensor(k_pe, assumed_align=4, leading_dim=1),
         _to_kernel_tensor(kv_cache, assumed_align=16, leading_dim=2),
         _to_kernel_tensor(slot_mapping, assumed_align=8, leading_dim=0),
         Int32(int(kv_c.stride(0))),
         Int32(int(k_pe.stride(0))),
         Int64(int(kv_cache.stride(0))),
         Int32(int(kv_cache.stride(1))),
+        Int32(slot_capacity),
         Int32(num_tokens),
         current_cuda_stream(),
     )
@@ -359,7 +364,7 @@ def _concat_and_cache_nvfp4_mla_fp8_rope_flat_launch(
     )
     spec = KernelCompileSpec.from_key(
         "attention.mla.nvfp4_fp8_rope_kv_cache",
-        1,
+        2,
         cache_key,
         labels=(
             "kv_c",
@@ -414,8 +419,8 @@ def concat_and_cache_nvfp4_mla_fp8_rope(
     :param k_pe: decoupled RoPE key, ``(>= num_tokens, 64)``, same dtype.
     :param kv_cache: paged cache viewed ``(num_blocks, block_size, 368)``
         uint8; mutated in place.
-    :param slot_mapping: ``(num_tokens,)`` int64 flat slot ids; entries < 0
-        are skipped.
+    :param slot_mapping: ``(num_tokens,)`` int64 flat slot ids; entries outside
+        ``[0, num_blocks * block_size)`` are skipped.
     :param scale: accepted for signature parity with the fp8 cache-op
         family; the nvfp4_ds_mla record has an implicit global scale of 1.0
         (group scales carry all magnitude), so it is unused.
@@ -438,6 +443,8 @@ def concat_and_cache_nvfp4_mla_fp8_rope(
             "kv_cache must be (num_blocks, block_size, "
             f"{_RECORD_BYTES}) uint8, got {tuple(kv_cache.shape)}"
         )
+    if int(kv_cache.shape[0]) <= 0 or int(kv_cache.shape[1]) <= 0:
+        raise ValueError("kv_cache num_blocks and block_size must be positive")
     if kv_cache.dtype != torch.uint8:
         raise TypeError(f"kv_cache must be uint8, got {kv_cache.dtype}")
     if slot_mapping.ndim != 1 or slot_mapping.dtype != torch.int64:
@@ -460,14 +467,14 @@ def concat_and_cache_nvfp4_mla_fp8_rope(
     if kv_c.stride(0) % 2 != 0 or kv_c.data_ptr() % 4 != 0:
         # The group loads are 32-bit (element pairs), same as the CUDA writer.
         raise ValueError("kv_c rows must be 4-byte aligned (even row stride)")
+    if k_pe.stride(0) % 2 != 0 or k_pe.data_ptr() % 4 != 0:
+        raise ValueError("k_pe rows must be 4-byte aligned (even row stride)")
     if (
-        kv_cache.data_ptr() % 8 != 0
-        or kv_cache.stride(0) % 8 != 0
-        or kv_cache.stride(1) % 8 != 0
+        kv_cache.data_ptr() % 16 != 0
+        or kv_cache.stride(0) % 16 != 0
+        or kv_cache.stride(1) % 16 != 0
     ):
-        raise ValueError(
-            "kv_cache records must be 8-byte aligned for the packed E2M1 stores"
-        )
+        raise ValueError("kv_cache records must be 16-byte aligned")
     if int(kv_cache.shape[0]) * int(kv_cache.shape[1]) >= 2**31:
         raise ValueError("kv_cache slot capacity must fit in int32")
     if not (

--- a/tests/test_attention_mla_kv_cache.py
+++ b/tests/test_attention_mla_kv_cache.py
@@ -61,6 +61,10 @@ def _invalid_writer_args(case: str) -> tuple[torch.Tensor, ...]:
         args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES - 1), dtype=torch.uint8)
     elif case == "cache_dtype":
         args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES), dtype=torch.bfloat16)
+    elif case == "zero_num_blocks":
+        args[2] = torch.empty((0, _PAGE_SIZE, _RECORD_BYTES), dtype=torch.uint8)
+    elif case == "zero_block_size":
+        args[2] = torch.empty((2, 0, _RECORD_BYTES), dtype=torch.uint8)
     elif case == "slot_dtype":
         args[3] = torch.arange(2, dtype=torch.int32)
     elif case == "slot_layout":
@@ -77,10 +81,19 @@ def _invalid_writer_args(case: str) -> tuple[torch.Tensor, ...]:
         args[0] = torch.empty((2, _V_HEAD_DIM + 1), dtype=torch.bfloat16)[
             :, :_V_HEAD_DIM
         ]
+    elif case == "k_pe_row_alignment":
+        args[1] = torch.empty((2, _HEAD_DIM - _V_HEAD_DIM + 1), dtype=torch.bfloat16)[
+            :, : _HEAD_DIM - _V_HEAD_DIM
+        ]
     elif case == "cache_record_alignment":
         args[2] = torch.empty((2, _PAGE_SIZE, _RECORD_BYTES + 1), dtype=torch.uint8)[
             ..., :_RECORD_BYTES
         ]
+    elif case == "cache_base_alignment":
+        numel = 2 * _PAGE_SIZE * _RECORD_BYTES
+        args[2] = torch.empty(numel + 8, dtype=torch.uint8)[8:].view(
+            2, _PAGE_SIZE, _RECORD_BYTES
+        )
     elif case != "cpu_device":
         raise AssertionError(f"unknown invalid writer case {case}")
     return tuple(args)
@@ -95,13 +108,17 @@ def _invalid_writer_args(case: str) -> tuple[torch.Tensor, ...]:
         ("k_pe_dtype", TypeError, "must match kv_c dtype"),
         ("cache_shape", ValueError, "kv_cache must be"),
         ("cache_dtype", TypeError, "kv_cache must be uint8"),
+        ("zero_num_blocks", ValueError, "num_blocks.*positive"),
+        ("zero_block_size", ValueError, "block_size.*positive"),
         ("slot_dtype", TypeError, "slot_mapping must be a 1-D int64 tensor"),
         ("slot_layout", ValueError, "slot_mapping must be contiguous"),
         ("short_source", ValueError, "must cover slot_mapping"),
         ("kv_c_inner_layout", ValueError, "must be innermost-contiguous"),
         ("cache_inner_layout", ValueError, "must be innermost-contiguous"),
         ("kv_c_row_alignment", ValueError, "must be 4-byte aligned"),
-        ("cache_record_alignment", ValueError, "must be 8-byte aligned"),
+        ("k_pe_row_alignment", ValueError, "k_pe.*4-byte aligned"),
+        ("cache_record_alignment", ValueError, "must be 16-byte aligned"),
+        ("cache_base_alignment", ValueError, "must be 16-byte aligned"),
         ("cpu_device", ValueError, "all tensors must be on CUDA"),
     ],
 )
@@ -241,7 +258,7 @@ def test_writer_preserves_skipped_slots_and_writes_the_record_abi(
     dtype: torch.dtype,
 ) -> None:
     device = require_sm120()
-    num_tokens = 4
+    num_tokens = 6
     kv_c, k_pe, expected_packed, expected_group_scales, expected_rope_scales = (
         _make_exactly_quantizable_inputs(
             num_tokens=num_tokens,
@@ -250,9 +267,10 @@ def test_writer_preserves_skipped_slots_and_writes_the_record_abi(
         )
     )
 
-    # The cache view has a full guard page on each side. A broken negative-slot
-    # branch therefore changes a visible guard record instead of corrupting an
-    # unowned allocation.
+    # The cache view has a full guard page on each side. The capacity slot
+    # targets the first trailing guard record without an upper-bound check. The
+    # huge slot's low 32 bits name an otherwise untouched in-cache record, so a
+    # check performed only after Int32 narrowing is also observable.
     backing = torch.full(
         (5, _PAGE_SIZE, _RECORD_BYTES),
         _SENTINEL,
@@ -260,7 +278,12 @@ def test_writer_preserves_skipped_slots_and_writes_the_record_abi(
         device=device,
     )
     cache = backing[1:4]
-    slot_mapping = torch.tensor([0, -1, 65, 130], dtype=torch.int64, device=device)
+    capacity = cache.shape[0] * cache.shape[1]
+    slot_mapping = torch.tensor(
+        [0, -1, capacity, 65, 2**40 + 17, 130],
+        dtype=torch.int64,
+        device=device,
+    )
     if dtype == torch.float16:
         concat_and_cache_nvfp4_mla_fp8_rope(
             kv_c,
@@ -288,7 +311,7 @@ def test_writer_preserves_skipped_slots_and_writes_the_record_abi(
     assert torch.equal(changed_records, expected_changed)
 
     live_slots = torch.tensor([0, 65, 130], dtype=torch.int64, device=device)
-    live_tokens = torch.tensor([0, 2, 3], dtype=torch.int64, device=device)
+    live_tokens = torch.tensor([0, 3, 5], dtype=torch.int64, device=device)
     records = cache.reshape(-1, _RECORD_BYTES).index_select(0, live_slots)
 
     # These byte ranges are the public record ABI consumed by the real readers.


### PR DESCRIPTION
## Summary
- require positive compact-cache block geometry before dispatch
- pass slot capacity as a runtime scalar and skip any Int64 slot outside `[0, capacity)` before narrowing or pointer arithmetic
- align the public validation contract with 32-bit RoPE loads and the kernel's 16-byte cache pointer assumption
- bump the writer compile-spec revision so cached kernels cannot reuse the old ABI

This is the follow-up to the two actionable post-merge review findings on #37.

## Validation
- `tests/test_attention_mla_kv_cache.py`: **22 passed** on RTX PRO 6000 Blackwell / SM120
- covers zero block geometry, k_pe 4-byte row alignment, cache 16-byte base/stride alignment, capacity-exact and `2**40 + 17` slots, BF16/FP16 byte ABI, and production decode/prefill readers
- repository-pinned `ruff check` and `ruff format --check`: passed

## Captured performance guard
Five alternating process pairs, one valid decode token, 400 CUDA-graph replays per process:

| Path | merged control | guarded candidate | delta |
|---|---:|---:|---:|
| one-call mean p50 | 12.1472 us | 12.1536 us | +0.053% |
| 78-call proxy mean p50 | 93.0272 us | 91.7568 us | -1.366% |

Control source SHA256 `8dc356fd7c4e1a6e72213f81f4d9c4f3b3f45a7de2beb905f098884cff168666`; candidate `d99d2c0e1d9b7f2af2b77736543ea488eea2d35ef5d794505561939b924b2d7c`. No serving-performance claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented KV cache writes to slot mappings beyond the cache’s available capacity.
  * Improved handling of skipped and out-of-range token slots.
  * Added validation for empty cache dimensions and stricter memory alignment requirements.
  * Corrected tensor alignment handling for key-position data.

* **Tests**
  * Expanded coverage for invalid cache dimensions, alignment errors, and out-of-range slot mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->