### PR TITLE
cute ops: probe nvvm.fmax signature instead of sniffing CUDA_VERSION (fixes engine init on PyPI DSL 4.6.0)

### DIFF
--- a/sparkinfer/attention/_shared/cute/ops.py
+++ b/sparkinfer/attention/_shared/cute/ops.py
@@ -57,6 +57,20 @@ def warp_reduce(
     return val
 
 
+def _nvvm_fmax_takes_result_type() -> bool:
+    # DSL <=4.5.x exposed ``nvvm.fmax(result_type, a, b, ...)`` on CUDA 12.9
+    # builds; DSL >=4.6.0 unified to ``nvvm.fmax(a, b, *, c=None, ...)`` and
+    # reports its bundled CTK as 12.9, so version sniffing misfires. Probe the
+    # actual signature once instead.
+    import inspect
+
+    params = list(inspect.signature(nvvm.fmax).parameters)
+    return bool(params) and params[0] not in ("a", "b")
+
+
+_NVVM_FMAX_RESULT_TYPE = _nvvm_fmax_takes_result_type()
+
+
 @dsl_user_op
 def fmax(
     a: float | Float32,
@@ -66,23 +80,15 @@ def fmax(
     loc=None,
     ip=None,
 ) -> Float32:
-    from cutlass import CUDA_VERSION
-
-    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
-        return Float32(
-            nvvm.fmax(
-                T.f32(),
-                Float32(a).ir_value(loc=loc, ip=ip),
-                Float32(b).ir_value(loc=loc, ip=ip),
-                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
-                loc=loc,
-                ip=ip,
-            )
-        )
+    args = (
+        Float32(a).ir_value(loc=loc, ip=ip),
+        Float32(b).ir_value(loc=loc, ip=ip),
+    )
+    if _NVVM_FMAX_RESULT_TYPE:
+        args = (T.f32(),) + args
     return Float32(
         nvvm.fmax(
-            Float32(a).ir_value(loc=loc, ip=ip),
-            Float32(b).ir_value(loc=loc, ip=ip),
+            *args,
             c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
             loc=loc,
             ip=ip,


### PR DESCRIPTION
Standalone fix on `master` (single commit, +21/−15 in `sparkinfer/attention/_shared/cute/ops.py`). Also unblocks #49, which requires nvidia-cutlass-dsl ≥ 4.6.0 — the stack currently cannot run on the only public 4.6.0 wheel.

The DSL wheels disagree about both the fmax ABI and what `cutlass.CUDA_VERSION` means:

| DSL build | reports | `nvvm.fmax` | existing sniff picks | result |
|---|---|---|---|---|
| PyPI 4.5.2 | 12.9 | legacy `(T.f32(), a, b, …)` | legacy | ok |
| **PyPI 4.6.0** | **12.9** | **unified `(a, b, *, c=None, …)`** | **legacy** | **`TypeError: fmax() takes 2 positional arguments but 3 … were given` — every attention JIT fails at engine init** |
| CTK-13.3 build (published EXL3 runtime image) | 13.3 | unified | modern | ok |

Since `fmax` sits under every attention softmax reduction (`fmax_reduce`, indexer quad-max, paged/extend running max), PyPI-4.6.0 users can't boot at all.

Fix: probe `inspect.signature(nvvm.fmax)` once at import (first parameter named `a`/`b` ⇒ unified form) and pick the call shape from the actual ABI instead of a version proxy. Verified on all three builds above — legacy form preserved on 4.5.2, attention JIT compiles clean on PyPI 4.6.0, and the 13.3 build takes the same branch it already does. No numerical or behavioral change.
