### PR TITLE
fix(moe): size W4A8 scratch for padded TP shards

### DIFF
--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -1187,6 +1187,20 @@ def _is_w4a8_quant_mode(quant_mode: str) -> bool:
     return quant_mode in _W4A8_QUANT_MODES
 
 
+def _dynamic_kernel_intermediate_size(n: int, quant_mode: str) -> int:
+    """Return the intermediate extent consumed by the dynamic kernel.
+
+    Prepared W4A8-MX weights use ceil-tiled N128 storage. The launch treats
+    that zero-padded tail as part of the kernel extent, so every plan-time
+    geometry and scratch calculation must use the same padded value.
+    """
+
+    n = int(n)
+    if _normalize_quant_mode(quant_mode) == "w4a8_mx":
+        return align_up(n, 128)
+    return n
+
+
 def _micro_scale_format_for_quant_mode(quant_mode: str) -> str:
     quant_mode = _normalize_quant_mode(quant_mode)
     return "e8m0_k32" if quant_mode == "w4a8_mx" else "e4m3_k16"
@@ -2567,9 +2581,10 @@ def _plan_core_workspace(
 
     # Tile planner: must match the kernel's choice (keyed identically on the
     # workspace capacity) so the grouped task/scale scratch is sized correctly.
+    dynamic_kernel_n = _dynamic_kernel_intermediate_size(n, quant_mode)
     dynamic_tile_m, dynamic_tile_n = _select_dynamic_tile_mn(
         routed_rows,
-        n,
+        dynamic_kernel_n,
         quant_mode,
         num_experts=state_E,
         activation=activation_spec.activation,
@@ -2577,7 +2592,7 @@ def _plan_core_workspace(
     if dynamic_physical_tiles is None or dynamic_task_capacity is None:
         dynamic_tiles, _, dynamic_max_tasks = _dynamic_task_geometry(
             state_E,
-            n,
+            dynamic_kernel_n,
             routed_rows,
             tile_m=dynamic_tile_m,
             tile_n=dynamic_tile_n,
@@ -2587,12 +2602,16 @@ def _plan_core_workspace(
             activation=activation_spec.activation,
             routed_rows=routed_rows,
             num_experts=state_E,
-            n=n,
+            n=dynamic_kernel_n,
             deterministic_output=False,
         ):
             direct_groups = max(
                 1,
-                ((n + dynamic_tile_n - 1) // dynamic_tile_n + _DYNAMIC_SLICE_CHUNK - 1)
+                (
+                    (dynamic_kernel_n + dynamic_tile_n - 1) // dynamic_tile_n
+                    + _DYNAMIC_SLICE_CHUNK
+                    - 1
+                )
                 // _DYNAMIC_SLICE_CHUNK,
             )
             dynamic_tiles = max(dynamic_tiles, routed_rows)
@@ -2623,7 +2642,7 @@ def _plan_core_workspace(
     if _is_w4a8_quant_mode(quant_mode):
         materialized_intermediate_bytes = max(
             16,
-            dynamic_rows_padded * (n + n // 32),
+            dynamic_rows_padded * (dynamic_kernel_n + dynamic_kernel_n // 32),
         )
     materialized_intermediate_rows = max(
         1,
@@ -4631,7 +4650,7 @@ def _resolve_workspace_layout(
                 return "micro", max(1, routed_rows), max(1, routed_rows)
             tile_m, _ = _select_dynamic_tile_mn(
                 routed_rows,
-                n,
+                _dynamic_kernel_intermediate_size(n, quant_mode),
                 quant_mode,
                 num_experts=weight_E,
                 activation=activation,
@@ -4765,13 +4784,14 @@ def plan_tp_moe_execution(
     dynamic_tile_n = None
     max_tokens_per_launch = num_tokens
     if implementation == "dynamic":
+        dynamic_kernel_n = _dynamic_kernel_intermediate_size(n, quant_mode)
         # Tile planner (same routed_rows/n as _plan_core_workspace and the kernel
         # build) -> the task/row geometry sized here matches what the kernel
         # indexes. Must NOT use the bare _dynamic_tile_m (would size for 128 while
         # the kernel runs the planner's tile -> scratch under-size).
         dynamic_tile_m, dynamic_tile_n = _select_dynamic_tile_mn(
             routed_rows,
-            n,
+            dynamic_kernel_n,
             quant_mode,
             num_experts=state_E,
             activation=activation,
@@ -4779,7 +4799,7 @@ def plan_tp_moe_execution(
         dynamic_physical_tiles, gate_tile_cnt, dynamic_task_capacity = (
             _dynamic_task_geometry(
                 state_E,
-                n,
+                dynamic_kernel_n,
                 routed_rows,
                 tile_m=dynamic_tile_m,
                 tile_n=dynamic_tile_n,
@@ -4790,7 +4810,7 @@ def plan_tp_moe_execution(
             activation=activation,
             routed_rows=routed_rows,
             num_experts=state_E,
-            n=n,
+            n=dynamic_kernel_n,
             deterministic_output=False,
         ):
             direct_groups = max(
@@ -7619,7 +7639,7 @@ def _launch_dynamic_flat(
         # n_pad therefore computes the exact result — the padded FC1 columns
         # are silu(0)*0 = 0 and w2's padded K rows are zero. tiny_decode
         # keeps the logical-n bounds for the decode band.
-        n = -(-int(n) // 128) * 128
+        n = _dynamic_kernel_intermediate_size(n, quant_mode)
     decode_regime = bool(
         w4a8_repacked
         and _w4a8_dynamic_decode_candidate(
@@ -7675,7 +7695,9 @@ def _launch_dynamic_flat(
             raise ValueError(
                 "dynamic W4A8 materialized scratch exceeds preplanned capacity: "
                 f"need {required_intermediate_bytes} bytes, have "
-                f"{available_intermediate_bytes}"
+                f"{available_intermediate_bytes}; physical_tiles_capacity="
+                f"{physical_tiles_capacity}, selected_tile_m={selected_tile_m}, "
+                f"n={n}, routed_rows={routed_rows}, m={m}, num_topk={num_topk}"
             )
     if not multicta_enabled:
         effective_mac = 1

--- a/tests/moe/test_tp_moe_scratch_bindings.py
+++ b/tests/moe/test_tp_moe_scratch_bindings.py
@@ -470,6 +470,9 @@ def test_w4a8_mx_tp6_prefill_scratch_uses_repacked_n128_extent(
     assert execution.n == 352
     assert kernel_n == 384
     assert available_bytes >= required_bytes
+    assert available_bytes < (
+        required_bytes + execution.k * tp_moe_impl._dtype_nbytes(intermediate.dtype)
+    )
 
 
 def test_w4a16_scratch_plan_uses_route_pack_capacity_buckets(

--- a/tests/moe/test_tp_moe_scratch_bindings.py
+++ b/tests/moe/test_tp_moe_scratch_bindings.py
@@ -408,6 +408,70 @@ def test_tp_moe_scratch_plan_can_skip_route_scratch() -> None:
     assert plan.scratch_specs()[0].name == "tp_moe.scratch"
 
 
+def test_w4a8_mx_tp6_prefill_scratch_uses_repacked_n128_extent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GLM TP6 plans logical N=352 but launches its repacked N=384 extent."""
+
+    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
+    monkeypatch.setattr(tp_moe_impl, "_current_compute_capability", lambda: (12, 0))
+    weight_plan = _weight_plan(
+        "w4a8_mx",
+        source_format="fp4_e8m0_k32",
+        experts=256,
+        k=6144,
+        n=352,
+    )
+    execution = tp_moe_impl.plan_tp_moe_execution(
+        num_tokens=4096,
+        num_topk=8,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a8_mx",
+    )
+    core = tp_moe_impl._plan_core_workspace(
+        execution.implementation,
+        execution.quant_mode,
+        execution.state_E,
+        execution.weight_E,
+        execution.k,
+        execution.n,
+        execution.num_topk,
+        execution.device,
+        execution.dtype,
+        routed_rows=execution.routed_rows,
+        max_rows=execution.max_rows,
+        activation=execution.activation,
+        dynamic_physical_tiles=execution.dynamic_physical_tiles,
+        dynamic_task_capacity=execution.dynamic_task_capacity,
+        source_format=weight_plan.source_format,
+    )
+    intermediate = next(
+        spec for spec in core.tensor_specs if spec.name == "materialized_intermediate"
+    )
+    available_bytes = tp_moe_impl._tensor_numel(
+        intermediate.shape
+    ) * tp_moe_impl._dtype_nbytes(intermediate.dtype)
+    kernel_n = tp_moe_impl._dynamic_kernel_intermediate_size(
+        execution.n, execution.quant_mode
+    )
+    tile_m, _ = tp_moe_impl._select_dynamic_tile_mn(
+        execution.routed_rows,
+        kernel_n,
+        execution.quant_mode,
+        num_experts=execution.state_E,
+        activation=execution.activation,
+        compute_capability=(12, 0),
+    )
+    required_bytes = (
+        execution.dynamic_physical_tiles * tile_m * (kernel_n + kernel_n // 32)
+    )
+
+    assert execution.n == 352
+    assert kernel_n == 384
+    assert available_bytes >= required_bytes
+
+
 def test_w4a16_scratch_plan_uses_route_pack_capacity_buckets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- use the repacked N128-padded extent consistently in W4A8-MX dynamic-kernel planning and launch
- size materialized activation/scale scratch and task geometry from that physical extent
- retain the logical expert width in the public execution plan
- add diagnostics and a regression test for the exact GLM-5.2 virtual-TP6 shape

## Root cause

For virtual TP6, GLM exposes a logical per-rank expert width of `N=352`. Repacked W4A8-MX weights launch a zero-padded `N=384` kernel extent. The previous planner used 352 while the launch used 384, so the dynamic kernel could exceed its preplanned materialized-intermediate scratch during startup profiling:

```text
dynamic W4A8 materialized scratch exceeds preplanned capacity
```

The fix centralizes the physical extent in `_dynamic_kernel_intermediate_size()` and uses it for tile selection, task geometry, direct-slice eligibility, scratch sizing, and launch. Other quant modes remain unchanged.

## Validation

- `ruff check sparkinfer/moe/fused_moe/_impl.py tests/moe/test_tp_moe_scratch_bindings.py`
- `pytest -q tests/moe/test_tp_moe_scratch_bindings.py`: 29 passed
- exact E2E GLM-5.2 MXFP4/A8 TP6+DCP3 startup and inference passed
- matched TP6/DCP3 MTP0 decode: 57.27 tok/s
- matched TP6/DCP3 KV capacity: 700,449 tokens at seq=16, batch=4096, GMU=0.95

This refresh rebases the original fix onto the renamed SparkInfer tree and supersedes the earlier implementation commit without changing the PR scope.