### PR TITLE
feat(pcie_dma): add block-INT8 wire modes for AG, ring, and A2A

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,40 @@ IPC-backed PCIe one-shot allreduce (`b12x/distributed/`). The
 planning, scratch layout, and policy, so integrations only supply metadata and
 capacity limits.
 
+## PCIe DMA wire modes
+
+`PCIeDmaAllReduce` can compress eligible BF16 all-reduces. Configure it with
+`B12X_PCIE_DMA_FP8` (the legacy name now selects either E4M3 or signed INT8),
+or pass the same value as the `fp8=` constructor argument. The b12x vLLM
+integration forwards `VLLM_PCIE_DMA_FP8`.
+
+| Mode | Reduce-scatter | All-gather | When to use it |
+|---|---|---|---|
+| `0` | BF16 ring | BF16 ring | Unquantized baseline |
+| `ag` | BF16 ring | block E4M3 ring | E4M3 with quantization limited to the final broadcast |
+| `ring` | block E4M3 ring, requantized per hop | block E4M3 ring | Compress both phases while retaining the neighbor-ring topology |
+| `a2a` | block E4M3 scatter with FP32 accumulation | block E4M3 broadcast | Quantize each input once and overlap direct peer transfers |
+| `i8` | BF16 ring | block INT8 ring | INT8 with quantization limited to the final broadcast |
+| `i8_ring` | block INT8 ring, requantized per hop | block INT8 ring | Compress both phases with the INT8 codec |
+| `i8_a2a` | block INT8 scatter with FP32 accumulation | block INT8 broadcast | Use the quantize-once all-to-all topology with INT8 |
+
+Every compressed mode stores 128 one-byte values plus one FP32 scale per
+128-value block: 132 bytes instead of 256 bytes for BF16, a 48.4% wire-byte
+reduction with the same staging footprint for E4M3 and INT8. These modes are
+most useful for large prefill collectives on PCIe-only multi-GPU systems where
+peer transport is the bottleneck; they do not change the KV-cache format and
+usually do not affect small decode collectives. Choose an INT8 mode when E4M3
+does not pass the model's quality gates, and benchmark the ring and all-to-all
+variants on the target PCIe topology before selecting one.
+
+Compressed transport requires BF16 input and a per-rank shard divisible by
+128 elements; other shapes use the BF16 path. For vLLM launchers that expose
+both names, keep them equal:
+
+```bash
+VLLM_PCIE_DMA_FP8=i8 B12X_PCIE_DMA_FP8=i8 vllm serve ...
+```
+
 ## Using it
 
 Kernels are registered as torch custom ops under the `b12x::` namespace, so

--- a/b12x/distributed/pcie_dma.cu
+++ b/b12x/distributed/pcie_dma.cu
@@ -105,7 +105,7 @@ __global__ void __launch_bounds__(256, 1) add_kernel(T* __restrict__ dst,
   }
 }
 
-// ---- FP8 wire path (quantize-once all-to-all) ----
+// ---- Compressed wire paths ----
 //
 // E4M3 payload with one fp32 amax scale per 128 elements, scales packed
 // contiguously after the payload so a single CE copy ships both. Values are
@@ -115,6 +115,7 @@ __global__ void __launch_bounds__(256, 1) add_kernel(T* __restrict__ dst,
 
 constexpr int kQuantBlock = 128;
 constexpr float kFp8Max = 448.0f;
+constexpr float kInt8Max = 127.0f;
 
 struct __align__(16) SrcPtrs {
   const void* ptrs[8];
@@ -143,6 +144,30 @@ __device__ __forceinline__ void store_fp8x4(
   *reinterpret_cast<__nv_fp8x4_e4m3*>(dst) = __nv_fp8x4_e4m3(v);
 }
 
+__device__ __forceinline__ float4 load_i8x4(const signed char* src) {
+  const char4 v = *reinterpret_cast<const char4*>(src);
+  return make_float4(
+      static_cast<float>(v.x), static_cast<float>(v.y),
+      static_cast<float>(v.z), static_cast<float>(v.w));
+}
+
+__device__ __forceinline__ signed char to_i8(float value) {
+  int quantized = __float2int_rn(value);
+  quantized = quantized > 127 ? 127 : quantized;
+  quantized = quantized < -127 ? -127 : quantized;
+  return static_cast<signed char>(quantized);
+}
+
+__device__ __forceinline__ void store_i8x4(
+    signed char* dst, const float4 v) {
+  char4 packed;
+  packed.x = to_i8(v.x);
+  packed.y = to_i8(v.y);
+  packed.z = to_i8(v.z);
+  packed.w = to_i8(v.w);
+  *reinterpret_cast<char4*>(dst) = packed;
+}
+
 // One warp per 128-element block: 4 elements per lane, warp amax, scale,
 // convert, store.
 __global__ void __launch_bounds__(256, 1) quant_kernel(
@@ -166,6 +191,35 @@ __global__ void __launch_bounds__(256, 1) quant_kernel(
     if (lane == 0) scales[block] = scale;
     const float inv_scale = 1.0f / scale;
     store_fp8x4(
+        payload + elem0,
+        make_float4(v.x * inv_scale, v.y * inv_scale,
+                    v.z * inv_scale, v.w * inv_scale));
+  }
+}
+
+// Symmetric signed-INT8 variant with the same one-byte payload and per-128
+// fp32 scale layout as the E4M3 wire codec.
+__global__ void __launch_bounds__(256, 1) quant_i8_kernel(
+    const nv_bfloat16* __restrict__ src,
+    signed char* __restrict__ payload,
+    float* __restrict__ scales,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float4 v = load_bf16x4(src + elem0);
+    float amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                       fmaxf(fabsf(v.z), fabsf(v.w)));
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, offset));
+    }
+    const float scale = amax > 0.0f ? amax / kInt8Max : 1.0f;
+    if (lane == 0) scales[block] = scale;
+    const float inv_scale = 1.0f / scale;
+    store_i8x4(
         payload + elem0,
         make_float4(v.x * inv_scale, v.y * inv_scale,
                     v.z * inv_scale, v.w * inv_scale));
