### PR TITLE
perf(indexer): keep exact long-context top-k on the fast path

### DIFF
--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -41,7 +41,18 @@ _THREADS_PER_CTA = 1024
 _DEFAULT_TOPK = 2048
 _SUPPORTED_TOPK = (512, 1024, 2048)
 _RADIX = 256
-_SMEM_CANDS = 4096
+# Use every SM120 CTA lane for the first histogram.  The four-times narrower
+# bucket keeps ordinary 32k/64k low-contrast rows on the buffered exact path;
+# truly degenerate buckets still use the rescan fallback below.
+_COARSE_RADIX_BITS = 10
+_COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
+_HIST_SLOTS = _COARSE_RADIX_BINS + 128
+# A 1024-thread selector CTA is already limited to one resident block per SM on
+# SM120 (1536 threads/SM).  Keeping 8192 candidates therefore avoids the common
+# long-context overflow without reducing occupancy; the complete shared-memory
+# allocation remains below the 99 KiB opt-in block limit.  The exact rescan below
+# still covers wider or degenerate threshold buckets.
+_SMEM_CANDS = 8192
 _SCAN_UNROLL = 4
 _SUPERTILE_K_ENV = "SPARKINFER_NSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
@@ -217,6 +228,19 @@ def _convert_to_uint8(x: Float32) -> Uint32:
     else:
         key16 = bits16 | Uint32(0x8000)
     return (key16 >> Uint32(8)) & Uint32(0xFF)
+
+
+@cute.jit
+def _convert_to_coarse_bin(x: Float32) -> Uint32:
+    h_bits = _cvt_rn_f16_f32(x)
+    bits16 = h_bits & Uint32(0xFFFF)
+    sign = bits16 & Uint32(0x8000)
+    key16 = Uint32(0)
+    if sign != Uint32(0):
+        key16 = Uint32(0xFFFF) ^ bits16
+    else:
+        key16 = bits16 | Uint32(0x8000)
+    return (key16 >> Uint32(16 - _COARSE_RADIX_BITS)) & Uint32(_COARSE_RADIX_BINS - 1)
 
 
 @cute.jit
@@ -455,9 +479,7 @@ def _to_kernel_tensor(tensor, dtype, *, assumed_align=16):
     return cute_tensor
 
 
-def _tensor_compile_key(
-    name, tensor, *, dynamic_dims=(), dynamic_strides=()
-):
+def _tensor_compile_key(name, tensor, *, dynamic_dims=(), dynamic_strides=()):
     return tensor_compile_fact(
         name, tensor, dynamic_dims=dynamic_dims, dynamic_strides=dynamic_strides
     )
@@ -666,8 +688,12 @@ class SparseNSATiledTopkKernel:
 
         @cute.struct
         class SharedStorage:
-            hist0: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 384], 128]
-            hist1: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 384], 128]
+            hist0: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _HIST_SLOTS], 128
+            ]
+            hist1: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, _HIST_SLOTS], 128
+            ]
             out_idx: cute.struct.Align[
                 cute.struct.MemRange[cutlass.Int32, topk_capacity], 128
             ]
@@ -685,8 +711,12 @@ class SparseNSATiledTopkKernel:
 
         storage = smem_alloc.allocate(SharedStorage)
 
-        s_hist0 = storage.hist0.get_tensor(cute.make_layout((384,), stride=(1,)))
-        s_hist1 = storage.hist1.get_tensor(cute.make_layout((384,), stride=(1,)))
+        s_hist0 = storage.hist0.get_tensor(
+            cute.make_layout((_HIST_SLOTS,), stride=(1,))
+        )
+        s_hist1 = storage.hist1.get_tensor(
+            cute.make_layout((_HIST_SLOTS,), stride=(1,))
+        )
         s_out = storage.out_idx.get_tensor(
             cute.make_layout((topk_capacity,), stride=(1,))
         )
@@ -755,8 +785,9 @@ class SparseNSATiledTopkKernel:
         if need_radix:
             topk = topk_static
 
-            if tx < Int32(257):
-                s_hist0[tx] = Int32(0)
+            s_hist0[tx] = Int32(0)
+            if tx == Int32(0):
+                s_hist0[Int32(_COARSE_RADIX_BINS)] = Int32(0)
             cute.arch.sync_threads()
 
             idx_base = Int32(tx)
