### PR TITLE
Fix Int32 overflow in direct-K fused-indexer page offsets

### DIFF
--- a/b12x/attention/indexer/fused_indexer.py
+++ b/b12x/attention/indexer/fused_indexer.py
@@ -350,7 +350,7 @@ def _score_tokens_direct_k(
     s_w: cute.Tensor,
     num_heads: Int32,
     k_quant_bytes: cute.Tensor,
-    k_byte_off: Int32,
+    k_byte_off: Int64,
     lane: Int32,
     num_q_head_tiles: cutlass.Constexpr[int],
 ):
@@ -368,13 +368,13 @@ def _score_tokens_direct_k(
     q_row = lane & Int32(15)
     q_half = lane >> Int32(4)
     k0_0 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off))
-    k1_0 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(16)))
-    k0_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(32)))
-    k1_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(48)))
-    k0_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(64)))
-    k1_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(80)))
-    k0_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(96)))
-    k1_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int32(112)))
+    k1_0 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(16)))
+    k0_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(32)))
+    k1_1 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(48)))
+    k0_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(64)))
+    k1_2 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(80)))
+    k0_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(96)))
+    k1_3 = ld_global_nc_u32(get_ptr_as_int64(k_quant_bytes, k_byte_off + Int64(112)))
     total0 = Float32(0.0)
     total1 = Float32(0.0)
     qgrp = lane // Int32(4)
