### PR TITLE
test(moe): cover GLM NVFP4 dispatch boundary

### DIFF
--- a/tests/moe/test_execution_model.py
+++ b/tests/moe/test_execution_model.py
@@ -240,8 +240,12 @@ def test_workspace_plan_uses_weight_plan_source_contract() -> None:
     assert plan.spec.source_weight_scale is ScaleEncoding.E8M0_K32
 
 
-def test_glm52_tp8_nvfp4_crosses_from_micro_to_dynamic_at_m8() -> None:
+def test_glm52_tp8_nvfp4_crosses_from_micro_to_dynamic_at_m8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The GLM decode M=8 case uses dynamic's atomic output contract."""
+
+    monkeypatch.delenv("SPARKINFER_DYNAMIC_DETERMINISTIC_OUTPUT", raising=False)
 
     weights = _weight_plan(
         "nvfp4",
@@ -250,12 +254,15 @@ def test_glm52_tp8_nvfp4_crosses_from_micro_to_dynamic_at_m8() -> None:
         n=2048 // 8,
         num_experts=256,
     )
+    # Planner construction is allocation-free. Use a CUDA device descriptor so
+    # the serving-only deterministic-output policy is exercised on CPU CI.
+    device = torch.device("cuda")
 
     plans = {
         m: plan_tp_moe_execution(
             num_tokens=m,
             num_topk=8,
-            device=torch.device("cpu"),
+            device=device,
             weight_plan=weights,
             quant_mode="nvfp4",
         )
@@ -265,6 +272,17 @@ def test_glm52_tp8_nvfp4_crosses_from_micro_to_dynamic_at_m8() -> None:
     assert plans[7].implementation == "micro"
     assert plans[8].implementation == "dynamic"
     assert not plans[8].deterministic_output
+
+    monkeypatch.setenv("SPARKINFER_DYNAMIC_DETERMINISTIC_OUTPUT", "1")
+    deterministic_m8 = plan_tp_moe_execution(
+        num_tokens=8,
+        num_topk=8,
+        device=device,
+        weight_plan=weights,
+        quant_mode="nvfp4",
+    )
+    assert deterministic_m8.implementation == "dynamic"
+    assert deterministic_m8.deterministic_output
 
 
 def test_native_w4a8_m1_alone_selects_fixed_materialized_regime(

--- a/tests/moe/test_execution_model.py
+++ b/tests/moe/test_execution_model.py
@@ -35,6 +35,7 @@ def _weight_plan(
     source_format: str,
     k: int = 128,
     n: int = 128,
+    num_experts: int = 32,
     w4a16_layout: PreparedWeightLayout | None = None,
 ):
     return plan_sparkinfer_fp4_moe_weights(
@@ -42,7 +43,7 @@ def _weight_plan(
         source_format=source_format,
         activation="silu",
         params_dtype=torch.bfloat16,
-        num_experts=32,
+        num_experts=num_experts,
         hidden_size=k,
         intermediate_size=n,
         w4a16_layout=w4a16_layout,
@@ -237,6 +238,33 @@ def test_workspace_plan_uses_weight_plan_source_contract() -> None:
 
     assert plan.spec.source_format == "fp4_e8m0_k32"
     assert plan.spec.source_weight_scale is ScaleEncoding.E8M0_K32
+
+
+def test_glm52_tp8_nvfp4_crosses_from_micro_to_dynamic_at_m8() -> None:
+    """The GLM decode M=8 case uses dynamic's atomic output contract."""
+
+    weights = _weight_plan(
+        "nvfp4",
+        source_format="modelopt_nvfp4",
+        k=6144,
+        n=2048 // 8,
+        num_experts=256,
+    )
+
+    plans = {
+        m: plan_tp_moe_execution(
+            num_tokens=m,
+            num_topk=8,
+            device=torch.device("cpu"),
+            weight_plan=weights,
+            quant_mode="nvfp4",
+        )
+        for m in (7, 8)
+    }
+
+    assert plans[7].implementation == "micro"
+    assert plans[8].implementation == "dynamic"
+    assert not plans[8].deterministic_output
 
 
 def test_native_w4a8_m1_alone_selects_fixed_materialized_regime(


### PR DESCRIPTION
## Summary

- parameterize the CPU weight-plan helper by expert count
- pin the real GLM-5.2 TP8 NVFP4 dispatch boundary in a planner test
- assert M=7 uses fused micro while M=8 uses dynamic with its default atomic-output contract

## Why

The investigation behind closed PR #60 initially treated M=8 variation as evidence about fused-micro auxiliary-stream overlap. Real checkpoint validation showed that M=8 does not execute fused micro at all: top-k 8 produces 64 routed rows, so the production planner selects the dynamic backend. Its default BF16 atomic scatter is intentionally not bitwise deterministic. M=7 remains on micro and is bitwise repeatable.

This test makes that boundary explicit so future overlap investigations do not compare two different kernel families as if they were one.

## Validation

- `pytest -q tests/moe/test_execution_model.py` in the CUDA test image: 16 passed
- real GLM layer 3, TP8/NVFP4: M=7 micro was bitwise stable; M=8 dynamic showed only expected atomic-order variation
- `SPARKINFER_DYNAMIC_DETERMINISTIC_OUTPUT=1` made all eight M=8 repeats bitwise identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for large-expert NVFP4 mixture-of-experts workloads by supporting a configurable expert count in the weight-planning helper.
  * Verified execution planning transitions from micro to dynamic mode at the expected workload size (m=8).
  * Confirmed m=8 output is non-deterministic by default, and becomes deterministic when `SPARKINFER_DYNAMIC_DETERMINISTIC_OUTPUT=1` is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->