### PR TITLE
[GG] Add BF16 MLA query projection and assembly

### DIFF
--- a/benchmarks/benchmark_mla_query_projection.py
+++ b/benchmarks/benchmark_mla_query_projection.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Benchmark fused MLA query projection against the existing staged path.
 
-The benchmark uses CUDA-graph replay for both arms, checks bitwise equality
+The benchmark uses CUDA-graph replay for both arms, gates numerical correctness
 before timing, records raw samples, and emits enough environment metadata to
-reproduce a performance claim.
+reproduce a performance claim. Native MXFP8 output remains bitwise checked;
+BF16 weights use a bounded tolerance because Triton and cuBLAS accumulate in a
+different order.
 """
 
 from __future__ import annotations
@@ -44,7 +46,8 @@ BMM_SPEC = {
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--device", type=int, default=0)
-    parser.add_argument("--heads", type=int, choices=(8, 16), default=8)
+    parser.add_argument("--weight-format", choices=("mxfp8", "bf16"), default="mxfp8")
+    parser.add_argument("--heads", type=int, choices=(8, 11, 16), default=8)
     parser.add_argument("--m", type=int, choices=range(1, 33), default=1)
     parser.add_argument("--output-dtype", choices=("bf16", "fp8"), default="fp8")
     parser.add_argument("--warmup", type=int, default=100)
@@ -177,8 +180,27 @@ def main() -> None:
     output_dtype = (
         torch.bfloat16 if args.output_dtype == "bf16" else torch.float8_e4m3fn
     )
+    if args.weight_format == "mxfp8" and args.heads not in (8, 16):
+        raise ValueError("MXFP8 query projection supports 8 or 16 heads")
     generator = torch.Generator(device=device).manual_seed(args.seed)
-    weight = make_weight(heads=args.heads, device=device, generator=generator)
+    if args.weight_format == "mxfp8":
+        weight: torch.Tensor | tuple[torch.Tensor, torch.Tensor] = make_weight(
+            heads=args.heads,
+            device=device,
+            generator=generator,
+        )
+    else:
+        weight = (
+            torch.randn(
+                args.heads,
+                NOPE_DIM,
+                LATENT_DIM,
+                device=device,
+                generator=generator,
+                dtype=torch.bfloat16,
+            )
+            * 0.05
+        )
     q_nope = torch.randn(
         args.heads,
         args.m,
@@ -198,10 +220,10 @@ def main() -> None:
     q_pe = q_full[..., LATENT_DIM:]
     q_scale = torch.tensor([0.037], device=device, dtype=torch.float32)
 
-    gemm.prewarm_bmm(weight, [args.m], **BMM_SPEC)
-    mla_query_projection.prewarm(
-        weight, [args.m], output_dtype=output_dtype
-    )
+    if args.weight_format == "mxfp8":
+        assert isinstance(weight, tuple)
+        gemm.prewarm_bmm(weight, [args.m], **BMM_SPEC)
+    mla_query_projection.prewarm(weight, [args.m], output_dtype=output_dtype)
 
     projected = torch.empty(
         args.heads,
@@ -227,7 +249,10 @@ def main() -> None:
     inv_scale = torch.reciprocal(q_scale)
 
     def baseline() -> None:
-        gemm.bmm(q_nope, weight, projected, **BMM_SPEC)
+        if isinstance(weight, torch.Tensor):
+            torch.bmm(q_nope, weight, out=projected)
+        else:
+            gemm.bmm(q_nope, weight, projected, **BMM_SPEC)
         torch.cat((projected.transpose(0, 1), q_pe), dim=-1, out=assembled_bf16)
         if output_dtype == torch.float8_e4m3fn:
             scaled_fp32.copy_(assembled_bf16)
@@ -252,10 +277,33 @@ def main() -> None:
     )
     finite = bool(torch.isfinite(fused_out.float()).all().item())
     nonzero = bool(torch.count_nonzero(fused_out).item())
-    if not bitwise_equal or not finite or not nonzero:
+    difference = (baseline_out.float() - fused_out.float()).abs()
+    max_abs = float(difference.max().item())
+    mean_abs = float(difference.mean().item())
+    close = bool(
+        torch.allclose(
+            baseline_out.float(),
+            fused_out.float(),
+            rtol=2e-2,
+            atol=2e-2,
+        )
+    )
+    rope_equal = torch.equal(
+        baseline_out[..., LATENT_DIM:].view(torch.uint8),
+        fused_out[..., LATENT_DIM:].view(torch.uint8),
+    )
+    correctness_passed = (
+        finite
+        and nonzero
+        and rope_equal
+        and (bitwise_equal if args.weight_format == "mxfp8" else close)
+    )
+    if not correctness_passed:
         raise RuntimeError(
             "correctness gate failed: "
-            f"bitwise_equal={bitwise_equal}, finite={finite}, nonzero={nonzero}"
+            f"bitwise_equal={bitwise_equal}, close={close}, "
+            f"rope_equal={rope_equal}, finite={finite}, nonzero={nonzero}, "
+            f"max_abs={max_abs}, mean_abs={mean_abs}"
         )
 
     baseline_graph = capture_graph(baseline)
@@ -280,7 +328,12 @@ def main() -> None:
         "compute_capability": torch.cuda.get_device_capability(device),
         "gpu_snapshot": gpu_snapshot(),
         "correctness": {
+            "passed": correctness_passed,
             "bitwise_equal": bitwise_equal,
+            "close_rtol_2e-2_atol_2e-2": close,
+            "rope_suffix_bitwise_equal": rope_equal,
+            "max_abs": max_abs,
+            "mean_abs": mean_abs,
             "finite": finite,
             "nonzero": nonzero,
             "cuda_graph_replay": True,
@@ -291,6 +344,7 @@ def main() -> None:
             "nope_dim": NOPE_DIM,
             "latent_dim": LATENT_DIM,
             "rope_dim": ROPE_DIM,
+            "weight_format": args.weight_format,
             "output_dtype": args.output_dtype,
         },
         "warmup": args.warmup,

--- a/sparkinfer/gemm/mla_query_projection/__init__.py
+++ b/sparkinfer/gemm/mla_query_projection/__init__.py
@@ -1,11 +1,11 @@
 """Fused SM12x MLA absorbed-query projection and assembly.
 
