### PR TITLE
Fix AttributeError in benchmark_nsa_indexer.py

### DIFF
--- a/benchmarks/benchmark_nsa_indexer.py
+++ b/benchmarks/benchmark_nsa_indexer.py
@@ -597,7 +597,7 @@ def main() -> None:
     cache_lens = _parse_csv_ints(args.cache_lens)
     decode_rows = _parse_csv_ints(args.decode_rows)
     extend_batches = _parse_csv_ints(args.extend_batches)
-    contiguous_q_lens = _parse_csv_ints(args.contiguous_q_lens)
+    contiguous_q_lens = _parse_csv_ints(args.extend_q_lens)
 
     case_seed = args.seed
     if args.mode in ("decode", "both"):


### PR DESCRIPTION
## Summary

`benchmarks/benchmark_nsa_indexer.py` reads `args.contiguous_q_lens` at line 609,
but the argparse flag is `--extend-q-lens` (no `dest` override), so every
invocation — including the default `--mode decode`, since the read sits above the
mode branches — crashes at startup with AttributeError.

The mismatch came from ad997e2 (extend -> contiguous API rename): the local
variable and the attribute access were renamed, but the CLI flag kept its
`--extend-q-lens` name. Fixing the consumer (rather than adding a new
`--contiguous-q-lens` flag, as the issue suggests) keeps the CLI surface
consistent with `--extend-batches` and `--mode extend`.

Fixes #12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected command-line handling for extended query lengths in benchmark tooling.
  * Eager-prefill chunk sizing now uses the values provided with the extend query lengths option.
  * Benchmark runs in extend/both modes now iterate query-length values as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->