@@ -777,8 +808,8 @@ class SparseNSATiledTopkKernel:
                         self.is_tiled,
                         self.is_first,
                     )
-                    bin8 = _convert_to_uint8(val)
-                    _smem_red_add(h0, Int32(bin8), Int32(1))
+                    coarse_bin = _convert_to_coarse_bin(val)
+                    _smem_red_add(h0, Int32(coarse_bin), Int32(1))
                 idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
             while idx_base < total_len:
                 val = _load_value_virtual(
@@ -794,30 +825,30 @@ class SparseNSATiledTopkKernel:
                     self.is_tiled,
                     self.is_first,
                 )
-                bin8 = _convert_to_uint8(val)
-                _smem_red_add(h0, Int32(bin8), Int32(1))
+                coarse_bin = _convert_to_coarse_bin(val)
+                _smem_red_add(h0, Int32(coarse_bin), Int32(1))
                 idx_base = idx_base + Int32(_THREADS_PER_CTA)
 
             cute.arch.sync_threads()
 
-            # Parallel prefix sum: 8 stages, double-buffer h0/h1
-            for stage in cutlass.range_constexpr(8):
+            # Parallel descending prefix sum over the widened coarse radix.
+            for stage in cutlass.range_constexpr(_COARSE_RADIX_BITS):
                 j = Int32(1 << stage)
-                if tx < Int32(256):
+                if tx < Int32(_COARSE_RADIX_BINS):
                     if (stage & 1) == 0:
                         value = Int32(s_hist0[tx])
-                        if tx < Int32(256) - j:
+                        if tx < Int32(_COARSE_RADIX_BINS) - j:
                             value = value + Int32(s_hist0[tx + j])
                         s_hist1[tx] = value
                     else:
                         value = Int32(s_hist1[tx])
-                        if tx < Int32(256) - j:
+                        if tx < Int32(_COARSE_RADIX_BINS) - j:
                             value = value + Int32(s_hist1[tx + j])
                         s_hist0[tx] = value
                 cute.arch.sync_threads()
 
             # Find threshold bin
-            if tx < Int32(256):
+            if tx < Int32(_COARSE_RADIX_BINS):
                 val_tx = Int32(s_hist0[tx])
                 val_tx1 = Int32(s_hist0[tx + Int32(1)])
                 if val_tx > topk:
@@ -851,8 +882,8 @@ class SparseNSATiledTopkKernel:
                             self.is_tiled,
                             self.is_first,
                         )
-                        bin8 = _convert_to_uint8(val)
-                        if Int32(bin8) > threshold_bin:
+                        coarse_bin = _convert_to_coarse_bin(val)
+                        if Int32(coarse_bin) > threshold_bin:
                             pos = _smem_xadd(ctr, Int32(0), Int32(1))
                             s_out[pos] = idx
                     idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
@@ -870,8 +901,8 @@ class SparseNSATiledTopkKernel:
                         self.is_tiled,
                         self.is_first,
                     )
-                    bin8 = _convert_to_uint8(val)
-                    if Int32(bin8) > threshold_bin:
+                    coarse_bin = _convert_to_coarse_bin(val)
+                    if Int32(coarse_bin) > threshold_bin:
                         pos = _smem_xadd(ctr, Int32(0), Int32(1))
                         s_out[pos] = idx_base
                     idx_base = idx_base + Int32(_THREADS_PER_CTA)
@@ -903,12 +934,12 @@ class SparseNSATiledTopkKernel:
                             self.is_tiled,
                             self.is_first,
                         )
-                        bin8 = _convert_to_uint8(raw_input)
-                        if Int32(bin8) > threshold_bin:
+                        coarse_bin = _convert_to_coarse_bin(raw_input)
+                        if Int32(coarse_bin) > threshold_bin:
                             pos = _smem_xadd(ctr, Int32(0), Int32(1))
                             s_out[pos] = idx
                         else:
-                            if Int32(bin8) == threshold_bin:
+                            if Int32(coarse_bin) == threshold_bin:
                                 cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
                                 if cand_pos < Int32(_SMEM_CANDS):
                                     s_cand0[cand_pos] = idx
