### PR TITLE
fix(mxfp8): support tail-padded linear output

### DIFF
--- a/b12x/gemm/mxfp8_linear.py
+++ b/b12x/gemm/mxfp8_linear.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import cutlass.cute as cute
@@ -36,6 +37,19 @@ def _c_dtype_name(dtype: torch.dtype) -> str:
     if dtype == torch.float16:
         return "float16"
     raise ValueError(f"b12x MXFP8 linear output dtype must be bf16/fp16, got {dtype}")
+
+
+def _tail_padded_output(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    tail_padding_bytes: int,
+) -> torch.Tensor:
+    numel = math.prod(shape)
+    pad_numel = math.ceil(tail_padding_bytes / dtype.itemsize)
+    owner = torch.empty(numel + pad_numel, dtype=dtype, device=device)
+    return owner[:numel].view(shape)
 
 
 def _source_2d(source: torch.Tensor) -> torch.Tensor:
@@ -178,17 +192,27 @@ def _mxfp8_linear_fused_op(
     out_features: int,
     expected_m: int,
     stream_int: int | None,
+    tail_padding_bytes: int,
 ) -> torch.Tensor:
     del weight_scale_rows
     tokens = int(source_2d.shape[0])
     source_for_quant = _pad_source_2d_k(source_2d, int(padded_in_features))
     x_q = quantize_block_fp8_linear_input_mxfp8(source_for_quant)
