### PR TITLE
Fix silent candidate-buffer overflow in indexer top-k

### DIFF
--- a/sparkinfer/attention/nsa_indexer/fused_indexer.py
+++ b/sparkinfer/attention/nsa_indexer/fused_indexer.py
@@ -63,6 +63,7 @@ from sparkinfer.attention.nsa_indexer.tiled_topk import (
     _THREADS_PER_CTA as _RADIX_THREADS,
     _convert_to_uint8,
     _convert_to_uint32,
+    _exact_overflow_fallback,
     _smem_ld,
     _smem_red_add,
     _smem_st,
@@ -1054,96 +1055,38 @@ def _fused_radix_select(
                     cute.arch.sync_threads()
 
     # ---- exact overflow fallback ----
-    # The buffered coarse+refine above drops winners when more than `cands` candidates
-    # share the coarse threshold bucket (clustered scores; the cross-CTA merge can pack
-    # up to ctas_per_group*topk candidates). When that happens, redo the selection
-    # EXACTLY with a 4-round 8-bit MSD radix that RE-SCANS vin each round filtered by the
-    # locked key prefix -- no candidate buffer, so no overflow. Same convention as the
-    # cooperative arm (_convert_to_uint32 monotone key, byte=(key>>shift)&0xFF). Slower
-    # (re-scans n_total per round on one CTA) but only taken on the rare clustered case;
-    # it overwrites s_out[0:topk]. Scalars: ni0=prefix, thr=remaining_k, ni1=bucket,
-    # lr=next remaining_k, ctr=output counter.
+    # The buffered coarse+refine above drops winners when more than `cands`
+    # candidates share the coarse threshold bucket (clustered scores; the
+    # cross-CTA merge can pack up to ctas_per_group*topk candidates). Redo the
+    # selection exactly by re-scanning vin -- see _exact_overflow_fallback. The
+    # single contiguous vin_v source uses the flat=True load path.
     if bin_count > Int32(cands):
-        if tx == Int32(0):
-            _smem_st(ni0, Int32(0), Int32(0))
-            _smem_st(thr, Int32(0), topk_static)
-        cute.arch.sync_threads()
-        for ex_round in cutlass.range_constexpr(4):
-            ex_shift = Uint32(24 - ex_round * 8)
-            ex_prefix = Uint32(_smem_ld(ni0, Int32(0)))
-            ex_remaining = Int32(_smem_ld(thr, Int32(0)))
-            if tx < Int32(256):
-                s_hist0[tx] = Int32(0)
-            cute.arch.sync_threads()
-            idx_base = Int32(tx)
-            while idx_base < n_total:
-                ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
-                if cutlass.const_expr(ex_round == 0):
-                    _smem_red_add(
-                        h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1)
-                    )
-                else:
-                    ex_mask = Uint32(0xFFFFFFFF) << Uint32(32 - ex_round * 8)
-                    if (ex_key & ex_mask) == ex_prefix:
-                        _smem_red_add(
-                            h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1)
-                        )
-                idx_base += Int32(_RADIX_THREADS)
-            cute.arch.sync_threads()
-            for ex_stage in cutlass.range_constexpr(8):
-                ex_j = Int32(1 << ex_stage)
-                if tx < Int32(256):
-                    if (ex_stage & 1) == 0:
-                        ex_v = Int32(s_hist0[tx])
-                        if tx < Int32(256) - ex_j:
-                            ex_v = ex_v + Int32(s_hist0[tx + ex_j])
-                        s_hist1[tx] = ex_v
-                    else:
-                        ex_v = Int32(s_hist1[tx])
-                        if tx < Int32(256) - ex_j:
-                            ex_v = ex_v + Int32(s_hist1[tx + ex_j])
-                        s_hist0[tx] = ex_v
-                cute.arch.sync_threads()
-            if tx == Int32(0):
-                _smem_st(ni1, Int32(0), Int32(0))
-                _smem_st(lr, Int32(0), ex_remaining)
-            cute.arch.sync_threads()
-            if tx < Int32(256):
-                ex_cge = Int32(s_hist0[tx])
-                ex_cgt = Int32(0)
-                if tx + Int32(1) < Int32(256):
-                    ex_cgt = Int32(s_hist0[tx + Int32(1)])
-                if (ex_cge >= ex_remaining) & (ex_cgt < ex_remaining):
-                    _smem_st(ni1, Int32(0), Int32(tx))
-                    _smem_st(lr, Int32(0), ex_remaining - ex_cgt)
-            cute.arch.sync_threads()
-            if tx == Int32(0):
-                ex_bucket = Uint32(_smem_ld(ni1, Int32(0)))
-                _smem_st(ni0, Int32(0), Int32(ex_prefix | (ex_bucket << ex_shift)))
-                _smem_st(thr, Int32(0), _smem_ld(lr, Int32(0)))
-            cute.arch.sync_threads()
-        ex_pivot = Uint32(_smem_ld(ni0, Int32(0)))
-        if tx == Int32(0):
-            _smem_st(ctr, Int32(0), Int32(0))
-        cute.arch.sync_threads()
-        idx_base = Int32(tx)
-        while idx_base < n_total:
-            ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
-            if ex_key > ex_pivot:
-                ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
-                if ex_pos < topk_static:
-                    s_out[ex_pos] = idx_base
-            idx_base += Int32(_RADIX_THREADS)
-        cute.arch.sync_threads()
-        idx_base = Int32(tx)
-        while idx_base < n_total:
-            ex_key = _convert_to_uint32(Float32(vin_v[idx_base]))
-            if ex_key == ex_pivot:
-                ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
-                if ex_pos < topk_static:
-                    s_out[ex_pos] = idx_base
-            idx_base += Int32(_RADIX_THREADS)
-        cute.arch.sync_threads()
+        _exact_overflow_fallback(
+            tx,
+            n_total,
+            topk_static,
+            s_hist0,
+            s_hist1,
+            s_out,
+            h0,
+            ctr,
+            thr,
+            ni0,
+            ni1,
+            lr,
+            flat=True,
+            flat_values=vin_v,
+            input_tensor=vin_v,
+            carry_values=vin_v,
+            row_base=Int32(0),
+            row_start=Int32(0),
+            carry_base=Int32(0),
+            chunk_len=Int32(0),
+            block_q=1,
+            block_k=1,
+            is_tiled=False,
+            is_first=True,
+        )
     cute.arch.sync_threads()
     i = Int32(tx)
     while i < topk_static:
