### PR TITLE
fix(moe): cooperatively launch fused W4A16 grids

### DIFF
--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -4460,6 +4460,11 @@ class W4A16FusedMoeKernel:
             grid=grid,
             block=[self.cta_threads, 1, 1],
             min_blocks_per_mp=self.blocks_per_sm,
+            # The fused body crosses software all-CTA barriers between FC1,
+            # activation, and FC2. Require whole-grid admission so unrelated
+            # work cannot occupy an SM while resident CTAs wait for peers that
+            # have not been scheduled yet.
+            cooperative=True,
             stream=stream,
         )
 
@@ -5211,6 +5216,10 @@ class W4A16FusedMoeHybridKernel:
             grid=(grid_x, 1, 1),
             block=[self.cta_threads, 1, 1],
             min_blocks_per_mp=self.blocks_per_sm,
+            # This fused two-tier body uses the same software all-CTA barriers
+            # as W4A16FusedMoeKernel and therefore has the same whole-grid
+            # residency requirement.
+            cooperative=True,
             stream=stream,
         )
 

--- a/tests/moe/test_fused_moe.py
+++ b/tests/moe/test_fused_moe.py
@@ -130,3 +130,69 @@ def test_run_w4a16_replays_under_cuda_graph_with_frozen_resolution() -> None:
         "no kernel may compile during or after warm capture"
     )
     torch.testing.assert_close(captured, eager, rtol=0, atol=0)
+
+
+def test_run_w4a16_m9_graph_replay_with_prequeued_aux_work() -> None:
+    """The route-packed W4A16 grid must remain valid beside aux work.
+
+    M=9 is the first size above the fused-micro decode range. It enters the
+    route-packed W4A16 body, whose FC1/activation/FC2 phases synchronize every
+    CTA through software grid barriers. Prequeued shared-expert work must not
+    prevent whole-grid admission when the serving graph replays.
+    """
+    require_sparkinfer()
+    torch.manual_seed(20260723)
+
+    from sparkinfer.moe import fused_moe
+
+    device = torch.device("cuda")
+    global_e, hidden_size, intermediate_size = 16, 6144, 512
+    m, topk = 9, 8
+    a = (torch.randn(m, hidden_size, device=device) * 0.25).to(torch.bfloat16)
+    weights = make_modelopt_weights(
+        experts=global_e,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    experts = prepare_experts(a, weights, torch.arange(global_e))
+    topk_ids = torch.randint(
+        0, global_e, (m, topk), dtype=torch.int32, device=device
+    )
+    topk_weights = torch.softmax(torch.randn(m, topk, device=device), dim=-1)
+    output = torch.empty_like(a)
+    binding = make_tp_moe_fp4_binding(
+        a=a,
+        experts=experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        output=output,
+        quant_mode="w4a16",
+    )
+
+    fused_moe.run(binding=binding)
+    torch.cuda.synchronize()
+    expected = output.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
+        fused_moe.run(binding=binding)
+    torch.cuda.current_stream().wait_stream(capture_stream)
+    torch.cuda.synchronize()
+
+    aux_stream = torch.cuda.Stream()
+    aux_a = torch.randn(4096, 4096, dtype=torch.bfloat16, device=device)
+    aux_b = torch.randn(4096, 4096, dtype=torch.bfloat16, device=device)
+    aux_out = torch.empty_like(aux_a)
+    output.zero_()
+    with torch.cuda.stream(aux_stream):
+        for _ in range(16):
+            torch.mm(aux_a, aux_b, out=aux_out)
+    graph.replay()
+    torch.cuda.current_stream().wait_stream(aux_stream)
+    torch.cuda.synchronize()
+
+    assert output.isfinite().all()
+    assert output.abs().sum().item() > 0
+    torch.testing.assert_close(output, expected, atol=2e-3, rtol=0.0)


### PR DESCRIPTION
## Summary

Launch the two barrier-bearing fused W4A16 MoE grids cooperatively.

Both `W4A16FusedMoeKernel` and `W4A16FusedMoeHybridKernel` synchronize every
CTA between FC1, activation, output initialization and FC2. Their planners
already cap the grid to `SM count * blocks_per_sm`, but the launch itself did
not request whole-grid cooperative admission.

This patch adds `cooperative=True` to those two launch sites. It does not
change the standalone W4A16 GEMM, launch geometry, tile selection,
quantization, routing or output math.

## Why

A software whole-grid barrier requires every participating CTA to be
resident. A bounded grid alone does not guarantee that: unrelated work on
another stream can occupy an SM after only part of the fused grid has been
admitted, leaving resident CTAs waiting for peers that cannot be scheduled.

SparkInfer already uses cooperative admission for the fused-micro W4A16 decode
path. The route-packed fallback entered above that micro range and the
two-tier hybrid path use the same barrier pattern but were missing the launch
contract.

The production workload that motivated the audit runs shared-expert and other
auxiliary-stream work beside MTP decode graph capture. This PR is deliberately
not presented as the fix for that workload's eventual CUDA illegal-address
failure: launch-blocking subsequently localized that separate failure to an
MLA query-absorption BMM, which has its own vLLM fix. Cooperative admission is
an independent correctness requirement visible directly in these fused
kernels.

## Validation

Completed:

- forward-port onto current SparkInfer `master`;
- `python -m py_compile` for both changed files;
- `git diff --check`;
- exact patched W4A16 source was byte-verified in the GLM-5.2 v20 candidate
  that completed profiling and production decode capture at sizes 16 through
  1, with 624/624 diagnostic boundaries passing and no CUDA/cuBLAS/OOM/Xid
  failure.

The engine result is combined-stack evidence, not an isolated A/B proof of
this change.

This PR adds a focused SM120 GPU regression:

```bash
pytest -q tests/moe/test_fused_moe.py \
  -k test_run_w4a16_m9_graph_replay_with_prequeued_aux_work
```

It captures the first route-packed size above the fused-micro range using the
GLM shard geometry, prequeues large BF16 GEMMs on an auxiliary stream, replays
the W4A16 graph concurrently, and checks finite, nonzero, stable output.

The test cannot run on the contributor's macOS host because CUTLASS DSL and
SM120 CUDA are unavailable. This PR remains draft until the focused GPU test
and the ongoing decode-throughput qualification are recorded.

## Tradeoff

Cooperative admission can alter scheduling latency when unrelated stream work
is queued. It does not serialize the streams globally or disable
shared-expert overlap; it only requires the complete bounded W4A16 grid to be
admitted as a unit, which is the execution contract required by its software
barriers.

## AI assistance

OpenAI Codex assisted with source tracing, forward-porting, regression-test
design and PR drafting. The submitted code and runtime evidence are being
reviewed by the human contributor and target-system operator before the draft
is marked ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of fused W4A16 Mixture-of-Experts operations, particularly during CUDA graph replay and concurrent GPU workloads.
  - Enhanced synchronization for supported cooperative execution scenarios.

- **Tests**
  - Added coverage for route-packed workloads and CUDA graph replay while auxiliary GPU work is running.
  - Verified results remain finite and numerically consistent under these conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->