@@ -200,6 +254,33 @@ __global__ void __launch_bounds__(256, 1) dequant_accum_kernel(
   }
 }
 
+__global__ void __launch_bounds__(256, 1) dequant_accum_i8_kernel(
+    nv_bfloat16* __restrict__ out,
+    const nv_bfloat16* __restrict__ inp,
+    SrcPtrs payloads,
+    SrcPtrs scales,
+    int nsrc,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    float4 acc = load_bf16x4(inp + elem0);
+    for (int j = 0; j < nsrc; ++j) {
+      const signed char* p =
+          reinterpret_cast<const signed char*>(payloads.ptrs[j]) + elem0;
+      const float scale = reinterpret_cast<const float*>(scales.ptrs[j])[block];
+      const float4 v = load_i8x4(p);
+      acc.x += v.x * scale;
+      acc.y += v.y * scale;
+      acc.z += v.z * scale;
+      acc.w += v.w * scale;
+    }
+    store_bf16x4(out + elem0, acc);
+  }
+}
+
 __global__ void __launch_bounds__(256, 1) dequant_store_kernel(
     nv_bfloat16* __restrict__ out,
     const __nv_fp8_e4m3* __restrict__ payload,
@@ -212,6 +293,24 @@ __global__ void __launch_bounds__(256, 1) dequant_store_kernel(
     const long long elem0 = block * kQuantBlock + lane * 4;
     const float scale = scales[block];
     const float4 v = load_fp8x4(payload + elem0);
+    store_bf16x4(
+        out + elem0,
+        make_float4(v.x * scale, v.y * scale, v.z * scale, v.w * scale));
+  }
+}
+
+__global__ void __launch_bounds__(256, 1) dequant_store_i8_kernel(
+    nv_bfloat16* __restrict__ out,
+    const signed char* __restrict__ payload,
+    const float* __restrict__ scales,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float scale = scales[block];
+    const float4 v = load_i8x4(payload + elem0);
     store_bf16x4(
         out + elem0,
         make_float4(v.x * scale, v.y * scale, v.z * scale, v.w * scale));
@@ -251,6 +350,43 @@ __global__ void __launch_bounds__(256, 1) dequant_add_quant_kernel(
     if (lane == 0) scales_out[block] = scale_out;
     const float inv_scale = 1.0f / scale_out;
     store_fp8x4(
+        payload_out + elem0,
+        make_float4(v.x * inv_scale, v.y * inv_scale,
+                    v.z * inv_scale, v.w * inv_scale));
+    if constexpr (StoreBf16) store_bf16x4(out + elem0, v);
+  }
+}
+
+template <bool StoreBf16>
+__global__ void __launch_bounds__(256, 1) dequant_add_quant_i8_kernel(
+    nv_bfloat16* __restrict__ out,
+    const nv_bfloat16* __restrict__ local,
+    const signed char* __restrict__ payload_in,
+    const float* __restrict__ scales_in,
+    signed char* __restrict__ payload_out,
+    float* __restrict__ scales_out,
+    long long blocks) {
+  const int warps_per_cta = blockDim.x >> 5;
+  const int lane = threadIdx.x & 31;
+  for (long long block = blockIdx.x * warps_per_cta + (threadIdx.x >> 5);
+       block < blocks; block += static_cast<long long>(gridDim.x) * warps_per_cta) {
+    const long long elem0 = block * kQuantBlock + lane * 4;
+    const float scale_in = scales_in[block];
+    const float4 a = load_bf16x4(local + elem0);
+    const float4 b = load_i8x4(payload_in + elem0);
+    const float4 v = make_float4(
+        a.x + b.x * scale_in, a.y + b.y * scale_in,
+        a.z + b.z * scale_in, a.w + b.w * scale_in);
+    float amax = fmaxf(fmaxf(fabsf(v.x), fabsf(v.y)),
+                       fmaxf(fabsf(v.z), fabsf(v.w)));
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, offset));
+    }
+    const float scale_out = amax > 0.0f ? amax / kInt8Max : 1.0f;
+    if (lane == 0) scales_out[block] = scale_out;
+    const float inv_scale = 1.0f / scale_out;
+    store_i8x4(
         payload_out + elem0,
         make_float4(v.x * inv_scale, v.y * inv_scale,
                     v.z * inv_scale, v.w * inv_scale));