@@ -930,12 +961,12 @@ class SparseNSATiledTopkKernel:
                         self.is_tiled,
                         self.is_first,
                     )
-                    bin8 = _convert_to_uint8(raw_input)
-                    if Int32(bin8) > threshold_bin:
+                    coarse_bin = _convert_to_coarse_bin(raw_input)
+                    if Int32(coarse_bin) > threshold_bin:
                         pos = _smem_xadd(ctr, Int32(0), Int32(1))
                         s_out[pos] = idx_base
                     else:
-                        if Int32(bin8) == threshold_bin:
+                        if Int32(coarse_bin) == threshold_bin:
                             cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
                             if cand_pos < Int32(_SMEM_CANDS):
                                 s_cand0[cand_pos] = idx_base
@@ -950,6 +981,14 @@ class SparseNSATiledTopkKernel:
                 # before the round loop clobbers ni0, to detect when the threshold
                 # bucket overflowed the candidate buffer (winners dropped past the cap).
                 bin_count = Int32(_smem_ld(ni0, Int32(0)))
+
+                # The exact fallback below rebuilds all top-k outputs from the full
+                # row.  Do not spend four radix rounds refining a truncated candidate
+                # buffer first: none of those intermediate outputs survive.  This is
+                # a CTA-uniform branch because every thread reads the same shared
+                # counter after the barrier above.
+                if bin_count > Int32(_SMEM_CANDS):
+                    topk = Int32(-1)
 
                 # Stage 2: refine with 8-bit radix passes
                 for round_idx in cutlass.range_constexpr(4):
