### PR TITLE
fix(pcie): isolate recycled CUDA graph streams

### DIFF
--- a/b12x/distributed/pcie_dcp_a2a.py
+++ b/b12x/distributed/pcie_dcp_a2a.py
@@ -512,6 +512,7 @@ class PCIeDCPA2APool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeDCPA2A] = {}
+        self._all_channels: list[PCIeDCPA2A] = []
         self._capture_channel_stack: list[PCIeDCPA2A] = []
         self._closed = False
         if channel_factory is None and exchange_group is None:
@@ -583,6 +584,7 @@ class PCIeDCPA2APool:
                 stream_affine=not self.single_channel,
             )
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
 
     def for_stream(self, stream: object = None) -> PCIeDCPA2A:
@@ -594,6 +596,17 @@ class PCIeDCPA2APool:
         else:
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)
+        if (
+            not self.single_channel
+            and _is_current_stream_capturing(self.device)
+            and self._capture_channel_stack
+        ):
+            # Independent graph managers may reuse a torch-owned nested stream
+            # key. The enclosing capture, not a stale key mapping, determines
+            # which IPC channel is safe for this graph.
+            channel = self._capture_channel_stack[-1]
+            self._channels[key] = channel
+            return channel
         channel = self._channels.get(key)
         if channel is not None:
             return channel
@@ -676,7 +689,20 @@ class PCIeDCPA2APool:
     @contextmanager
     def capture(self, stream: object = None):
         """Bind nested CUDA captures to the enclosing stream's channel."""
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe DCP A2A capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            key = 0 if stream_key is None else int(stream_key)
+            # Keep a graph-owned channel even when CUDA recycles the enclosing
+            # stream handle used by a previously captured graph manager.
+            channel = self._new_channel(stream_key)
+            self._channels[key] = channel
         self._capture_channel_stack.append(channel)
         try:
             yield channel
@@ -690,10 +716,11 @@ class PCIeDCPA2APool:
             return
         self._closed = True
         seen: set[int] = set()
-        for channel in self._channels.values():
+        for channel in (*self._all_channels, *self._channels.values()):
             if id(channel) not in seen:
                 seen.add(id(channel))
                 channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -913,6 +913,7 @@ class PCIeOneshotAllReducePool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeOneshotAllReduce] = {}
+        self._all_channels: list[PCIeOneshotAllReduce] = []
         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
         self._closed = False
 
@@ -980,6 +981,7 @@ class PCIeOneshotAllReducePool:
             if self.single_channel:
                 channel._stream_affine = False
             channel._bind_stream_key(stream_key)
+            self._all_channels.append(channel)
             return channel
 
         if self.exchange_group is None or self._ipc is None or self._ext is None:
@@ -1019,6 +1021,7 @@ class PCIeOneshotAllReducePool:
                     self._ipc.cudaFree(shared.local_ptr)
             raise
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
 
     def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
@@ -1040,6 +1043,17 @@ class PCIeOneshotAllReducePool:
 
         stream_key = _current_stream_key(self.device, stream)
         channel_key = 0 if stream_key is None else int(stream_key)
+        if (
+            _is_current_stream_capturing(self.device)
+            and self._capture_channel_stack
+        ):
+            # CUDA and torch/Inductor may recycle a nested capture stream key
+            # between independent target and draft graph managers. The active
+            # enclosing capture owns the channel even if that key still maps
+            # to a channel captured by an earlier manager.
+            channel = self._capture_channel_stack[-1]
+            self._channels[channel_key] = channel
+            return channel
         channel = self._channels.get(channel_key)
         if channel is not None:
             return channel
@@ -1117,7 +1131,22 @@ class PCIeOneshotAllReducePool:
 
     @contextmanager
     def capture(self, stream: object = None):
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe oneshot capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            channel_key = 0 if stream_key is None else int(stream_key)
+            # A CUDA stream handle can be recycled after one graph manager
+            # finishes capture. Graphs retain the channel pointers, so a new
+            # manager must receive a fresh channel even when the numeric stream
+            # key is identical. _all_channels keeps replaced channels alive.
+            channel = self._new_channel(stream_key)
+            self._channels[channel_key] = channel
         with channel.capture(stream=stream):
             self._capture_channel_stack.append(channel)
             try:
@@ -1131,8 +1160,12 @@ class PCIeOneshotAllReducePool:
         if self._closed:
             return
         self._closed = True
-        for channel in self._channels.values():
-            channel.close()
+        seen: set[int] = set()
+        for channel in (*self._all_channels, *self._channels.values()):
+            if id(channel) not in seen:
+                seen.add(id(channel))
+                channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/tests/distributed/test_pcie_dcp_a2a.py
+++ b/tests/distributed/test_pcie_dcp_a2a.py
@@ -251,3 +251,57 @@ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
     assert pool._channels[70] is target_channel
     assert pool._channels[80] is draft_channel
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [1234]
+    assert draft_channel._ext.dispose_calls == [1234]

--- a/tests/distributed/test_pcie_oneshot.py
+++ b/tests/distributed/test_pcie_oneshot.py
@@ -705,3 +705,56 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
     assert pool._channels[70] is target_channel
     assert pool._channels[80] is draft_channel
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    # CUDA may recycle both handles for the next graph manager. Neither stale
+    # mapping may make the draft graph retain the target graph's IPC channel.
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [12345]
+    assert draft_channel._ext.dispose_calls == [12345]


### PR DESCRIPTION
## Problem

vLLM captures the target model, draft prefill, and draft decode in separate CUDA graph manager contexts. CUDA/PyTorch may recycle the same numeric outer and nested capture stream handles between those contexts. The PCIe oneshot and DCP A2A pools cached channels only by stream key, so a later draft capture could retain the target graph channel and race on its signal/staging buffers during replay. The existing nested-capture tests used distinct stream IDs and did not cover reuse.

A TP6/DCP6/MTP3 E2E run reproduced an Xid 13 out-of-range address at CC16; the same workload completed with CUDA_LAUNCH_BLOCKING=1, which is consistent with this stream-channel race.

## Fix

- Allocate one graph-owned channel for every independent pool capture context, even when its outer stream key was recycled.
- Make the active enclosing capture channel take precedence over stale nested stream-key aliases.
- Keep replaced graph-owned channels alive until pool shutdown, because captured graphs retain their IPC pointers.
- Apply the same ownership rule to PCIe oneshot all-reduce and PCIe DCP A2A.

## Tests

- Add target/draft regressions that deliberately reuse the same outer and nested stream IDs.
- Verify all replaced channels remain owned and are disposed on pool close.
- `34 passed, 1 skipped` across both PCIe suites plus the GPU torture test (GPU-only test skipped in the unit-test container).
- Ruff and `git diff --check` pass.

E2E validation against TP6/DCP6/MTP3 and TP8/DCP2 long-prefill configurations follows in the integration image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA graph capture handling for PCIe communication pools.
  - Separate capture sessions now receive distinct communication channels, even when stream keys are reused.
  - Nested or active captures now consistently reuse the correct enclosing channel.
  - Pool shutdown now reliably closes all channels created during normal use and graph capture, preventing resource leaks.

- **Tests**
  - Added coverage for reused capture stream keys, channel isolation, and complete cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->