### PR TITLE
fix(pcie): isolate CUDA graph channel lifecycle

### DIFF
--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -19,6 +19,7 @@ from .pcie_oneshot import (
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
     _align_up,
+    _coordinated_close_channels,
     _current_stream_key,
     _is_current_stream_capturing,
     _normalize_device,
@@ -205,6 +206,8 @@ class PCIeDCPA2A:
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
+        self._ipc_imports_closed = False
+        self._ipc_exports_freed = False
         self._ptr = self._ext.init_dcp_a2a(
             list(signal_ptrs),
             list(staging0_ptrs),
@@ -460,20 +463,35 @@ class PCIeDCPA2A:
         )
         return out
 
-    def close(self) -> None:
-        if self._closed:
+    def _close_ipc_imports(self) -> None:
+        if self._ipc_imports_closed:
             return
         self._closed = True
-        with suppress(Exception):
-            self._ext.dispose(self._ptr)
+        if getattr(self, "_ptr", 0):
+            with suppress(Exception):
+                self._ext.dispose(self._ptr)
+            self._ptr = 0
         if self._ipc is not None:
             for shared in self._owned_buffers:
                 for ptr in shared.remote_ptrs:
                     with suppress(Exception):
                         self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._ipc_imports_closed = True
+
+    def _free_ipc_exports(self) -> None:
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports()
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
                 with suppress(Exception):
                     self._ipc.cudaFree(shared.local_ptr)
         self._owned_buffers.clear()
+        self._ipc_exports_freed = True
+
+    def close(self) -> None:
+        self._close_ipc_imports()
+        self._free_ipc_exports()
 
     def __del__(self) -> None:
         with suppress(Exception):
@@ -512,6 +530,7 @@ class PCIeDCPA2APool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeDCPA2A] = {}
+        self._all_channels: list[PCIeDCPA2A] = []
         self._capture_channel_stack: list[PCIeDCPA2A] = []
         self._closed = False
         if channel_factory is None and exchange_group is None:
@@ -583,7 +602,50 @@ class PCIeDCPA2APool:
                 stream_affine=not self.single_channel,
             )
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
+
+    def checkpoint_channels(self) -> tuple[int, dict[int, PCIeDCPA2A]]:
+        """Snapshot channel ownership before a throwaway graph capture."""
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2APool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot checkpoint channels during capture")
+        return len(self._all_channels), dict(self._channels)
+
+    def rollback_channels(
+        self,
+        checkpoint: tuple[int, dict[int, PCIeDCPA2A]],
+    ) -> None:
+        """Close channels created after ``checkpoint`` and restore mappings.
+
+        Callers must destroy and synchronize any graphs that reference the
+        transient channels before rolling back.
+        """
+        if self._closed:
+            raise RuntimeError("PCIeDCPA2APool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot roll back channels during capture")
+        all_channels_len, channels = checkpoint
+        if not 0 <= all_channels_len <= len(self._all_channels):
+            raise ValueError("channel checkpoint does not belong to this pool")
+
+        retained = self._all_channels[:all_channels_len]
+        retained_ids = {id(channel) for channel in retained}
+        transient = self._all_channels[all_channels_len:]
+        self._all_channels = retained
+        self._channels = dict(channels)
+
+        channels_to_close = tuple(
+            dict.fromkeys(
+                channel for channel in transient if id(channel) not in retained_ids
+            )
+        )
+        _coordinated_close_channels(
+            channels_to_close,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
     def for_stream(self, stream: object = None) -> PCIeDCPA2A:
         if self._closed:
@@ -594,6 +656,17 @@ class PCIeDCPA2APool:
         else:
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)
+        if (
+            not self.single_channel
+            and _is_current_stream_capturing(self.device)
+            and self._capture_channel_stack
+        ):
+            # Independent graph managers may reuse a torch-owned nested stream
+            # key. The enclosing capture, not a stale key mapping, determines
+            # which IPC channel is safe for this graph.
+            channel = self._capture_channel_stack[-1]
+            self._channels[key] = channel
+            return channel
         channel = self._channels.get(key)
         if channel is not None:
             return channel
@@ -676,7 +749,20 @@ class PCIeDCPA2APool:
     @contextmanager
     def capture(self, stream: object = None):
         """Bind nested CUDA captures to the enclosing stream's channel."""
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe DCP A2A capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            key = 0 if stream_key is None else int(stream_key)
+            # Keep a graph-owned channel even when CUDA recycles the enclosing
+            # stream handle used by a previously captured graph manager.
+            channel = self._new_channel(stream_key)
+            self._channels[key] = channel
         self._capture_channel_stack.append(channel)
         try:
             yield channel
