### PR TITLE
[SparkInfer] Account persistent PCIe DMA output in KV profiling

### DIFF
--- a/sparkinfer/comm/pcie/pcie_dma.py
+++ b/sparkinfer/comm/pcie/pcie_dma.py
@@ -141,12 +141,38 @@ def _align_up(value: int, alignment: int) -> int:
     return (value + alignment - 1) // alignment * alignment
 
 
+def _persistent_output_view(
+    storage: torch.Tensor,
+    inp: torch.Tensor,
+    max_bytes: int,
+) -> torch.Tensor:
+    """Return an input-shaped view over an exact-capacity byte workspace."""
+    size_bytes = inp.numel() * inp.element_size()
+    if size_bytes > max_bytes:
+        raise ValueError(
+            f"input needs {size_bytes} output bytes, capacity is {max_bytes}"
+        )
+    if (
+        storage.device != inp.device
+        or storage.dtype is not torch.uint8
+        or not storage.is_contiguous()
+    ):
+        raise ValueError("output storage must be contiguous uint8 on the input device")
+    if storage.numel() < max_bytes:
+        raise ValueError(
+            f"output storage has {storage.numel()} bytes, capacity is {max_bytes}"
+        )
+    return storage[:size_bytes].view(inp.dtype).view(inp.shape)
+
+
 class PCIeDmaAllReduce:
     """Single-channel ring allreduce over IPC scratch buffers.
 
     A channel is a single ordered stream context; concurrent use from
     multiple CUDA streams needs separate channels (same contract as the
-    oneshot runtime).
+    oneshot runtime). When ``out`` is omitted, the returned tensor uses a
+    channel-owned workspace and remains valid until the next default-output
+    invocation on that channel.
     """
 
     def __init__(
@@ -195,6 +221,12 @@ class PCIeDmaAllReduce:
         self._wait_counters = torch.zeros(
             FLAG_SLOTS, dtype=torch.int32, device=self.device
         )
+        # The communicator exists before vLLM takes its initial memory
+        # snapshot. Allocate this exact-capacity workspace on the first DMA
+        # dispatch instead, so a profiling forward charges it to the KV-cache
+        # budget. Keeping it alive prevents a large first runtime dispatch from
+        # allocating after KV cache has consumed the remaining device memory.
+        self._output_storage: torch.Tensor | None = None
         self._copy_stream = torch.cuda.Stream(device=self.device)
         self._flag_stream = torch.cuda.Stream(device=self.device)
         # Separate CE/flag streams for the a2a broadcast phase so allgather
@@ -332,6 +364,15 @@ class PCIeDmaAllReduce:
             return False
         return inp.is_contiguous() and size_bytes <= self.max_bytes
 
+    def _ensure_output_storage(self) -> torch.Tensor:
+        if self._output_storage is None:
+            self._output_storage = torch.empty(
+                self.max_bytes,
+                dtype=torch.uint8,
+                device=self.device,
+            )
+        return self._output_storage
+
     def all_reduce(
         self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
@@ -341,7 +382,11 @@ class PCIeDmaAllReduce:
                 f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
             )
         if out is None:
-            out = torch.empty_like(inp)
+            out = _persistent_output_view(
+                self._ensure_output_storage(),
+                inp,
+                self.max_bytes,
+            )
         elif (
             out.shape != inp.shape or out.dtype != inp.dtype or not out.is_contiguous()
         ):
@@ -794,6 +839,7 @@ class PCIeDmaAllReduce:
                 self._ipc.cudaIpcCloseMemHandle(ptr)
         with suppress(Exception):
             self._ipc.cudaFree(self._slab.local_ptr)
+        self._output_storage = None
 
     def __del__(self) -> None:
         with suppress(Exception):

--- a/tests/comm/test_pcie_dma_gpu.py
+++ b/tests/comm/test_pcie_dma_gpu.py
@@ -76,6 +76,16 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         max_bytes=max_rows * hidden * 4,
     )
     try:
