### PR TITLE
test(pcie): enforce default all-reduce output lifetime

### DIFF
--- a/sparkinfer/comm/pcie/pcie_dma.py
+++ b/sparkinfer/comm/pcie/pcie_dma.py
@@ -341,6 +341,8 @@ class PCIeDmaAllReduce:
                 f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
             )
         if out is None:
+            # Preserve normal out-of-place collective semantics. Callers can
+            # retain this result while a later collective is in flight.
             out = torch.empty_like(inp)
         elif (
             out.shape != inp.shape or out.dtype != inp.dtype or not out.is_contiguous()

--- a/tests/comm/test_pcie_dma_gpu.py
+++ b/tests/comm/test_pcie_dma_gpu.py
@@ -76,6 +76,15 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         max_bytes=max_rows * hidden * 4,
     )
     try:
+        explicit_inp = _make_input(8, hidden, torch.bfloat16, device, rank, 0)
+        explicit_ref = _reference(explicit_inp)
+        explicit_out = torch.empty_like(explicit_inp)
+        ring.all_reduce(explicit_inp, out=explicit_out)
+        torch.cuda.synchronize(device)
+        _assert_close(explicit_out, explicit_ref, world_size)
+
+        retained_outputs: list[torch.Tensor] = []
+        retained_refs: list[torch.Tensor] = []
         for dtype in (torch.bfloat16,):
             for rows in (8, 64, 256):
                 inp = _make_input(rows, hidden, dtype, device, rank, 0)
@@ -83,8 +92,17 @@ def _worker(rank: int, world_size: int, port: int) -> None:
                 out = ring.all_reduce(inp)
                 torch.cuda.synchronize(device)
                 _assert_close(out, ref, world_size)
+                assert all(
+                    out.data_ptr() != prior.data_ptr() for prior in retained_outputs
+                )
+                retained_outputs.append(out)
+                retained_refs.append(ref)
+                for retained, retained_ref in zip(
+                    retained_outputs, retained_refs, strict=True
+                ):
+                    _assert_close(retained, retained_ref, world_size)
 
-        # Graph capture and replay with changing inputs.
+        # Captured callers provide stable output storage explicitly.
         rows = 256
         dtype = torch.bfloat16
         inp = _make_input(rows, hidden, dtype, device, rank, 0)
@@ -113,6 +131,7 @@ def test_pcie_dma_all_reduce_eager_and_graph() -> None:
         pytest.skip(
             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
         )
+    _load_extension()
     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
 
 
@@ -143,6 +162,7 @@ def test_pcie_dma_all_reduce_compressed_wire(mode: str) -> None:
         pytest.skip(
             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
         )
+    _load_extension()
     mp.spawn(
         _fp8_worker,
         args=(world_size, _free_port(), mode),


### PR DESCRIPTION
## Summary

Protect the normal out-of-place lifetime contract of `PCIeDmaAllReduce.all_reduce()` when `out` is omitted.

SparkInfer `master` already has the correct runtime behavior: it returns a fresh `torch.empty_like(inp)`. This PR adds the missing regression coverage and a concise source comment. It does not add a persistent output workspace or change the explicit caller-owned `out=` path used by CUDA graphs.

This clean, direct-to-`master` PR supersedes the unsafe persistent-output proposal in #76 and the stacked revert in #80.

## Why

A transformer may retain one collective result across a later collective. GLM-5.2 retains the embedding all-reduce output as the layer-0 residual while attention issues another all-reduce. Reusing one communicator-owned default output silently overwrites that live residual.

Tracked in https://github.com/local-inference-lab/vllm/issues/181.

## Tests

- Python compilation and `git diff --check`.
- Two-GPU eager and CUDA-graph test: PASS.
- Four-rank production-geometry lifetime proof, `2735 x 6144` BF16 with `i8_ring`: PASS.
  - `pointer_alias=false`
  - `retained_mismatches=0 / 16,803,840`
  - rank-consistent output hashes
- The test retains every eager default-output result, launches later collectives, and revalidates both storage identity and contents.
- CUDA graph replay remains on explicit caller-owned output storage.

Reproduction harness: https://gist.github.com/yatesdr/a2e84aa3171ee0b355649704f04f96a8

## AI assistance disclosure

The audit, test extension, GPU validation, and write-up were prepared with OpenAI Codex assistance and reviewed by the human submitter.