@@ -325,6 +461,18 @@ static void dma_quant(int64_t src_ptr, int64_t payload_ptr, int64_t scales_ptr,
       reinterpret_cast<float*>(scales_ptr), blocks);
 }
 
+static void dma_quant_i8(int64_t src_ptr, int64_t payload_ptr,
+                         int64_t scales_ptr, int64_t elems) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::quant_i8_kernel<<<_fp8_blocks_grid(blocks, threads), threads, 0,
+                              stream>>>(
+      reinterpret_cast<const nv_bfloat16*>(src_ptr),
+      reinterpret_cast<signed char*>(payload_ptr),
+      reinterpret_cast<float*>(scales_ptr), blocks);
+}
+
 static void dma_dequant_accum(int64_t out_ptr, int64_t inp_ptr,
                               const std::vector<int64_t>& payload_ptrs,
                               const std::vector<int64_t>& scale_ptrs,
@@ -347,6 +495,28 @@ static void dma_dequant_accum(int64_t out_ptr, int64_t inp_ptr,
       static_cast<int>(payload_ptrs.size()), blocks);
 }
 
+static void dma_dequant_accum_i8(
+    int64_t out_ptr, int64_t inp_ptr,
+    const std::vector<int64_t>& payload_ptrs,
+    const std::vector<int64_t>& scale_ptrs, int64_t elems) {
+  TORCH_CHECK(payload_ptrs.size() == scale_ptrs.size());
+  TORCH_CHECK(payload_ptrs.size() <= 8);
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  pcie_dma::SrcPtrs payloads{};
+  pcie_dma::SrcPtrs scales{};
+  for (size_t j = 0; j < payload_ptrs.size(); ++j) {
+    payloads.ptrs[j] = reinterpret_cast<const void*>(payload_ptrs[j]);
+    scales.ptrs[j] = reinterpret_cast<const void*>(scale_ptrs[j]);
+  }
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::dequant_accum_i8_kernel<<<
+      _fp8_blocks_grid(blocks, threads), threads, 0, stream>>>(
+      reinterpret_cast<nv_bfloat16*>(out_ptr),
+      reinterpret_cast<const nv_bfloat16*>(inp_ptr), payloads, scales,
+      static_cast<int>(payload_ptrs.size()), blocks);
+}
+
 static void dma_dequant_store(int64_t out_ptr, int64_t payload_ptr,
                               int64_t scales_ptr, int64_t elems) {
   auto stream = c10::cuda::getCurrentCUDAStream().stream();
@@ -356,6 +526,18 @@ static void dma_dequant_store(int64_t out_ptr, int64_t payload_ptr,
                                    stream>>>(
       reinterpret_cast<nv_bfloat16*>(out_ptr),
       reinterpret_cast<const __nv_fp8_e4m3*>(payload_ptr),
+      reinterpret_cast<const float*>(scales_ptr), blocks);
+}
+
+static void dma_dequant_store_i8(int64_t out_ptr, int64_t payload_ptr,
+                                 int64_t scales_ptr, int64_t elems) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  pcie_dma::dequant_store_i8_kernel<<<_fp8_blocks_grid(blocks, threads), threads,
+                                      0, stream>>>(
+      reinterpret_cast<nv_bfloat16*>(out_ptr),
+      reinterpret_cast<const signed char*>(payload_ptr),
       reinterpret_cast<const float*>(scales_ptr), blocks);
 }
 
@@ -383,13 +565,46 @@ static void dma_dequant_add_quant(
 #undef LAUNCH_DEQUANT_ADD_QUANT
 }
 