-The operation multiplies BF16 ``q_nope`` by the native rowwise-MXFP8
-``W_UK_T`` pack and writes the result directly into a token-major MLA query.
-It appends the existing 64-wide RoPE query in the same launch.  The caller may
-request BF16 output, or static per-tensor E4M3 output for an FP8 attention
-backend.  FP8 mode deliberately rounds the GEMM result through BF16 before
-scaling, preserving the established two-kernel numerical contract.
+The operation multiplies BF16 ``q_nope`` by either BF16 ``W_UK_T`` or its
+native rowwise-MXFP8 pack and writes the result directly into a token-major MLA
+query.  It appends the existing 64-wide RoPE query in the same launch.  The
+caller may request BF16 output, or static per-tensor E4M3 output for an FP8
+attention backend.  FP8 mode deliberately rounds the GEMM result through BF16
+before scaling, preserving the established two-kernel numerical contract.
 """
 
 from __future__ import annotations
@@ -26,18 +26,18 @@ META = OpMeta(
         "clear_caches",
     ),
     dtypes=("bf16", "fp8_e4m3"),
-    recipes=("mxfp8", "glm_nsa"),
+    recipes=("bf16", "mxfp8"),
     provenance=Provenance(
         repo="https://github.com/local-inference-lab/sparkinfer",
-        commit="982d7319",
+        commit="f8b62f6",
         paths=(
-            "sparkinfer/attention/mla_query/",
-            "sparkinfer/gemm/_bmm/_mxfp8.py",
+            "sparkinfer/gemm/mla_query_projection/",
+            "sparkinfer/gemm/_shared/mxfp8_bmm.py",
         ),
     ),
     test_path="tests/gemm/test_mla_query_projection.py",
     since="1.0.1",
-    notes="Fused MXFP8 query BMM, RoPE append, and optional static E4M3 quant.",
+    notes="Fused BF16/MXFP8 query BMM, RoPE append, and optional E4M3 quant.",
 )
 
 if TYPE_CHECKING:

--- a/sparkinfer/gemm/mla_query_projection/_bf16.py
+++ b/sparkinfer/gemm/mla_query_projection/_bf16.py
@@ -1,0 +1,378 @@
+"""Tiny-M BF16 absorbed-query GEMM with fused MLA query assembly."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from .._shared.mxfp8_bmm import _overlaps, _torch_stream
+
+_NOPE_DIM = 192
+_LATENT_DIM = 512
+_ROPE_DIM = 64
+_QUERY_DIM = _LATENT_DIM + _ROPE_DIM
+_MAX_M = 32
+_QUALIFIED_HEADS = frozenset((8, 11, 16))
+_BLOCK_N = 32
+_BLOCK_K = 64
+_COMPILED_SIGNATURES: set[tuple[int, int, bool]] = set()
+
+
+@triton.jit
+def _mla_query_projection_bf16_kernel(
+    q_nope_ptr,
+    weight_ptr,
+    q_pe_ptr,
+    q_scale_ptr,
+    out_ptr,
+    m,
+    q_stride_h,
+    q_stride_m,
+    w_stride_h,
+    w_stride_k,
+    pe_stride_m,
+    pe_stride_h,
+    out_stride_m,
+    out_stride_h,
+    OUTPUT_FP8: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    LATENT_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    n_block = tl.program_id(0)
+    head = tl.program_id(1)
+    rows = tl.arange(0, BLOCK_M)
+    cols = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+    row_mask = rows < m
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    for k_start in tl.static_range(0, NOPE_DIM, BLOCK_K):
+        ks = k_start + tl.arange(0, BLOCK_K)
+        q_ptrs = (
+            q_nope_ptr + head * q_stride_h + rows[:, None] * q_stride_m + ks[None, :]
+        )
+        w_ptrs = (
+            weight_ptr + head * w_stride_h + ks[:, None] * w_stride_k + cols[None, :]
+        )
+        q_tile = tl.load(q_ptrs, mask=row_mask[:, None], other=0.0)
+        w_tile = tl.load(w_ptrs)
+        acc += tl.dot(q_tile, w_tile, out_dtype=tl.float32)
+
+    # Preserve the established BMM contract: project to BF16 before an
+    # optional static E4M3 quantization of the assembled attention query.
+    projected = acc.to(tl.bfloat16)
+    out_ptrs = (
+        out_ptr + rows[:, None] * out_stride_m + head * out_stride_h + cols[None, :]
+    )
+    if OUTPUT_FP8:
+        inv_scale = 1.0 / tl.load(q_scale_ptr)
+        projected_fp32 = projected.to(tl.float32) * inv_scale
+        projected_fp32 = tl.maximum(tl.minimum(projected_fp32, 448.0), -448.0)
+        tl.store(out_ptrs, projected_fp32, mask=row_mask[:, None])
+    else:
+        tl.store(out_ptrs, projected, mask=row_mask[:, None])
+
+    # The first N tile also copies the existing RoPE suffix. This is disjoint
+    # from the projected columns and removes the separate concat/quant launch.
+    if n_block == 0:
+        rope_cols = tl.arange(0, ROPE_DIM)
+        pe_ptrs = (
+            q_pe_ptr
+            + rows[:, None] * pe_stride_m
+            + head * pe_stride_h
+            + rope_cols[None, :]
+        )
+        rope = tl.load(pe_ptrs, mask=row_mask[:, None], other=0.0)
+        rope_out_ptrs = (
+            out_ptr
+            + rows[:, None] * out_stride_m
+            + head * out_stride_h
+            + LATENT_DIM
+            + rope_cols[None, :]
+        )
+        if OUTPUT_FP8:
+            rope_fp32 = rope.to(tl.float32) * inv_scale
+            rope_fp32 = tl.maximum(tl.minimum(rope_fp32, 448.0), -448.0)
+            tl.store(rope_out_ptrs, rope_fp32, mask=row_mask[:, None])
+        else:
+            tl.store(rope_out_ptrs, rope, mask=row_mask[:, None])
+
+
+def _validate(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: Optional[torch.Tensor],
+    out: torch.Tensor,
+) -> tuple[int, int, bool]:
+    if q_nope.ndim != 3:
+        raise ValueError(f"q_nope must have shape [H,M,192], got {q_nope.shape}")
+    heads, m, nope_dim = map(int, q_nope.shape)
+    if heads not in _QUALIFIED_HEADS or not 1 <= m <= _MAX_M or nope_dim != _NOPE_DIM:
+        raise NotImplementedError(
+            "the BF16 fused MLA query specialization requires "
+            f"H in {sorted(_QUALIFIED_HEADS)}, 1<=M<=32, K=192; "
+            f"got H={heads}, M={m}, K={nope_dim}"
+        )
+    if tuple(weight.shape) != (heads, _NOPE_DIM, _LATENT_DIM):
+        raise ValueError(
+            "weight must have shape "
+            f"{(heads, _NOPE_DIM, _LATENT_DIM)}, got {tuple(weight.shape)}"
+        )
+    if tuple(q_pe.shape) != (m, heads, _ROPE_DIM):
+        raise ValueError(
+            f"q_pe must have shape {(m, heads, _ROPE_DIM)}, got {tuple(q_pe.shape)}"
+        )
+    if tuple(out.shape) != (m, heads, _QUERY_DIM):
+        raise ValueError(
+            f"out must have shape {(m, heads, _QUERY_DIM)}, got {tuple(out.shape)}"
+        )
+    if q_nope.dtype != torch.bfloat16:
+        raise TypeError(f"q_nope must be bfloat16, got {q_nope.dtype}")
+    if weight.dtype != torch.bfloat16:
+        raise TypeError(f"weight must be bfloat16, got {weight.dtype}")
+    if q_pe.dtype != torch.bfloat16:
+        raise TypeError(f"q_pe must be bfloat16, got {q_pe.dtype}")
+    output_fp8 = out.dtype == torch.float8_e4m3fn
+    if not output_fp8 and out.dtype != torch.bfloat16:
+        raise ValueError(f"out must be bfloat16 or float8_e4m3fn, got {out.dtype}")
+    if output_fp8:
+        if q_scale is None:
+            raise ValueError("q_scale is required for float8_e4m3fn output")
+        if q_scale.dtype != torch.float32 or q_scale.numel() != 1:
+            raise ValueError(
+                "q_scale must be a scalar float32 tensor, "
+                f"got shape={tuple(q_scale.shape)}, dtype={q_scale.dtype}"
+            )
+    tensors = [q_nope, weight, q_pe, out]
+    if output_fp8:
+        assert q_scale is not None
+        tensors.append(q_scale)
+    if not all(tensor.is_cuda for tensor in tensors):
+        raise ValueError("BF16 MLA query operands must be CUDA tensors")
+    if any(tensor.device != q_nope.device for tensor in tensors[1:]):
+        raise ValueError("BF16 MLA query operands must be on the same CUDA device")
+    for name, tensor in (
+        ("q_nope", q_nope),
+        ("weight", weight),
+        ("q_pe", q_pe),
+        ("out", out),
+    ):
+        if int(tensor.stride(-1)) != 1:
+            raise ValueError(f"{name} innermost dimension must be contiguous")
+    sources = [
+        ("q_nope", q_nope),
+        ("weight", weight),
+        ("q_pe", q_pe),
+    ]
+    if output_fp8:
+        assert q_scale is not None
+        sources.append(("q_scale", q_scale))
+    for name, source in sources:
+        if _overlaps(out, source):
+            raise ValueError(f"out must not overlap {name}")
+    return heads, m, output_fp8
+
+
+def _launch(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: Optional[torch.Tensor],
+    out: torch.Tensor,
+) -> None:
+    heads, m, output_fp8 = _validate(q_nope, weight, q_pe, q_scale, out)
+    block_m = 16 if m <= 16 else 32
+    device_index = int(
+        q_nope.device.index
+        if q_nope.device.index is not None
+        else torch.cuda.current_device()
+    )
+    signature = (device_index, block_m, output_fp8)
+    if (
+        torch.cuda.is_current_stream_capturing()
+        and signature not in _COMPILED_SIGNATURES
+    ):
+        raise RuntimeError(
+            "BF16 MLA query compile miss during CUDA-graph capture for "
+            f"M={m}, output_fp8={output_fp8}; "
+            "call mla_query_projection.prewarm first"
+        )
+    # This geometry wins across the complete qualified envelope (M=1..32 and
+    # H=8/11/16). Keeping one shape also bounds prewarm to two M regimes.
+    grid = (triton.cdiv(_LATENT_DIM, _BLOCK_N), heads)
+    _mla_query_projection_bf16_kernel[grid](
+        q_nope,
+        weight,
+        q_pe,
+        q_scale if q_scale is not None else out,
+        out,
+        m,
+        q_nope.stride(0),
+        q_nope.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        q_pe.stride(0),
+        q_pe.stride(1),
+        out.stride(0),
+        out.stride(1),
+        OUTPUT_FP8=output_fp8,
+        NOPE_DIM=_NOPE_DIM,
+        LATENT_DIM=_LATENT_DIM,
+        ROPE_DIM=_ROPE_DIM,
+        BLOCK_M=block_m,
+        BLOCK_N=_BLOCK_N,
+        BLOCK_K=_BLOCK_K,
+        num_warps=4,
+        num_stages=2,
+    )
+    _COMPILED_SIGNATURES.add(signature)
+
+
+@torch.library.custom_op("sparkinfer::mla_query_projection_bf16", mutates_args=("out",))
+def _op(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: Optional[torch.Tensor],
+    out: torch.Tensor,
+) -> None:
+    _launch(q_nope, weight, q_pe, q_scale, out)
+
+
+@_op.register_fake
+def _fake(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: Optional[torch.Tensor],
+    out: torch.Tensor,
+) -> None:
+    del q_nope, weight, q_pe, q_scale, out
+
+
+def run(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    q_scale: Optional[torch.Tensor] = None,
+    stream: Optional[object] = None,
+) -> torch.Tensor:
+    """Run the BF16 absorbed projection and query-assembly epilogue."""
+    if stream is None:
+        torch.ops.sparkinfer.mla_query_projection_bf16(
+            q_nope, weight, q_pe, q_scale, out
+        )
+        return out
+    target = _torch_stream(stream, q_nope.device)
+    with torch.cuda.stream(target):
+        torch.ops.sparkinfer.mla_query_projection_bf16(
+            q_nope, weight, q_pe, q_scale, out
+        )
+        tensors = [q_nope, weight, q_pe, out]
+        if q_scale is not None:
+            tensors.append(q_scale)
+        for tensor in tensors:
+            tensor.record_stream(target)
+    return out
+
+
+def prewarm(
+    weight: torch.Tensor,
+    m_values: Iterable[int],
+    *,
+    output_dtype: torch.dtype,
+    stream: Optional[object] = None,
+    synchronize: bool = True,
+) -> int:
+    """Compile and first-launch every required BF16 fused-query regime."""
+    if output_dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError(
+            f"output_dtype must be bfloat16 or float8_e4m3fn, got {output_dtype}"
+        )
+    if weight.ndim != 3:
+        raise ValueError(f"weight must have shape [H,192,512], got {weight.shape}")
+    heads = int(weight.shape[0])
+    values = tuple(dict.fromkeys(int(value) for value in m_values if int(value) > 0))
+    for m in values:
+        if not can_implement(
+            num_heads=heads,
+            max_m=m,
+            nope_dim=int(weight.shape[1]),
+            latent_dim=int(weight.shape[2]),
+            output_dtype=output_dtype,
+            device=weight.device,
+        ):
+            raise NotImplementedError(
+                "the BF16 fused MLA query specialization cannot prewarm "
+                f"H={heads}, M={m}, weight={tuple(weight.shape)}, "
+                f"output_dtype={output_dtype}"
+            )
+    target = _torch_stream(stream, weight.device)
+    q_scale = (
+        torch.ones(1, dtype=torch.float32, device=weight.device)
+        if output_dtype == torch.float8_e4m3fn
+        else None
+    )
+    warmed_regimes: set[int] = set()
+    with torch.cuda.stream(target):
+        for m in values:
+            block_m = 16 if m <= 16 else 32
+            if block_m in warmed_regimes:
+                continue
+            warmed_regimes.add(block_m)
+            q_nope = torch.zeros(
+                (heads, m, _NOPE_DIM), dtype=torch.bfloat16, device=weight.device
+            )
+            q_pe = torch.zeros(
+                (m, heads, _ROPE_DIM), dtype=torch.bfloat16, device=weight.device
+            )
+            out = torch.empty(
+                (m, heads, _QUERY_DIM), dtype=output_dtype, device=weight.device
+            )
+            torch.ops.sparkinfer.mla_query_projection_bf16(
+                q_nope, weight, q_pe, q_scale, out
+            )
+            for tensor in (q_nope, q_pe, out):
+                tensor.record_stream(target)
+        if q_scale is not None:
+            q_scale.record_stream(target)
+    if synchronize:
+        target.synchronize()
+    return len(warmed_regimes)
+
+
+def can_implement(
+    *,
+    num_heads: int,
+    max_m: int,
+    nope_dim: int,
+    latent_dim: int,
+    output_dtype: torch.dtype,
+    device=None,
+) -> bool:
+    """Return whether the qualified BF16 fused-query kernel covers a plan."""
+    del device
+    return bool(
+        int(num_heads) in _QUALIFIED_HEADS
+        and 1 <= int(max_m) <= _MAX_M
+        and int(nope_dim) == _NOPE_DIM
+        and int(latent_dim) == _LATENT_DIM
+        and output_dtype in (torch.bfloat16, torch.float8_e4m3fn)
+    )
+
+
+def clear_caches() -> None:
+    _COMPILED_SIGNATURES.clear()
+
+
+__all__ = ["can_implement", "clear_caches", "prewarm", "run"]

--- a/sparkinfer/gemm/mla_query_projection/api.py
+++ b/sparkinfer/gemm/mla_query_projection/api.py
@@ -3,18 +3,22 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Optional
+from typing import Literal, Optional, TypeAlias
 
 import torch
 
 from ..._lib.gating import default_is_supported
 from .._shared import mxfp8_bmm as _mxfp8
 from . import META
+from . import _bf16
+
+Mxfp8Weight: TypeAlias = tuple[torch.Tensor, torch.Tensor]
+MlaQueryWeight: TypeAlias = torch.Tensor | Mxfp8Weight
 
 
 def run(
     q_nope: torch.Tensor,
-    weight: tuple[torch.Tensor, torch.Tensor],
+    weight: MlaQueryWeight,
     q_pe: torch.Tensor,
     out: torch.Tensor,
     *,
@@ -23,11 +27,21 @@ def run(
 ) -> torch.Tensor:
     """Assemble an MLA query into caller-owned ``out``.
 
-    ``q_nope`` is head-major ``[H,M,192]``; ``weight`` is the N-major native
-    MXFP8 ``W_UK_T`` pack; ``q_pe`` and ``out`` are token-major
+    ``q_nope`` is head-major ``[H,M,192]``; ``weight`` is either a BF16
+    ``[H,192,512]`` tensor or the N-major native MXFP8 ``W_UK_T`` pack.
+    ``q_pe`` and ``out`` are token-major
     ``[M,H,64]`` and ``[M,H,576]``.  ``out`` may be BF16 or E4M3.
     ``q_scale`` is required only for E4M3 output.
     """
+    if isinstance(weight, torch.Tensor):
+        return _bf16.run(
+            q_nope,
+            weight,
+            q_pe,
+            out,
+            q_scale=q_scale,
+            stream=stream,
+        )
     return _mxfp8.mla_query_projection(
         q_nope,
         weight,
@@ -41,7 +55,7 @@ def run(
 
 
 def prewarm(
-    weight: tuple[torch.Tensor, torch.Tensor],
+    weight: MlaQueryWeight,
     m_values: Iterable[int],
     *,
     output_dtype: torch.dtype,
@@ -49,6 +63,14 @@ def prewarm(
     synchronize: bool = True,
 ) -> int:
     """Compile and first-launch each caller-declared graph-visible ``M``."""
+    if isinstance(weight, torch.Tensor):
+        return _bf16.prewarm(
+            weight,
+            m_values,
+            output_dtype=output_dtype,
+            stream=stream,
+            synchronize=synchronize,
+        )
     return _mxfp8.prewarm_mla_query_projection(
         weight,
         m_values,
@@ -67,18 +89,32 @@ def can_implement(
     nope_dim: int,
     latent_dim: int,
     output_dtype: torch.dtype,
+    weight_format: Literal["bf16", "mxfp8"] = "mxfp8",
     device=None,
 ) -> bool:
     """Return whether the qualified fused-query specialization covers a plan."""
-    return is_supported(device) and _mxfp8.can_implement_mla_query_projection(
-        batch=num_heads,
-        max_m=max_m,
-        n=latent_dim,
-        k=nope_dim,
-        output_dtype=output_dtype,
-        b_major="n",
-        sf_axis="n",
-    )
+    if not is_supported(device):
+        return False
+    if weight_format == "bf16":
+        return _bf16.can_implement(
+            num_heads=num_heads,
+            max_m=max_m,
+            nope_dim=nope_dim,
+            latent_dim=latent_dim,
+            output_dtype=output_dtype,
+            device=device,
+        )
+    if weight_format == "mxfp8":
+        return _mxfp8.can_implement_mla_query_projection(
+            batch=num_heads,
+            max_m=max_m,
+            n=latent_dim,
+            k=nope_dim,
+            output_dtype=output_dtype,
+            b_major="n",
+            sf_axis="n",
+        )
+    return False
 
 
 def is_supported(device=None) -> bool:
@@ -89,6 +125,7 @@ def is_supported(device=None) -> bool:
 def clear_caches() -> None:
     """Clear compiled fused-query projection specializations."""
     _mxfp8.clear_mla_query_projection_caches()
+    _bf16.clear_caches()
 
 
 __all__ = list(META.entry_points)

--- a/tests/gemm/test_mla_query_projection.py
+++ b/tests/gemm/test_mla_query_projection.py
@@ -50,6 +50,29 @@ def _reference_fp8(query: torch.Tensor, q_scale: torch.Tensor) -> torch.Tensor:
     return (query.float() * inv_scale).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
 
 
+def _bf16_inputs(
+    *, num_heads: int, m: int, seed: int = 47
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(seed)
+    q_nope = torch.randn(num_heads, m, 192, device="cuda", dtype=torch.bfloat16) * 0.5
+    weight = (
+        torch.randn(num_heads, 192, 512, device="cuda", dtype=torch.bfloat16) * 0.05
+    )
+    q_full = torch.randn(m, num_heads, 576, device="cuda", dtype=torch.bfloat16)
+    q_pe = q_full[..., 512:]
+    q_scale = torch.tensor([0.037], device="cuda", dtype=torch.float32)
+    return q_nope, weight, q_pe, q_scale
+
+
+def _reference_bf16_weight(
+    q_nope: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+) -> torch.Tensor:
+    projected = torch.bmm(q_nope, weight).transpose(0, 1)
+    return torch.cat((projected, q_pe), dim=-1)
+
+
 @pytest.mark.parametrize("num_heads", [8, 16])
 @pytest.mark.parametrize("m", [1, 6, 9, 32])
 @pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
@@ -92,9 +115,7 @@ def test_fused_query_matches_two_stage_reference(
 def test_fused_query_cuda_graph_replays_fresh_inputs(output_dtype: torch.dtype) -> None:
     require_sparkinfer()
     q_nope, weight, q_pe, q_scale = _inputs(num_heads=8, m=4)
-    assert mla_query_projection.prewarm(
-        weight, [4], output_dtype=output_dtype
-    ) == 1
+    assert mla_query_projection.prewarm(weight, [4], output_dtype=output_dtype) == 1
     out = torch.empty(4, 8, 576, device="cuda", dtype=output_dtype)
 
     graph = torch.cuda.CUDAGraph()
@@ -157,6 +178,111 @@ def test_fused_query_rejects_wrong_rope_layout() -> None:
 def test_fused_query_requires_scale_only_for_fp8() -> None:
     require_sparkinfer()
     q_nope, weight, q_pe, _ = _inputs(num_heads=8, m=2)
+    out_bf16 = torch.empty(2, 8, 576, device="cuda", dtype=torch.bfloat16)
+    mla_query_projection.run(q_nope, weight, q_pe, out_bf16)
+
+    out_fp8 = torch.empty(2, 8, 576, device="cuda", dtype=torch.float8_e4m3fn)
+    with pytest.raises(ValueError, match="q_scale is required"):
+        mla_query_projection.run(q_nope, weight, q_pe, out_fp8)
+
+
+@pytest.mark.parametrize("num_heads", [8, 11, 16])
+@pytest.mark.parametrize("m", [1, 6, 17, 32])
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_bf16_weight_matches_staged_projection(
+    num_heads: int, m: int, output_dtype: torch.dtype
+) -> None:
+    require_sparkinfer()
+    q_nope, weight, q_pe, q_scale = _bf16_inputs(num_heads=num_heads, m=m)
+    reference_bf16 = _reference_bf16_weight(q_nope, weight, q_pe)
+
+    # Exercise the pitched caller-owned layout used by DCP workspaces.
+    backing = torch.empty(m, num_heads, 584, device="cuda", dtype=output_dtype)
+    out = backing[..., :576]
+    returned = mla_query_projection.run(
+        q_nope,
+        weight,
+        q_pe,
+        out,
+        q_scale=q_scale if output_dtype == torch.float8_e4m3fn else None,
+    )
+
+    assert returned is out
+    if output_dtype == torch.bfloat16:
+        torch.testing.assert_close(out, reference_bf16, rtol=2e-2, atol=2e-2)
+        assert torch.equal(out[..., 512:], q_pe)
+    else:
+        fused_bf16 = torch.empty(
+            (m, num_heads, 576), device="cuda", dtype=torch.bfloat16
+        )
+        mla_query_projection.run(q_nope, weight, q_pe, fused_bf16)
+        torch.testing.assert_close(fused_bf16, reference_bf16, rtol=2e-2, atol=2e-2)
+        expected = _reference_fp8(fused_bf16, q_scale)
+        assert torch.equal(out.view(torch.uint8), expected.view(torch.uint8))
+
+
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_bf16_weight_cuda_graph_replays_fresh_inputs(
+    output_dtype: torch.dtype,
+) -> None:
+    require_sparkinfer()
+    q_nope, weight, q_pe, q_scale = _bf16_inputs(num_heads=11, m=4)
+    assert mla_query_projection.prewarm(weight, [4], output_dtype=output_dtype) == 1
+    out = torch.empty(4, 11, 576, device="cuda", dtype=output_dtype)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        mla_query_projection.run(
+            q_nope,
+            weight,
+            q_pe,
+            out,
+            q_scale=q_scale if output_dtype == torch.float8_e4m3fn else None,
+        )
+
+    fresh_nope = torch.randn_like(q_nope) * 0.5
+    fresh_pe = torch.randn_like(q_pe)
+    q_nope.copy_(fresh_nope)
+    q_pe.copy_(fresh_pe)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    reference_bf16 = _reference_bf16_weight(fresh_nope, weight, fresh_pe)
+    if output_dtype == torch.bfloat16:
+        torch.testing.assert_close(out, reference_bf16, rtol=2e-2, atol=2e-2)
+    else:
+        fused_bf16 = torch.empty_like(out, dtype=torch.bfloat16)
+        mla_query_projection.run(fresh_nope, weight, fresh_pe, fused_bf16)
+        torch.testing.assert_close(fused_bf16, reference_bf16, rtol=2e-2, atol=2e-2)
+        expected = _reference_fp8(fused_bf16, q_scale)
+        assert torch.equal(out.view(torch.uint8), expected.view(torch.uint8))
+
+
+def test_bf16_weight_supports_virtual_tp_heads() -> None:
+    device = require_sparkinfer()
+    kwargs = dict(
+        num_heads=11,
+        max_m=32,
+        nope_dim=192,
+        latent_dim=512,
+        output_dtype=torch.bfloat16,
+        weight_format="bf16",
+        device=device,
+    )
+    assert mla_query_projection.can_implement(**kwargs)
+    assert mla_query_projection.can_implement(
+        **{**kwargs, "output_dtype": torch.float8_e4m3fn}
+    )
+    assert not mla_query_projection.can_implement(**{**kwargs, "num_heads": 12})
+    assert not mla_query_projection.can_implement(**{**kwargs, "max_m": 33})
+    assert not mla_query_projection.can_implement(
+        **{**kwargs, "weight_format": "mxfp8"}
+    )
+
+
+def test_bf16_weight_requires_scale_only_for_fp8() -> None:
+    require_sparkinfer()
+    q_nope, weight, q_pe, _ = _bf16_inputs(num_heads=8, m=2)
     out_bf16 = torch.empty(2, 8, 576, device="cuda", dtype=torch.bfloat16)
     mla_query_projection.run(q_nope, weight, q_pe, out_bf16)
 


### PR DESCRIPTION
## What

Extends the merged `sparkinfer.gemm.mla_query_projection` operation with a
small-M BF16-weight specialization for GLM MLA query absorption.

- BF16 `q_nope [H,M,192]` x BF16 `W_UK_T [H,192,512]`.
- Direct caller-owned `[M,H,576]` output with the 64-wide RoPE suffix appended
  in the same launch.
- BF16 or static E4M3 output.
- Qualified only for H=8/11/16 and M=1..32 on SM120/SM121.
- H=11 covers virtual TP6 without padding the model weight.

This is a second weight-format dispatch inside the operation introduced by
#74. It does not restore the removed `sparkinfer.attention.mla_query` package
and does not modify the merged MXFP8 lowering.

## Contract

- Operation ownership remains under `gemm.mla_query_projection`.
- Native MXFP8 continues to use `gemm/_shared/mxfp8_bmm.py`.
- BF16 output needs no dummy `q_scale`; E4M3 output requires one.
- Existing stream, overlap, stride, CUDA graph prewarm, and cache contracts are
  preserved.
- The checked-in benchmark adds `--weight-format bf16` instead of creating a
  parallel API.

The kernel accumulates in FP32 and rounds the 512-wide projection to BF16
before optional E4M3 conversion, matching the staged operation boundary.
Triton and cuBLAS may reduce K in a different order, so BF16 projection is not
promised bitwise identical. Across H=8/11/16 and M=1/4/6/17/32:

- the RoPE suffix was bitwise identical;
- output was finite and nonzero;
- stress inputs observed at most 0.25 absolute difference and about 1e-6 mean
  absolute difference;
- the lower-amplitude checked-in benchmark observed 0 to 0.00390625 maximum
  absolute difference.

Native MXFP8 behavior remains bitwise checked and unchanged.

## Performance evidence

Exact paired TP8/DCP1/MTP0 profiling, averaged over eight ranks:

| Metric | Staged | Fused | Delta |
| --- | ---: | ---: | ---: |
| Query BMM + concat per layer | 4.047940 us | 2.880912 us | -28.8% |
| CUDA kernel events, four steps | 10,200 | 9,888 | -312 |
| GPU trace span | 50,940.968 us | 50,450.708 us | -0.96% |

The 312 removed events are exactly 78 layers x 4 steps. Both traces contain 12
`cudaStreamWaitEvent`, 8 event records, and 4 graph launches. Final
TP8/DCP1/MTP0 duration validation produced aggregate 87.658/87.610 tok/s
(mean 87.634), active per-user 88.359/88.313 tok/s (mean 88.336), and zero
errors.

The standalone graph-replay benchmark remains launch-floor dominated for this
small BF16 operation. Across H=8/11/16 and M=1/4/32, its fused/staged median
ratio was 0.994 to 1.024 over 1,000 balanced AB/BA samples per shape.

## E2E integration matrix

Paired vLLM PR: `local-inference-lab/vllm#174` at `1f2bf43c6b`. All values are
aggregate CC1 output tok/s; 64k cases include prefill-to-decode transition.

| Model path | TP | DCP | MTP | ctx0 | ctx64k | Errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| NF3 MXFP8 | 4 | 1 | 0 | 64.44 | 61.66 | 0 |
| NF3 MXFP8 | 4 | 2 | 0 | 58.11 | 57.51 | 0 |
| NF3 MXFP8 | 4 | 4 | 0 | 57.61 | 56.24 | 0 |
| Luke BF16 | 6 | 1 | 0 | 68.69 | 67.11 | 0 |
| Luke BF16 | 6 | 2 | 0 | 58.11 | 57.27 | 0 |
| Luke BF16 | 6 | 3 | 0 | 52.38 | 50.82 | 0 |
| Luke BF16 | 6 | 6 | 0 | 42.66 | 41.98 | 0 |
| Luke BF16 | 8 | 1 | 0 | 87.63 | - | 0 |
| Luke BF16 | 8 | 2 | 0 | 73.39 | 71.33 | 0 |
| Luke BF16 | 8 | 4 | 0 | 71.79 | 69.47 | 0 |
| Luke BF16 | 8 | 8 | 0 | 66.43 | 65.83 | 0 |
| NF3 MXFP8 | 4 | 4 | 3 | 111.60 | 102.13 | 0 |
| Luke BF16 | 6 | 3 | 3 | 89.15 | 79.04 | 0 |
| Luke BF16 | 8 | 4 | 3 | 124.27 | 111.77 | 0 |

Every worker logged fused-query warmup. No final server log contained a
traceback, Xid, illegal-memory-access, `CUBLAS_STATUS`, `FAULT_PDE`,
invalid-layout, or engine-initialization failure.

## Validation

- `tests/gemm/test_bmm.py`, `tests/gemm/test_mla_query_projection.py`, and
  `tests/test_registry.py`: 93 passed on GPU 0.
- BF16 and MXFP8 weights; BF16 and E4M3 output; H=8/11/16;
  M=1/6/9/17/32; pitched outputs; scale validation; and CUDA graph replay with
  mutated inputs are covered.
- Paired vLLM integration suites: 14 passed, plus the final DCP/FP8 guard
  selection at 9 passed and 2325 deselected.
- Direct H=11 BF16 custom-op smoke passed.
- Ruff, Ruff format, `compileall`, and `git diff --check` passed.

Paired vLLM integration: `local-inference-lab/vllm#174`