@@ -690,10 +776,11 @@ class PCIeDCPA2APool:
             return
         self._closed = True
         seen: set[int] = set()
-        for channel in self._channels.values():
+        for channel in (*self._all_channels, *self._channels.values()):
             if id(channel) not in seen:
                 seen.add(id(channel))
                 channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/sparkinfer/comm/pcie/pcie_oneshot.py
+++ b/sparkinfer/comm/pcie/pcie_oneshot.py
@@ -162,6 +162,30 @@ class _OwnedSharedBuffer:
     remote_ptrs: tuple[int, ...]
 
 
+def _coordinated_close_channels(
+    channels: Sequence[object],
+    *,
+    exchange_group: Optional[ProcessGroup],
+    device: torch.device,
+) -> None:
+    """Release exported CUDA IPC allocations after every peer unmaps them."""
+    unique_channels = tuple(dict.fromkeys(channels))
+    if exchange_group is None:
+        for channel in unique_channels:
+            channel.close()
+        return
+
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    dist.barrier(group=exchange_group)
+    for channel in unique_channels:
+        channel._close_ipc_imports()
+    dist.barrier(group=exchange_group)
+    for channel in unique_channels:
+        channel._free_ipc_exports()
+    dist.barrier(group=exchange_group)
+
+
 @dataclass(frozen=True)
 class _ChannelSharedBuffers:
     owned_buffer: _OwnedSharedBuffer
@@ -291,6 +315,8 @@ class PCIeOneshotAllReduce:
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
+        self._ipc_imports_closed = False
+        self._ipc_exports_freed = False
         self._ext = ext_module or _load_extension()
 
         if ext_module is None and self.device.type != "cuda":
@@ -870,21 +896,36 @@ class PCIeOneshotAllReduce:
             logger.info("\n".join(lines))
         return crossover
 
-    def close(self) -> None:
-        if self._closed:
+    def _close_ipc_imports(self) -> None:
+        if self._ipc_imports_closed:
             return
         self._closed = True
         if getattr(self, "_ptr", 0):
-            self._ext.dispose(self._ptr)
+            with suppress(Exception):
+                self._ext.dispose(self._ptr)
             self._ptr = 0
-        for shared in self._owned_buffers:
-            for ptr in shared.remote_ptrs:
-                if self._ipc is not None:
-                    self._ipc.cudaIpcCloseMemHandle(ptr)
-            if self._ipc is not None:
-                self._ipc.cudaFree(shared.local_ptr)
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                for ptr in shared.remote_ptrs:
+                    with suppress(Exception):
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._ipc_imports_closed = True
+
+    def _free_ipc_exports(self) -> None:
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports()
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                with suppress(Exception):
+                    self._ipc.cudaFree(shared.local_ptr)
         self._owned_buffers.clear()
         self._registered_input_ptrs.clear()
+        self._ipc_exports_freed = True
+
+    def close(self) -> None:
+        self._close_ipc_imports()
+        self._free_ipc_exports()
 
     def __del__(self) -> None:
         with suppress(Exception):
@@ -943,6 +984,7 @@ class PCIeOneshotAllReducePool:
         self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeOneshotAllReduce] = {}
+        self._all_channels: list[PCIeOneshotAllReduce] = []
         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
         self._closed = False
 
@@ -1014,6 +1056,7 @@ class PCIeOneshotAllReducePool:
             if self.single_channel:
                 channel._stream_affine = False
             channel._bind_stream_key(stream_key)
+            self._all_channels.append(channel)
             return channel
 
         if self.exchange_group is None or self._ipc is None or self._ext is None:
@@ -1053,7 +1096,52 @@ class PCIeOneshotAllReducePool:
                     self._ipc.cudaFree(shared.local_ptr)
             raise
         channel._bind_stream_key(stream_key)
+        self._all_channels.append(channel)
         return channel
