### PR TITLE
test(packaging): support TOML parsing on Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "tomli>=2.0; python_version < '3.11'",
 ]
 
 [build-system]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 
 ROOT = Path(__file__).parents[1]


### PR DESCRIPTION
## Summary
- use the standard-library `tomllib` on Python 3.11+ and the `tomli` backport on Python 3.10
- declare `tomli` only in the Python 3.10 development dependency set

This follows up the valid compatibility finding left on merged PR #57. The project declares `requires-python >=3.10`, while the packaging test previously imported `tomllib` unconditionally. Runtime dependencies are unchanged.

## Validation
- `pytest -q tests/test_packaging.py`
- direct execution under Python 3.10 with `tomli>=2.0`
- `ruff check tests/test_packaging.py`
- `ruff format --check tests/test_packaging.py`