@@ -2499,19 +2442,21 @@ def _launch_fused(kernel, cute_args, key_tensors, policy):
     # grid-barrier arm for the serial last-CTA arm (see coop_co_resident) -- a distinct
     # traced kernel, so it needs its own cache key. This also invalidates any stale
     # pre-fix cubin for those variants, which baked in the deadlocking coop arm.
+    # v5/v3 (bumped from v4/v2): the candidate-buffer overflow fix changed the
+    # radix-select body, so every variant needs a fresh key to drop stale cubins.
     if kernel.direct_k_score:
         # direct-K needs ctas_per_group <= 16, co-resident on every real SM12x part,
         # so this keeps its historical key. The suffix keeps the key honest (no trace
         # collision) if a <16-SM device ever oversubscribes a direct-K build.
         variant = (
-            "fused_indexer_v4_directk64"
+            "fused_indexer_v5_directk64"
             if kernel.coop_co_resident
-            else "fused_indexer_v4_directk64_oversub_serial"
+            else "fused_indexer_v5_directk64_oversub_serial"
         )
     elif kernel.coop_co_resident:
-        variant = "fused_indexer_v2_coop"
+        variant = "fused_indexer_v3_coop"
     else:
-        variant = "fused_indexer_v2_oversub_serial"
+        variant = "fused_indexer_v3_oversub_serial"
     cache_key = tuple(_fused_indexer_tensor_key(name, t) for name, t in key_tensors) + (
         (variant,) + tuple(policy),
     )