+
+    def checkpoint_channels(
+        self,
+    ) -> tuple[int, dict[int, PCIeOneshotAllReduce]]:
+        """Snapshot channel ownership before a throwaway graph capture."""
+        if self._closed:
+            raise RuntimeError("pool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot checkpoint channels during capture")
+        return len(self._all_channels), dict(self._channels)
+
+    def rollback_channels(
+        self,
+        checkpoint: tuple[int, dict[int, PCIeOneshotAllReduce]],
+    ) -> None:
+        """Close channels created after ``checkpoint`` and restore mappings.
+
+        Callers must destroy and synchronize any graphs that reference the
+        transient channels before rolling back.
+        """
+        if self._closed:
+            raise RuntimeError("pool is closed")
+        if self._capture_channel_stack:
+            raise RuntimeError("cannot roll back channels during capture")
+        all_channels_len, channels = checkpoint
+        if not 0 <= all_channels_len <= len(self._all_channels):
+            raise ValueError("channel checkpoint does not belong to this pool")
+
+        retained = self._all_channels[:all_channels_len]
+        retained_ids = {id(channel) for channel in retained}
+        transient = self._all_channels[all_channels_len:]
+        self._all_channels = retained
+        self._channels = dict(channels)
+
+        channels_to_close = tuple(
+            dict.fromkeys(
+                channel for channel in transient if id(channel) not in retained_ids
+            )
+        )
+        _coordinated_close_channels(
+            channels_to_close,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
     def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
         if self._closed:
@@ -1074,6 +1162,14 @@ class PCIeOneshotAllReducePool:
 
         stream_key = _current_stream_key(self.device, stream)
         channel_key = 0 if stream_key is None else int(stream_key)
+        if _is_current_stream_capturing(self.device) and self._capture_channel_stack:
+            # CUDA and torch/Inductor may recycle a nested capture stream key
+            # between independent target and draft graph managers. The active
+            # enclosing capture owns the channel even if that key still maps
+            # to a channel captured by an earlier manager.
+            channel = self._capture_channel_stack[-1]
+            self._channels[channel_key] = channel
+            return channel
         channel = self._channels.get(channel_key)
         if channel is not None:
             return channel
@@ -1151,7 +1247,22 @@ class PCIeOneshotAllReducePool:
 
     @contextmanager
     def capture(self, stream: object = None):
-        channel = self.for_stream(stream)
+        if self.single_channel:
+            channel = self.for_stream(stream)
+        else:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIe oneshot capture context must be entered before CUDA "
+                    "graph capture starts"
+                )
+            stream_key = _current_stream_key(self.device, stream)
+            channel_key = 0 if stream_key is None else int(stream_key)
+            # A CUDA stream handle can be recycled after one graph manager
+            # finishes capture. Graphs retain the channel pointers, so a new
+            # manager must receive a fresh channel even when the numeric stream
+            # key is identical. _all_channels keeps replaced channels alive.
+            channel = self._new_channel(stream_key)
+            self._channels[channel_key] = channel
         with channel.capture(stream=stream):
             self._capture_channel_stack.append(channel)
             try:
@@ -1165,8 +1276,12 @@ class PCIeOneshotAllReducePool:
         if self._closed:
             return
         self._closed = True
-        for channel in self._channels.values():
-            channel.close()
+        seen: set[int] = set()
+        for channel in (*self._all_channels, *self._channels.values()):
+            if id(channel) not in seen:
+                seen.add(id(channel))
+                channel.close()
+        self._all_channels.clear()
         self._channels.clear()
 
     def __del__(self) -> None:

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -5,6 +5,7 @@ import torch
 
 from sparkinfer.comm.pcie.pcie_dcp_a2a import (
     PCIeDCPA2A,
+    PCIeDCPA2APool,
     _staging_layout,
     lse_reduce_scatter_reference,
 )
@@ -202,3 +203,202 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
         runtime.all_gather_heads(good_output[:, :8])
     with pytest.raises(ValueError, match="exceeds configured capacity"):
         runtime.all_gather_heads(torch.zeros(5, 16, 64, dtype=torch.bfloat16))
