### PR TITLE
fix(concurrency): isolate capture channels and barrier-free NVFP4 decode

### DIFF
--- a/b12x/distributed/pcie_dcp_a2a.py
+++ b/b12x/distributed/pcie_dcp_a2a.py
@@ -19,6 +19,7 @@ from .pcie_oneshot import (
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
     _align_up,
+    _coordinated_close_channels,
     _current_stream_key,
     _is_current_stream_capturing,
     _normalize_device,
@@ -205,6 +206,8 @@ class PCIeDCPA2A:
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
+        self._ipc_imports_closed = False
+        self._ipc_exports_freed = False
         self._ptr = self._ext.init_dcp_a2a(
             list(signal_ptrs),
             list(staging0_ptrs),
@@ -460,20 +463,35 @@ class PCIeDCPA2A:
         )
         return out
 
-    def close(self) -> None:
-        if self._closed:
+    def _close_ipc_imports(self) -> None:
+        if self._ipc_imports_closed:
             return
         self._closed = True
-        with suppress(Exception):
-            self._ext.dispose(self._ptr)
+        if getattr(self, "_ptr", 0):
+            with suppress(Exception):
+                self._ext.dispose(self._ptr)
+            self._ptr = 0
         if self._ipc is not None:
             for shared in self._owned_buffers:
                 for ptr in shared.remote_ptrs:
                     with suppress(Exception):
                         self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._ipc_imports_closed = True
+
+    def _free_ipc_exports(self) -> None:
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports()
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
                 with suppress(Exception):
                     self._ipc.cudaFree(shared.local_ptr)
         self._owned_buffers.clear()
+        self._ipc_exports_freed = True
+
+    def close(self) -> None:
+        self._close_ipc_imports()
+        self._free_ipc_exports()
 
     def __del__(self) -> None:
         with suppress(Exception):
@@ -618,12 +636,16 @@ class PCIeDCPA2APool:
         self._all_channels = retained
         self._channels = dict(channels)
 
-        closed: set[int] = set()
-        for channel in transient:
-            channel_id = id(channel)
-            if channel_id not in retained_ids and channel_id not in closed:
-                closed.add(channel_id)
-                channel.close()
+        channels_to_close = tuple(
+            dict.fromkeys(
+                channel for channel in transient if id(channel) not in retained_ids
+            )
+        )
+        _coordinated_close_channels(
+            channels_to_close,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
     def for_stream(self, stream: object = None) -> PCIeDCPA2A:
         if self._closed:

--- a/b12x/distributed/pcie_dcp_a2a.py
+++ b/b12x/distributed/pcie_dcp_a2a.py
@@ -587,6 +587,44 @@ class PCIeDCPA2APool:
         self._all_channels.append(channel)
         return channel
 
+    def checkpoint_channels(self) -> tuple[int, dict[int, PCIeDCPA2A]]:
+        """Snapshot channel ownership before a throwaway graph capture."""
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2APool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot checkpoint channels during capture")
+        return len(self._all_channels), dict(self._channels)
+
+    def rollback_channels(
+        self,
+        checkpoint: tuple[int, dict[int, PCIeDCPA2A]],
+    ) -> None:
+        """Close channels created after ``checkpoint`` and restore mappings.
+
+        Callers must destroy and synchronize any graphs that reference the
+        transient channels before rolling back.
+        """
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2APool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot roll back channels during capture")
+        all_channels_len, channels = checkpoint
+        if not 0 <= all_channels_len <= len(self._all_channels):
+            raise ValueError("channel checkpoint does not belong to this pool")
+
+        retained = self._all_channels[:all_channels_len]
+        retained_ids = {id(channel) for channel in retained}
+        transient = self._all_channels[all_channels_len:]
+        self._all_channels = retained
+        self._channels = dict(channels)
+
+        closed: set[int] = set()
+        for channel in transient:
+            channel_id = id(channel)
+            if channel_id not in retained_ids and channel_id not in closed:
+                closed.add(channel_id)
+                channel.close()
+
     def for_stream(self, stream: object = None) -> PCIeDCPA2A:
         if self._closed:
             raise RuntimeError("PCIeDCPA2APool is closed")

--- a/b12x/distributed/pcie_dcp_a2a.py
+++ b/b12x/distributed/pcie_dcp_a2a.py
@@ -512,6 +512,7 @@ class PCIeDCPA2APool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeDCPA2A] = {}
+        self._all_channels: list[PCIeDCPA2A] = []
         self._capture_channel_stack: list[PCIeDCPA2A] = []
         self._closed = False
         if channel_factory is None and exchange_group is None:
@@ -583,6 +584,7 @@ class PCIeDCPA2APool:
                 stream_affine=not self.single_channel,
             )
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
 
     def for_stream(self, stream: object = None) -> PCIeDCPA2A:
@@ -594,6 +596,17 @@ class PCIeDCPA2APool:
         else:
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)
+        if (
+            not self.single_channel
+            and _is_current_stream_capturing(self.device)
+            and self._capture_channel_stack
+        ):
+            # Independent graph managers may reuse a torch-owned nested stream
+            # key. The enclosing capture, not a stale key mapping, determines
+            # which IPC channel is safe for this graph.
+            channel = self._capture_channel_stack[-1]
+            self._channels[key] = channel
+            return channel
         channel = self._channels.get(key)
         if channel is not None:
             return channel