--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -231,6 +231,218 @@ def _convert_to_uint32(x: Float32) -> Uint32:
     return result
 
 
+@cute.jit
+def _fallback_load_value(
+    flat: cutlass.Constexpr[bool],
+    idx: Int32,
+    flat_values,
+    input_tensor,
+    carry_values,
+    row_base: Int32,
+    row_start: Int32,
+    carry_base: Int32,
+    chunk_len: Int32,
+    block_q: cutlass.Constexpr[int],
+    block_k: cutlass.Constexpr[int],
+    is_tiled: cutlass.Constexpr[bool],
+    is_first: cutlass.Constexpr[bool],
+) -> Float32:
+    """Load a candidate value for the exact overflow fallback.
+
+    When ``flat`` the value comes straight from a single contiguous source
+    (``flat_values[idx]``, the fused kernel's ``vin_v``); otherwise it routes
+    through the tiled kernel's virtual loader so the same fallback body serves
+    both the local-tiled and carry-fold candidate ranges. The unused branch is
+    constexpr-elided, so the stand-in tensors passed for it are never indexed.
+    """
+    value = Float32(0.0)
+    if cutlass.const_expr(flat):
+        value = Float32(flat_values[idx])
+    else:
+        value = _load_value_virtual(
+            input_tensor,
+            carry_values,
+            row_base,
+            row_start,
+            carry_base,
+            chunk_len,
+            idx,
+            block_q,
+            block_k,
+            is_tiled,
+            is_first,
+        )
+    return value
+
+
+@cute.jit
+def _exact_overflow_fallback(
+    tx: Int32,
+    n_total: Int32,
+    topk_static: Int32,
+    s_hist0: cute.Tensor,
+    s_hist1: cute.Tensor,
+    s_out: cute.Tensor,
+    h0: Int32,
+    ctr: Int32,
+    thr: Int32,
+    ni0: Int32,
+    ni1: Int32,
+    lr: Int32,
+    flat: cutlass.Constexpr[bool],
+    flat_values,
+    input_tensor,
+    carry_values,
+    row_base: Int32,
+    row_start: Int32,
+    carry_base: Int32,
+    chunk_len: Int32,
+    block_q: cutlass.Constexpr[int],
+    block_k: cutlass.Constexpr[int],
+    is_tiled: cutlass.Constexpr[bool],
+    is_first: cutlass.Constexpr[bool],
+):
+    """Exact overflow fallback shared by the tiled and fused radix kernels.
+
+    The buffered coarse+refine select drops winners when more than the candidate
+    buffer capacity share the coarse threshold bucket (clustered scores). When
+    that happens, redo the selection EXACTLY with a 4-round 8-bit MSD radix that
+    RE-SCANS the values each round filtered by the locked key prefix -- no
+    candidate buffer, so no overflow. Same convention as the buffered arm
+    (``_convert_to_uint32`` monotone key, byte=(key>>shift)&0xFF). Slower
+    (re-scans n_total per round on one CTA) but only taken on the rare clustered
+    case; it overwrites s_out[0:topk_static]. All 1024 threads must call this.
+    Scalars: ni0=prefix, thr=remaining_k, ni1=bucket, lr=next remaining_k,
+    ctr=output counter.
+    """
+    if tx == Int32(0):
+        _smem_st(ni0, Int32(0), Int32(0))
+        _smem_st(thr, Int32(0), topk_static)
+    cute.arch.sync_threads()
+    for ex_round in cutlass.range_constexpr(4):
+        ex_shift = Uint32(24 - ex_round * 8)
+        ex_prefix = Uint32(_smem_ld(ni0, Int32(0)))
+        ex_remaining = Int32(_smem_ld(thr, Int32(0)))
+        if tx < Int32(256):
+            s_hist0[tx] = Int32(0)
+        cute.arch.sync_threads()
+        idx_base = Int32(tx)
+        while idx_base < n_total:
+            ex_key = _convert_to_uint32(
+                _fallback_load_value(
+                    flat,
+                    idx_base,
+                    flat_values,
+                    input_tensor,
+                    carry_values,
+                    row_base,
+                    row_start,
+                    carry_base,
+                    chunk_len,
+                    block_q,
+                    block_k,
+                    is_tiled,
+                    is_first,
+                )
+            )
+            if cutlass.const_expr(ex_round == 0):
+                _smem_red_add(h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1))
+            else:
+                ex_mask = Uint32(0xFFFFFFFF) << Uint32(32 - ex_round * 8)
+                if (ex_key & ex_mask) == ex_prefix:
+                    _smem_red_add(
+                        h0, Int32((ex_key >> ex_shift) & Uint32(0xFF)), Int32(1)
+                    )
+            idx_base += Int32(_THREADS_PER_CTA)
+        cute.arch.sync_threads()
+        for ex_stage in cutlass.range_constexpr(8):
+            ex_j = Int32(1 << ex_stage)
+            if tx < Int32(256):
+                if (ex_stage & 1) == 0:
+                    ex_v = Int32(s_hist0[tx])
+                    if tx < Int32(256) - ex_j:
+                        ex_v = ex_v + Int32(s_hist0[tx + ex_j])
+                    s_hist1[tx] = ex_v
+                else:
+                    ex_v = Int32(s_hist1[tx])
+                    if tx < Int32(256) - ex_j:
+                        ex_v = ex_v + Int32(s_hist1[tx + ex_j])
+                    s_hist0[tx] = ex_v
+            cute.arch.sync_threads()
+        if tx == Int32(0):
+            _smem_st(ni1, Int32(0), Int32(0))
+            _smem_st(lr, Int32(0), ex_remaining)
+        cute.arch.sync_threads()
+        if tx < Int32(256):
+            ex_cge = Int32(s_hist0[tx])
+            ex_cgt = Int32(0)
+            if tx + Int32(1) < Int32(256):
+                ex_cgt = Int32(s_hist0[tx + Int32(1)])
+            if (ex_cge >= ex_remaining) & (ex_cgt < ex_remaining):
+                _smem_st(ni1, Int32(0), Int32(tx))
+                _smem_st(lr, Int32(0), ex_remaining - ex_cgt)
+        cute.arch.sync_threads()
+        if tx == Int32(0):
+            ex_bucket = Uint32(_smem_ld(ni1, Int32(0)))
+            _smem_st(ni0, Int32(0), Int32(ex_prefix | (ex_bucket << ex_shift)))
+            _smem_st(thr, Int32(0), _smem_ld(lr, Int32(0)))
+        cute.arch.sync_threads()
+    ex_pivot = Uint32(_smem_ld(ni0, Int32(0)))
+    if tx == Int32(0):
+        _smem_st(ctr, Int32(0), Int32(0))
+    cute.arch.sync_threads()
+    idx_base = Int32(tx)
+    while idx_base < n_total:
+        ex_key = _convert_to_uint32(
+            _fallback_load_value(
+                flat,
+                idx_base,
+                flat_values,
+                input_tensor,
+                carry_values,
+                row_base,
+                row_start,
+                carry_base,
+                chunk_len,
+                block_q,
+                block_k,
+                is_tiled,
+                is_first,
+            )
+        )
+        if ex_key > ex_pivot:
+            ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
+            if ex_pos < topk_static:
+                s_out[ex_pos] = idx_base
+        idx_base += Int32(_THREADS_PER_CTA)
+    cute.arch.sync_threads()
+    idx_base = Int32(tx)
+    while idx_base < n_total:
+        ex_key = _convert_to_uint32(
+            _fallback_load_value(
+                flat,
+                idx_base,
+                flat_values,
+                input_tensor,
+                carry_values,
+                row_base,
+                row_start,
+                carry_base,
+                chunk_len,
+                block_q,
+                block_k,
+                is_tiled,
+                is_first,
+            )
+        )
+        if ex_key == ex_pivot:
+            ex_pos = _smem_xadd(ctr, Int32(0), Int32(1))
+            if ex_pos < topk_static:
+                s_out[ex_pos] = idx_base
+        idx_base += Int32(_THREADS_PER_CTA)
+    cute.arch.sync_threads()
+
+
 def _to_kernel_tensor(tensor, dtype, *, assumed_align=16):
     cute_tensor = from_dlpack(tensor, assumed_align=assumed_align)
     cute_tensor.element_type = dtype
