### PR TITLE
fix(cute): make DSL option cache keys process-stable

### DIFF
--- a/b12x/cute/compiler.py
+++ b/b12x/cute/compiler.py
@@ -2006,7 +2006,9 @@ def compile(
 
             compile_callable = CompileCallable(dsl_compile_options)
         kwargs = dict(kwargs)
-        kwargs["__dsl_compile_options_key"] = repr(dsl_compile_options)
+        kwargs["__dsl_compile_options_key"] = _structural_cache_key(
+            dsl_compile_options
+        )
     memory_cache_key = _compile_memory_cache_key(
         compile_callable, func, args, kwargs, compile_spec
     )

--- a/tests/test_cutlass_runtime_patches.py
+++ b/tests/test_cutlass_runtime_patches.py
@@ -11,6 +11,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
+from cutlass.base_dsl.compiler import OptLevel
 from cutlass.base_dsl.dsl import BaseDSL
 from cutlass.base_dsl.jit_executor import ExecutionArgs
 from cutlass.base_dsl._mlir_helpers import op as cutlass_op_helpers
@@ -642,6 +643,43 @@ def test_b12x_compile_uses_memory_cache_when_disk_disabled(monkeypatch) -> None:
     info = cute_compiler.compile_cache_info()
     assert info["memory_cache_hits"] == 1
     assert info["compile_misses"] == 1
+
+
+def test_dsl_compile_options_use_stable_cache_key(monkeypatch) -> None:
+    captured_keys = []
+    cached = object()
+
+    def capture_memory_key(compile_callable, func, args, kwargs, compile_spec):
+        captured_keys.append(kwargs["__dsl_compile_options_key"])
+        return ("captured", len(captured_keys))
+
+    monkeypatch.setattr(
+        cute_compiler, "_compile_memory_cache_key", capture_memory_key
+    )
+    monkeypatch.setattr(cute_compiler, "_memory_cache_get", lambda key: cached)
+
+    def kernel() -> None:
+        pass
+
+    assert cute_compiler.compile(
+        kernel, dsl_compile_options=OptLevel(2)
+    ) is cached
+    assert cute_compiler.compile(
+        kernel, dsl_compile_options=OptLevel(2)
+    ) is cached
+    assert cute_compiler.compile(
+        kernel, dsl_compile_options=OptLevel(3)
+    ) is cached
+
+    assert captured_keys[0] == captured_keys[1]
+    assert captured_keys[0] != captured_keys[2]
+    assert captured_keys[0][:3] == (
+        "object",
+        "cutlass.base_dsl.compiler",
+        "OptLevel",
+    )
+    assert captured_keys[0][3] == (("_value", 2),)
+    assert "object at" not in repr(captured_keys[0])
 
 
 def test_compile_progress_prints_before_after_and_running_total(


### PR DESCRIPTION
## Problem

`b12x.cute.compiler.compile()` included `repr(dsl_compile_options)` in persistent CuTe cache keys. CUTLASS `OptLevel` uses the default object repr, so the key contained a process-specific address such as `0x7f...`. Every server process therefore missed the same on-disk kernel, and dynamic W4A8 MoE could recompile after vLLM reported the engine ready.

This caused cache growth and timing-dependent first/second-run performance when a benchmark raced the post-start compile.

## Fix

Use B12X structural serialization for the caller-provided DSL option object. For `OptLevel(2)`, the key is now the stable semantic value:

```text
["object", "cutlass.base_dsl.compiler", "OptLevel", [["_value", 2]]]
```

Different option levels still produce different keys. The fix does not alter the selected compile callable or compiler options.

## Validation

- `tests/test_cutlass_runtime_patches.py`: 35 passed, 1 skipped on the v19 CUDA 13.2 / CUTLASS DSL 4.5.2 image.
- Real GLM-5.2 TP6/DCP3/MTP3 W4A8 run: first request created one dynamic MoE object with key `72eaa97b...`.
- Identical process restart: 0 B12X compile starts; all six ranks reported `disk-cache-hit` with the same key.
- Cache object count remained exactly `360 -> 360` after decode.
- Identical restart reached health in 95 s versus 190 s for the cache-populating run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DSL compilation caching by generating a more stable cache key for equivalent compilation option settings.
  * Ensures different option values produce different cached entries.
* **Tests**
  * Added a test validating consistent cache-key behavior across repeated calls and confirming cache keys don’t include object memory addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->