+        assert ring._output_storage is None
+        explicit_inp = _make_input(8, hidden, torch.bfloat16, device, rank, 0)
+        explicit_ref = _reference(explicit_inp)
+        explicit_out = torch.empty_like(explicit_inp)
+        ring.all_reduce(explicit_inp, out=explicit_out)
+        torch.cuda.synchronize(device)
+        _assert_close(explicit_out, explicit_ref, world_size)
+        assert ring._output_storage is None
+
+        default_output_ptr = None
         for dtype in (torch.bfloat16,):
             for rows in (8, 64, 256):
                 inp = _make_input(rows, hidden, dtype, device, rank, 0)
@@ -83,15 +93,22 @@ def _worker(rank: int, world_size: int, port: int) -> None:
                 out = ring.all_reduce(inp)
                 torch.cuda.synchronize(device)
                 _assert_close(out, ref, world_size)
+                if default_output_ptr is None:
+                    default_output_ptr = out.data_ptr()
+                else:
+                    assert out.data_ptr() == default_output_ptr
 
-        # Graph capture and replay with changing inputs.
+        assert ring._output_storage is not None
+        assert ring._output_storage.numel() == ring.max_bytes
+
+        # Default-output graph capture and replay with changing inputs.
         rows = 256
         dtype = torch.bfloat16
         inp = _make_input(rows, hidden, dtype, device, rank, 0)
-        out = torch.empty_like(inp)
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph):
-            ring.all_reduce(inp, out=out)
+            out = ring.all_reduce(inp)
+        assert out.data_ptr() == default_output_ptr
         for iteration in range(1, 4):
             inp.copy_(_make_input(rows, hidden, dtype, device, rank, iteration))
             ref = _reference(inp)
@@ -102,7 +119,9 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         dist.barrier()
     finally:
         ring.close()
+        output_storage_released = ring._output_storage is None
         dist.destroy_process_group()
+        assert output_storage_released
 
 
 def test_pcie_dma_all_reduce_eager_and_graph() -> None:
@@ -113,6 +132,10 @@ def test_pcie_dma_all_reduce_eager_and_graph() -> None:
         pytest.skip(
             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
         )
+    # Build once in the parent. Concurrent first-build imports from spawned
+    # ranks can observe the extension directory before its shared object is
+    # atomically installed.
+    _load_extension()
     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
 
 
@@ -143,6 +166,7 @@ def test_pcie_dma_all_reduce_compressed_wire(mode: str) -> None:
         pytest.skip(
             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
         )
