### PR TITLE
fix(indexer): add validated bounded compatibility policy

### DIFF
--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -50,14 +50,21 @@ _SELECTION_POLICIES = frozenset(
         _SELECTION_POLICY_BOUNDED_COMPAT,
     }
 )
-_SELECTION_POLICY = os.environ.get(
-    _SELECTION_POLICY_ENV, _SELECTION_POLICY_EXACT
-).strip().lower()
-if _SELECTION_POLICY not in _SELECTION_POLICIES:
-    raise ValueError(
-        f"{_SELECTION_POLICY_ENV} must be one of "
-        f"{sorted(_SELECTION_POLICIES)}, got {_SELECTION_POLICY!r}"
-    )
+
+
+def _resolve_selection_policy(value: str | None) -> str:
+    policy = (value or _SELECTION_POLICY_EXACT).strip().lower()
+    if policy not in _SELECTION_POLICIES:
+        raise ValueError(
+            f"{_SELECTION_POLICY_ENV} must be one of "
+            f"{sorted(_SELECTION_POLICIES)}, got {policy!r}"
+        )
+    return policy
+
+
+_SELECTION_POLICY = _resolve_selection_policy(
+    os.environ.get(_SELECTION_POLICY_ENV)
+)
 _BOUNDED_COMPAT = _SELECTION_POLICY == _SELECTION_POLICY_BOUNDED_COMPAT
 # Use every SM120 CTA lane for the first histogram.  The four-times narrower
 # bucket keeps ordinary 32k/64k low-contrast rows on the buffered exact path;
@@ -65,9 +72,8 @@ _BOUNDED_COMPAT = _SELECTION_POLICY == _SELECTION_POLICY_BOUNDED_COMPAT
 #
 # ``bounded_compat`` intentionally retains the historical 8-bit coarse bucket
 # and bounded 4096-candidate refinement.  This is an explicit model-compatibility
-# policy, not an accidental overflow: writes remain bounds checked, while
-# candidates beyond the deterministic buffer budget are omitted.  The default
-# remains exact.
+# policy, not an unsafe overflow: writes remain bounds checked, while candidates
+# beyond the fixed buffer budget are omitted.  The default remains exact.
 _COARSE_RADIX_BITS = 8 if _BOUNDED_COMPAT else 10
 _COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
 _HIST_SLOTS = _COARSE_RADIX_BINS + 128

--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -41,10 +41,34 @@ _THREADS_PER_CTA = 1024
 _DEFAULT_TOPK = 2048
 _SUPPORTED_TOPK = (512, 1024, 2048)
 _RADIX = 256
+_SELECTION_POLICY_ENV = "SPARKINFER_NSA_TOPK_SELECTION_POLICY"
+_SELECTION_POLICY_EXACT = "exact"
+_SELECTION_POLICY_BOUNDED_COMPAT = "bounded_compat"
+_SELECTION_POLICIES = frozenset(
+    {
+        _SELECTION_POLICY_EXACT,
+        _SELECTION_POLICY_BOUNDED_COMPAT,
+    }
+)
+_SELECTION_POLICY = os.environ.get(
+    _SELECTION_POLICY_ENV, _SELECTION_POLICY_EXACT
+).strip().lower()
+if _SELECTION_POLICY not in _SELECTION_POLICIES:
+    raise ValueError(
+        f"{_SELECTION_POLICY_ENV} must be one of "
+        f"{sorted(_SELECTION_POLICIES)}, got {_SELECTION_POLICY!r}"
+    )
+_BOUNDED_COMPAT = _SELECTION_POLICY == _SELECTION_POLICY_BOUNDED_COMPAT
 # Use every SM120 CTA lane for the first histogram.  The four-times narrower
 # bucket keeps ordinary 32k/64k low-contrast rows on the buffered exact path;
 # truly degenerate buckets still use the rescan fallback below.
-_COARSE_RADIX_BITS = 10
+#
+# ``bounded_compat`` intentionally retains the historical 8-bit coarse bucket
+# and bounded 4096-candidate refinement.  This is an explicit model-compatibility
+# policy, not an accidental overflow: writes remain bounds checked, while
+# candidates beyond the deterministic buffer budget are omitted.  The default
+# remains exact.
+_COARSE_RADIX_BITS = 8 if _BOUNDED_COMPAT else 10
 _COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
 _HIST_SLOTS = _COARSE_RADIX_BINS + 128
 # A 1024-thread selector CTA is already limited to one resident block per SM on