+
+
+def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    with pool.capture(8) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 80
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[70] is target_channel
+    assert pool._channels[80] is draft_channel
+    assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [1234]
+    assert draft_channel._ext.dispose_calls == [1234]
+
+
+def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+    created = []
+
+    def make_channel(stream_key):
+        runtime = _make_runtime()
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: 3 if stream is None else int(stream),
+    )
+
+    eager_channel = pool.for_stream()
+    checkpoint = pool.checkpoint_channels()
+    with pool.capture(7) as profile_channel:
+        pass
+
+    pool.rollback_channels(checkpoint)
+
+    assert pool._all_channels == [eager_channel]
+    assert pool._channels == {3: eager_channel}
+    assert profile_channel._ext.dispose_calls == [1234]
+    assert eager_channel._ext.dispose_calls == []
+
+
+def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+    events = []
+
+    class FakeChannel:
+        def _close_ipc_imports(self):
+            events.append("close-imports")
+
+        def _free_ipc_exports(self):
+            events.append("free-exports")
+
+    group = object()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        exchange_group=group,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    retained = FakeChannel()
+    transient = FakeChannel()
+    pool._all_channels = [retained]
+    pool._channels = {3: retained}
+    checkpoint = pool.checkpoint_channels()
+    pool._all_channels.append(transient)
+    pool._channels[7] = transient
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    pool.rollback_channels(checkpoint)
+
+    assert events == [
+        "barrier",
+        "close-imports",
+        "barrier",
+        "free-exports",
+        "barrier",
+    ]
+    assert pool._all_channels == [retained]
+    assert pool._channels == {3: retained}
+
+
+def test_pool_rejects_channel_rollback_during_capture():
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    checkpoint = pool.checkpoint_channels()
+
+    with pool.capture(7), pytest.raises(RuntimeError, match="during capture"):
+        pool.rollback_channels(checkpoint)

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -342,7 +342,9 @@ def test_should_allreduce_checks_device_dtype_size_alignment_and_contiguity():
     assert runtime.should_allreduce(torch.arange(4, dtype=torch.int32)) is False
     assert runtime.should_allreduce(torch.arange(16, dtype=torch.bfloat16)) is False
     assert runtime.should_allreduce(torch.arange(7, dtype=torch.bfloat16)) is False
-    assert runtime.should_allreduce(torch.arange(16, dtype=torch.bfloat16)[::2]) is False
+    assert (
+        runtime.should_allreduce(torch.arange(16, dtype=torch.bfloat16)[::2]) is False
+    )
 
 
 def test_graph_buffer_api_exposes_explicit_registration_hooks():
@@ -525,8 +527,13 @@ def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
 
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
-    monkeypatch.setattr("torch.distributed.get_process_group_ranks", lambda group=None: [0, 1])
-    monkeypatch.setattr("sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device", lambda group: "cpu")
+    monkeypatch.setattr(
+        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+        lambda group: "cpu",
+    )
 
     def fake_broadcast(object_list, src, group=None, device=None):
         object_list[0] = remote_meta[src]
@@ -545,11 +552,18 @@ def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
 def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
-    monkeypatch.setattr("torch.distributed.get_process_group_ranks", lambda group=None: [0, 1])
-    monkeypatch.setattr("sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device", lambda group: "cpu")
+    monkeypatch.setattr(
+        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+        lambda group: "cpu",
+    )
     monkeypatch.setattr(
         "torch.distributed.broadcast_object_list",
-        lambda object_list, src, group=None, device=None: object_list.__setitem__(0, ([], [])),
+        lambda object_list, src, group=None, device=None: object_list.__setitem__(
+            0, ([], [])
+        ),
     )
 
     runtime = _make_runtime(exchange_group=object())
@@ -566,7 +580,9 @@ def test_capture_registers_graph_buffers_after_context(monkeypatch):
     runtime = _make_runtime(exchange_group=object())
     calls = []
 
-    monkeypatch.setattr(runtime, "register_graph_buffers", lambda: calls.append("registered"))
+    monkeypatch.setattr(
+        runtime, "register_graph_buffers", lambda: calls.append("registered")
+    )
 
     with runtime.capture():
         pass
@@ -578,7 +594,9 @@ def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
     runtime = _make_runtime(eager=True, exchange_group=object())
     calls = []
 
-    monkeypatch.setattr(runtime, "register_graph_buffers", lambda: calls.append("registered"))
+    monkeypatch.setattr(
+        runtime, "register_graph_buffers", lambda: calls.append("registered")
+    )
 
     with runtime.capture():
         pass
@@ -651,8 +669,14 @@ def test_pool_requires_precreated_channel_during_capture(monkeypatch):
         channel_factory=lambda stream_key: _make_runtime(eager=True),
     )
 
-    monkeypatch.setattr("sparkinfer.comm.pcie.pcie_oneshot._current_stream_key", lambda device, stream=None: 7)
-    monkeypatch.setattr("sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing", lambda device: True)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: 7,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing",
+        lambda device: True,
+    )
 
     with pytest.raises(RuntimeError, match="before capture starts"):
         pool.for_stream()