+static void dma_dequant_add_quant_i8(
+    int64_t out_ptr, int64_t local_ptr, int64_t payload_in_ptr,
+    int64_t scales_in_ptr, int64_t payload_out_ptr, int64_t scales_out_ptr,
+    int64_t elems, bool store_bf16) {
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+  const long long blocks = elems / pcie_dma::kQuantBlock;
+  const int threads = 256;
+  const int grid = _fp8_blocks_grid(blocks, threads);
+#define LAUNCH_DEQUANT_ADD_QUANT_I8(STORE)                                  \
+  pcie_dma::dequant_add_quant_i8_kernel<STORE>                              \
+      <<<grid, threads, 0, stream>>>(                                       \
+          reinterpret_cast<nv_bfloat16*>(out_ptr),                          \
+          reinterpret_cast<const nv_bfloat16*>(local_ptr),                  \
+          reinterpret_cast<const signed char*>(payload_in_ptr),             \
+          reinterpret_cast<const float*>(scales_in_ptr),                    \
+          reinterpret_cast<signed char*>(payload_out_ptr),                  \
+          reinterpret_cast<float*>(scales_out_ptr), blocks)
+  if (store_bf16) {
+    LAUNCH_DEQUANT_ADD_QUANT_I8(true);
+  } else {
+    LAUNCH_DEQUANT_ADD_QUANT_I8(false);
+  }
+#undef LAUNCH_DEQUANT_ADD_QUANT_I8
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("dma_quant", &dma_quant, "quantize bf16 to e4m3 with per-128 scales");
+  m.def("dma_quant_i8", &dma_quant_i8,
+        "quantize bf16 to signed int8 with per-128 scales");
   m.def("dma_dequant_accum", &dma_dequant_accum,
         "out = inp + sum of dequantized sources (fp32 accumulate)");
+  m.def("dma_dequant_accum_i8", &dma_dequant_accum_i8,
+        "out = inp + sum of signed-int8 sources (fp32 accumulate)");
   m.def("dma_dequant_store", &dma_dequant_store, "dequantize e4m3 to bf16");
+  m.def("dma_dequant_store_i8", &dma_dequant_store_i8,
+        "dequantize signed int8 to bf16");
   m.def("dma_dequant_add_quant", &dma_dequant_add_quant,
         "add a BF16 contribution to an FP8 partial and requantize");
+  m.def("dma_dequant_add_quant_i8", &dma_dequant_add_quant_i8,
+        "add a BF16 contribution to an INT8 partial and requantize");
   m.def("dma_copy", &dma_copy, "CE peer copy on the current stream");
   m.def("dma_set_flag", &dma_set_flag, "publish a monotonic flag to a peer");
   m.def("dma_wait_flag", &dma_wait_flag, "wait for a monotonic peer flag");

--- a/b12x/distributed/pcie_dma.py
+++ b/b12x/distributed/pcie_dma.py
@@ -43,7 +43,7 @@ FP8_QUANT_BLOCK = 128
 
 
 def _fp8_mode() -> str:
-    """Opt-in E4M3 wire transport mode.
+    """Opt-in compressed wire transport mode.
 
     "ag" (also "1"): keep the saturated bf16 reduce-scatter ring and
     quantize only the allgather phase. Final values quantize exactly once
@@ -56,10 +56,14 @@ def _fp8_mode() -> str:
     "a2a": quantize-once all-to-all (two roundings, half the wire in both
     phases).
 
-    Every FP8 mode materializes the locally owned reduced shard through the
-    same FP8 payload as its peers.  An all-reduce result must be rank-identical;
-    retaining a pre-wire BF16 owner shard while peers dequantize that shard
-    gives every TP rank a different replicated activation.
+    "i8" / "i8_ring" / "i8_a2a": the matching topology with a symmetric
+    signed-INT8 payload.  Both codecs use the same layout: one payload byte
+    per value plus one fp32 scale per 128 values.
+
+    Every compressed mode materializes the locally owned reduced shard through
+    the same wire payload as its peers.  An all-reduce result must be
+    rank-identical; retaining a pre-wire BF16 owner shard while peers dequantize
+    that shard gives every TP rank a different replicated activation.
     """
 
     return _normalize_fp8_mode(os.getenv("B12X_PCIE_DMA_FP8", "0"))
@@ -71,6 +75,20 @@ def _normalize_fp8_mode(value: str | None) -> str:
         return ""
     if raw in ("a2a", "ring"):
         return raw
+    if raw in (
+        "i8",
+        "int8",
+        "i8_ag",
+        "i8-ag",
+        "ag_i8",
+        "int8_ag",
+        "int8-ag",
+    ):
+        return "i8"
+    if raw in ("i8_ring", "i8-ring", "int8_ring", "int8-ring", "ring_i8"):
+        return "i8_ring"
+    if raw in ("i8_a2a", "i8-a2a", "int8_a2a", "int8-a2a", "a2a_i8"):
+        return "i8_a2a"
     return "ag"
 
 
@@ -178,7 +196,14 @@ class PCIeDmaAllReduce:
             )
             self._fp8_stage_stride = stride
         self.min_bytes = 0
-        self.wire_mode = f"fp8-{self._fp8}" if self._fp8 else "bf16"
+        wire_modes = {
+            "i8": "int8-ag",
+            "i8_ring": "int8-ring",
+            "i8_a2a": "int8-a2a",
+        }
+        self.wire_mode = wire_modes.get(
+            self._fp8, f"fp8-{self._fp8}" if self._fp8 else "bf16"
+        )
         logger.debug("[PCIe DMA allreduce] wire mode: %s", self.wire_mode)
         if logger.isEnabledFor(logging.DEBUG):
             self._log_peer_copy_bandwidth()
@@ -295,15 +320,35 @@ class PCIeDmaAllReduce:
         shard_elems = inp.numel() // world
         shard_bytes = shard_elems * elem
 
-        fp8_eligible = (
+        compressed_eligible = (
             bool(self._fp8)
             and inp.dtype == torch.bfloat16
             and shard_elems % FP8_QUANT_BLOCK == 0
         )
-        if fp8_eligible and self._fp8 == "a2a":
-            return self._all_reduce_fp8(inp, out, shard_elems)
-        fp8_ring = fp8_eligible and self._fp8 == "ring"
-        fp8_ag = fp8_eligible and self._fp8 in ("ag", "ring")
+        int8_wire = compressed_eligible and self._fp8.startswith("i8")
+        if compressed_eligible and self._fp8 in ("a2a", "i8_a2a"):
+            return self._all_reduce_fp8(
+                inp, out, shard_elems, int8_wire=int8_wire
+            )
+        compressed_ring = compressed_eligible and self._fp8 in (
+            "ring",
+            "i8_ring",
+        )
+        compressed_ag = compressed_eligible and self._fp8 in (
+            "ag",
+            "ring",
+            "i8",
+            "i8_ring",
+        )
+        quantize = ext.dma_quant_i8 if int8_wire else ext.dma_quant
+        dequantize_store = (
+            ext.dma_dequant_store_i8 if int8_wire else ext.dma_dequant_store
+        )
+        dequantize_add_quant = (
+            ext.dma_dequant_add_quant_i8
+            if int8_wire
+            else ext.dma_dequant_add_quant
+        )
 
         base = out.data_ptr()
 
@@ -313,11 +358,11 @@ class PCIeDmaAllReduce:
         # chunking amortizes the flag round trip further as long as each
         # piece's copy time dominates the ~5us sub-step overhead.
         pieces = self._pick_pieces(shard_elems, shard_bytes)
-        if fp8_ag and (shard_elems // pieces) % FP8_QUANT_BLOCK != 0:
+        if compressed_ag and (shard_elems // pieces) % FP8_QUANT_BLOCK != 0:
             pieces = 1
         piece_elems = shard_elems // pieces
         piece_bytes = piece_elems * elem
-        # fp8 AG slices are piece-contiguous: [payload][scales] per piece.
+        # Compressed slices are piece-contiguous: [payload][scales] per piece.
         piece_slice_bytes = piece_elems + piece_elems // FP8_QUANT_BLOCK * 4
         steps = 2 * (world - 1)
 
@@ -358,7 +403,7 @@ class PCIeDmaAllReduce:
         def fp8_scratch_piece(owner: int, step: int, piece: int) -> int:
             return self._scratch_ptr(owner, step) + piece * piece_slice_bytes
 
-        stage = self._fp8_stage.data_ptr() if fp8_ag else 0
+        stage = self._fp8_stage.data_ptr() if compressed_ag else 0
 
         def fp8_stage_piece(chunk: int, piece: int) -> int:
             return stage + chunk * self._fp8_stage_stride + piece * piece_slice_bytes
@@ -371,17 +416,19 @@ class PCIeDmaAllReduce:
             else:
                 send_chunk = (rank + 1 - (k - (world - 1))) % world
                 recv_chunk = (rank - (k - (world - 1))) % world
-            fp8_reduce = fp8_ring and reduce_phase
-            fp8_step = fp8_reduce or (fp8_ag and not reduce_phase)
-            if fp8_step and k == world - 1:
+            compressed_reduce = compressed_ring and reduce_phase
+            compressed_step = compressed_reduce or (
+                compressed_ag and not reduce_phase
+            )
+            if compressed_step and k == world - 1:
                 # The AG-only mode quantizes the fully reduced owner chunk
                 # here.  The FP8 ring's fused final reduce hop already
                 # emitted the same payload.  Both modes forward those bytes
                 # verbatim, with no additional all-gather rounding.
-                if not fp8_ring:
+                if not compressed_ring:
                     for p in range(pieces):
                         ag_stage = fp8_stage_piece(send_chunk, p)
-                        ext.dma_quant(
+                        quantize(
                             piece_ptr(send_chunk, p),
                             ag_stage,
                             ag_stage + piece_elems,
@@ -398,17 +445,17 @@ class PCIeDmaAllReduce:
                 # all ranks receive bit-identical BF16 values for every shard.
                 for p in range(pieces):
                     owner_stage = fp8_stage_piece(send_chunk, p)
-                    ext.dma_dequant_store(
+                    dequantize_store(
                         piece_ptr(send_chunk, p),
                         owner_stage,
                         owner_stage + piece_elems,
                         piece_elems,
                     )
             for p in range(pieces):
-                if fp8_reduce:
+                if compressed_reduce:
                     send_src = fp8_stage_piece(send_chunk, p)
                     if k == 0:
-                        ext.dma_quant(
+                        quantize(
                             in_piece_ptr(send_chunk, p),
                             send_src,
                             send_src + piece_elems,
@@ -417,7 +464,7 @@ class PCIeDmaAllReduce:
                         self._a2a_qdone[p].record(main)
                     send_bytes = piece_slice_bytes
                     send_dst = fp8_scratch_piece(nxt, k, p)
-                elif not fp8_step:
+                elif not compressed_step:
                     send_src = (
                         in_piece_ptr(send_chunk, p) if k == 0
                         else piece_ptr(send_chunk, p)
@@ -433,11 +480,11 @@ class PCIeDmaAllReduce:
                     send_bytes = piece_slice_bytes
                     send_dst = fp8_scratch_piece(nxt, k, p)
                 with torch.cuda.stream(copy_stream):
-                    if fp8_reduce:
+                    if compressed_reduce:
                         copy_stream.wait_event(
                             self._a2a_qdone[p] if k == 0 else add_done[p]
                         )
-                    elif fp8_step and k == world - 1:
+                    elif compressed_step and k == world - 1:
                         copy_stream.wait_event(self._ag_ready)
                     elif k > 0:
                         copy_stream.wait_event(add_done[p])
@@ -454,10 +501,10 @@ class PCIeDmaAllReduce:
                     self._counter_ptr(self._wait_counters, slot(k, p)),
                 )
                 if reduce_phase:
-                    if fp8_reduce:
+                    if compressed_reduce:
                         payload = fp8_scratch_piece(rank, k, p)
                         reduced = fp8_stage_piece(recv_chunk, p)
-                        ext.dma_dequant_add_quant(
+                        dequantize_add_quant(
                             piece_ptr(recv_chunk, p),
                             in_piece_ptr(recv_chunk, p),
                             payload,
@@ -475,7 +522,7 @@ class PCIeDmaAllReduce:
                             piece_elems,
                             dtype_code,
                         )
-                elif fp8_step:
+                elif compressed_step:
                     payload = fp8_scratch_piece(rank, k, p)
                     # Forwarding reads the received FP8 payload verbatim, so
                     # it only depends on the receive flag, not on the local
@@ -483,7 +530,7 @@ class PCIeDmaAllReduce:
                     # dequantization to overlap the next hop's CE copy with
                     # this rank's read-only dequant/store.
                     add_done[p].record(main)
-                    ext.dma_dequant_store(
+                    dequantize_store(
                         piece_ptr(recv_chunk, p),
                         payload,
                         payload + piece_elems,
@@ -495,7 +542,7 @@ class PCIeDmaAllReduce:
                         scratch_piece(rank, k, p),
                         piece_bytes,
                     )
-                if reduce_phase or not fp8_step:
+                if reduce_phase or not compressed_step:
                     add_done[p].record(main)
 
         # Neighbor handshake so the next call (or graph replay) cannot
@@ -526,9 +573,14 @@ class PCIeDmaAllReduce:
         return 1
 
     def _all_reduce_fp8(
-        self, inp: torch.Tensor, out: torch.Tensor, shard_elems: int
+        self,
+        inp: torch.Tensor,
+        out: torch.Tensor,
+        shard_elems: int,
+        *,
+        int8_wire: bool = False,
     ) -> torch.Tensor:
-        """Pipelined quantize-once E4M3 all-to-all.
+        """Pipelined quantize-once compressed all-to-all.
 
         Slices are split into chunks; each chunk's quantize -> scatter ->
         fp32 dequant-accumulate -> quantize-once broadcast wave overlaps the
@@ -542,6 +594,13 @@ class PCIeDmaAllReduce:
         """
 
         ext = self._ext
+        quantize = ext.dma_quant_i8 if int8_wire else ext.dma_quant
+        dequantize_accum = (
+            ext.dma_dequant_accum_i8 if int8_wire else ext.dma_dequant_accum
+        )
+        dequantize_store = (
+            ext.dma_dequant_store_i8 if int8_wire else ext.dma_dequant_store
+        )
         world = self.world_size
         rank = self.rank
         shard_bytes = shard_elems * 2
@@ -585,7 +644,7 @@ class PCIeDmaAllReduce:
         # ready while later quants still run.
         for c in range(chunks):
             for j in peers:
-                ext.dma_quant(
+                quantize(
                     in_base + j * shard_bytes + c * chunk_bytes,
                     stage_chunk(j, c),
                     stage_chunk(j, c) + chunk_payload,
@@ -623,10 +682,10 @@ class PCIeDmaAllReduce:
             payloads = [rs_chunk(rank, i, c) for i in range(world - 1)]
             scales = [ptr + chunk_payload for ptr in payloads]
             own = rank * shard_bytes + c * chunk_bytes
-            ext.dma_dequant_accum(
+            dequantize_accum(
                 out_base + own, in_base + own, payloads, scales, chunk_elems
             )
-            ext.dma_quant(
+            quantize(
                 out_base + own,
                 stage_chunk(rank, c),
                 stage_chunk(rank, c) + chunk_payload,
@@ -638,7 +697,7 @@ class PCIeDmaAllReduce:
             # Peers materialize this reduced shard from the broadcast FP8
             # payload.  The owner must do the same or every rank enters the
             # next TP layer with a different replicated activation.
-            ext.dma_dequant_store(
+            dequantize_store(
                 out_base + own,
                 stage_chunk(rank, c),
                 stage_chunk(rank, c) + chunk_payload,
@@ -670,7 +729,7 @@ class PCIeDmaAllReduce:
                     self._counter_ptr(self._wait_counters, slot),
                 )
                 payload = ag_chunk(rank, i, c)
-                ext.dma_dequant_store(
+                dequantize_store(
                     out_base + src * shard_bytes + c * chunk_bytes,
                     payload,
                     payload + chunk_payload,

--- a/tests/distributed/test_pcie_dma_gpu.py
+++ b/tests/distributed/test_pcie_dma_gpu.py
@@ -122,7 +122,9 @@ def _fp8_worker(rank: int, world_size: int, port: int, mode: str) -> None:
     _worker(rank, world_size, port)
 
 
-@pytest.mark.parametrize("mode", ["ag", "a2a", "ring"])
+@pytest.mark.parametrize(
+    "mode", ["ag", "a2a", "ring", "i8", "i8_a2a", "i8_ring"]
+)
 def test_pcie_dma_all_reduce_fp8_wire(mode: str) -> None:
     if not torch.cuda.is_available():
         pytest.skip("CUDA is not available")

--- a/tests/distributed/test_pcie_dma_int8_codec.py
+++ b/tests/distributed/test_pcie_dma_int8_codec.py
@@ -1,0 +1,96 @@
+"""Dependency-free proofs for the block-INT8 PCIe-DMA wire codec."""
+
+from __future__ import annotations
+
+import math
+import random
+
+
+BLOCK = 128
+QMAX = 127
+
+
+def _quantize(values: list[float]) -> tuple[list[int], list[float]]:
+    assert len(values) % BLOCK == 0
+    payload: list[int] = []
+    scales: list[float] = []
+    for offset in range(0, len(values), BLOCK):
+        block = values[offset : offset + BLOCK]
+        amax = max(abs(value) for value in block)
+        scale = amax / QMAX if amax > 0.0 else 1.0
+        scales.append(scale)
+        payload.extend(
+            max(-QMAX, min(QMAX, round(value / scale))) for value in block
+        )
+    return payload, scales
+
+
+def _dequantize(payload: list[int], scales: list[float]) -> list[float]:
+    return [
+        value * scales[index // BLOCK]
+        for index, value in enumerate(payload)
+    ]
+
+
+def test_int8_layout_matches_e4m3_wire_bytes() -> None:
+    # Both modes ship 128 one-byte values plus one fp32 scale per block.
+    assert BLOCK + 4 == 132
+
+
+def test_int8_roundtrip_has_half_step_error_bound() -> None:
+    rng = random.Random(0)
+    values = [rng.uniform(-20.0, 20.0) for _ in range(4 * BLOCK)]
+    values[17] = 311.0
+    values[BLOCK + 9] = -0.0002
+    payload, scales = _quantize(values)
+    restored = _dequantize(payload, scales)
+
+    assert min(payload) >= -QMAX
+    assert max(payload) <= QMAX
+    for index, (actual, expected) in enumerate(zip(restored, values)):
+        assert abs(actual - expected) <= scales[index // BLOCK] / 2 + 1e-12
+
+
+def test_zero_block_is_finite_and_exact() -> None:
+    payload, scales = _quantize([0.0] * BLOCK)
+    assert payload == [0] * BLOCK
+    assert scales == [1.0]
+    assert _dequantize(payload, scales) == [0.0] * BLOCK
+    assert all(math.isfinite(value) for value in scales)
+
+
+def test_ag_ring_and_a2a_forward_one_canonical_payload() -> None:
+    rng = random.Random(1)
+    contributions = [
+        [rng.uniform(-2.0, 2.0) for _ in range(BLOCK)] for _ in range(4)
+    ]
+
+    # AG: the BF16 reduce-scatter result is quantized once at its owner.
+    reduced = [sum(values) for values in zip(*contributions)]
+    ag_payload = _quantize(reduced)
+    ag_results = [_dequantize(*ag_payload) for _ in contributions]
+
+    # Ring: each hop consumes and emits one canonical INT8 partial. The final
+    # payload is forwarded verbatim and also rematerialized by its owner.
+    ring_payload = _quantize(contributions[0])
+    for local in contributions[1:]:
+        partial = _dequantize(*ring_payload)
+        ring_payload = _quantize(
+            [local_value + partial_value for local_value, partial_value in zip(local, partial)]
+        )
+    ring_results = [_dequantize(*ring_payload) for _ in contributions]
+
+    # A2A: incoming source payloads are accumulated in float, then the owner
+    # quantizes once for the common broadcast payload.
+    incoming = [_quantize(values) for values in contributions[1:]]
+    accumulated = contributions[0].copy()
+    for source in incoming:
+        accumulated = [
+            current + value
+            for current, value in zip(accumulated, _dequantize(*source))
+        ]
+    a2a_payload = _quantize(accumulated)
+    a2a_results = [_dequantize(*a2a_payload) for _ in contributions]
+
+    for results in (ag_results, ring_results, a2a_results):
+        assert all(result == results[0] for result in results[1:])

--- a/tests/distributed/test_pcie_dma_rank_consistency_gpu.py
+++ b/tests/distributed/test_pcie_dma_rank_consistency_gpu.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Four-GPU gate for rank-identical FP8 PCIe-DMA all-reduce outputs.
+"""Four-GPU gate for rank-identical compressed PCIe-DMA all-reduce outputs.
 
 Run inside the target image after installing the overlay:
 
     python test_pcie_dma_rank_consistency_gpu.py --mode ag
     python test_pcie_dma_rank_consistency_gpu.py --mode ring
     python test_pcie_dma_rank_consistency_gpu.py --mode a2a
+    python test_pcie_dma_rank_consistency_gpu.py --mode i8
+    python test_pcie_dma_rank_consistency_gpu.py --mode i8_ring
+    python test_pcie_dma_rank_consistency_gpu.py --mode i8_a2a
 """
 
 from __future__ import annotations
@@ -124,7 +127,11 @@ def worker(rank: int, world: int, port: int, mode: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", required=True, choices=("ag", "ring", "a2a"))
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("ag", "ring", "a2a", "i8", "i8_ring", "i8_a2a"),
+    )
     args = parser.parse_args()
     world = 4
     if not torch.cuda.is_available() or torch.cuda.device_count() < world:


### PR DESCRIPTION
# `feat(pcie_dma): add block-INT8 wire modes for AG, ring, and A2A`

## Summary

Adds an opt-in symmetric block-INT8 codec to the existing PCIe-DMA compressed
all-reduce paths:

- `i8`: BF16 reduce-scatter + INT8 all-gather
- `i8_ring`: INT8 reduce-scatter ring + INT8 all-gather
- `i8_a2a`: quantize-once INT8 all-to-all + INT8 broadcast

Each 128-value block uses 128 signed payload bytes and one FP32 scale
(`scale = amax / 127`), so the wire and staging footprint is exactly the same
as the existing E4M3 codec: **132 bytes per block**. The change is opt-in;
BF16 and all existing E4M3 modes retain their current routing and kernels.

This builds on the rank-consistency correction merged in #44. Owners
materialize their shard from the same final wire payload forwarded to peers in
all three INT8 topologies.

## Why

On a GLM-5.2 TP4/DCP4 deployment, the rank-consistent E4M3 AG path recovered
needle retrieval through 200k but continued to fail reproducibly at 300k and
350k. Replacing only the one-byte E4M3 payload with symmetric block INT8, while
keeping the block size, FP32 scale, topology, staging allocation, and owner
materialization unchanged, restored deep retrieval:

| Wire mode | 300k | 350k |
|---|---:|---:|
| E4M3 AG | 0/3 | 0/3 |
| block-INT8 AG | 3/3 | 3/3 |

All six INT8 passes returned the expected needle (`738216`) with
`finish_reason=stop`. `RestartCount` remained zero throughout those retrieval
runs. This isolates the residual quality loss to E4M3 representation rather
than transport topology, wire size, or rank divergence.

## Implementation

- Adds CUDA kernels/bindings for:
  - BF16 -> signed INT8 quantization with one scale per 128 values
  - signed INT8 -> BF16 materialization
  - multi-source INT8 dequantization with FP32 accumulation for A2A
  - fused INT8 dequantize-add-requantize for each ring reduce-scatter hop
- Extends the existing mode normalization and routing without changing the
  BF16/E4M3 behavior.
- Keeps the collective route rank-invariant: it depends only on configured
  mode, dtype, and aligned tensor shape.
- Reuses the existing compressed scratch/staging layout; there is no codec
  workspace increase relative to E4M3.
- Extends eager, CUDA-graph, and cross-rank bit-identity gates to all three
  INT8 modes.
- Adds dependency-free codec proofs covering the 132-byte layout, zero blocks,
  the half-quantization-step error bound, and canonical-payload forwarding for
  AG, ring, and A2A.

Accepted aliases include `int8`, `int8-ag`, `int8-ring`, and `int8-a2a`; the
canonical mode names are `i8`, `i8_ring`, and `i8_a2a`.

## Evidence and validation status

Completed:

- All three modes passed four-rank bit-identity checks in eager and CUDA-graph
  execution at rows 512 and 3072. Maximum absolute error versus BF16 was
  0.01758 (`i8`), 0.01953 (`i8_ring`), and 0.01563 (`i8_a2a`).
- Full-depth needle retrieval passed at 50k, 200k, 300k, 350k, and 475k for
  every topology. `i8` passed 300k and 350k 3/3. One non-monotonic
  `i8_a2a` miss at 350k followed a 475k pass and cleared a 3/3 recheck.
- Cold prefill retained the E4M3 performance class:

  | Context | `i8` | `i8_ring` | `i8_a2a` |
  |---:|---:|---:|---:|
  | 8k | 1,487 | **1,607** | 1,463 |
  | 50k | 1,519 | **1,641** | 1,432 |

- Decode throughput was topology-invariant, as expected because decode
  messages remain below the 6.29 MiB DMA threshold:

  | Context 0 | C1 | C2 | C4 | C8 | C16 |
  |---|---:|---:|---:|---:|---:|
  | `i8` | 61.9 | 74.8 | 96.7 | 127.9 | 164.2 |
  | `i8_ring` | 63.2 | 72.7 | 95.7 | 127.2 | 165.1 |
  | `i8_a2a` | 62.1 | 75.3 | 104.7 | 122.6 | 162.7 |

- Clean verified boots reported a 644,864-token KV pool for all three modes,
  with no mode-correlated capacity change.
- Dependency-free codec/topology proofs: 4/4 pass.
- Python compile and CUDA binding/call-site structural checks pass.
- `git diff --check` passes.

`i8_ring` is the recommended PCIe mode on the tested no-NVLink topology: its
1,641 tok/s at 50k matches E4M3 ring (1,639) while preserving deep retrieval.

One `i8_a2a` performance run encountered a downstream
`CUBLAS_STATUS_INTERNAL_ERROR` in a BF16 MLA projection during decode, where
the PCIe-DMA path is inactive. A clean rerun completed. This is tracked as a
separate v19 concurrency issue and is not attributed to the INT8 codec or A2A
topology.

## Files changed

- `b12x/distributed/pcie_dma.cu`
- `b12x/distributed/pcie_dma.py`
- `tests/distributed/test_pcie_dma_gpu.py`
- `tests/distributed/test_pcie_dma_rank_consistency_gpu.py`
- `tests/distributed/test_pcie_dma_int8_codec.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional INT8 compressed PCIe DMA wire modes for all-reduce operations.
  * Supports `i8`, `i8_ring`, and `i8_a2a` transport modes alongside existing modes.
  * Added per-block scaling for compressed BF16 transfers, with support for reduce-scatter, ring, and all-to-all workflows.

* **Documentation**
  * Added configuration guidance, supported mode details, storage overhead, constraints, and example environment settings.

* **Tests**
  * Expanded GPU coverage and added validation for INT8 accuracy, layout, zero blocks, and collective consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->