@@ -676,7 +689,20 @@ class PCIeDCPA2APool:
     @contextmanager
     def capture(self, stream: object = None):
         """Bind nested CUDA captures to the enclosing stream's channel."""
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe DCP A2A capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            key = 0 if stream_key is None else int(stream_key)
+            # Keep a graph-owned channel even when CUDA recycles the enclosing
+            # stream handle used by a previously captured graph manager.
+            channel = self._new_channel(stream_key)
+            self._channels[key] = channel
         self._capture_channel_stack.append(channel)
         try:
             yield channel
@@ -690,10 +716,11 @@ class PCIeDCPA2APool:
             return
         self._closed = True
         seen: set[int] = set()
-        for channel in self._channels.values():
+        for channel in (*self._all_channels, *self._channels.values()):
             if id(channel) not in seen:
                 seen.add(id(channel))
                 channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -1024,6 +1024,46 @@ class PCIeOneshotAllReducePool:
         self._all_channels.append(channel)
         return channel
 
+    def checkpoint_channels(
+        self,
+    ) -> tuple[int, dict[int, PCIeOneshotAllReduce]]:
+        """Snapshot channel ownership before a throwaway graph capture."""
+        if self._closed:
+            raise RuntimeError("pool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot checkpoint channels during capture")
+        return len(self._all_channels), dict(self._channels)
+
+    def rollback_channels(
+        self,
+        checkpoint: tuple[int, dict[int, PCIeOneshotAllReduce]],
+    ) -> None:
+        """Close channels created after ``checkpoint`` and restore mappings.
+
+        Callers must destroy and synchronize any graphs that reference the
+        transient channels before rolling back.
+        """
+        if self._closed:
+            raise RuntimeError("pool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot roll back channels during capture")
+        all_channels_len, channels = checkpoint
+        if not 0 <= all_channels_len <= len(self._all_channels):
+            raise ValueError("channel checkpoint does not belong to this pool")
+
+        retained = self._all_channels[:all_channels_len]
+        retained_ids = {id(channel) for channel in retained}
+        transient = self._all_channels[all_channels_len:]
+        self._all_channels = retained
+        self._channels = dict(channels)
+
+        closed: set[int] = set()
+        for channel in transient:
+            channel_id = id(channel)
+            if channel_id not in retained_ids and channel_id not in closed:
+                closed.add(channel_id)
+                channel.close()
+
     def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
         if self._closed:
             raise RuntimeError("pool is closed")

--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -873,21 +873,24 @@ class PCIeOneshotAllReduce:
             return
         self._closed = True
         if getattr(self, "_ptr", 0):
-            self._ext.dispose(self._ptr)
+            with suppress(Exception):
+                self._ext.dispose(self._ptr)
             self._ptr = 0
-        for shared in self._owned_buffers:
-            for ptr in shared.remote_ptrs:
-                if self._ipc is not None:
-                    self._ipc.cudaIpcCloseMemHandle(ptr)
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
         self._ipc_imports_closed = True
 
     def _free_ipc_exports(self) -> None:
         if self._ipc_exports_freed:
             return
         self._close_ipc_imports()
-        for shared in self._owned_buffers:
-            if self._ipc is not None:
-                self._ipc.cudaFree(shared.local_ptr)
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                with suppress(Exception):
+                    self._ipc.cudaFree(shared.local_ptr)
         self._owned_buffers.clear()
         self._registered_input_ptrs.clear()
         self._ipc_exports_freed = True

--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -147,6 +147,30 @@ class _OwnedSharedBuffer:
     remote_ptrs: tuple[int, ...]
 
 
+def _coordinated_close_channels(
+    channels: Sequence[object],
+    *,
+    exchange_group: Optional[ProcessGroup],
+    device: torch.device,
+) -> None:
+    """Release exported CUDA IPC allocations after every peer unmaps them."""
+    unique_channels = tuple(dict.fromkeys(channels))
+    if exchange_group is None:
+        for channel in unique_channels:
+            channel.close()
+        return
+
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    dist.barrier(group=exchange_group)
+    for channel in unique_channels:
+        channel._close_ipc_imports()
+    dist.barrier(group=exchange_group)
+    for channel in unique_channels:
+        channel._free_ipc_exports()
+    dist.barrier(group=exchange_group)
+
+
 @dataclass(frozen=True)
 class _ChannelSharedBuffers:
     owned_buffer: _OwnedSharedBuffer
@@ -276,6 +300,8 @@ class PCIeOneshotAllReduce:
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
+        self._ipc_imports_closed = False
+        self._ipc_exports_freed = False
         self._ext = ext_module or _load_extension()
 
         if ext_module is None and self.device.type != "cuda":
@@ -842,8 +868,8 @@ class PCIeOneshotAllReduce:
             logger.info("\n".join(lines))
         return crossover
 
-    def close(self) -> None:
-        if self._closed:
+    def _close_ipc_imports(self) -> None:
+        if self._ipc_imports_closed:
             return
         self._closed = True
         if getattr(self, "_ptr", 0):
@@ -853,10 +879,22 @@ class PCIeOneshotAllReduce:
             for ptr in shared.remote_ptrs:
                 if self._ipc is not None:
                     self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._ipc_imports_closed = True
+
+    def _free_ipc_exports(self) -> None:
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports()
+        for shared in self._owned_buffers:
             if self._ipc is not None:
                 self._ipc.cudaFree(shared.local_ptr)
         self._owned_buffers.clear()
         self._registered_input_ptrs.clear()
+        self._ipc_exports_freed = True
+
+    def close(self) -> None:
+        self._close_ipc_imports()
+        self._free_ipc_exports()
 
     def __del__(self) -> None:
         with suppress(Exception):
