### PR TITLE
fix(pcie): support head-major DCP reduce outputs

### DIFF
--- a/sparkinfer/attention/_shared/workspace.py
+++ b/sparkinfer/attention/_shared/workspace.py
@@ -201,10 +201,15 @@ def _split_tmp_output_stride(
     num_q_heads: int,
     max_chunks_per_row: int,
     v_head_dim: int,
+    head_major_output: bool = False,
 ) -> tuple[int, int, int, int]:
     del max_chunks_per_row
-    row_stride = int(num_q_heads) * int(v_head_dim)
-    head_stride = int(v_head_dim)
+    if head_major_output:
+        row_stride = int(v_head_dim)
+        head_stride = int(max_total_q) * int(v_head_dim)
+    else:
+        row_stride = int(num_q_heads) * int(v_head_dim)
+        head_stride = int(v_head_dim)
     chunk_stride = int(max_total_q) * int(num_q_heads) * int(v_head_dim)
     return (row_stride, head_stride, chunk_stride, 1)
 
@@ -236,11 +241,26 @@ def _allocate_split_tmp_output(
     )
 
 
-def _split_output_buffer_from_tmp(tmp_output: torch.Tensor) -> torch.Tensor:
+def _split_output_buffer_from_tmp(
+    tmp_output: torch.Tensor,
+    *,
+    head_major_output: bool = False,
+) -> torch.Tensor:
     if tmp_output.ndim != 4:
         raise ValueError(f"tmp_output must be rank 4, got {tmp_output.ndim}")
     output = tmp_output[:, :, 0, :]
-    if not output.is_contiguous():
+    if head_major_output:
+        expected_stride = (
+            int(output.shape[2]),
+            int(output.shape[0]) * int(output.shape[2]),
+            1,
+        )
+        if tuple(output.stride()) != expected_stride:
+            raise RuntimeError(
+                "split MLA tmp_output layout must make chunk 0 head-major: "
+                f"expected stride={expected_stride}, got {tuple(output.stride())}"
+            )
+    elif not output.is_contiguous():
         raise RuntimeError(
             "split MLA tmp_output layout must make chunk 0 a contiguous output buffer"
         )

--- a/sparkinfer/attention/sparse_mla/_scratch.py
+++ b/sparkinfer/attention/sparse_mla/_scratch.py
@@ -53,6 +53,7 @@ class SPARKINFERSparseMLAScratchCaps:
     max_chunks_per_row: int = 64
     max_q_chunks: int | None = None
     page_size: int = 64
+    head_major_output: bool = False
 
     def __post_init__(self) -> None:
         device = torch.device(self.device)
@@ -110,6 +111,7 @@ class SPARKINFERSparseMLAScratch:
     mode: str = "decode"
     fixed_capacity: bool = True
     use_cuda_graph: bool = False
+    head_major_output: bool = False
     tmp_output: torch.Tensor | None = None
     tmp_lse: torch.Tensor | None = None
     output_buffer: torch.Tensor | None = None
@@ -180,8 +182,6 @@ def _validate_q(q: torch.Tensor, *, scratch: object) -> torch.Tensor:
         raise ValueError(f"q must be rank-3, got {tuple(q.shape)}")
     if q.dtype != scratch.dtype:
         raise TypeError(f"q must have dtype {scratch.dtype}, got {q.dtype}")
-    if not q.is_contiguous():
-        raise ValueError("q must be contiguous")
     _validate_device(q, scratch=scratch, name="q")
     if int(q.shape[0]) > int(scratch.max_total_q):
         raise ValueError(
@@ -195,6 +195,8 @@ def _validate_q(q: torch.Tensor, *, scratch: object) -> torch.Tensor:
         raise ValueError(
             f"q head_dim {int(q.shape[2])} does not match scratch head_dim {scratch.head_dim}"
         )
+    if not q.is_contiguous():
+        raise ValueError("q must be contiguous")
     return q.detach()
 
 
@@ -396,10 +398,14 @@ def _materialize_sparse_mla_scratch(
                 num_q_heads=num_q_heads,
                 max_chunks_per_row=max_chunks_per_row,
                 v_head_dim=v_head_dim,
+                head_major_output=caps.head_major_output,
             ),
             dtype=caps.dtype,
         )