@@ -1513,9 +1513,9 @@ class SparseNSAFusedIndexerKernel:
                 t1 = Float32(0.0)
                 if pid >= Int32(0):
                     k_off = (
-                        pid * Int32(self.k_quant_page_stride)
-                        + (tip0 + lane // Int32(4)) * Int32(_INDEX_HEAD_DIM)
-                        + lane4 * Int32(4)
+                        Int64(pid) * Int64(self.k_quant_page_stride)
+                        + Int64((tip0 + lane // Int32(4)) * Int32(_INDEX_HEAD_DIM))
+                        + Int64(lane4 * Int32(4))
                     )
                     t0, t1 = _score_tokens_direct_k(
                         q_smem_base_addr,

--- a/tests/test_fused_indexer.py
+++ b/tests/test_fused_indexer.py
@@ -498,3 +498,81 @@ def test_fused_indexer_mla_matches_reference(rows):
         logit = (torch.relu(torch.einsum("hd,td->ht", qf[r], kf[a:b])) * weights[r].unsqueeze(1)).sum(0) * k_scales[a:b]
         gset = set((torch.topk(logit, topk).indices + a).tolist())  # absolute index
         assert set(idx[r].tolist()) == gset
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
+    # Regression: the direct-K score path computed K byte offsets as
+    # pid * Int32(k_quant_page_stride). Serving passes strided views of a
+    # packed per-page record (observed stride 1,077,120 B, vs 8448 for a
+    # bare [pages, 64, 128]+scales tensor), so the Int32 product wraps at
+    # pid >= ceil(2^31 / 1_077_120) = 1994 and the load lands ~GBs before
+    # the tensor -> CUDA_ERROR_ILLEGAL_ADDRESS on the first long-context
+    # request of a DSV4-Flash dspark deployment (GB10, rows>=3).
+    # ctas_per_group is forced <= 16 so the direct-K gate engages on any
+    # SM count; heads=64 gives the 4-head-tile paged decode contract.
+    device = torch.device("cuda")
+    record_bytes = 1_077_120  # packed page record: quant + scales + metadata
+    pid_lo, pages_used = 2000, 64
+    pool_pages = pid_lo + pages_used + 4
+    need = pool_pages * record_bytes + (1 << 29)
+    free, _ = torch.cuda.mem_get_info(device)
+    if free < need:
+        pytest.skip(f"needs ~{need / 2**30:.1f} GiB free device memory")
+
+    rows, heads, topk = 4, 64, 512
+    seqlen = pages_used * _PS
+    g = torch.Generator(device="cpu").manual_seed(7)
+    pool = torch.zeros(pool_pages * record_bytes, dtype=torch.uint8, device=device)
+    k_quant = pool.as_strided((pool_pages, _PS, 128), (record_bytes, 128, 1))
+    k_scales = pool.view(torch.float32).as_strided(
+        (pool_pages, _PS), (record_bytes // 4, 1), storage_offset=2048
+    )
+    k_fp8 = (torch.randn((pages_used, _PS, 128), generator=g) / 3).to(
+        torch.float8_e4m3fn
+    )
+    k_quant[pid_lo : pid_lo + pages_used] = k_fp8.view(torch.uint8).to(device)
+    k_scales[pid_lo : pid_lo + pages_used] = (
+        torch.rand((pages_used, _PS), generator=g) + 0.1
+    ).to(device)
+
+    q_fp8 = (torch.randn((rows, heads, 128), generator=g) / 3).to(
+        torch.float8_e4m3fn
+    ).to(device)
+    weights = torch.randn((rows, heads), generator=g, dtype=torch.float32).to(device)
+    page_table = (
+        torch.arange(pid_lo, pid_lo + pages_used, dtype=torch.int32, device=device)
+        .repeat(rows, 1)
+        .contiguous()
+    )
+    seqlens = torch.full((rows,), seqlen, dtype=torch.int32, device=device)
+
+    idx, val = run_fused_paged_indexer(
+        q_bytes=q_fp8.view(torch.uint8),
+        weights=weights,
+        k_quant_bytes=k_quant,
+        k_scales=k_scales,
+        real_page_table=page_table,
+        seqlens=seqlens,
+        num_heads=heads,
+        topk=topk,
+        ctas_per_group=8,
+    )
+    torch.cuda.synchronize(device)
+
+    gold_vals, gold_idx_sets = _golden_topk(
+        q_fp8,
+        weights,
+        k_quant.view(torch.float8_e4m3fn)[pid_lo : pid_lo + pages_used],
+        k_scales[pid_lo : pid_lo + pages_used],
+        page_table - pid_lo,
+        seqlens,
+        topk,
+    )
+    assert torch.allclose(
+        torch.sort(val, dim=1, descending=True).values, gold_vals, atol=1e-2, rtol=0
+    )
+    for r in range(rows):
+        assert set(idx[r].tolist()) == gold_idx_sets[r]
+    del pool
+    torch.cuda.empty_cache()


### PR DESCRIPTION
# Fix Int32 overflow in direct-K fused-indexer page offsets

## Summary

The warp-owns-tokens direct-L2 score path (`39d7404`) computes the per-warp K
fragment byte offset in Int32:

```python
k_off = (
    pid * Int32(self.k_quant_page_stride)
    + (tip0 + lane // Int32(4)) * Int32(_INDEX_HEAD_DIM)
    + lane4 * Int32(4)
)
```

Serving integrations hand this kernel **strided views of a packed per-page
record** — we observe `k_quant_bytes.stride(0) = 1,077,120 B` in a vLLM
DSV4-Flash deployment, vs the 8448 of a bare `[pages, 64, 128]`+scales
tensor. With that stride the Int32 product wraps at
`pid >= ceil(2^31 / 1,077,120) = 1994`; the wrapped value sign-extends and
the `ld.global.nc` lands ~1.2 GB *before* the tensor →
`CUDA_ERROR_ILLEGAL_ADDRESS`, killing the CUDA context.

Because standalone tensors need `pid >= 254,187` to overflow, unit tests and
benchmarks never see it. In serving it presents as: *stable for hours at
short context, then the first request past ~50k tokens kills the engine* —
page ids only climb past 1994 once enough KV has been allocated.

## Who hits it

- **GB10 / DGX Spark (48 SMs):** `ctas_per_group = 48 // rows`, so **every
  speculative-verify batch (rows ≥ 3) takes the direct-K path**. DSpark K=5/6
  serving dies on the first long-context request. mtp0 (rows 1) stays on the
  staged pipeline and is unaffected — which made this look like a spec-decode
  bug for a while.
- **SM120 / RTX PRO 6000 (188 SMs):** the default resolver keeps small-row
  batches on the staged path, but decode batches of **rows ≥ 12** (or any
  caller passing `ctas_per_group <= 16`) reach the same code. Reproduced on
  RTX PRO 6000 with `ctas_per_group=8`: identical fault.

## Evidence

GPU core dump from a 2-node GB10 TP2 pair
(`CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1`, cuda-gdb): Warp MMU Fault in
`SparseNSAFusedIndexerKernel`, faulting SASS

```
IMAD R6, R41, 0x106f80, R6      ; offset = pid * 1,077,120 (32-bit)
SHF.R.S32.HI R7, RZ, 0x1f, R6   ; sign-extend
IADD.64 R14, R6, UR8            ; base + wrapped offset
LDG.E.CONSTANT R12, [R14.64]    ; MMU fault
```

with `R41 = pid = 6839` (6839 × 1,077,120 ≈ 6.9 GB, truncates to ≈ −1.2 GB).

## Fix

Compute the page term as `Int64(pid) * Int64(stride)` and carry the offset
through `_score_tokens_direct_k` as Int64 — the same convention the staged
pipeline already uses (`Int64(page_id) * page_stride_bytes` in
`_load_permute_k_page_g2s` / `_stream_issue_k_page_cp_async`). Intra-page
terms are Int32-safe and only widened for the final add. 11 lines.

The neighboring `k_scales[pid, tip0 + col]` access goes through cute layout
algebra which compiles 64-bit — verified clean to pid 15,900 (a 4.28-billion-
element scale index) with the fix applied.

## Validation

- **Regression test** (included, house style): reconstructs the packed
  stride with `pid >= 2000`, forces `ctas_per_group=8`. Fails on the unfixed
  kernel in ~4 s with the CUDA error; passes with the fix. Verified on
  SM120 (RTX PRO 6000) and SM121 (GB10).
- **Full `tests/test_fused_indexer.py` suite:** 73/73 pass with the fix
  (RTX PRO 6000, torch 2.13/cu130, cutlass-dsl 4.6).
- **Serving (2× GB10 TP2, DSV4-Flash DSpark K=6, b12x-a8):** stock IMAs at
  49,637 real tokens every attempt; with the fix (direct-K active) survives
  49,637 / 66,179 / 88,234 / 132,345 tokens eager AND with FULL_AND_PIECEWISE
  cudagraphs through **239,628 tokens** (≈ max_model_len), spec decoding
  healthy at depth 6 throughout.
- Standalone parity repro also available (stock faults at pid 2000, fixed
  passes through pid 15,900).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected high-memory address calculations for direct-K scoring, improving reliability when processing data stored at large page offsets.
  * Preserved accurate top-k results for paged indexing in these scenarios.

* **Tests**
  * Added GPU regression coverage for high page IDs and large byte offsets.
  * Verified selected values and indices match expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->