+    output = None
+    if tail_padding_bytes > 0:
+        output = _tail_padded_output(
+            (tokens, out_features, 1),
+            dtype=source_2d.dtype,
+            device=source_2d.device,
+            tail_padding_bytes=tail_padding_bytes,
+        )
     return dense_gemm(
         (x_q.values.reshape(tokens, padded_in_features, 1), x_q.scale_mma),
         (
             weight_values.reshape(out_features, padded_in_features, 1),
             weight_scale_mma,
         ),
+        out=output,
         ab_dtype="float8_e4m3fn",
         sf_dtype="float8_e8m0fnu",
         c_dtype=_c_dtype_name(source_2d.dtype),
@@ -210,8 +234,9 @@ def _mxfp8_linear_fused_fake(
     out_features: int,
     expected_m: int,
     stream_int: int | None,
+    tail_padding_bytes: int,
 ) -> torch.Tensor:
-    del stream_int
+    del stream_int, tail_padding_bytes
     del weight_values, weight_scale_rows, weight_scale_mma
     del in_features, padded_in_features, expected_m
     return torch.empty(
@@ -228,6 +253,7 @@ def mxfp8_linear(
     bias: torch.Tensor | None = None,
     expected_m: int | None = None,
     stream: object = None,
+    tail_padding_bytes: int = 0,
 ) -> torch.Tensor:
     """Run a ModelOpt MXFP8 linear through the native b12x dense GEMM path."""
 
@@ -235,6 +261,8 @@ def mxfp8_linear(
     if not isinstance(packed_weight, MXFP8LinearWeight):
         raise TypeError("packed_weight must be an MXFP8LinearWeight")
     source_2d = _source_2d(source)
+    if tail_padding_bytes < 0:
+        raise ValueError("tail_padding_bytes must be non-negative")
     tokens, in_features = map(int, source_2d.shape)
     if in_features != int(packed_weight.in_features):
         raise ValueError(
@@ -246,7 +274,12 @@ def mxfp8_linear(
 
     out_features = int(packed_weight.out_features)
     if tokens == 0:
-        output = source_2d.new_empty((0, out_features))
+        output = _tail_padded_output(
+            (0, out_features),
+            dtype=source_2d.dtype,
+            device=source_2d.device,
+            tail_padding_bytes=tail_padding_bytes,
+        )
     else:
         output = torch.ops.b12x.mxfp8_linear_fused(
             source_2d,
@@ -258,9 +291,10 @@ def mxfp8_linear(
             packed_weight.out_features,
             int(expected_m) if expected_m is not None else tokens,
             cuda_stream_to_int(stream),
+            tail_padding_bytes,
         )
     if bias is not None:
-        output = output + bias
+        output.add_(bias)
     return output.view(*source.shape[:-1], out_features)
 
 

--- a/b12x/gemm/mxfp8_linear.py
+++ b/b12x/gemm/mxfp8_linear.py
@@ -236,9 +236,16 @@ def _mxfp8_linear_fused_fake(
     stream_int: int | None,
     tail_padding_bytes: int,
 ) -> torch.Tensor:
-    del stream_int, tail_padding_bytes
+    del stream_int
     del weight_values, weight_scale_rows, weight_scale_mma
     del in_features, padded_in_features, expected_m
+    if tail_padding_bytes > 0:
+        return _tail_padded_output(
+            (source_2d.shape[0], out_features),
+            dtype=source_2d.dtype,
+            device=source_2d.device,
+            tail_padding_bytes=tail_padding_bytes,
+        )
     return torch.empty(
         (source_2d.shape[0], out_features),
         dtype=source_2d.dtype,

--- a/tests/test_gemm_mxfp8_linear.py
+++ b/tests/test_gemm_mxfp8_linear.py
@@ -6,6 +6,7 @@ import torch
 
 from b12x.gemm.block_fp8_linear import quantize_block_fp8_linear_input_mxfp8
 from b12x.gemm.mxfp8_linear import (
+    _mxfp8_linear_fused_fake,
     mxfp8_linear,
     pack_mxfp8_linear_weight,
 )
@@ -76,6 +77,27 @@ def _storage_tail_bytes(tensor: torch.Tensor) -> int:
     )
     logical_end = (last_item + 1) * tensor.element_size()
     return tensor.untyped_storage().nbytes() - logical_end
+
+
+def test_mxfp8_linear_fake_models_tail_padded_storage() -> None:
+    source = torch.empty((3, 128), dtype=torch.bfloat16)
+    placeholder = torch.empty(1)
+
+    output = _mxfp8_linear_fused_fake(
+        source,
+        placeholder,
+        placeholder,
+        placeholder,
+        128,
+        128,
+        64,
+        3,
+        None,
+        8 * 1024,
+    )
+
+    assert output.shape == (3, 64)
+    assert _storage_tail_bytes(output) >= 8 * 1024
 
 
 def test_mxfp8_linear_matches_quantized_reference_small_n() -> None:
@@ -162,9 +184,7 @@ def test_mxfp8_linear_default_fused_path_captures_with_k_padding() -> None:
     weight, weight_scale = _quantize_modelopt_mxfp8_rows(weight_bf16)
     packed = pack_mxfp8_linear_weight(weight, weight_scale)
 
-    eager = mxfp8_linear(
-        source, packed, tail_padding_bytes=64 * 1024
-    ).clone()
+    eager = mxfp8_linear(source, packed, tail_padding_bytes=64 * 1024).clone()
     torch.cuda.synchronize()
 
     mxfp8_linear(source, packed, tail_padding_bytes=64 * 1024)
@@ -197,9 +217,7 @@ def test_mxfp8_linear_writes_directly_to_tail_padded_output() -> None:
     packed = pack_mxfp8_linear_weight(weight, weight_scale)
 
     expected = mxfp8_linear(source, packed, bias=bias)
-    actual = mxfp8_linear(
-        source, packed, bias=bias, tail_padding_bytes=64 * 1024
-    )
+    actual = mxfp8_linear(source, packed, bias=bias, tail_padding_bytes=64 * 1024)
     torch.cuda.synchronize()
 
     assert _storage_tail_bytes(actual) >= 64 * 1024

--- a/tests/test_gemm_mxfp8_linear.py
+++ b/tests/test_gemm_mxfp8_linear.py
@@ -69,6 +69,15 @@ def _reference_from_packed(source: torch.Tensor, packed_weight) -> torch.Tensor:
     return x_deq @ w_deq.T
 
 
+def _storage_tail_bytes(tensor: torch.Tensor) -> int:
+    last_item = tensor.storage_offset() + sum(
+        (size - 1) * stride
+        for size, stride in zip(tensor.shape, tensor.stride(), strict=True)
+    )
+    logical_end = (last_item + 1) * tensor.element_size()
+    return tensor.untyped_storage().nbytes() - logical_end
+
+
 def test_mxfp8_linear_matches_quantized_reference_small_n() -> None:
     require_sm120()
     require_mxf8_mma()
@@ -153,16 +162,45 @@ def test_mxfp8_linear_default_fused_path_captures_with_k_padding() -> None:
     weight, weight_scale = _quantize_modelopt_mxfp8_rows(weight_bf16)
     packed = pack_mxfp8_linear_weight(weight, weight_scale)
 
-    eager = mxfp8_linear(source, packed).clone()
+    eager = mxfp8_linear(
+        source, packed, tail_padding_bytes=64 * 1024
+    ).clone()
     torch.cuda.synchronize()
 
-    mxfp8_linear(source, packed)
+    mxfp8_linear(source, packed, tail_padding_bytes=64 * 1024)
     torch.cuda.synchronize()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        actual = mxfp8_linear(source, packed)
+        actual = mxfp8_linear(source, packed, tail_padding_bytes=64 * 1024)
     for _ in range(3):
         graph.replay()
     torch.cuda.synchronize()
 
+    assert _storage_tail_bytes(actual) >= 64 * 1024
     torch.testing.assert_close(actual, eager, rtol=0, atol=0)
+
+
+def test_mxfp8_linear_writes_directly_to_tail_padded_output() -> None:
+    require_sm120()
+    require_mxf8_mma()
+    torch.manual_seed(20260720)
+
+    tokens, in_features, out_features = 6, 128, 64
+    source = torch.randn(
+        (tokens, in_features), device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    weight_bf16 = torch.randn(
+        (out_features, in_features), device="cuda", dtype=torch.bfloat16
+    ).contiguous()
+    bias = torch.randn((out_features,), device="cuda", dtype=torch.bfloat16)
+    weight, weight_scale = _quantize_modelopt_mxfp8_rows(weight_bf16)
+    packed = pack_mxfp8_linear_weight(weight, weight_scale)
+
+    expected = mxfp8_linear(source, packed, bias=bias)
+    actual = mxfp8_linear(
+        source, packed, bias=bias, tail_padding_bytes=64 * 1024
+    )
+    torch.cuda.synchronize()
+
+    assert _storage_tail_bytes(actual) >= 64 * 1024
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Add an optional `tail_padding_bytes` argument to the native MXFP8 linear path and write the dense GEMM result directly into output storage with a mapped tail.

## Why

The vLLM GLM MLA path feeds some linear outputs into SM120 cuBLAS strided BMMs. The guarded repro showed cuBLAS may read up to the next 64 KiB boundary past the logical BF16 tensor end for the relevant `_v_up_proj` shape. Normal PyTorch allocations usually hide this with allocator slack; tight custom/provided buffers can fault.

This change lets vLLM request a small mapped tail for MXFP8 linear outputs without adding a separate hot-path `.clone()` / `.contiguous()` copy.

## Changes

- Add internal tail-padded output allocation for `mxfp8_linear`.
- Pass that output directly to `dense_gemm(..., out=...)`.
- Preserve existing default behavior when `tail_padding_bytes=0`.
- Apply bias in-place after GEMM so the padded storage owner is preserved.
- Extend the CUDA test to assert the tail-padding contract, including the bias path.

## Validation

- `python -m pytest -q tests/test_gemm_mxfp8_linear.py -k "test_mxfp8_linear_writes_directly_to_tail_padded_output"` in a CUDA 13.2 diagnostic container: 1 passed.
- Direct CUDA smoke test with bias: output shape `[6, 64]`, tail bytes `65536`, bitwise match against the non-tail-padded path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional tail padding for MXFP8 linear outputs via `tail_padding_bytes`, reserving extra output storage.
  * Works across normal execution, zero-token handling, and CUDA graph capture/replay.
  * Added input validation to reject negative `tail_padding_bytes`.
  * Bias is now applied in place on the output.
* **Tests**
  * Added assertions for tail-padded storage behavior and numerical equivalence with non-tail-padded outputs.
  * Updated CUDA graph capture/replay coverage to include tail padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->