-        output_buffer = _split_output_buffer_from_tmp(tmp_output)
+        output_buffer = _split_output_buffer_from_tmp(
+            tmp_output,
+            head_major_output=caps.head_major_output,
+        )
         tmp_lse, _ = materialize_scratch_view(
             scratch_storage,
             offset_bytes=layout.tmp_lse_offset_bytes,
@@ -425,12 +431,21 @@ def _materialize_sparse_mla_scratch(
             dtype=torch.int32,
         )
     else:
-        output_buffer, _ = materialize_scratch_view(
-            scratch_storage,
-            offset_bytes=layout.output_offset_bytes,
-            shape=(max_total_q, num_q_heads, v_head_dim),
-            dtype=caps.dtype,
-        )
+        if caps.head_major_output:
+            output_buffer, _ = materialize_scratch_strided_view(
+                scratch_storage,
+                offset_bytes=layout.output_offset_bytes,
+                shape=(max_total_q, num_q_heads, v_head_dim),
+                stride=(v_head_dim, max_total_q * v_head_dim, 1),
+                dtype=caps.dtype,
+            )
+        else:
+            output_buffer, _ = materialize_scratch_view(
+                scratch_storage,
+                offset_bytes=layout.output_offset_bytes,
+                shape=(max_total_q, num_q_heads, v_head_dim),
+                dtype=caps.dtype,
+            )
 
     sm_scale_tensor, _ = materialize_scratch_view(
         scratch_storage,
@@ -453,6 +468,7 @@ def _materialize_sparse_mla_scratch(
         max_chunks_per_row=max_chunks_per_row,
         page_size=caps.page_size,
         mode=caps.mode,
+        head_major_output=caps.head_major_output,
         tmp_output=tmp_output,
         tmp_lse=tmp_lse,
         output_buffer=output_buffer,

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -152,7 +152,11 @@ __global__ void __launch_bounds__(512, 1)
                           RankStaging staging, int64_t lse_offset,
                           RankSignals signals, Signal *self,
                           T *__restrict__ output, int rank, int batch,
-                          int total_heads, int head_dim, bool natural_log) {
+                          int total_heads, int head_dim,
+                          int64_t input_stride_batch,
+                          int64_t input_stride_head,
+                          int64_t output_stride_batch,
+                          int64_t output_stride_head, bool natural_log) {
   constexpr int kPackElems = 8;
   const int heads_per_rank = total_heads / world_size;
   const int packs_per_head = head_dim / kPackElems;
@@ -175,9 +179,12 @@ __global__ void __launch_bounds__(512, 1)
     for (int dest = 0; dest < world_size; ++dest) {
       const int64_t source_row = int64_t(batch_index) * total_heads +
                                  dest * heads_per_rank + local_head;
-      const int64_t base = source_row * packs_per_head;
+      const int64_t input_base =
+          int64_t(batch_index) * input_stride_batch +
+          int64_t(dest * heads_per_rank + local_head) * input_stride_head;
+      const int64_t staging_base = source_row * packs_per_head;
       for (int pack = lane; pack < packs_per_head; pack += warpSize) {
-        staging_out[base + pack] = local_packs[base + pack];
+        staging_out[staging_base + pack] = local_packs[input_base + pack];
       }
       if (lane == 0) {
         staging_lse[source_row] = local_lse[source_row];
@@ -240,12 +247,19 @@ __global__ void __launch_bounds__(512, 1)
     }
     const float inv_weight_sum = 1.0f / fmaxf(weight_sum, 1.0e-10f);
 
-    const int64_t source_base = source_row * packs_per_head;
-    const int64_t output_base = int64_t(row) * packs_per_head;
+    const int64_t staging_base = source_row * packs_per_head;
+    const int64_t local_base =
+        int64_t(batch_index) * input_stride_batch +
+        int64_t(global_head) * input_stride_head;
+    const int64_t output_base =
+        int64_t(batch_index) * output_stride_batch +
+        int64_t(local_head) * output_stride_head;
     for (int pack = lane; pack < packs_per_head; pack += warpSize) {
       float accum[kPackElems] = {};
 #pragma unroll
       for (int i = 0; i < world_size; ++i) {
+        const int src = (rank + i) % world_size;
+        const int64_t source_base = src == rank ? local_base : staging_base;
         const Pack<T> values = rot_packs[i][source_base + pack];
         const float weight = weights[i] * inv_weight_sum;
 #pragma unroll
@@ -348,7 +362,10 @@ public:
   template <typename T>
   void run(cudaStream_t stream, const T *partial_output,
            const float *partial_lse, T *output, int batch, int total_heads,
-           int head_dim, bool natural_log, int threads, int block_limit) {
+           int head_dim, int64_t input_stride_batch,
+           int64_t input_stride_head, int64_t output_stride_batch,
+           int64_t output_stride_head, bool natural_log, int threads,
+           int block_limit) {
     const int64_t output_elems = int64_t(batch) * total_heads * head_dim;
     const int64_t lse_elems = int64_t(batch) * total_heads;
     if (output_elems > output_capacity_elems_ || lse_elems > lse_capacity_) {
@@ -389,7 +406,9 @@ public:
 #define LAUNCH(world)                                                          \
   dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
       partial_output, partial_lse, staging_[slot], lse_offset_, signals_,      \
-      self_signal_, output, rank_, batch, total_heads, head_dim, natural_log)
+      self_signal_, output, rank_, batch, total_heads, head_dim,               \
+      input_stride_batch, input_stride_head, output_stride_batch,              \
+      output_stride_head, natural_log)
     switch (world_size_) {
     case 2:
       LAUNCH(2);
@@ -503,8 +522,7 @@ static void lse_reduce_scatter(fptr_t pointer, torch::Tensor &partial_output,
 
   TORCH_CHECK(partial_output.is_cuda() && partial_lse.is_cuda() &&
               output.is_cuda());
-  TORCH_CHECK(partial_output.is_contiguous() && partial_lse.is_contiguous() &&
-              output.is_contiguous());
+  TORCH_CHECK(partial_lse.is_contiguous());
   TORCH_CHECK_EQ(partial_output.dim(), 3);
   TORCH_CHECK_EQ(partial_lse.dim(), 2);
   TORCH_CHECK_EQ(output.dim(), 3);
@@ -521,6 +539,35 @@ static void lse_reduce_scatter(fptr_t pointer, torch::Tensor &partial_output,
   TORCH_CHECK_EQ(output.size(0), batch);
   TORCH_CHECK_EQ(output.size(1), total_heads / runtime->world_size_);
   TORCH_CHECK_EQ(output.size(2), head_dim);
+  TORCH_CHECK_EQ(partial_output.stride(2), 1);
+  TORCH_CHECK_EQ(output.stride(2), 1);
+
+  const auto input_heads = partial_output.size(1);
+  const auto output_heads = output.size(1);
+  const bool input_token_major =
+      partial_output.stride(0) == input_heads * head_dim &&
+      partial_output.stride(1) == head_dim;
+  const bool input_head_major =
+      partial_output.stride(0) == head_dim &&
+      partial_output.stride(1) >= batch * head_dim;
+  const bool output_token_major =
+      output.stride(0) == output_heads * head_dim &&
+      output.stride(1) == head_dim;
+  const bool output_head_major =
+      output.stride(0) == head_dim && output.stride(1) >= batch * head_dim;
+  TORCH_CHECK(input_token_major || input_head_major,
+              "partial_output must be packed token-major or head-major");
+  TORCH_CHECK(output_token_major || output_head_major,
+              "output must be packed token-major or head-major");
+  TORCH_CHECK_EQ(partial_output.stride(0) % 8, 0);
+  TORCH_CHECK_EQ(partial_output.stride(1) % 8, 0);
+  TORCH_CHECK_EQ(output.stride(0) % 8, 0);
+  TORCH_CHECK_EQ(output.stride(1) % 8, 0);
+
+  const int64_t input_stride_batch = partial_output.stride(0) / 8;
+  const int64_t input_stride_head = partial_output.stride(1) / 8;
+  const int64_t output_stride_batch = output.stride(0) / 8;
+  const int64_t output_stride_head = output.stride(1) / 8;
 
   switch (partial_output.scalar_type()) {
   case at::ScalarType::Half:
@@ -528,8 +575,9 @@ static void lse_reduce_scatter(fptr_t pointer, torch::Tensor &partial_output,
                  reinterpret_cast<const half *>(partial_output.data_ptr()),
                  reinterpret_cast<const float *>(partial_lse.data_ptr()),
                  reinterpret_cast<half *>(output.data_ptr()), int(batch),
-                 int(total_heads), int(head_dim), natural_log, int(threads),
-                 int(block_limit));
+                 int(total_heads), int(head_dim), input_stride_batch,
+                 input_stride_head, output_stride_batch, output_stride_head,
+                 natural_log, int(threads), int(block_limit));
     break;
   case at::ScalarType::BFloat16:
     runtime->run(
@@ -537,8 +585,9 @@ static void lse_reduce_scatter(fptr_t pointer, torch::Tensor &partial_output,
         reinterpret_cast<const nv_bfloat16 *>(partial_output.data_ptr()),
         reinterpret_cast<const float *>(partial_lse.data_ptr()),
         reinterpret_cast<nv_bfloat16 *>(output.data_ptr()), int(batch),
-        int(total_heads), int(head_dim), natural_log, int(threads),
-        int(block_limit));
+        int(total_heads), int(head_dim), input_stride_batch,
+        input_stride_head, output_stride_batch, output_stride_head,
+        natural_log, int(threads), int(block_limit));
     break;
   default:
     TORCH_CHECK(false, "partial_output must be float16 or bfloat16");

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -40,11 +40,11 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         stride_batch == heads * head_dim and stride_head == head_dim
     )
     capacity_strided_head_major = (
-        stride_batch == head_dim and stride_head >= batch * head_dim
+        stride_batch == head_dim
+        and stride_head >= batch * head_dim
+        and stride_head % 8 == 0
     )
     return packed_token_major or capacity_strided_head_major
-
-
 @dataclass(frozen=True)
 class _StagingLayout:
     signal_bytes: int

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -30,6 +30,21 @@ SUPPORTED_WORLD_SIZES = (2, 4, 8)
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 
 
+def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+    """Accept packed token-major or capacity-strided head-major BHD views."""
+    if tensor.ndim != 3 or int(tensor.stride(2)) != 1:
+        return False
+    batch, heads, head_dim = (int(value) for value in tensor.shape)
+    stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+    packed_token_major = (
+        stride_batch == heads * head_dim and stride_head == head_dim
+    )
+    capacity_strided_head_major = (
+        stride_batch == head_dim and stride_head >= batch * head_dim
+    )
+    return packed_token_major or capacity_strided_head_major
+
+
 @dataclass(frozen=True)
 class _StagingLayout:
     signal_bytes: int
@@ -367,12 +382,14 @@ class PCIeDCPA2A:
             raise ValueError(
                 f"output shape must be {expected_out}, got {tuple(out.shape)}"
             )
-        if not partial_output.is_contiguous():
-            raise ValueError("partial_output must be contiguous")
+        if not _is_supported_bhd_layout(partial_output):
+            raise ValueError(
+                "partial_output must be packed token-major or head-major"
+            )
         if not partial_lse.is_contiguous():
             raise ValueError("partial_lse must be contiguous")
-        if not out.is_contiguous():
-            raise ValueError("output must be contiguous")
+        if not _is_supported_bhd_layout(out):
+            raise ValueError("output must be packed token-major or head-major")
 
     def lse_reduce_scatter(
         self,

--- a/tests/attention/test_compressed_scratch_bindings.py
+++ b/tests/attention/test_compressed_scratch_bindings.py
@@ -535,6 +535,41 @@ def test_sparse_mla_scratch_plan_exposes_one_opaque_arena_spec() -> None:
     assert plan.layout.nbytes == specs[0].nbytes
 
 
+@pytest.mark.parametrize("mode", ["decode", "extend"])
+def test_sparse_mla_scratch_can_expose_head_major_output(mode: str) -> None:
+    caps = SPARKINFERSparseMLAScratchCaps(
+        device="cpu",
+        num_q_heads=8,
+        max_q_rows=6,
+        max_width=32,
+        head_dim=576,
+        v_head_dim=512,
+        mode=mode,
+        max_chunks_per_row=4,
+        head_major_output=True,
+    )
+    plan = plan_sparse_mla_scratch(caps)
+    scratch = _one_scratch(plan)
+    q = torch.empty((6, 8, 576), dtype=torch.bfloat16)
+    binding = plan.bind(
+        scratch=scratch,
+        q=q,
+        selected_indices=torch.empty((6, 32), dtype=torch.int32),
+        cache_seqlens_int32=torch.empty((6,), dtype=torch.int32),
+        nsa_cache_seqlens_int32=torch.empty((6,), dtype=torch.int32),
+    )
+
+    output = binding.scratch.output_buffer
+    assert output is not None
+    assert output.shape == (6, 8, 512)
+    assert output.stride() == (512, 6 * 512, 1)
+    assert not output.is_contiguous()
+    assert binding.scratch.head_major_output
+    if mode == "decode":
+        assert binding.scratch.tmp_output is not None
+        assert output.data_ptr() == binding.scratch.tmp_output[:, :, 0, :].data_ptr()
+
+
 def test_sparse_mla_scratch_bind_does_not_call_workspace_factory(
     monkeypatch,
 ) -> None:

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -183,6 +183,24 @@ def test_runtime_validates_and_dispatches_to_extension():
     assert ext.dispose_calls == [1234]
 
 
+def test_runtime_accepts_head_major_input_and_output():
+    ext = _FakeExt()
+    runtime = _make_runtime(ext)
+    input_storage = torch.arange(
+        32 * 4 * 64, dtype=torch.bfloat16
+    ).reshape(32, 4, 64)
+    partial_output = input_storage.transpose(0, 1)[:2]
+    partial_lse = torch.zeros(2, 32, dtype=torch.float32)
+    output_storage = torch.empty(16, 2, 64, dtype=torch.bfloat16)
+    out = output_storage.transpose(0, 1)
+
+    actual = runtime.lse_reduce_scatter(partial_output, partial_lse, out=out)
+
+    assert actual is out
+    assert actual.stride() == (64, 2 * 64, 1)
+    torch.testing.assert_close(actual, partial_output[:, :16])
+
+
 def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
     runtime = _make_runtime()
     good_output = torch.zeros(1, 32, 64, dtype=torch.bfloat16)
@@ -197,6 +215,9 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
             torch.zeros(5, 32, 64, dtype=torch.bfloat16),
             torch.zeros(5, 32, dtype=torch.float32),
         )
+    unsupported_view = torch.zeros(1, 33, 64, dtype=torch.bfloat16)[:, :32]
+    with pytest.raises(ValueError, match="packed token-major or head-major"):
+        runtime.lse_reduce_scatter(unsupported_view, good_lse)
 
     with pytest.raises(ValueError, match="configured local heads/head_dim"):
         runtime.all_gather_heads(good_output[:, :8])

--- a/tests/comm/test_pcie_dcp_a2a_gpu.py
+++ b/tests/comm/test_pcie_dcp_a2a_gpu.py
@@ -20,10 +20,11 @@ pytestmark = pytest.mark.skipif(
     reason="set SPARKINFER_RUN_PCIE_DCP_A2A_TEST=1 to run PCIe DCP A2A GPU tests",
 )
 
-TOTAL_HEADS = 32
+TOTAL_HEADS = 16
 HEAD_DIM = 512
 QUERY_HEAD_DIM = 576
-MAX_BATCH = 4
+MAX_BATCH = 64
+TEST_BATCHES = (1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64)
 
 
 def _free_port() -> int:
@@ -105,7 +106,7 @@ def _check_eager(
     device: torch.device,
 ) -> None:
     for dtype in (torch.bfloat16, torch.float16):
-        for step, batch in enumerate((1, 2, 4), start=1):
+        for step, batch in enumerate(TEST_BATCHES, start=1):
             local_q = _rank_query(
                 step + 100,
                 rank,
@@ -144,6 +145,33 @@ def _check_eager(
             )
             torch.testing.assert_close(out, expected, rtol=2e-2, atol=2e-2)
 
+            input_storage = torch.empty(
+                TOTAL_HEADS,
+                MAX_BATCH,
+                HEAD_DIM,
+                dtype=dtype,
+                device=device,
+            )
+            head_major_input = input_storage.transpose(0, 1)[:batch]
+            head_major_input.copy_(partial_output)
+            output_storage = torch.empty(
+                TOTAL_HEADS // world_size,
+                MAX_BATCH,
+                HEAD_DIM,
+                dtype=dtype,
+                device=device,
+            )
+            head_major_output = output_storage.transpose(0, 1)[:batch]
+            actual = pool.lse_reduce_scatter(
+                head_major_input,
+                partial_lse,
+                out=head_major_output,
+            )
+            torch.cuda.synchronize(device)
+            assert actual is head_major_output
+            assert actual.movedim(0, 1).stride(0) == MAX_BATCH * HEAD_DIM
+            torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
 
 def _check_graph(
     pool: PCIeDCPA2APool,
@@ -154,30 +182,34 @@ def _check_graph(
     stream = torch.cuda.Stream(device=device)
     channel = pool.for_stream(stream)
     layers = 7
-    inputs = [
+    input_storages = [
         torch.empty(
-            1,
             TOTAL_HEADS,
+            MAX_BATCH,
             HEAD_DIM,
             dtype=torch.bfloat16,
             device=device,
         )
         for _ in range(layers)
     ]
+    inputs = [storage.transpose(0, 1) for storage in input_storages]
     lses = [
-        torch.empty(1, TOTAL_HEADS, dtype=torch.float32, device=device)
+        torch.empty(MAX_BATCH, TOTAL_HEADS, dtype=torch.float32, device=device)
         for _ in range(layers)
     ]
-    outputs = [
+    output_storages = [
         torch.empty(
-            1,
             TOTAL_HEADS // world_size,
+            MAX_BATCH,
             HEAD_DIM,
             dtype=torch.bfloat16,
             device=device,
         )
         for _ in range(layers)
     ]
+    outputs = [storage.transpose(0, 1) for storage in output_storages]
+    assert all(tensor.stride(1) == MAX_BATCH * HEAD_DIM for tensor in inputs)
+    assert all(tensor.stride(1) == MAX_BATCH * HEAD_DIM for tensor in outputs)
     local_queries = [
         torch.empty(
             1,
@@ -220,7 +252,7 @@ def _check_graph(
             partial_output, partial_lse = _rank_inputs(
                 step,
                 rank,
-                1,
+                MAX_BATCH,
                 torch.bfloat16,
                 device,
             )
@@ -257,7 +289,7 @@ def _check_graph(
                     step,
                     rank,
                     world_size,
-                    1,
+                    MAX_BATCH,
                     torch.bfloat16,
                     device,
                 )


### PR DESCRIPTION
## Summary

Fixes the DCP PCIe LSE reduce output contract so callers can provide a BHD tensor whose logical layout is token-major but whose physical storage is head-major. This avoids handing cuBLAS a strided view backed by a tight IPC/custom allocation in the downstream MLA V up-projection path.

## Root Cause

The GLM MLA `_v_up_proj` call uses a strided batched GEMM layout. Guarded repros showed cuBLAS can legally read ahead to the next 64 KiB boundary for this pattern. Normal PyTorch allocator segments make that safe, but tight DCP IPC/pool outputs can fault on the first unmapped page after the logical tensor.

Padding every allocation or cloning pool outputs fixes correctness but costs either KV capacity or decode latency. This PR instead lets the DCP producer write directly into caller-provided head-major storage while preserving the public BHD shape.

## Changes

- Accept packed token-major and capacity-strided head-major BHD tensors in the PCIe DCP LSE reduce path.
- Pass input/output batch/head strides into the CUDA kernel instead of assuming contiguous tensors.
- Add `head_major_output` scratch planning for sparse MLA output buffers.
- Add CPU validation tests and extend the PCIe DCP GPU test to cover head-major input/output views across batch sizes.

## Validation

- `python3 -m pytest tests/comm/test_pcie_dcp_a2a.py::test_runtime_accepts_head_major_input_and_output tests/comm/test_pcie_dcp_a2a.py::test_runtime_validates_and_dispatches_to_extension -q` -> 2 passed
- Scratch head-major smoke script using `SPARKINFERSparseMLAScratchCaps(head_major_output=True)` -> passed
- Earlier overlay validation on 8x RTX PRO 6000 Blackwell with the same logic:
  - B12X PCIe DCP GPU integration test -> passed
  - GLM 5.2 TP8/DCP2 long-context decode smoke -> no Xid / no CJK / no CUDA errors
  - GLM 5.2 TP8/DCP4 long-context decode smoke -> no Xid / no CJK / no CUDA errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for head-major output layouts in sparse MLA scratch buffers.
  * Extended PCIe DCP LSE reduce-scatter to work with compatible head-major tensor views.
  * Allow reuse of preallocated output buffers while preserving the requested layout.
* **Bug Fixes**
  * Improved layout validation and error messaging for unsupported input/output views.
* **Tests**
  * Added parameterized tests for head-major scratch bindings across decode/extend.
  * Expanded PCIe test coverage, including head-major paths and larger batch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->