@@ -1057,12 +1095,16 @@ class PCIeOneshotAllReducePool:
         self._all_channels = retained
         self._channels = dict(channels)
 
-        closed: set[int] = set()
-        for channel in transient:
-            channel_id = id(channel)
-            if channel_id not in retained_ids and channel_id not in closed:
-                closed.add(channel_id)
-                channel.close()
+        channels_to_close = tuple(
+            dict.fromkeys(
+                channel for channel in transient if id(channel) not in retained_ids
+            )
+        )
+        _coordinated_close_channels(
+            channels_to_close,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
     def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
         if self._closed:

--- a/b12x/distributed/pcie_oneshot.py
+++ b/b12x/distributed/pcie_oneshot.py
@@ -913,6 +913,7 @@ class PCIeOneshotAllReducePool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeOneshotAllReduce] = {}
+        self._all_channels: list[PCIeOneshotAllReduce] = []
         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
         self._closed = False
 
@@ -980,6 +981,7 @@ class PCIeOneshotAllReducePool:
             if self.single_channel:
                 channel._stream_affine = False
             channel._bind_stream_key(stream_key)
+            self._all_channels.append(channel)
             return channel
 
         if self.exchange_group is None or self._ipc is None or self._ext is None:
@@ -1019,6 +1021,7 @@ class PCIeOneshotAllReducePool:
                     self._ipc.cudaFree(shared.local_ptr)
             raise
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
 
     def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
@@ -1040,6 +1043,17 @@ class PCIeOneshotAllReducePool:
 
         stream_key = _current_stream_key(self.device, stream)
         channel_key = 0 if stream_key is None else int(stream_key)
+        if (
+            _is_current_stream_capturing(self.device)
+            and self._capture_channel_stack
+        ):
+            # CUDA and torch/Inductor may recycle a nested capture stream key
+            # between independent target and draft graph managers. The active
+            # enclosing capture owns the channel even if that key still maps
+            # to a channel captured by an earlier manager.
+            channel = self._capture_channel_stack[-1]
+            self._channels[channel_key] = channel
+            return channel
         channel = self._channels.get(channel_key)
         if channel is not None:
             return channel
@@ -1117,7 +1131,22 @@ class PCIeOneshotAllReducePool:
 
     @contextmanager
     def capture(self, stream: object = None):
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe oneshot capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            channel_key = 0 if stream_key is None else int(stream_key)
+            # A CUDA stream handle can be recycled after one graph manager
+            # finishes capture. Graphs retain the channel pointers, so a new
+            # manager must receive a fresh channel even when the numeric stream
+            # key is identical. _all_channels keeps replaced channels alive.
+            channel = self._new_channel(stream_key)
+            self._channels[channel_key] = channel
         with channel.capture(stream=stream):
             self._capture_channel_stack.append(channel)
             try:
@@ -1131,8 +1160,12 @@ class PCIeOneshotAllReducePool:
         if self._closed:
             return
         self._closed = True