@@ -729,6 +941,11 @@ class SparseNSATiledTopkKernel:
                     idx_base = idx_base + Int32(_THREADS_PER_CTA)
 
                 cute.arch.sync_threads()
+                # ni0 now holds the FULL threshold-bin candidate count: the xadd
+                # ran for every bin-matching key, even past _SMEM_CANDS. Capture it
+                # before the round loop clobbers ni0, to detect when the threshold
+                # bucket overflowed the candidate buffer (winners dropped past the cap).
+                bin_count = Int32(_smem_ld(ni0, Int32(0)))
 
                 # Stage 2: refine with 8-bit radix passes
                 for round_idx in cutlass.range_constexpr(4):
@@ -876,6 +1093,37 @@ class SparseNSATiledTopkKernel:
                                 i = i + Int32(_THREADS_PER_CTA)
 
                             cute.arch.sync_threads()
+
+                # Exact overflow fallback: the buffered refine above dropped
+                # winners when more than _SMEM_CANDS candidates shared the coarse
+                # threshold bucket. Redo the selection exactly by re-scanning.
+                if bin_count > Int32(_SMEM_CANDS):
+                    _exact_overflow_fallback(
+                        tx,
+                        total_len,
+                        topk_static,
+                        s_hist0,
+                        s_hist1,
+                        s_out,
+                        h0,
+                        ctr,
+                        thr,
+                        ni0,
+                        ni1,
+                        lr,
+                        flat=False,
+                        flat_values=input_tensor,
+                        input_tensor=input_tensor,
+                        carry_values=carry_values,
+                        row_base=row_base,
+                        row_start=row_start,
+                        carry_base=out_base,
+                        chunk_len=length,
+                        block_q=self.block_q,
+                        block_k=self.block_k,
+                        is_tiled=self.is_tiled,
+                        is_first=self.is_first,
+                    )
 
             cute.arch.sync_threads()
             idx0 = Int32(tx)
