### PR TITLE
mla: split latent_scale identity/dynamic compile-cache entries

### DIFF
--- a/sparkinfer/attention/_shared/mla/kernel.py
+++ b/sparkinfer/attention/_shared/mla/kernel.py
@@ -2581,10 +2581,11 @@ def _sparse_mla_decode_grid_flat_launch(
             )
     compile_spec = KernelCompileSpec.from_fields(
         "attention.mla.sm120.decode",
-        # v17 adds the runtime FP8-RoPE record format specialization.  The
-        # explicit cache key does not hash source, so this ABI bump rejects
-        # cubins compiled for the 432-byte BF16-RoPE record.
-        17,
+        # v18: latent_scale == 1.0 is folded out at trace time, producing a
+        # cubin without the outer-scale multiply; the identity and dynamic
+        # variants must not share a cache entry.
+        18,
+        key_field("latent_scale_identity", int(float(latent_scale) == 1.0)),
         *spec_fields,
     )
     if per_token_len:

--- a/sparkinfer/attention/_shared/mla/prefill_mg.py
+++ b/sparkinfer/attention/_shared/mla/prefill_mg.py
@@ -3840,9 +3840,11 @@ def _sparse_mla_prefill_mg_flat_launch(
         )
     compile_spec = KernelCompileSpec.from_fields(
         "attention.mla.sm120.prefill_mg",
-        # v3 adds the FP8-RoPE record specialization/read path. The explicit
-        # cache key does not hash source, so do not reuse v2 KLD-only cubins.
-        3,
+        # v4: latent_scale == 1.0 is folded out at trace time, producing a
+        # cubin without the outer-scale multiply; the identity and dynamic
+        # variants must not share a cache entry.
+        4,
+        key_field("latent_scale_identity", int(float(latent_scale) == 1.0)),
         *spec_fields,
     )
     entry = kernel.call_dual if has_extra else kernel


### PR DESCRIPTION
CuTeDSL folds the NVFP4 outer-scale multiply out of the MLA kernels when
`latent_scale` traces at exactly 1.0. The explicit compile keys
(`attention.mla.sm120.decode` v17, `attention.mla.sm120.prefill_mg` v3, now at `sparkinfer/attention/_shared/mla/`) hash
neither kernel source nor scalar values, so a persistent cache populated by
scale-1.0 runs replays identity cubins for launches with real per-layer
scales — the restore is silently dropped.

Repro (GLM-5.2, SM120, TP4+DCP4, `nvfp4_ds_mla` + `VLLM_NVFP4_MLA_SCALES_FILE`):
teacher-forced prefill KLD 0.13 → 6.7–7.4 on a stale cache; 0.13 on a fresh
cache, identical config. Short prompts through serving degenerate to
near-immediate EOS.

Fix: add `latent_scale_identity` as a compile-spec fact and bump both spec
versions (decode 17→18, prefill_mg 3→4), following the v17 FP8-RoPE ABI-bump
pattern. Two entries max per config; both directions correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Supersedes #52 (authored against the pre-restructure b12x layout; identical fix, ported to the sparkinfer paths).