### PR TITLE
fix(pcie_dma): FP8 all-reduce returns rank-divergent output (owner keeps pre-wire BF16)

### DIFF
--- a/b12x/distributed/pcie_dma.py
+++ b/b12x/distributed/pcie_dma.py
@@ -55,6 +55,11 @@ def _fp8_mode() -> str:
 
     "a2a": quantize-once all-to-all (two roundings, half the wire in both
     phases).
+
+    Every FP8 mode materializes the locally owned reduced shard through the
+    same FP8 payload as its peers.  An all-reduce result must be rank-identical;
+    retaining a pre-wire BF16 owner shard while peers dequantize that shard
+    gives every TP rank a different replicated activation.
     """
 
     return _normalize_fp8_mode(os.getenv("B12X_PCIE_DMA_FP8", "0"))
@@ -382,7 +387,23 @@ class PCIeDmaAllReduce:
                             ag_stage + piece_elems,
                             piece_elems,
                         )
+                # Publish the payload before the local materialization so the
+                # CE broadcast can overlap this read-only dequant kernel.
                 self._ag_ready.record(main)
+                # The owner used to retain its pre-wire BF16 shard while the
+                # other ranks materialized this same shard from FP8.  That
+                # violates the replicated-output contract of all-reduce and
+                # lets the next TP layer consume rank-dependent activations.
+                # Round-trip the owner through the exact forwarded payload so
+                # all ranks receive bit-identical BF16 values for every shard.
+                for p in range(pieces):
+                    owner_stage = fp8_stage_piece(send_chunk, p)
+                    ext.dma_dequant_store(
+                        piece_ptr(send_chunk, p),
+                        owner_stage,
+                        owner_stage + piece_elems,
+                        piece_elems,
+                    )
             for p in range(pieces):
                 if fp8_reduce:
                     send_src = fp8_stage_piece(send_chunk, p)
@@ -611,7 +632,18 @@ class PCIeDmaAllReduce:
                 stage_chunk(rank, c) + chunk_payload,
                 chunk_elems,
             )
+            # Publish the payload first so its CE broadcast can overlap the
+            # local read-only materialization below.
             self._a2a_ownq[c].record(main)
+            # Peers materialize this reduced shard from the broadcast FP8
+            # payload.  The owner must do the same or every rank enters the
+            # next TP layer with a different replicated activation.
+            ext.dma_dequant_store(
+                out_base + own,
+                stage_chunk(rank, c),
+                stage_chunk(rank, c) + chunk_payload,
+                chunk_elems,
+            )
             with torch.cuda.stream(ag_copy):
                 ag_copy.wait_event(self._a2a_ownq[c])
                 for i, j in enumerate(peers):

--- a/tests/distributed/test_pcie_dma_rank_consistency_gpu.py
+++ b/tests/distributed/test_pcie_dma_rank_consistency_gpu.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Four-GPU gate for rank-identical FP8 PCIe-DMA all-reduce outputs.
+
+Run inside the target image after installing the overlay:
+
+    python test_pcie_dma_rank_consistency_gpu.py --mode ag
+    python test_pcie_dma_rank_consistency_gpu.py --mode ring
+    python test_pcie_dma_rank_consistency_gpu.py --mode a2a
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def make_input(rank: int, device: torch.device, iteration: int = 0) -> torch.Tensor:
+    rows = 512
+    hidden = 6144
+    values = torch.arange(rows * hidden, device=device, dtype=torch.float32)
+    values = values.reshape(rows, hidden)
+    return (
+        torch.sin(values * 0.001 + rank * 0.31 + iteration * 0.17) * 0.5
+    ).to(torch.bfloat16)
+
+
+def assert_output(
+    output: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    rank: int,
+    world: int,
+    mode: str,
+    label: str,
+) -> None:
+    rank0_output = output.clone() if rank == 0 else torch.empty_like(output)
+    dist.broadcast(rank0_output, src=0)
+    if not torch.equal(output, rank0_output):
+        mismatch = (output.float() - rank0_output.float()).abs()
+        raise AssertionError(
+            f"mode={mode} {label} rank={rank} output differs from rank0: "
+            f"count={int(torch.count_nonzero(mismatch).item())} "
+            f"max_abs={float(mismatch.max().item())}"
+        )
+    torch.testing.assert_close(
+        output.float(), reference, rtol=1.5e-1, atol=6e-2 * world
+    )
+
+
+def worker(rank: int, world: int, port: int, mode: str) -> None:
+    os.environ["B12X_PCIE_DMA_FP8"] = mode
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world,
+    )
+    from b12x.distributed.pcie_dma import PCIeDmaAllReduce
+
+    ring = PCIeDmaAllReduce(
+        exchange_group=dist.group.WORLD,
+        device=device,
+        max_bytes=512 * 6144 * 2,
+        fp8=mode,
+    )
+    try:
+        inp = make_input(rank, device)
+        reference = inp.float()
+        dist.all_reduce(reference)
+        output = ring.all_reduce(inp)
+        torch.cuda.synchronize(device)
+        assert_output(
+            output,
+            reference,
+            rank=rank,
+            world=world,
+            mode=mode,
+            label="eager",
+        )
+
+        graph_input = make_input(rank, device, 1)
+        graph_output = torch.empty_like(graph_input)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            ring.all_reduce(graph_input, out=graph_output)
+        for iteration in range(2, 5):
+            graph_input.copy_(make_input(rank, device, iteration))
+            graph_reference = graph_input.float()
+            dist.all_reduce(graph_reference)
+            graph.replay()
+            torch.cuda.synchronize(device)
+            assert_output(
+                graph_output,
+                graph_reference,
+                rank=rank,
+                world=world,
+                mode=mode,
+                label=f"graph-replay-{iteration}",
+            )
+
+        dist.barrier()
+        if rank == 0:
+            print(
+                f"PASS mode={mode} world={world}: eager and graph-replay "
+                "outputs bit-identical"
+            )
+    finally:
+        ring.close()
+        dist.destroy_process_group()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, choices=("ag", "ring", "a2a"))
+    args = parser.parse_args()
+    world = 4
+    if not torch.cuda.is_available() or torch.cuda.device_count() < world:
+        raise RuntimeError("this gate requires four visible CUDA GPUs")
+    mp.spawn(worker, args=(world, free_port(), args.mode), nprocs=world, join=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The FP8 PCIe-DMA all-reduce (`PcieRingAllReduce`) does not return one replicated value across ranks. In `ag`, `ring`, and `a2a`, each shard's **owner** keeps its pre-wire BF16 reduced value while **peer** ranks dequantize the FP8 payload. Because each rank owns a different shard, every tensor-parallel rank returns a **different** activation for the same all-reduce.

A TP all-reduce is supposed to represent one replicated activation. If rank `r` evaluates the next weight shard on `x_r` while rank `s` uses `x_s`, the layer no longer evaluates one model function at a common input. Above the DMA dispatch threshold (~6 MiB) this recurs throughout a large prefill, not once per request.

## Fix

Materialize the owner shard from the exact FP8 payload already forwarded to peers, for all three FP8 modes. Dequant-only:
- No added communication, allocations, events, or CUDA source changes.
- No second FP8 rounding (`ag`): the owner is materialized from the one payload peers already receive.
- `ring`: on the last reduce-scatter hop `dma_dequant_add_quant` already writes the final FP8 payload/scale; the patch reads the same stage slot and overwrites the BF16 owner output with its dequantized value.
- **BF16 wire mode is behaviorally unchanged** — both additions are inside FP8-only branches.

## Evidence

- **Off-GPU schedule proof** (dependency-free simulation of the reduce-scatter/all-gather schedule): legacy yields `world` distinct outputs (one per rank) at TP 2/4/8; patched yields **one** rank-identical output. PASS for `ag`, `ring`, `a2a`.
- **Four-GPU equality gate** (`tests/distributed/test_pcie_dma_rank_consistency_gpu.py`, added in this PR): outputs **bit-identical across all four ranks in both eager and CUDA graph replay**, for `ag`, `ring`, `a2a`. A tolerance-only comparison does not catch this (that was the gap in the prior GPU test).
- **Byte pins:** applies against `b12x/distributed/pcie_dma.py` MD5 `96e07e55c3843766999b88e184ce06dd`; patched output MD5 `830d136566ec3383fd100eb997aa11b9`.

## Downstream note (context, not part of the correctness claim)

Observed on GLM-5.2 hybrid, TP4/DCP4, 480k, on the v19 image. On an identical harness, BF16 retrieved deep-context needles cleanly at every depth (50k–480k), while the pre-patch fp8 modes dropped them — `ring` returned empty at 350k (reproduced 3×) and 480k; `ag` returned empty at 350k and 480k. Same defect, both modes.

With the collective fixed, `ag` retrieval improved — clean at 50k and 200k (`finish_reason=stop`, correct answer) — but **300k+ still fails** (empty content, early `finish_reason=stop`) where BF16 passes. That residual looks like intrinsic E4M3 activation error, separate from this rank-divergence defect.

**On `ring`/`a2a`:** the four-GPU equality gate passes for all three modes, so the collective fix applies equally. Server-level deep-context re-validation post-patch was run on `ag` only — we stopped there because `ag` did not clear the needle gate, and by the same reasoning `ring` and `a2a` are expected to share the residual and remain separately gated (`a2a` has no server data in either state).

So this PR fixes the collective correctness bug for **all three** fp8 modes; it is **not** claimed to resolve downstream FP8 quality, and a deep-context deployment should stay on BF16 until that is separately addressed.

Throughput is unaffected by the patch (55k cold prefill ~1,463 tok/s, matching pre-patch fp8; decode unchanged).

Preliminary PR for review, per request — flagging in case it relates to the issue you're chasing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 distributed reductions so all ranks produce bit-identical results across AG, ring, and A2A modes.
  * Ensured locally owned reduced data is consistently reconstructed from the shared FP8 payload.

* **Tests**
  * Added four-GPU coverage for rank consistency, numerical accuracy, and CUDA graph replay across supported FP8 reduction modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->