### PR TITLE
gemm: qualify TP8 MLA shards for opt-in MXFP8 BMM

### DIFF
--- a/sparkinfer/gemm/_bmm/_mxfp8.py
+++ b/sparkinfer/gemm/_bmm/_mxfp8.py
@@ -890,9 +890,10 @@ class _Mxfp8Launch:
 
 
 _LAUNCH_CACHE: dict[tuple[object, ...], _Mxfp8Launch] = {}
+_QUALIFIED_BATCHES = frozenset((8, 16))
 _QUALIFIED_GEOMETRIES = {
-    _BMajor.N: (16, 192, 512),
-    _BMajor.K: (16, 512, 256),
+    _BMajor.N: (192, 512),
+    _BMajor.K: (512, 256),
 }
 
 
@@ -1103,7 +1104,8 @@ def _geometry_is_qualified(
 ) -> bool:
     return (
         1 <= int(m) <= _MAX_M
-        and (int(groups), int(k), int(n)) == _QUALIFIED_GEOMETRIES[b_major]
+        and int(groups) in _QUALIFIED_BATCHES
+        and (int(k), int(n)) == _QUALIFIED_GEOMETRIES[b_major]
     )
 
 

--- a/tests/gemm/test_bmm.py
+++ b/tests/gemm/test_bmm.py
@@ -28,11 +28,11 @@ def _spec(b_major: str) -> dict[str, object]:
     return {**BASE_SPEC, "b_major": b_major, "sf_axis": b_major}
 
 