@@ -52,7 +76,7 @@ _HIST_SLOTS = _COARSE_RADIX_BINS + 128
 # long-context overflow without reducing occupancy; the complete shared-memory
 # allocation remains below the 99 KiB opt-in block limit.  The exact rescan below
 # still covers wider or degenerate threshold buckets.
-_SMEM_CANDS = 8192
+_SMEM_CANDS = 4096 if _BOUNDED_COMPAT else 8192
 _SCAN_UNROLL = 4
 _SUPERTILE_K_ENV = "SPARKINFER_NSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
@@ -539,6 +563,7 @@ class SparseNSATiledTopkKernel:
         # or the user's final output.
         self.is_first = bool(is_first)
         self.output_physical_slots = bool(output_physical_slots)
+        self.bounded_compat = bool(_BOUNDED_COMPAT)
 
     @cute.jit
     def __call__(
@@ -987,8 +1012,9 @@ class SparseNSATiledTopkKernel:
                 # buffer first: none of those intermediate outputs survive.  This is
                 # a CTA-uniform branch because every thread reads the same shared
                 # counter after the barrier above.
-                if bin_count > Int32(_SMEM_CANDS):
-                    topk = Int32(-1)
+                if not cutlass.const_expr(self.bounded_compat):
+                    if bin_count > Int32(_SMEM_CANDS):
+                        topk = Int32(-1)
 
                 # Stage 2: refine with 8-bit radix passes
                 for round_idx in cutlass.range_constexpr(4):
@@ -1140,33 +1166,34 @@ class SparseNSATiledTopkKernel:
                 # Exact overflow fallback: the buffered refine above dropped
                 # winners when more than _SMEM_CANDS candidates shared the coarse
                 # threshold bucket. Redo the selection exactly by re-scanning.
-                if bin_count > Int32(_SMEM_CANDS):
-                    _exact_overflow_fallback(
-                        tx,
-                        total_len,
-                        topk_static,
-                        s_hist0,
-                        s_hist1,
-                        s_out,
-                        h0,
-                        ctr,
-                        thr,
-                        ni0,
-                        ni1,
-                        lr,
-                        flat=False,
-                        flat_values=input_tensor,
-                        input_tensor=input_tensor,
-                        carry_values=carry_values,
-                        row_base=row_base,
-                        row_start=row_start,
-                        carry_base=out_base,
-                        chunk_len=length,
-                        block_q=self.block_q,
-                        block_k=self.block_k,
-                        is_tiled=self.is_tiled,
-                        is_first=self.is_first,
-                    )
+                if not cutlass.const_expr(self.bounded_compat):
+                    if bin_count > Int32(_SMEM_CANDS):
+                        _exact_overflow_fallback(
+                            tx,
+                            total_len,
+                            topk_static,
+                            s_hist0,
+                            s_hist1,
+                            s_out,
+                            h0,
+                            ctr,
+                            thr,
+                            ni0,
+                            ni1,
+                            lr,
+                            flat=False,
+                            flat_values=input_tensor,
+                            input_tensor=input_tensor,
+                            carry_values=carry_values,
+                            row_base=row_base,
+                            row_start=row_start,
+                            carry_base=out_base,
+                            chunk_len=length,
+                            block_q=self.block_q,
+                            block_k=self.block_k,
+                            is_tiled=self.is_tiled,
+                            is_first=self.is_first,
+                        )
 
             cute.arch.sync_threads()
             idx0 = Int32(tx)
@@ -1543,7 +1570,8 @@ def run_tiled_topk(
             dynamic_strides=(0,),
         ),
         (
-            "tiled_topk_v26_wide_coarse",
+            "tiled_topk_v27_selection_policy",
+            _SELECTION_POLICY,
             topk,
             block_q,
             block_k,
@@ -1713,7 +1741,8 @@ def run_row_topk(
             "carry_indices", carry_indices_key_tensor, dynamic=True
         ),
         (
-            "row_topk_v6",
+            "row_topk_v7_selection_policy",
+            _SELECTION_POLICY,
             topk,
             output_gather_table is not None,
         ),

--- a/tests/attention/test_nsa_topk_selection_policy.py
+++ b/tests/attention/test_nsa_topk_selection_policy.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from sparkinfer.attention.nsa_indexer.tiled_topk import (
+    _resolve_selection_policy,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "exact"),
+        ("", "exact"),
+        ("exact", "exact"),
+        (" EXACT ", "exact"),
+        ("bounded_compat", "bounded_compat"),
+        (" BOUNDED_COMPAT ", "bounded_compat"),
+    ],
+)
+def test_resolve_selection_policy(raw: str | None, expected: str) -> None:
+    assert _resolve_selection_policy(raw) == expected
+
+
+def test_resolve_selection_policy_rejects_unknown_value() -> None:
+    with pytest.raises(
+        ValueError,
+        match="SPARKINFER_NSA_TOPK_SELECTION_POLICY must be one of",
+    ):
+        _resolve_selection_policy("legacy")