-        for channel in self._channels.values():
-            channel.close()
+        seen: set[int] = set()
+        for channel in (*self._all_channels, *self._channels.values()):
+            if id(channel) not in seen:
+                seen.add(id(channel))
+                channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/b12x/integration/__init__.py
+++ b/b12x/integration/__init__.py
@@ -67,6 +67,7 @@ from .tp_moe import (
     plan_tp_moe_execution,
     plan_b12x_fp4_moe_weights,
     prepare_b12x_fp4_moe_weights,
+    tp_moe_plan_supports_aux_stream_overlap,
 )
 from .ep_moe import (
     EPExpertMap,
@@ -136,6 +137,7 @@ __all__ = [
     "plan_tp_moe_execution",
     "plan_b12x_fp4_moe_weights",
     "prepare_b12x_fp4_moe_weights",
+    "tp_moe_plan_supports_aux_stream_overlap",
     "EPExpertMap",
     "EPMoEFP4Binding",
     "EPMoEScratchCaps",

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8179,10 +8179,9 @@ def tp_moe_plan_supports_aux_stream_overlap(plan: TPMoEPlan) -> bool:
     if plan.num_topk <= 0 or plan.routed_rows % plan.num_topk != 0:
         return False
     # The compact native-NVFP4 micro grid is a bounded, single-wave decode
-    # launch. vLLM submits it before the auxiliary shared-expert work. M=1..7
-    # survives graph-replay concurrency stress; M=8 changes the launch geometry
-    # and corrupts output under the same stress, so that boundary and all larger
-    # resident plans must remain serialized.
+    # launch. M=1..7 survives graph-replay concurrency stress; M=8 changes the
+    # launch geometry, so that boundary and all larger resident plans must
+    # remain serialized.
     return plan.routed_rows // plan.num_topk <= 7 and _is_native_nvfp4_micro_decode(
         quant_mode=plan.quant_mode,
         num_tokens=plan.routed_rows // plan.num_topk,

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8135,6 +8135,42 @@ def _launch_dynamic_topk_sum(
     )
 
 
+def _use_barrier_free_nvfp4_split(
+    *,
+    quant_mode: str,
+    num_tokens: int,
+    activation: str,
+) -> bool:
+    """Return whether decode uses separate FC1/FC2 launches.
+
+    The fused micro kernel synchronizes its CTAs with a software grid barrier,
+    which requires exclusive residency. Splitting FC1 and FC2 removes that
+    barrier and makes the launch safe to co-schedule with CUDA work on another
+    stream.
+    """
+    return (
+        _normalize_quant_mode(quant_mode) in {"nvfp4", "w4a8_nvfp4"}
+        and 1 <= int(num_tokens) <= _MICRO_MAX_TOKENS
+        and activation == "silu"
+        and os.environ.get("B12X_NVFP4_SPLIT_DECODE", "1") != "0"
+    )
+
+
+def tp_moe_plan_supports_aux_stream_overlap(plan: TPMoEPlan) -> bool:
+    """Whether a planned MoE launch can safely overlap unrelated CUDA work."""
+    if not isinstance(plan, TPMoEPlan):
+        raise TypeError("plan must be a TPMoEPlan")
+    if plan.implementation != "micro":
+        return False
+    if plan.num_topk <= 0 or plan.routed_rows % plan.num_topk != 0:
+        return False
+    return _use_barrier_free_nvfp4_split(
+        quant_mode=plan.quant_mode,
+        num_tokens=plan.routed_rows // plan.num_topk,
+        activation=plan.activation,
+    )
+
+
 def _launch_compact_micro_flat(
     *,
     barrier_count: torch.Tensor,
@@ -8170,11 +8206,10 @@ def _launch_compact_micro_flat(
     quant_mode = _normalize_quant_mode(quant_mode)
     activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
     micro_cls = activation_spec.micro_kernel_cls
-    use_native_nvfp4_split = (
-        quant_mode == "w4a8_nvfp4"
-        and 1 <= m <= 8
-        and activation == "silu"
-        and os.environ.get("B12X_NVFP4_SPLIT_DECODE", "1") != "0"
+    use_native_nvfp4_split = _use_barrier_free_nvfp4_split(
+        quant_mode=quant_mode,
+        num_tokens=m,
+        activation=activation,
     )
     if use_native_nvfp4_split:
         # Preserve the ModelOpt NVFP4 representation and scalar math exactly.

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8135,24 +8135,38 @@ def _launch_dynamic_topk_sum(
     )
 
 
+def _is_native_nvfp4_micro_decode(
+    *,
+    quant_mode: str,
+    num_tokens: int,
+    activation: str,
+) -> bool:
+    """Return whether this is the bounded native-NVFP4 micro decode band."""
+    return (
+        _normalize_quant_mode(quant_mode) in {"nvfp4", "w4a8_nvfp4"}
+        and 1 <= int(num_tokens) <= _MICRO_MAX_TOKENS
+        and activation == "silu"
+    )
+
+
 def _use_barrier_free_nvfp4_split(
     *,
     quant_mode: str,
     num_tokens: int,
     activation: str,
 ) -> bool:
-    """Return whether decode uses separate FC1/FC2 launches.
+    """Return whether native NVFP4 decode uses separate FC1/FC2 launches.
 
-    The fused micro kernel synchronizes its CTAs with a software grid barrier,
-    which requires exclusive residency. Splitting FC1 and FC2 removes that
-    barrier and makes the launch safe to co-schedule with CUDA work on another
-    stream.
+    The split path remains available for diagnostics, but it loses the serving
+    benefit of the bounded micro launch overlapping GLM shared experts.
     """
     return (
-        _normalize_quant_mode(quant_mode) in {"nvfp4", "w4a8_nvfp4"}
-        and 1 <= int(num_tokens) <= _MICRO_MAX_TOKENS
-        and activation == "silu"
-        and os.environ.get("B12X_NVFP4_SPLIT_DECODE", "1") != "0"
+        _is_native_nvfp4_micro_decode(
+            quant_mode=quant_mode,
+            num_tokens=num_tokens,
+            activation=activation,
+        )
+        and os.environ.get("B12X_NVFP4_SPLIT_DECODE", "0") == "1"
     )
 
 
@@ -8164,7 +8178,12 @@ def tp_moe_plan_supports_aux_stream_overlap(plan: TPMoEPlan) -> bool:
         return False
     if plan.num_topk <= 0 or plan.routed_rows % plan.num_topk != 0:
         return False
-    return _use_barrier_free_nvfp4_split(
+    # The compact native-NVFP4 micro grid is a bounded, single-wave decode
+    # launch. vLLM submits it before the auxiliary shared-expert work. M=1..7
+    # survives graph-replay concurrency stress; M=8 changes the launch geometry
+    # and corrupts output under the same stress, so that boundary and all larger
+    # resident plans must remain serialized.
+    return plan.routed_rows // plan.num_topk <= 7 and _is_native_nvfp4_micro_decode(
         quant_mode=plan.quant_mode,
         num_tokens=plan.routed_rows // plan.num_topk,
         activation=plan.activation,

--- a/b12x/integration/tp_moe.py
+++ b/b12x/integration/tp_moe.py
@@ -8178,13 +8178,20 @@ def tp_moe_plan_supports_aux_stream_overlap(plan: TPMoEPlan) -> bool:
         return False
     if plan.num_topk <= 0 or plan.routed_rows % plan.num_topk != 0:
         return False
+    num_tokens = plan.routed_rows // plan.num_topk
+    if _use_barrier_free_nvfp4_split(
+        quant_mode=plan.quant_mode,
+        num_tokens=num_tokens,
+        activation=plan.activation,
+    ):
+        return False
     # The compact native-NVFP4 micro grid is a bounded, single-wave decode
     # launch. M=1..7 survives graph-replay concurrency stress; M=8 changes the
     # launch geometry, so that boundary and all larger resident plans must
     # remain serialized.
-    return plan.routed_rows // plan.num_topk <= 7 and _is_native_nvfp4_micro_decode(
+    return num_tokens <= 7 and _is_native_nvfp4_micro_decode(
         quant_mode=plan.quant_mode,
-        num_tokens=plan.routed_rows // plan.num_topk,
+        num_tokens=num_tokens,
         activation=plan.activation,
     )
 

--- a/tests/distributed/test_pcie_dcp_a2a.py
+++ b/tests/distributed/test_pcie_dcp_a2a.py
@@ -251,3 +251,57 @@ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
     assert pool._channels[70] is target_channel
     assert pool._channels[80] is draft_channel
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [1234]
+    assert draft_channel._ext.dispose_calls == [1234]

--- a/tests/distributed/test_pcie_dcp_a2a.py
+++ b/tests/distributed/test_pcie_dcp_a2a.py
@@ -342,6 +342,52 @@ def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
     assert eager_channel._ext.dispose_calls == []
 
 
+def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+    events = []
+
+    class FakeChannel:
+        def _close_ipc_imports(self):
+            events.append("close-imports")
+
+        def _free_ipc_exports(self):
+            events.append("free-exports")
+
+    group = object()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        exchange_group=group,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    retained = FakeChannel()
+    transient = FakeChannel()
+    pool._all_channels = [retained]
+    pool._channels = {3: retained}
+    checkpoint = pool.checkpoint_channels()
+    pool._all_channels.append(transient)
+    pool._channels[7] = transient
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    pool.rollback_channels(checkpoint)
+
+    assert events == [
+        "barrier",
+        "close-imports",
+        "barrier",
+        "free-exports",
+        "barrier",
+    ]
+    assert pool._all_channels == [retained]
+    assert pool._channels == {3: retained}
+
+
 def test_pool_rejects_channel_rollback_during_capture():
     pool = PCIeDCPA2APool(
         rank=0,

--- a/tests/distributed/test_pcie_dcp_a2a.py
+++ b/tests/distributed/test_pcie_dcp_a2a.py
@@ -305,3 +305,54 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
     pool.close()
     assert target_channel._ext.dispose_calls == [1234]
     assert draft_channel._ext.dispose_calls == [1234]
+
+
+def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+    created = []
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: 3 if stream is None else int(stream),
+    )
+
+    eager_channel = pool.for_stream()
+    checkpoint = pool.checkpoint_channels()
+    with pool.capture(7) as profile_channel:
+        pass
+
+    pool.rollback_channels(checkpoint)
+
+    assert pool._all_channels == [eager_channel]
+    assert pool._channels == {3: eager_channel}
+    assert profile_channel._ext.dispose_calls == [1234]
+    assert eager_channel._ext.dispose_calls == []
+
+
+def test_pool_rejects_channel_rollback_during_capture():
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    checkpoint = pool.checkpoint_channels()
+
+    with pool.capture(7), pytest.raises(RuntimeError, match="during capture"):
+        pool.rollback_channels(checkpoint)

--- a/tests/distributed/test_pcie_oneshot.py
+++ b/tests/distributed/test_pcie_oneshot.py
@@ -705,3 +705,56 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
     assert pool._channels[70] is target_channel
     assert pool._channels[80] is draft_channel
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    # CUDA may recycle both handles for the next graph manager. Neither stale
+    # mapping may make the draft graph retain the target graph's IPC channel.
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [12345]
+    assert draft_channel._ext.dispose_calls == [12345]

--- a/tests/distributed/test_pcie_oneshot.py
+++ b/tests/distributed/test_pcie_oneshot.py
@@ -835,6 +835,60 @@ def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
     assert pool._channels == {3: retained}
 
 
+def test_channel_teardown_completes_when_ipc_cleanup_raises():
+    events = []
+
+    class FailingExt:
+        def dispose(self, ptr):
+            events.append(("dispose", ptr))
+            raise RuntimeError("dispose failed")
+
+    class FailingIPC:
+        def cudaIpcCloseMemHandle(self, ptr):
+            events.append(("close", ptr))
+            raise RuntimeError("close failed")
+
+        def cudaFree(self, ptr):
+            events.append(("free", ptr))
+            raise RuntimeError("free failed")
+
+    class SharedBuffer:
+        def __init__(self, local_ptr, remote_ptrs):
+            self.local_ptr = local_ptr
+            self.remote_ptrs = remote_ptrs
+
+    channel = object.__new__(PCIeOneshotAllReduce)
+    channel._closed = False
+    channel._ipc_imports_closed = False
+    channel._ipc_exports_freed = False
+    channel._ptr = 123
+    channel._ext = FailingExt()
+    channel._ipc = FailingIPC()
+    channel._owned_buffers = [
+        SharedBuffer(1000, (2000, 3000)),
+        SharedBuffer(4000, (5000,)),
+    ]
+    channel._registered_input_ptrs = {1: (2,)}
+
+    channel.close()
+    channel.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("close", 5000),
+        ("free", 1000),
+        ("free", 4000),
+    ]
+    assert channel._ptr == 0
+    assert channel._closed
+    assert channel._ipc_imports_closed
+    assert channel._ipc_exports_freed
+    assert channel._owned_buffers == []
+    assert channel._registered_input_ptrs == {}
+
+
 def test_pool_rejects_channel_rollback_during_capture():
     pool = PCIeOneshotAllReducePool(
         rank=0,

--- a/tests/distributed/test_pcie_oneshot.py
+++ b/tests/distributed/test_pcie_oneshot.py
@@ -792,6 +792,49 @@ def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
     assert eager_channel._ext.dispose_calls == []
 
 
+def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+    events = []
+
+    class FakeChannel:
+        def _close_ipc_imports(self):
+            events.append("close-imports")
+
+        def _free_ipc_exports(self):
+            events.append("free-exports")
+
+    group = object()
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        exchange_group=group,
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    retained = FakeChannel()
+    transient = FakeChannel()
+    pool._all_channels = [retained]
+    pool._channels = {3: retained}
+    checkpoint = pool.checkpoint_channels()
+    pool._all_channels.append(transient)
+    pool._channels[7] = transient
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    pool.rollback_channels(checkpoint)
+
+    assert events == [
+        "barrier",
+        "close-imports",
+        "barrier",
+        "free-exports",
+        "barrier",
+    ]
+    assert pool._all_channels == [retained]
+    assert pool._channels == {3: retained}
+
+
 def test_pool_rejects_channel_rollback_during_capture():
     pool = PCIeOneshotAllReducePool(
         rank=0,

--- a/tests/distributed/test_pcie_oneshot.py
+++ b/tests/distributed/test_pcie_oneshot.py
@@ -758,3 +758,48 @@ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
     pool.close()
     assert target_channel._ext.dispose_calls == [12345]
     assert draft_channel._ext.dispose_calls == [12345]
+
+
+def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+    created = []
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "b12x.distributed.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: 3 if stream is None else int(stream),
+    )
+
+    eager_channel = pool.for_stream()
+    checkpoint = pool.checkpoint_channels()
+    with pool.capture(7) as profile_channel:
+        pass
+
+    pool.rollback_channels(checkpoint)
+
+    assert pool._all_channels == [eager_channel]
+    assert pool._channels == {3: eager_channel}
+    assert profile_channel._ext.dispose_calls == [12345]
+    assert eager_channel._ext.dispose_calls == []
+
+
+def test_pool_rejects_channel_rollback_during_capture():
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    checkpoint = pool.checkpoint_channels()
+
+    with pool.capture(7), pytest.raises(RuntimeError, match="during capture"):
+        pool.rollback_channels(checkpoint)

--- a/tests/test_moe_execution_model.py
+++ b/tests/test_moe_execution_model.py
@@ -4,7 +4,11 @@ import pytest
 import torch
 
 from b12x.integration import tp_moe as tp_moe_impl
-from b12x.integration import plan_b12x_fp4_moe_weights, plan_tp_moe_execution
+from b12x.integration import (
+    plan_b12x_fp4_moe_weights,
+    plan_tp_moe_execution,
+    tp_moe_plan_supports_aux_stream_overlap,
+)
 from b12x.moe.execution import (
     GemmEngine,
     MoERegime,
@@ -212,6 +216,49 @@ def test_workspace_plan_maps_kernel_family_to_execution_contract() -> None:
     assert w4a16.execution.route_block_rows is not None
 
 
+@pytest.mark.parametrize("quant_mode", ["nvfp4", "w4a8_nvfp4"])
+def test_nvfp4_split_micro_allows_aux_stream_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+    quant_mode: str,
+) -> None:
+    monkeypatch.delenv("B12X_NVFP4_SPLIT_DECODE", raising=False)
+    weights = _weight_plan(quant_mode, source_format="modelopt_nvfp4")
+    plan = plan_tp_moe_execution(
+        num_tokens=8,
+        num_topk=2,
+        device=torch.device("cpu"),
+        weight_plan=weights,
+        quant_mode=quant_mode,
+    )
+
+    assert plan.implementation == "micro"
+    assert tp_moe_plan_supports_aux_stream_overlap(plan)
+
+
+def test_aux_stream_overlap_rejects_barrier_launches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weights = _weight_plan("nvfp4", source_format="modelopt_nvfp4")
+    micro = plan_tp_moe_execution(
+        num_tokens=8,
+        num_topk=2,
+        device=torch.device("cpu"),
+        weight_plan=weights,
+        quant_mode="nvfp4",
+    )
+    dynamic = plan_tp_moe_execution(
+        num_tokens=64,
+        num_topk=2,
+        device=torch.device("cpu"),
+        weight_plan=weights,
+        quant_mode="nvfp4",
+    )
+
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "0")
+    assert not tp_moe_plan_supports_aux_stream_overlap(micro)
+    assert not tp_moe_plan_supports_aux_stream_overlap(dynamic)
+
+
 def test_workspace_plan_uses_weight_plan_source_contract() -> None:
     weights = _weight_plan(
         "w4a8_mx",
@@ -318,12 +365,9 @@ def test_non_128_aligned_e8m0_w4a16_shards_stay_source_native() -> None:
         plan = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=shard)
         assert WeightPreparationTransform.W4A16_NATIVE in plan.transforms
         assert (
-            plan.required_weight_layout("w4a16")
-            is PreparedWeightLayout.SOURCE_NATIVE
+            plan.required_weight_layout("w4a16") is PreparedWeightLayout.SOURCE_NATIVE
         )
 
     aligned = _weight_plan("w4a16", source_format="fp4_e8m0_k32", n=256)
     assert WeightPreparationTransform.W4A16_PACKED in aligned.transforms
-    assert (
-        aligned.required_weight_layout("w4a16") is PreparedWeightLayout.MMA_PACKED
-    )
+    assert aligned.required_weight_layout("w4a16") is PreparedWeightLayout.MMA_PACKED

--- a/tests/test_moe_execution_model.py
+++ b/tests/test_moe_execution_model.py
@@ -274,6 +274,22 @@ def test_native_nvfp4_split_decode_is_opt_in(
     )
 
 
+def test_native_nvfp4_split_decode_rejects_aux_stream_overlap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weights = _weight_plan("nvfp4", source_format="modelopt_nvfp4")
+    plan = plan_tp_moe_execution(
+        num_tokens=1,
+        num_topk=2,
+        device=torch.device("cpu"),
+        weight_plan=weights,
+        quant_mode="nvfp4",
+    )
+
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "1")
+    assert not tp_moe_plan_supports_aux_stream_overlap(plan)
+
+
 def test_workspace_plan_uses_weight_plan_source_contract() -> None:
     weights = _weight_plan(
         "w4a8_mx",

--- a/tests/test_moe_execution_model.py
+++ b/tests/test_moe_execution_model.py
@@ -217,14 +217,16 @@ def test_workspace_plan_maps_kernel_family_to_execution_contract() -> None:
 
 
 @pytest.mark.parametrize("quant_mode", ["nvfp4", "w4a8_nvfp4"])
-def test_nvfp4_split_micro_allows_aux_stream_overlap(
+@pytest.mark.parametrize("num_tokens", [1, 7])
+def test_native_nvfp4_micro_allows_aux_stream_overlap(
     monkeypatch: pytest.MonkeyPatch,
     quant_mode: str,
+    num_tokens: int,
 ) -> None:
     monkeypatch.delenv("B12X_NVFP4_SPLIT_DECODE", raising=False)
     weights = _weight_plan(quant_mode, source_format="modelopt_nvfp4")
     plan = plan_tp_moe_execution(
-        num_tokens=8,
+        num_tokens=num_tokens,
         num_topk=2,
         device=torch.device("cpu"),
         weight_plan=weights,
@@ -235,11 +237,11 @@ def test_nvfp4_split_micro_allows_aux_stream_overlap(
     assert tp_moe_plan_supports_aux_stream_overlap(plan)
 
 
-def test_aux_stream_overlap_rejects_barrier_launches(
+def test_aux_stream_overlap_rejects_large_resident_launches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     weights = _weight_plan("nvfp4", source_format="modelopt_nvfp4")
-    micro = plan_tp_moe_execution(
+    boundary_micro = plan_tp_moe_execution(
         num_tokens=8,
         num_topk=2,
         device=torch.device("cpu"),
@@ -255,8 +257,21 @@ def test_aux_stream_overlap_rejects_barrier_launches(
     )
 
     monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "0")
-    assert not tp_moe_plan_supports_aux_stream_overlap(micro)
+    assert not tp_moe_plan_supports_aux_stream_overlap(boundary_micro)
     assert not tp_moe_plan_supports_aux_stream_overlap(dynamic)
+
+
+def test_native_nvfp4_split_decode_is_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("B12X_NVFP4_SPLIT_DECODE", raising=False)
+    assert not tp_moe_impl._use_barrier_free_nvfp4_split(
+        quant_mode="nvfp4", num_tokens=1, activation="silu"
+    )
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "1")
+    assert tp_moe_impl._use_barrier_free_nvfp4_split(
+        quant_mode="nvfp4", num_tokens=1, activation="silu"
+    )
 
 
 def test_workspace_plan_uses_weight_plan_source_contract() -> None:

--- a/tests/test_w4a8_tp_moe.py
+++ b/tests/test_w4a8_tp_moe.py
@@ -197,3 +197,88 @@ def test_native_nvfp4_split_matches_fused(
     split = _run_mode(4, "nvfp4", seed=113)
 
     torch.testing.assert_close(split, fused, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("m", range(1, 8))
+def test_native_nvfp4_fused_micro_graph_replay_with_aux_stream_work(
+    monkeypatch: pytest.MonkeyPatch,
+    m: int,
+) -> None:
+    """The bounded native-NVFP4 decode grid is stable beside aux work."""
+    if not torch.cuda.is_available():
+        pytest.skip("No CUDA")
+    from benchmarks.benchmark_moe import make_shape_only_expert_weights
+    from b12x.integration.tp_moe import (
+        allocate_tp_moe_workspace_pool,
+        b12x_moe_fp4,
+        build_tp_moe_fp4_binding,
+        clear_tp_moe_caches,
+    )
+
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "0")
+    clear_tp_moe_caches()
+    device = torch.device("cuda")
+    spec = ModelSpec(
+        hidden_size=6144,
+        intermediate_size=2048,
+        num_experts=16,
+        top_k=8,
+        tp_size=8,
+        tp_rank=0,
+    )
+    weights = make_shape_only_expert_weights(
+        spec,
+        layer_idx=0,
+        activation="silu",
+    )
+    x, topk_ids, topk_weights = make_routed_inputs(spec, m, seed=211 + m, device=device)
+    experts = prepare_tp_moe_fp4_experts(
+        a=x,
+        a1_gscale=weights.w13_input_scale_quant_per_expert,
+        w1_fp4=weights.w13_weight,
+        w1_blockscale=weights.w13_blockscale_swizzled,
+        w1_alphas=weights.g1_alphas_per_expert,
+        a2_gscale=weights.w2_input_scale_quant_per_expert,
+        w2_fp4=weights.w2_weight,
+        w2_blockscale=weights.w2_blockscale_swizzled,
+        w2_alphas=weights.g2_alphas_per_expert,
+        quant_mode="nvfp4",
+        w13_layout=weights.w13_layout,
+    )
+    output = torch.empty_like(x)
+    binding = build_tp_moe_fp4_binding(
+        scratch=allocate_tp_moe_workspace_pool(),
+        a=x,
+        experts=experts,
+        topk_weights=topk_weights.contiguous(),
+        topk_ids=topk_ids.contiguous(),
+        output=output,
+        input_scales_static=True,
+        quant_mode="nvfp4",
+    )
+
+    b12x_moe_fp4(binding=binding)
+    torch.cuda.synchronize()
+    expected = output.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+        b12x_moe_fp4(binding=binding)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+    torch.cuda.synchronize()
+
+    aux_stream = torch.cuda.Stream()
+    aux_a = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
+    aux_b = torch.randn(2048, 2048, dtype=torch.bfloat16, device=device)
+    aux_out = torch.empty_like(aux_a)
+    for _ in range(64):
+        output.zero_()
+        aux_stream.wait_stream(torch.cuda.current_stream())
+        graph.replay()
+        with torch.cuda.stream(aux_stream):
+            torch.mm(aux_a, aux_b, out=aux_out)
+        torch.cuda.current_stream().wait_stream(aux_stream)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, expected, atol=2e-3, rtol=0.0)

--- a/tests/test_w4a8_tp_moe.py
+++ b/tests/test_w4a8_tp_moe.py
@@ -130,11 +130,19 @@ def _w4a8_oracle(m: int, seed: int) -> tuple[torch.Tensor, torch.Tensor]:
 
     out = moe_reference_w4a8_mx(
         x.float(),
-        weights.w13_weight.view(torch.uint8), w13_mx,
-        w13_res.view(torch.float8_e4m3fn), alpha1,
-        weights.w2_weight.view(torch.uint8), w2_mx,
-        w2_res.view(torch.float8_e4m3fn), alpha2,
-        topk_ids, topk_weights.float(), E, k, n,
+        weights.w13_weight.view(torch.uint8),
+        w13_mx,
+        w13_res.view(torch.float8_e4m3fn),
+        alpha1,
+        weights.w2_weight.view(torch.uint8),
+        w2_mx,
+        w2_res.view(torch.float8_e4m3fn),
+        alpha2,
+        topk_ids,
+        topk_weights.float(),
+        E,
+        k,
+        n,
         activation="silu",
     )
     return out, x
@@ -175,3 +183,17 @@ def test_w4a8_nvfp4_dispatch_tracks_nvfp4(m: int) -> None:
     ).item()
     assert cos > 0.97, (m, cos, n_ref, n_w4a8)
     assert 0.8 < n_w4a8 / n_ref < 1.25, (m, n_ref, n_w4a8)
+
+
+def test_native_nvfp4_split_matches_fused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The barrier-free native A4 launch preserves fused-kernel numerics."""
+    _skip_if_unavailable()
+
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "0")
+    fused = _run_mode(4, "nvfp4", seed=113)
+    monkeypatch.setenv("B12X_NVFP4_SPLIT_DECODE", "1")
+    split = _run_mode(4, "nvfp4", seed=113)
+
+    torch.testing.assert_close(split, fused, atol=0.0, rtol=0.0)


### PR DESCRIPTION
## Summary

- key recycled CUDA graph stream channels by capture ownership instead of a reused stream handle
- apply the same ownership rule to PCIe oneshot all-reduce and DCP A2A pools
- checkpoint disposable graph channels and roll them back after profiling captures
- coordinate rollback across ranks: synchronize, unmap every imported IPC handle, then free exported allocations only after a process-group barrier
- run native NVFP4 A4 micro decode as separate FC1/FC2 launches for M<=8, removing its resident-grid software barrier
- expose a plan capability telling vLLM when B12X MoE can safely overlap unrelated auxiliary-stream CUDA work
- retain `B12X_NVFP4_SPLIT_DECODE=0` as a diagnostic fallback

## Root causes

Two independent concurrency hazards surfaced under target/draft CUDA graphs and GLM shared-expert overlap. Recycled capture streams could inherit a channel selected for a prior capture owner. Separately, the fused B12X micro MoE launch uses a resident-grid software barrier; co-scheduling unrelated work can prevent every barrier participant from becoming resident.

Disposable profiling graphs add a lifetime constraint: all ranks must destroy graph users and unmap imported CUDA IPC allocations before any rank frees the corresponding exported slab. Rank-local close/free could otherwise leave a peer with a stale mapping. The rollback path now uses a three-barrier teardown protocol and restores only the pre-profile channel map.

The existing W4A8-on-NVFP4 two-phase launch already removed the micro barrier. This PR applies the same split to native NVFP4 A4 and exports the selected launch-plan capability. Dynamic and W4A16 resident launches remain correctly marked unsafe for external overlap.

## Validation

- 40 targeted B12X PCIe channel/lifecycle tests passed
- teardown tests assert the cross-rank `barrier -> close imports -> barrier -> free exports -> barrier` order for both pools
- native A4 fused versus split on the GLM TP8 expert shape: bit-identical, max/mean absolute difference 0
- native A4 CUDA graph replay with changed input and routing: bit-identical on two replays
- exact TP8/DCP2/MTP3 GLM reproducer passed short and 300k-token requests with the vLLM integration and native allocator
- Ruff and `git diff --check` passed

## Integration

Pair with local-inference-lab/vllm#131 for disposable profiling-graph cleanup and local-inference-lab/vllm#132 for stream/workspace isolation and MoE scheduling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed a new integration API to indicate when micro MoE plans can overlap auxiliary CUDA work.
  - Added opt-in native NVFP4 “split decode” support (eligibility rules + environment flag).
  - Added channel pool checkpoint/rollback for both PCIe DCP A2A and PCIe oneshot flows.
- **Bug Fixes**
  - Improved idempotent, ordered IPC import/export teardown and safer channel close behavior.
  - Tightened CUDA-graph capture handling and channel isolation during reused capture keys.
- **Tests**
  - Added/expanded distributed and CUDA-graph replay coverage, including rollback safety during capture and teardown resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->