### PR TITLE
fix(packaging): include PCIe CUDA sources in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ where = ["."]
 include = ["sparkinfer*"]
 
 [tool.setuptools.package-data]
-"sparkinfer.distributed" = ["*.cu"]
+"sparkinfer.comm.pcie" = ["*.cu"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "SIM"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+PCIE_PACKAGE = "sparkinfer.comm.pcie"
+RUNTIME_CUDA_SOURCES = {
+    "pcie_dcp_a2a.cu",
+    "pcie_dma.cu",
+    "pcie_oneshot.cu",
+    "pcie_twoshot.cu",
+}
+
+
+def test_runtime_cuda_sources_are_in_package_data() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    package_data = config["tool"]["setuptools"]["package-data"]
+
+    assert package_data[PCIE_PACKAGE] == ["*.cu"]
+    assert {
+        path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
+    } == RUNTIME_CUDA_SOURCES


### PR DESCRIPTION
## Summary

- update setuptools package data after the `b12x.distributed` to `sparkinfer.comm.pcie` namespace migration
- include all four runtime-compiled PCIe CUDA sources in the wheel
- add a regression test for the package-data contract and source inventory

## Root cause

The namespaced wheel omitted `sparkinfer/comm/pcie/*.cu` because `pyproject.toml` still targeted the removed `sparkinfer.distributed` package. `OneshotAllReducePool` therefore failed to initialize at runtime with `FileNotFoundError: pcie_oneshot.cu`, and vLLM silently fell back from the fused PCIe all-reduce + RMSNorm path to PyNCCL. On TP8 GLM-5.2 A16 CC1 this changed measured decode from about 87 tok/s to about 75 tok/s.

## Validation

- `pytest -q tests/test_packaging.py tests/comm/test_pcie.py` (`7 passed`)
- built the wheel with the release container toolchain and inspected it; all four `sparkinfer/comm/pcie/*.cu` sources are present
- Torch profiler isolated the regression to NCCL all-reduce fallback; MoE and attention kernel timings remained equivalent

This PR is ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package configuration so required CUDA source files are included for PCIe communication functionality.

* **Tests**
  * Added packaging validation to ensure all expected CUDA sources are included in distributed builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->