-def _make_pack(seed: int = 7) -> tuple[torch.Tensor, torch.Tensor]:
+def _make_pack(seed: int = 7, batch: int = BATCH) -> tuple[torch.Tensor, torch.Tensor]:
     generator = torch.Generator(device="cuda").manual_seed(seed)
     values = (
         torch.randn(
-            BATCH * PACK_ROWS,
+            batch * PACK_ROWS,
             K_K_MAJOR,
             device="cuda",
             generator=generator,
@@ -43,7 +43,7 @@ def _make_pack(seed: int = 7) -> tuple[torch.Tensor, torch.Tensor]:
     scales = torch.randint(
         118,
         132,
-        (BATCH * PACK_ROWS, K_K_MAJOR // 32),
+        (batch * PACK_ROWS, K_K_MAJOR // 32),
         device="cuda",
         generator=generator,
         dtype=torch.uint8,
@@ -52,10 +52,10 @@ def _make_pack(seed: int = 7) -> tuple[torch.Tensor, torch.Tensor]:
 
 
 def _rhs_views(
-    values: torch.Tensor, scales: torch.Tensor
+    values: torch.Tensor, scales: torch.Tensor, batch: int = BATCH
 ) -> dict[str, tuple[torch.Tensor, torch.Tensor]]:
-    values_3d = values.view(BATCH, PACK_ROWS, K_K_MAJOR)
-    scales_3d = scales.view(BATCH, PACK_ROWS, K_K_MAJOR // 32)
+    values_3d = values.view(batch, PACK_ROWS, K_K_MAJOR)
+    scales_3d = scales.view(batch, PACK_ROWS, K_K_MAJOR // 32)
     return {
         # B-major N: logical/physical [B,K,N], scales grouped along N.
         "n": (
@@ -84,18 +84,18 @@ def _logical_b(rhs: tuple[torch.Tensor, torch.Tensor], b_major: str) -> torch.Te
 
 
 def _graph_output(
-    *, b_major: str, m: int, n: int
+    *, b_major: str, m: int, n: int, batch: int = BATCH
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
     if b_major == "k":
         backing = torch.full(
-            (m, BATCH, n + 8),
+            (m, batch, n + 8),
             torch.nan,
             device="cuda",
             dtype=torch.bfloat16,
         )
         return backing[..., :n].transpose(0, 1), backing[..., n:]
     return (
-        torch.empty(BATCH, m, n, device="cuda", dtype=torch.bfloat16),
+        torch.empty(batch, m, n, device="cuda", dtype=torch.bfloat16),
         None,
     )
 
@@ -337,10 +337,60 @@ def test_can_implement_reports_only_qualified_specialization() -> None:
         **_spec("n"),
     )
     assert gemm.can_implement_bmm(**kwargs)
+    assert gemm.can_implement_bmm(**{**kwargs, "batch": 8})
     assert not gemm.can_implement_bmm(**{**kwargs, "max_m": 33})
     assert not gemm.can_implement_bmm(**{**kwargs, "batch": BATCH - 1})
+    assert not gemm.can_implement_bmm(**{**kwargs, "batch": 7})
     assert not gemm.can_implement_bmm(**{**kwargs, "sf_axis": "k"})
     assert not gemm.can_implement_bmm(**{**kwargs, "b_dtype": "bfloat16"})
+
+
+@pytest.mark.parametrize("b_major", ["n", "k"])
+def test_tp8_geometry_matches_reference_and_cuda_graph(b_major: str) -> None:
+    """The GLM TP8 shard uses eight MLA heads per rank."""
+    require_sparkinfer()
+    batch = 8
+    m = 4
+    values, scales = _make_pack(seed=23, batch=batch)
+    rhs = _rhs_views(values, scales, batch=batch)[b_major]
+    logical_b = _logical_b(rhs, b_major)
+    k = int(logical_b.shape[1])
+    n = int(logical_b.shape[2])
+    assert gemm.can_implement_bmm(
+        batch=batch,
+        max_m=32,
+        n=n,
+        k=k,
+        device=values.device,
+        **_spec(b_major),
+    )
+    assert gemm.prewarm_bmm(rhs, (m,), **_spec(b_major)) == 1
+
+    lhs = torch.zeros(batch, m, k, device="cuda", dtype=torch.bfloat16)
+    out, padding = _graph_output(
+        b_major=b_major,
+        m=m,
+        n=n,
+        batch=batch,
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        returned = gemm.bmm(lhs, rhs, out, **_spec(b_major))
+    assert returned is out
+
+    fresh = torch.randn_like(lhs)
+    lhs.copy_(fresh)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected = torch.bmm(fresh, logical_b)
+    reference64 = torch.bmm(fresh.double(), logical_b.double())
+    candidate_error = (out.double() - reference64).abs().max().item()
+    cublas_error = (expected.double() - reference64).abs().max().item()
+    assert torch.isfinite(out).all()
+    assert candidate_error <= cublas_error * 1.05 + 1e-12
+    if padding is not None:
+        assert torch.isnan(padding).all()
 
 
 @pytest.mark.parametrize("b_major", ["n", "k"])


### PR DESCRIPTION
## Summary

- qualify the existing generic MXFP8 BMM for GLM-5.2 TP8 shards (`groups=8`)
- keep the existing TP4 specialization (`groups=16`) unchanged
- add numerical, CUDA Graph replay, output-layout, and eligibility coverage for TP8

## Why

GLM-5.2 has 64 MLA heads, so TP8 exposes 8 heads per rank. The vLLM absorbed-projection path already delegates eligibility to `can_implement_bmm()`, but SparkInfer previously qualified only 16 groups and therefore forced TP8 back to materialized BF16 `W_UK_T`/`W_UV` weights. The K/N geometry and kernel contract are otherwise identical.

This remains explicitly gated by vLLM's `VLLM_B12X_ABSORB_BMM=1`. With the option unset, serving behavior is unchanged. Unsupported group counts still fail `can_implement_bmm()` and retain the BF16 fallback.

## Validation

- `tests/gemm/test_bmm.py`: **39 passed** on SM120
- TP8 tests cover both B-major orientations, reference error envelope, CUDA Graph capture/replay, direct output writes, and rejection of unsupported groups
- `ruff check`, formatting, and `git diff --check` passed

E2E was measured with GLM-5.2 NVFP4, online MXFP8 including `kv_b_proj`, TP8/DCP1/MTP0, CC1, and two physical GPU allocations with ON/OFF swapped:

| Metric | BF16 absorbed pair | Direct MXFP8 BMM |
|---|---:|---:|
| Mean decode | 93.22 tok/s | 92.14 tok/s (-1.16%) |
| Model memory | 52.38 GiB/GPU | 52.12 GiB/GPU (-0.26 GiB) |
| KV capacity | 624,064 tokens | 629,760 tokens (+0.91%) |

This is therefore an opt-in capacity trade-off on TP8, not a default performance optimization. TP4 remains the more favorable geometry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded supported MXFP8 batched matrix multiplication configurations to include batch sizes 8 and 16 where geometry requirements are met.
  * Improved validation for supported and unsupported BMM configurations.

* **Tests**
  * Added coverage for batch-size variations and TP8 geometries.
  * Verified CUDA graph execution, numerical results, and padding behavior against reference computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->