@@ -1245,7 +1493,7 @@ def run_tiled_topk(
             dynamic_dims=(0,),
         ),
         (
-            "tiled_topk_v21",
+            "tiled_topk_v22",
             topk,
             block_q,
             block_k,
@@ -1415,7 +1663,7 @@ def run_row_topk(
             "carry_indices", carry_indices_key_tensor, dynamic=True
         ),
         (
-            "row_topk_v5",
+            "row_topk_v6",
             topk,
             output_gather_table is not None,
         ),

--- a/tests/attention/test_paged_prefill_topk_long_context.py
+++ b/tests/attention/test_paged_prefill_topk_long_context.py
@@ -1,0 +1,232 @@
+"""Regression test: paged prefill indexer top-k must stay correct on low-contrast rows.
+
+The tiled radix-select top-k (``SparseNSATiledTopkKernel``, reached via ``index_topk_fp8``
+/ ``packed_contiguous``) buckets candidates by the top bits of the score and stores the
+threshold bucket in a fixed 4096-slot shared buffer (``_SMEM_CANDS``). When a single
+bucket holds more than 4096 candidates -- e.g. many tokens with near-equal scores, as
+happens on low-contrast attention rows at longer context -- the pre-fix code silently
+dropped the overflow and kept the lowest-indexed (here lowest-scoring) survivors, so it
+selected tokens far below the true top-k threshold. The fix re-runs an exact, buffer-free
+MSD radix (``_exact_overflow_fallback``) whenever the bucket overflows.
+
+Cases (verified by score, not index, so a miss is genuine and not a tie-break):
+
+* ``seq_len`` sweep: 16384 keeps the hot bucket at 4091 <= 4096 (never overflowed);
+  16448 pushes it just over 4096 with almost no extra context, proving the trigger is the
+  4096 bucket cap and not the context length; 32768 overflows it hard.
+* all-equal scores: one coarse+fine bucket holds every token, so the fallback's tie-fill
+  branch must fill the whole top-k from a single pivot key.
+* logical output (``output_physical_slots=False``): exercises the two-level fold, whose
+  level-1 extent-split pass and level-2 ``run_row_topk`` share the same radix class.
+* carry fold (``supertile_k`` < context): multi-chunk streaming fold, so the overflow
+  fallback runs in the ``is_first=False`` carry path through the virtual value loader.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sparkinfer.attention.nsa_indexer._impl import clear_indexer_caches
+from sparkinfer.attention.nsa_indexer.paged import (
+    index_topk_fp8,
+    pack_paged_index_k_cache_reference,
+    prepare_paged_indexer_metadata,
+)
+from tests.attention.test_paged_indexer_integration import (
+    _bind_paged_indexer,
+    _make_real_page_table,
+    _paged_index_logits,
+)
+
+_PAGE = 64
+_ROWS = 16
+_NUM_HEADS = 32
+_TOPK = 2048
+_PAGE_START = 3
+
+
+def _build_scene(device: torch.device, seq_len: int, scores: str) -> dict:
+    """Build a paged prefill scene plus its fp32 reference top-k threshold.
+
+    ``scores="monotonic"`` gives each token a strictly increasing score so the true
+    top-k is unambiguous; ``scores="equal"`` gives every token the same score, which
+    lands the whole row in one radix bucket (degenerate tie-fill).
+    """
+    width_blocks = (seq_len + _PAGE - 1) // _PAGE
+    total_pages = _PAGE_START + width_blocks + 8
+
+    q_fp8 = torch.full(
+        (_ROWS, _NUM_HEADS, 128), 0.5, dtype=torch.float32, device=device
+    ).to(torch.float8_e4m3fn)
+    weights = torch.ones((_ROWS, _NUM_HEADS), dtype=torch.float32, device=device)
+    if scores == "monotonic":
+        token_scores = torch.linspace(
+            0.25, 1.25, seq_len, dtype=torch.float32, device=device
+        )
+    elif scores == "equal":
+        token_scores = torch.full((seq_len,), 0.5, dtype=torch.float32, device=device)
+    else:
+        raise ValueError(f"unknown scores mode {scores!r}")
+    raw_k = torch.zeros((total_pages * _PAGE, 128), dtype=torch.float32, device=device)
+    raw_k[_PAGE_START * _PAGE : _PAGE_START * _PAGE + seq_len] = token_scores.unsqueeze(
+        1
+    ).expand(-1, 128)
+    index_k_cache = pack_paged_index_k_cache_reference(raw_k)
+
+    real_page_table = _make_real_page_table(
+        page_starts=[_PAGE_START] * _ROWS,
+        seqlens=[seq_len] * _ROWS,
+        width_blocks=width_blocks,
+        device=device,
+    )
+    shared_page_table = _make_real_page_table(
+        page_starts=[_PAGE_START],
+        seqlens=[seq_len],
+        width_blocks=width_blocks,
+        device=device,
+    )
+    seqlens = torch.full((_ROWS,), seq_len, dtype=torch.int32, device=device)
+
+    ref_logits = _paged_index_logits(
+        q_fp8=q_fp8,
+        weights=weights,
+        index_k_cache=index_k_cache,
+        real_page_table=real_page_table,
+        seqlens=seqlens,
+    )
+    kth_score = torch.topk(ref_logits, _TOPK, dim=1).values[:, -1]
+    return {
+        "seq_len": seq_len,
+        "width_blocks": width_blocks,
+        "q_fp8": q_fp8,
+        "weights": weights,
+        "index_k_cache": index_k_cache,
+        "shared_page_table": shared_page_table,
+        "seqlens": seqlens,
+        "ref_logits": ref_logits,
+        "kth_score": kth_score,
+    }
+
+
+def _run_indexer(
+    monkeypatch,
+    scene: dict,
+    *,
+    supertile_k: int,
+    output_physical_slots: bool,
+) -> torch.Tensor:
+    monkeypatch.setenv("SPARKINFER_PAGED_INDEX_SUPERTILE_K", str(supertile_k))
+    seqlens = scene["seqlens"]
+    shared_page_table = scene["shared_page_table"]
+    binding = _bind_paged_indexer(
+        device=scene["q_fp8"].device,
+        num_heads=_NUM_HEADS,
+        rows=_ROWS,
+        width_blocks=scene["width_blocks"],
+        topk=_TOPK,
+        real_page_table=shared_page_table.expand(_ROWS, -1),
+        seqlens=seqlens,
+        supertile_k=supertile_k,
+        shared_page_table=True,
+        route="packed_contiguous",
+        output_physical_slots=output_physical_slots,
+    )
+    prepare_paged_indexer_metadata(
+        real_page_table=shared_page_table.expand(_ROWS, -1),
+        cache_seqlens_int32=seqlens,
+        expected_num_q_heads=_NUM_HEADS,
+        build_schedule=False,
+        shared_page_table=True,
+    )
+    selected = torch.empty((_ROWS, _TOPK), dtype=torch.int32, device=scene["q_fp8"].device)
+    clear_indexer_caches()
+    index_topk_fp8(
+        q_fp8=scene["q_fp8"],
+        weights=scene["weights"].unsqueeze(-1),
+        index_k_cache=scene["index_k_cache"],
+        topk=_TOPK,
+        expected_num_q_heads=_NUM_HEADS,
+        binding=binding,
+        out_indices=selected,
+        supertile_k=supertile_k,
+    )
+    torch.cuda.synchronize(scene["q_fp8"].device)
+    return selected
+
+
+def _assert_selects_true_topk(
+    scene: dict, selected: torch.Tensor, *, output_physical_slots: bool
+) -> None:
+    seq_len = scene["seq_len"]
+    if output_physical_slots:
+        # Physical slot -> logical (contiguous page table starting at _PAGE_START).
+        raw_logical = selected.long() - _PAGE_START * _PAGE
+    else:
+        # Logical output is already request-relative.
+        raw_logical = selected.long()
+    # Every selected slot must map to a real in-range token, and a top-k list must not
+    # repeat a token. These hold regardless of score, so they -- unlike the score check
+    # below -- catch a tie-fill that emits duplicate or out-of-range indices.
+    assert bool(((raw_logical >= 0) & (raw_logical < seq_len)).all()), (
+        f"selected index outside [0, {seq_len}) at seq_len={seq_len}"
+    )
+    for r in range(selected.shape[0]):
+        row = raw_logical[r].tolist()
+        assert len(set(row)) == len(row), (
+            f"row {r} selected duplicate indices at seq_len={seq_len}"
+        )
+    logical = raw_logical.clamp(0, seq_len - 1)
+    selected_score = torch.gather(scene["ref_logits"], 1, logical)
+    n_below = int(
+        (selected_score < (scene["kth_score"][:, None] - 1e-4)).sum().item()
+    )
+    assert n_below == 0, (
+        f"{n_below}/{_ROWS * _TOPK} selected tokens score below the true top-{_TOPK} "
+        f"threshold at seq_len={seq_len}"
+    )
+
+
+@pytest.mark.parametrize("seq_len", [16384, 16448, 32768])
+def test_paged_prefill_topk_selects_true_topk_at_long_context(
+    monkeypatch, seq_len: int
+) -> None:
+    device = torch.device("cuda")
+    scene = _build_scene(device, seq_len, "monotonic")
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=32768, output_physical_slots=True
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=True)
+
+
+def test_paged_prefill_topk_all_equal_scores_tie_fill(monkeypatch) -> None:
+    """One bucket holds every token: the fallback must tie-fill the whole top-k."""
+    device = torch.device("cuda")
+    scene = _build_scene(device, 32768, "equal")
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=32768, output_physical_slots=True
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=True)
+
+
+def test_paged_prefill_topk_logical_output_two_level_fold(monkeypatch) -> None:
+    """output_physical_slots=False routes through the two-level (extent-split + row) fold."""
+    device = torch.device("cuda")
+    scene = _build_scene(device, 32768, "monotonic")
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=32768, output_physical_slots=False
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=False)
+
+
+def test_paged_prefill_topk_carry_fold_overflow(monkeypatch) -> None:
+    """supertile_k < context forces the multi-chunk carry fold (is_first=False path).
+
+    All-equal scores guarantee every 8192-token chunk overflows its single bucket, so
+    the exact fallback runs through the virtual (carry-aware) value loader.
+    """
+    device = torch.device("cuda")
+    scene = _build_scene(device, 32768, "equal")
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=8192, output_physical_slots=True
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=True)


### PR DESCRIPTION
## Summary

`SparseNSATiledTopkKernel` selects the top-k by bucketing candidates on a radix key and storing the threshold bucket in a fixed 4096-slot shared buffer (`_SMEM_CANDS`). When a single bucket holds more than 4096 candidates — which happens on **low-contrast rows** (many near-equal scores) at longer context — the overflow is silently dropped and the lowest-indexed survivors are kept, so the paged prefill top-k (`index_topk_fp8` / `packed_contiguous`) selects tokens scoring far below the true top-k threshold. It fails silently (no error, just wrong tokens), so it surfaces only as a quality regression on long prompts, not a crash.

The failure boundary is bucket-population > 4096, not context length per se: a monotonic-score row of 16384 tokens keeps the hot bucket at 4091 and passes; 16448 and 32768 overflow it and select ~99% wrong tokens (verified by score against an fp32 reference).

## Fix

The fused decode kernel already handled this exact case with an inline *exact overflow fallback* — a candidate-buffer-free 4-round 8-bit MSD radix that re-scans the values each round filtered by the locked key prefix, so it cannot overflow. This PR extracts that fallback into a shared `@cute.jit` helper (`_exact_overflow_fallback` in `tiled_topk.py`, with a `flat` constexpr flag selecting the value loader) and routes both kernels through it:

- `SparseNSATiledTopkKernel` (and `run_row_topk`, the same kernel class backing the two-level fold) now invoke it when the threshold bucket overflows — **fixing the bug**.
- `fused_indexer.py` drops its inline copy and calls the shared helper — **removing the duplication**.

The fast (non-overflow) path is unchanged: one uniform smem load + compare per CTA gates the fallback, which runs only on the rare clustered case. Kernel cache-version strings are bumped so stale JIT binaries are invalidated.

## Testing

New regression test `tests/test_paged_prefill_topk_long_context.py` fails before this change and passes after. It checks selection by **score** against an fp32 reference (robust to ties, unlike an index match), plus **uniqueness and in-range** of the selected slots, across:

- the bucket-overflow boundary (16384 passes; 16448 and 32768 overflow),
- all-equal-score tie-fill (single bucket holds every token),
- logical-output two-level fold (`output_physical_slots=False`),
- multi-chunk carry fold (`supertile_k < context`).

Existing `test_paged_indexer_integration` (11/11) and `test_fused_indexer` continue to pass; the fused overflow-merge path is exercised directly and matches the fp32 golden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved top-k selection reliability when candidate buffers become full.
  - Prevented valid results from being omitted during high-volume or threshold-heavy selections.
  - Added an exact fallback path to ensure deterministic, accurate candidate ranking in overflow scenarios.
  - Updated compiled kernel variants to ensure the corrected selection behavior is used consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->