+    _load_extension()
     mp.spawn(
         _fp8_worker,
         args=(world_size, _free_port(), mode),

--- a/tests/comm/test_pcie_dma_output.py
+++ b/tests/comm/test_pcie_dma_output.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sparkinfer.comm.pcie.pcie_dma import (
+    PCIeDmaAllReduce,
+    _persistent_output_view,
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_persistent_output_view_reuses_exact_capacity_storage(
+    dtype: torch.dtype,
+) -> None:
+    max_bytes = 4096
+    storage = torch.empty(max_bytes, dtype=torch.uint8)
+    elements = max_bytes // dtype.itemsize
+    inp = torch.empty((16, elements // 16), dtype=dtype)
+
+    output = _persistent_output_view(storage, inp, max_bytes)
+    smaller = _persistent_output_view(storage, inp[:1], max_bytes)
+
+    assert output.shape == inp.shape
+    assert output.dtype == dtype
+    assert output.is_contiguous()
+    assert output.data_ptr() == storage.data_ptr()
+    assert smaller.data_ptr() == output.data_ptr()
+    assert storage.numel() == max_bytes
+    assert output.untyped_storage().nbytes() == max_bytes
+
+
+def test_persistent_output_view_rejects_request_over_capacity() -> None:
+    storage = torch.empty(128, dtype=torch.uint8)
+    inp = torch.empty(65, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="capacity is 128"):
+        _persistent_output_view(storage, inp, 128)
+
+
+def test_persistent_output_view_rejects_undersized_storage() -> None:
+    storage = torch.empty(64, dtype=torch.uint8)
+    inp = torch.empty(16, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="storage has 64 bytes"):
+        _persistent_output_view(storage, inp, 128)
+
+
+def test_persistent_output_view_rejects_wrong_storage_layout() -> None:
+    inp = torch.empty(16, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="contiguous uint8"):
+        _persistent_output_view(torch.empty(128), inp, 128)
+
+    non_contiguous = torch.empty((128, 2), dtype=torch.uint8)[:, 0]
+    with pytest.raises(ValueError, match="contiguous uint8"):
+        _persistent_output_view(non_contiguous, inp, 128)
+
+
+def test_close_releases_persistent_output_storage() -> None:
+    class FakeCudaRuntime:
+        def cudaIpcCloseMemHandle(self, _ptr: int) -> None:
+            pass
+
+        def cudaFree(self, _ptr: int) -> None:
+            pass
+
+    ring = object.__new__(PCIeDmaAllReduce)
+    ring._closed = False
+    ring._ipc = FakeCudaRuntime()
+    ring._slab = SimpleNamespace(remote_ptrs=(1, 2), local_ptr=3)
+    ring._output_storage = torch.empty(128, dtype=torch.uint8)
+
+    ring.close()
+
+    assert ring._closed
+    assert ring._output_storage is None


### PR DESCRIPTION
## Summary

- replace per-call default-output allocation in PCIe DMA all-reduce with one
  reusable, exact-capacity workspace;
- allocate it lazily on the first default-output dispatch, so vLLM profiling
  observes the persistent allocation before KV-cache sizing;
- preserve a stable output pointer across eager calls and CUDA graph replay;
- keep explicit `out=` calls allocation-free;
- release the owner reference during `close()`.

The allocation is exactly `max_bytes`. This PR does not add a mapped tail or
permit any downstream kernel to access bytes outside the logical allocation.

## Root cause and scope

A long prefill could be the first call to
`PCIeDmaAllReduce.all_reduce(..., out=None)` after vLLM had already assigned
remaining memory to KV blocks. The late default-output allocation could then
fail, and allocating a fresh output per call also violates the stable-address
contract required by CUDA graph replay.

Constructor allocation is too early for this integration: the ring exists
before vLLM's initial memory snapshot, so constructor-owned bytes are not
charged by the later profile delta. The first profiled default-output dispatch
is both early enough and visible to KV sizing.

The separately reproduced cuBLAS read-ahead issue is not solved by allocator
padding here. Its consumer path must use a legal GEMM/layout contract; carrying
a 64 KiB tail in a general communication allocator would hide an invalid
consumer and permanently waste memory per pool.

## Validation

- `test_pcie_dma_output.py` and `test_pcie_dma_gpu.py` with the two-GPU opt-in:
  **18 passed**;
- eager default-output calls reuse one pointer across shapes;
- explicit-output calls do not instantiate persistent storage;
- CUDA graph capture/replay passes with changing inputs;
- all configured compressed wire modes pass on two GPUs;
- backing storage is asserted to be exactly `max_bytes` and is released on
  close.

Complete
[rtx6kpro#34](https://github.com/local-inference-lab/rtx6kpro/issues/34)
E2E validation used current GG, vLLM #172 plus the MRV2 pool-lifecycle
successor to #168, and this PR:

| Gate | Result |
|---|---|
| TP4/DCP4/MTP3 NF3, GMU 0.98, graph 64 | booted; 563,712 KV tokens; 300,017-token prefill plus 16 decode completed |
| TP8/DCP2/MTP3 A4 online MXFP8, ring DMA | 300,066-token prefill plus 512 decode completed in 65.924 s; server remained healthy |

## AI assistance disclosure

The implementation review, tests, E2E validation, and this write-up were
prepared with OpenAI Codex assistance and reviewed by the human submitter.