@@ -705,3 +729,198 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
     assert pool._channels[70] is target_channel
     assert pool._channels[80] is draft_channel
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+    created = []
+    current_stream = [7]
+    capturing = [False]
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    with pool.capture(7) as target_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is target_channel
+        capturing[0] = False
+
+    # CUDA may recycle both handles for the next graph manager. Neither stale
+    # mapping may make the draft graph retain the target graph's IPC channel.
+    with pool.capture(7) as draft_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is draft_channel
+        capturing[0] = False
+
+    assert target_channel is not draft_channel
+    assert pool._channels[7] is draft_channel
+    assert pool._channels[70] is draft_channel
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
+    assert [entry[0] for entry in created] == [7, 7]
+
+    pool.close()
+    assert target_channel._ext.dispose_calls == [12345]
+    assert draft_channel._ext.dispose_calls == [12345]
+
+
+def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+    created = []
+
+    def make_channel(stream_key):
+        runtime = _make_runtime(eager=True)
+        created.append((stream_key, runtime))
+        return runtime
+
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=make_channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: 3 if stream is None else int(stream),
+    )
+
+    eager_channel = pool.for_stream()
+    checkpoint = pool.checkpoint_channels()
+    with pool.capture(7) as profile_channel:
+        pass
+
+    pool.rollback_channels(checkpoint)
+
+    assert pool._all_channels == [eager_channel]
+    assert pool._channels == {3: eager_channel}
+    assert profile_channel._ext.dispose_calls == [12345]
+    assert eager_channel._ext.dispose_calls == []
+
+
+def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+    events = []
+
+    class FakeChannel:
+        def _close_ipc_imports(self):
+            events.append("close-imports")
+
+        def _free_ipc_exports(self):
+            events.append("free-exports")
+
+    group = object()
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        exchange_group=group,
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    retained = FakeChannel()
+    transient = FakeChannel()
+    pool._all_channels = [retained]
+    pool._channels = {3: retained}
+    checkpoint = pool.checkpoint_channels()
+    pool._all_channels.append(transient)
+    pool._channels[7] = transient
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    pool.rollback_channels(checkpoint)
+
+    assert events == [
+        "barrier",
+        "close-imports",
+        "barrier",
+        "free-exports",
+        "barrier",
+    ]
+    assert pool._all_channels == [retained]
+    assert pool._channels == {3: retained}
+
+
+def test_channel_teardown_completes_when_ipc_cleanup_raises():
+    events = []
+
+    class FailingExt:
+        def dispose(self, ptr):
+            events.append(("dispose", ptr))
+            raise RuntimeError("dispose failed")
+
+    class FailingIPC:
+        def cudaIpcCloseMemHandle(self, ptr):
+            events.append(("close", ptr))
+            raise RuntimeError("close failed")
+
+        def cudaFree(self, ptr):
+            events.append(("free", ptr))
+            raise RuntimeError("free failed")
+
+    class SharedBuffer:
+        def __init__(self, local_ptr, remote_ptrs):
+            self.local_ptr = local_ptr
+            self.remote_ptrs = remote_ptrs
+
+    channel = object.__new__(PCIeOneshotAllReduce)
+    channel._closed = False
+    channel._ipc_imports_closed = False
+    channel._ipc_exports_freed = False
+    channel._ptr = 123
+    channel._ext = FailingExt()
+    channel._ipc = FailingIPC()
+    channel._owned_buffers = [
+        SharedBuffer(1000, (2000, 3000)),
+        SharedBuffer(4000, (5000,)),
+    ]
+    channel._registered_input_ptrs = {1: (2,)}
+
+    channel.close()
+    channel.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("close", 5000),
+        ("free", 1000),
+        ("free", 4000),
+    ]
+    assert channel._ptr == 0
+    assert channel._closed
+    assert channel._ipc_imports_closed
+    assert channel._ipc_exports_freed
+    assert channel._owned_buffers == []
+    assert channel._registered_input_ptrs == {}
+
+
+def test_pool_rejects_channel_rollback_during_capture():
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    checkpoint = pool.checkpoint_channels()
+
+    with pool.capture(7), pytest.raises(RuntimeError, match="during capture"):
+        pool.rollback_channels(checkpoint)


### PR DESCRIPTION
## Summary

- bind recycled target and draft CUDA graph streams to independent PCIe channels
- checkpoint and roll back channels created by disposable graph captures
- coordinate IPC teardown across ranks and make rollback fail-safe
- keep all MoE execution-plan changes out of this PR

## Why

Target and speculative graph managers can reuse CUDA stream identities while retaining different live graph resources. Sharing or prematurely recycling a PCIe channel across those captures can leave stale IPC state or destroy a channel still owned by a replayable graph.

This PR contains only the PCIe lifecycle half of #58 and is based directly on `master`.

## Validation

- `tests/comm/test_pcie_dcp_a2a.py`
- `tests/comm/test_pcie_oneshot.py`
- **41 passed**
- Ruff lint and format checks passed
- split integration tree is byte-identical to the PCIe files in #58