@@ -1504,7 +1543,7 @@ def run_tiled_topk(
             dynamic_strides=(0,),
         ),
         (
-            "tiled_topk_v23",
+            "tiled_topk_v26_wide_coarse",
             topk,
             block_q,
             block_k,

--- a/tests/attention/test_paged_prefill_topk_long_context.py
+++ b/tests/attention/test_paged_prefill_topk_long_context.py
@@ -2,8 +2,8 @@
 
 The tiled radix-select top-k (``SparseNSATiledTopkKernel``, reached via ``index_topk_fp8``
 / ``packed_contiguous``) buckets candidates by the top bits of the score and stores the
-threshold bucket in a fixed 4096-slot shared buffer (``_SMEM_CANDS``). When a single
-bucket holds more than 4096 candidates -- e.g. many tokens with near-equal scores, as
+threshold bucket in a fixed shared buffer (``_SMEM_CANDS``). When a single bucket
+holds more candidates than that buffer -- e.g. many tokens with near-equal scores, as
 happens on low-contrast attention rows at longer context -- the pre-fix code silently
 dropped the overflow and kept the lowest-indexed (here lowest-scoring) survivors, so it
 selected tokens far below the true top-k threshold. The fix re-runs an exact, buffer-free
@@ -11,9 +11,9 @@ MSD radix (``_exact_overflow_fallback``) whenever the bucket overflows.
 
 Cases (verified by score, not index, so a miss is genuine and not a tie-break):
 
-* ``seq_len`` sweep: 16384 keeps the hot bucket at 4091 <= 4096 (never overflowed);
-  16448 pushes it just over 4096 with almost no extra context, proving the trigger is the
-  4096 bucket cap and not the context length; 32768 overflows it hard.
+* ``seq_len`` sweep: 32768 and 32832 straddle the old 8-bit/8192-candidate
+  boundary, while 65536 verifies that the wider coarse radix remains exact at long
+  context without relying on the historical truncated result.
 * all-equal scores: one coarse+fine bucket holds every token, so the fallback's tie-fill
   branch must fill the whole top-k from a single pivot key.
 * logical output (``output_physical_slots=False``): exercises the two-level fold, whose
@@ -21,6 +21,7 @@ Cases (verified by score, not index, so a miss is genuine and not a tie-break):
 * carry fold (``supertile_k`` < context): multi-chunk streaming fold, so the overflow
   fallback runs in the ``is_first=False`` carry path through the virtual value loader.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -138,7 +139,9 @@ def _run_indexer(
         build_schedule=False,
         shared_page_table=True,
     )
-    selected = torch.empty((_ROWS, _TOPK), dtype=torch.int32, device=scene["q_fp8"].device)
+    selected = torch.empty(
+        (_ROWS, _TOPK), dtype=torch.int32, device=scene["q_fp8"].device
+    )
     clear_indexer_caches()
     index_topk_fp8(
         q_fp8=scene["q_fp8"],
@@ -177,16 +180,14 @@ def _assert_selects_true_topk(
         )
     logical = raw_logical.clamp(0, seq_len - 1)
     selected_score = torch.gather(scene["ref_logits"], 1, logical)
-    n_below = int(
-        (selected_score < (scene["kth_score"][:, None] - 1e-4)).sum().item()
-    )
+    n_below = int((selected_score < (scene["kth_score"][:, None] - 1e-4)).sum().item())
     assert n_below == 0, (
         f"{n_below}/{_ROWS * _TOPK} selected tokens score below the true top-{_TOPK} "
         f"threshold at seq_len={seq_len}"
     )
 
 
-@pytest.mark.parametrize("seq_len", [16384, 16448, 32768])
+@pytest.mark.parametrize("seq_len", [32768, 32832, 65536])
 def test_paged_prefill_topk_selects_true_topk_at_long_context(
     monkeypatch, seq_len: int
 ) -> None:
@@ -221,8 +222,9 @@ def test_paged_prefill_topk_logical_output_two_level_fold(monkeypatch) -> None:
 def test_paged_prefill_topk_carry_fold_overflow(monkeypatch) -> None:
     """supertile_k < context forces the multi-chunk carry fold (is_first=False path).
 
-    All-equal scores guarantee every 8192-token chunk overflows its single bucket, so
-    the exact fallback runs through the virtual (carry-aware) value loader.
+    All-equal scores put each 8192-token local chunk in one bucket. The first chunk
+    exactly fills the 8192-slot buffer; the next fold adds the carried 2048 winners and
+    therefore overflows, exercising the virtual (carry-aware) exact fallback.
     """
     device = torch.device("cuda")
     scene = _build_scene(device, 32768, "equal")


### PR DESCRIPTION
## Summary

- widen the tiled selector's coarse radix from 8 to 10 bits
- increase the shared candidate capacity from 4,096 to 8,192 entries
- skip buffered refinement once overflow has already selected the exact rescan path
- retain the candidate-buffer-free exact fallback introduced by #55

## Why

#55 fixed silent top-k corruption when the threshold bucket exceeded the fixed candidate buffer. On GLM-5.2 long-context prefill, however, the 8-bit coarse bucket commonly exceeded 4,096 entries. That sent ordinary rows through four full exact rescans and reduced 64k prefill throughput.

SM120 already runs this 1,024-thread selector at one CTA per SM. The wider histogram uses all CTA lanes, and the larger candidate arrays keep the complete shared-memory allocation below the 99 KiB opt-in block limit without reducing occupancy. Truly degenerate rows still take the exact fallback.

## Validation

- `ruff check` passed on both changed files
- `7 passed` in `test_paged_prefill_topk_long_context.py` on SM120
- coverage includes 32k/64k low-contrast rows, all-equal overflow, logical two-level fold, and multi-chunk carry fold
- disabling the exact fallback was tested only as a diagnostic and failed at 64k; this PR does not remove or weaken it

Matched TP8/DCP1/MTP0 GLM-5.2 runs:

| Variant | 64k prefill tok/s |
|---|---:|
| v19, before #55 | 5,917 |
| v20 with #55 | 5,782 |
| 8,192 candidates + skipped discarded refine | 5,877 |
| This PR, default 32k supertile | 5,895 |
| This PR + runtime 64k supertile | 5,914 |

The last row uses `SPARKINFER_PAGED_INDEX_SUPERTILE_K=65536`, which is deliberately not made a library-wide default in this PR. It measured 87.70 tok/s CC1 decode and reduced KV capacity by 2,816 tokens (0.51%) versus the default 32k supertile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved top-k selection accuracy for long-context attention workloads, especially in low-contrast cases.
  * Enhanced handling of candidate overflows to ensure exact fallback selection when intermediate buffers are exceeded.
  * Expanded coarse threshold detection to improve reliability and reduce incorrect selections.

* **Tests**
  * Added regression coverage for larger sequence lengths and overflow scenarios.
  * Clarified validation of selected results against the true top-k cutoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->