### PR DESCRIPTION
## Summary

Add an explicit `SPARKINFER_NSA_TOPK_SELECTION_POLICY=bounded_compat`
policy for sparse-MLA deployments whose checkpoints were validated against
the historical bounded radix selector.

The default remains `exact`. Unknown values fail closed at import time.

Fixes the SparkInfer component of
[local-inference-lab/vllm#182](https://github.com/local-inference-lab/vllm/issues/182).

## Root cause

The v20 exact-overflow changes (`1012199e`, later optimized by `83a58444`)
changed the selected sparse-attention set at long context. On captured
production tensors:

- exact v20 matches the quantized-proxy top-k 2,048/2,048;
- historical bounded selection matches 1,872--1,896/2,048;
- the changed exact-only candidates are all in the final quarter of context;
- the bounded-only candidates are predominantly in the first half.

This model has no separate sliding/local window in sparse layers. The exact
proxy selector therefore reallocates part of the only 2,048-entry sparse
attention budget away from older positions. Exactness for the
E4M3-query/FP8-key proxy did not preserve end-to-end retrieval quality.

## Change

`bounded_compat` explicitly selects the historical:

- 8-bit coarse radix;
- 4,096-entry candidate buffer;
- bounded refinement without the exact overflow rescan.

All shared-memory writes remain bounds-checked. The selection policy is part
of the compile-cache key. No behavior changes unless the new policy is
explicitly enabled.

## Reproduction and causal evidence

Frozen production posture:

- GLM-5.2 NF3 hybrid weights;
- TP4/DCP4/MTP3, MNBT 3,072;
- NVFP4 MLA KV, FP8 RoPE;
- `i8_ring`;
- cold cache (`cached_tokens=0`);
- identical rendered prompts, token IDs, and seeds.

Results:

| Cell | Stock exact v20 | `bounded_compat` |
|---|---|---|
| 250k control | EXACT | EXACT |
| 350k seed 1 | ABSENT | EXACT |
| 350k seed 2 | ABSENT | EXACT |
| 350k seed 3 | ABSENT | EXACT |

All recovered responses finalized normally with content `738216`. The
discriminator boot remained healthy with a 507,612-token KV pool at 460k,
zero restarts, and no illegal-access, cuBLAS, EngineDead, OOM, traceback,
assertion, or worker-died signatures.

An independent cold generalization ladder on the same process also passed:

| Rendered context | Result | Cached tokens |
|---:|---|---:|
| 49,100 | EXACT | 0 |
| 147,275 | EXACT | 0 |
| 294,619 | EXACT | 0 |
| 441,964 | EXACT | 0 |

The trace-free production candidate then passed the established deepest cold
gate at a 480,000-token admission limit:

| Rendered context | Result | Cached tokens | Finish | Content |
|---:|---|---:|---|---|
| 466,493 | EXACT | 0 | `stop` | `738216` |

That candidate was derived from the clean `5517197/be0edca` release image and
contained only PR #80 plus this PR. It exposed a 500,992-token KV pool, remained
healthy with zero restarts, and had zero fatal signatures.

Full reproduction, frozen prompt hashes, boundary traces, learned-tensor
replay, and evidence hashes are in
[vLLM issue #182](https://github.com/local-inference-lab/vllm/issues/182#issuecomment-5084645265).

## Validation

- `python -m py_compile` passes for the changed module and policy test.
- A derived v20 image compiled the new policy, completed production and
  speculator graph capture, and passed the frozen causal gate above.
- Existing exact behavior remains the default and its kernel branches are
  unchanged.

The focused pytest was not run on the authoring Mac because that environment
does not have pytest installed; CI should run
`tests/attention/test_nsa_topk_selection_policy.py`.

## Scope

This PR provides a visible compatibility policy, not a claim that bounded
selection should become the universal default. A future default should be
deterministic and justified by end-to-end model quality rather than only
quantized-proxy exactness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable selection policies for top-k processing, including exact and bounded-compatibility modes.
  * Policy values now support whitespace trimming and normalization.

* **Bug Fixes**
  * Improved handling of large candidate sets under bounded compatibility mode.

* **Tests**
  * Added coverage for valid, normalized, missing, and invalid selection-policy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->