### PR TITLE
fix(indexer): preserve oldest threshold-boundary candidates

### DIFF
--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -36,15 +36,47 @@ from sparkinfer._lib.intrinsics import (
     st_shared_i32,
 )
 from sparkinfer._lib.utils import current_cuda_stream
+from sparkinfer.attention._shared.cute import ops as cute_ops
 
 _THREADS_PER_CTA = 1024
 _DEFAULT_TOPK = 2048
 _SUPPORTED_TOPK = (512, 1024, 2048)
 _RADIX = 256
+_SELECTION_POLICY_ENV = "SPARKINFER_NSA_TOPK_SELECTION_POLICY"
+_SELECTION_POLICY_EXACT = "exact"
+_SELECTION_POLICY_OLDEST_BOUNDARY = "oldest_boundary"
+_SELECTION_POLICIES = frozenset(
+    {
+        _SELECTION_POLICY_EXACT,
+        _SELECTION_POLICY_OLDEST_BOUNDARY,
+    }
+)
+
+
+def _resolve_selection_policy(value: str | None) -> str:
+    policy = (value or _SELECTION_POLICY_EXACT).strip().lower()
+    if policy not in _SELECTION_POLICIES:
+        raise ValueError(
+            f"{_SELECTION_POLICY_ENV} must be one of "
+            f"{sorted(_SELECTION_POLICIES)}, got {policy!r}"
+        )
+    return policy
+
+
+_SELECTION_POLICY = _resolve_selection_policy(
+    os.environ.get(_SELECTION_POLICY_ENV)
+)
+_OLDEST_BOUNDARY = _SELECTION_POLICY == _SELECTION_POLICY_OLDEST_BOUNDARY
 # Use every SM120 CTA lane for the first histogram.  The four-times narrower
 # bucket keeps ordinary 32k/64k low-contrast rows on the buffered exact path;
 # truly degenerate buckets still use the rescan fallback below.
-_COARSE_RADIX_BITS = 10
+#
+# ``oldest_boundary`` gives the required positional behavior an explicit
+# contract: all candidates in strictly higher coarse buckets remain eligible,
+# while the threshold bucket is refined over its oldest 4096 virtual positions
+# in stable index order. No candidate write may cross the allocation. The
+# default remains exact.
+_COARSE_RADIX_BITS = 8 if _OLDEST_BOUNDARY else 10
 _COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
 _HIST_SLOTS = _COARSE_RADIX_BINS + 128
 # A 1024-thread selector CTA is already limited to one resident block per SM on
@@ -52,7 +84,7 @@ _HIST_SLOTS = _COARSE_RADIX_BINS + 128
 # long-context overflow without reducing occupancy; the complete shared-memory
 # allocation remains below the 99 KiB opt-in block limit.  The exact rescan below
 # still covers wider or degenerate threshold buckets.
-_SMEM_CANDS = 8192
+_SMEM_CANDS = 4096 if _OLDEST_BOUNDARY else 8192
 _SCAN_UNROLL = 4
 _SUPERTILE_K_ENV = "SPARKINFER_NSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
@@ -539,6 +571,7 @@ class SparseNSATiledTopkKernel:
         # or the user's final output.
         self.is_first = bool(is_first)
         self.output_physical_slots = bool(output_physical_slots)
+        self.oldest_boundary = bool(_OLDEST_BOUNDARY)
 
     @cute.jit
     def __call__(
@@ -910,17 +943,106 @@ class SparseNSATiledTopkKernel:
             if topk != Int32(0):
                 cute.arch.sync_threads()
 
-                if tx < Int32(257):
-                    s_hist0[tx] = Int32(0)
-                cute.arch.sync_threads()
+                if cutlass.const_expr(self.oldest_boundary):
+                    # Stable-compaction reference for the threshold bucket.
+                    # Each 1024-position tile is compacted in logical index
+                    # order: warp-local inclusive scans feed a 32-warp prefix,
+                    # and the shared running count assigns a unique ordinal.
+                    # Only ordinals [0, _SMEM_CANDS) are materialized, but ni0
+                    # records the full bucket population. This turns the old
+                    # capacity/atomic-order accident into explicit,
+                    # deterministic oldest-history semantics.
+                    if tx == Int32(0):
+                        _smem_st(ni0, Int32(0), Int32(0))
+                    cute.arch.sync_threads()
 
-                idx_base = Int32(tx)
-                full_scan_limit = total_len - Int32(
-                    (_SCAN_UNROLL - 1) * _THREADS_PER_CTA
-                )
-                while idx_base < full_scan_limit:
-                    for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
-                        idx = idx_base + Int32(scan_u * _THREADS_PER_CTA)
+                    lane_idx = tx - (tx // Int32(32)) * Int32(32)
+                    warp_idx = tx // Int32(32)
+                    warp_count_base = Int32(_COARSE_RADIX_BINS)
+                    tile_base = Int32(0)
+                    while tile_base < total_len:
+                        idx = tile_base + Int32(tx)
+                        is_boundary = Int32(0)
+                        if idx < total_len:
+                            raw_input = _load_value_virtual(
+                                input_tensor,
+                                carry_values,
+                                row_base,
+                                row_start,
+                                out_base,
+                                length,
+                                idx,
+                                self.block_q,
+                                self.block_k,
+                                self.is_tiled,
+                                self.is_first,
+                            )
+                            coarse_bin = _convert_to_coarse_bin(raw_input)
+                            if Int32(coarse_bin) > threshold_bin:
+                                pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                                s_out[pos] = idx
+                            else:
+                                if Int32(coarse_bin) == threshold_bin:
+                                    is_boundary = Int32(1)
+
+                        warp_prefix = cute_ops.warp_prefix_sum(
+                            is_boundary, lane_idx
+                        )
+                        if lane_idx == Int32(31):
+                            s_hist0[warp_count_base + warp_idx] = warp_prefix
+                        cute.arch.sync_threads()
+
+                        if warp_idx == Int32(0):
+                            warp_count = Int32(
+                                s_hist0[warp_count_base + lane_idx]
+                            )
+                            warp_cumulative = cute_ops.warp_prefix_sum(
+                                warp_count, lane_idx
+                            )
+                            s_hist1[warp_count_base + lane_idx] = warp_cumulative
+                        cute.arch.sync_threads()
+
+                        prior_total = Int32(_smem_ld(ni0, Int32(0)))
+                        prior_warps = Int32(0)
+                        if warp_idx > Int32(0):
+                            prior_warps = Int32(
+                                s_hist1[warp_count_base + warp_idx - Int32(1)]
+                            )
+                        if is_boundary != Int32(0):
+                            cand_pos = (
+                                prior_total
+                                + prior_warps
+                                + warp_prefix
+                                - Int32(1)
+                            )
+                            if cand_pos < Int32(_SMEM_CANDS):
+                                s_cand0[cand_pos] = idx
+                        cute.arch.sync_threads()
+
+                        if tx == Int32(0):
+                            tile_count = Int32(
+                                s_hist1[warp_count_base + Int32(31)]
+                            )
+                            _smem_st(
+                                ni0,
+                                Int32(0),
+                                prior_total + tile_count,
+                            )
+                        cute.arch.sync_threads()
+                        tile_base = tile_base + Int32(_THREADS_PER_CTA)
+
+                    bin_count = Int32(_smem_ld(ni0, Int32(0)))
+                    if tx < Int32(257):
+                        s_hist0[tx] = Int32(0)
+                    cute.arch.sync_threads()
+                    stable_count = (
+                        bin_count
+                        if bin_count < Int32(_SMEM_CANDS)
+                        else Int32(_SMEM_CANDS)
+                    )
+                    stable_i = Int32(tx)
+                    while stable_i < stable_count:
+                        c_idx = Int32(s_cand0[stable_i])
                         raw_input = _load_value_virtual(
                             input_tensor,
                             carry_values,
@@ -928,7 +1050,70 @@ class SparseNSATiledTopkKernel:
                             row_start,
                             out_base,
                             length,
-                            idx,
+                            c_idx,
+                            self.block_q,
+                            self.block_k,
+                            self.is_tiled,
+                            self.is_first,
+                        )
+                        key32 = _convert_to_uint32(raw_input)
+                        sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                        _smem_red_add(h0, Int32(sub_bin), Int32(1))
+                        stable_i = stable_i + Int32(_THREADS_PER_CTA)
+                    cute.arch.sync_threads()
+                else:
+                    if tx < Int32(257):
+                        s_hist0[tx] = Int32(0)
+                    cute.arch.sync_threads()
+
+                    idx_base = Int32(tx)
+                    full_scan_limit = total_len - Int32(
+                        (_SCAN_UNROLL - 1) * _THREADS_PER_CTA
+                    )
+                    while idx_base < full_scan_limit:
+                        for scan_u in cutlass.range_constexpr(_SCAN_UNROLL):
+                            idx = idx_base + Int32(scan_u * _THREADS_PER_CTA)
+                            raw_input = _load_value_virtual(
+                                input_tensor,
+                                carry_values,
+                                row_base,
+                                row_start,
+                                out_base,
+                                length,
+                                idx,
+                                self.block_q,
+                                self.block_k,
+                                self.is_tiled,
+                                self.is_first,
+                            )
+                            coarse_bin = _convert_to_coarse_bin(raw_input)
+                            if Int32(coarse_bin) > threshold_bin:
+                                pos = _smem_xadd(ctr, Int32(0), Int32(1))
+                                s_out[pos] = idx
+                            else:
+                                if Int32(coarse_bin) == threshold_bin:
+                                    cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
+                                    if cand_pos < Int32(_SMEM_CANDS):
+                                        s_cand0[cand_pos] = idx
+                                        key32 = _convert_to_uint32(raw_input)
+                                        sub_bin = (
+                                            key32 >> Uint32(24)
+                                        ) & Uint32(0xFF)
+                                        _smem_red_add(
+                                            h0, Int32(sub_bin), Int32(1)
+                                        )
+                        idx_base = idx_base + Int32(
+                            _THREADS_PER_CTA * _SCAN_UNROLL
+                        )
+                    while idx_base < total_len:
+                        raw_input = _load_value_virtual(
+                            input_tensor,
+                            carry_values,
+                            row_base,
+                            row_start,
+                            out_base,
+                            length,
+                            idx_base,
                             self.block_q,
                             self.block_k,
                             self.is_tiled,
@@ -937,58 +1122,35 @@ class SparseNSATiledTopkKernel:
                         coarse_bin = _convert_to_coarse_bin(raw_input)
                         if Int32(coarse_bin) > threshold_bin:
                             pos = _smem_xadd(ctr, Int32(0), Int32(1))
-                            s_out[pos] = idx
+                            s_out[pos] = idx_base
                         else:
                             if Int32(coarse_bin) == threshold_bin:
                                 cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
                                 if cand_pos < Int32(_SMEM_CANDS):
-                                    s_cand0[cand_pos] = idx
+                                    s_cand0[cand_pos] = idx_base
                                     key32 = _convert_to_uint32(raw_input)
-                                    sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
+                                    sub_bin = (
+                                        key32 >> Uint32(24)
+                                    ) & Uint32(0xFF)
                                     _smem_red_add(h0, Int32(sub_bin), Int32(1))
-                    idx_base = idx_base + Int32(_THREADS_PER_CTA * _SCAN_UNROLL)
-                while idx_base < total_len:
-                    raw_input = _load_value_virtual(
-                        input_tensor,
-                        carry_values,
-                        row_base,
-                        row_start,
-                        out_base,
-                        length,
-                        idx_base,
-                        self.block_q,
-                        self.block_k,
-                        self.is_tiled,
-                        self.is_first,
-                    )
-                    coarse_bin = _convert_to_coarse_bin(raw_input)
-                    if Int32(coarse_bin) > threshold_bin:
-                        pos = _smem_xadd(ctr, Int32(0), Int32(1))
-                        s_out[pos] = idx_base
-                    else:
-                        if Int32(coarse_bin) == threshold_bin:
-                            cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
-                            if cand_pos < Int32(_SMEM_CANDS):
-                                s_cand0[cand_pos] = idx_base
-                                key32 = _convert_to_uint32(raw_input)
-                                sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
-                                _smem_red_add(h0, Int32(sub_bin), Int32(1))
-                    idx_base = idx_base + Int32(_THREADS_PER_CTA)
+                        idx_base = idx_base + Int32(_THREADS_PER_CTA)
+
+                    cute.arch.sync_threads()
+                    # ni0 now holds the FULL threshold-bin candidate count: the
+                    # xadd ran for every bin-matching key, even past
+                    # _SMEM_CANDS.
+                    bin_count = Int32(_smem_ld(ni0, Int32(0)))
 
                 cute.arch.sync_threads()
-                # ni0 now holds the FULL threshold-bin candidate count: the xadd
-                # ran for every bin-matching key, even past _SMEM_CANDS. Capture it
-                # before the round loop clobbers ni0, to detect when the threshold
-                # bucket overflowed the candidate buffer (winners dropped past the cap).
-                bin_count = Int32(_smem_ld(ni0, Int32(0)))
 
                 # The exact fallback below rebuilds all top-k outputs from the full
                 # row.  Do not spend four radix rounds refining a truncated candidate
                 # buffer first: none of those intermediate outputs survive.  This is
                 # a CTA-uniform branch because every thread reads the same shared
                 # counter after the barrier above.
-                if bin_count > Int32(_SMEM_CANDS):
-                    topk = Int32(-1)
+                if not cutlass.const_expr(self.oldest_boundary):
+                    if bin_count > Int32(_SMEM_CANDS):
+                        topk = Int32(-1)
 
                 # Stage 2: refine with 8-bit radix passes
                 for round_idx in cutlass.range_constexpr(4):
@@ -1140,33 +1302,34 @@ class SparseNSATiledTopkKernel:
                 # Exact overflow fallback: the buffered refine above dropped
                 # winners when more than _SMEM_CANDS candidates shared the coarse
                 # threshold bucket. Redo the selection exactly by re-scanning.
-                if bin_count > Int32(_SMEM_CANDS):
-                    _exact_overflow_fallback(
-                        tx,
-                        total_len,
-                        topk_static,
-                        s_hist0,
-                        s_hist1,
-                        s_out,
-                        h0,
-                        ctr,
-                        thr,
-                        ni0,
-                        ni1,
-                        lr,
-                        flat=False,
-                        flat_values=input_tensor,
-                        input_tensor=input_tensor,
-                        carry_values=carry_values,
-                        row_base=row_base,
-                        row_start=row_start,
-                        carry_base=out_base,
-                        chunk_len=length,
-                        block_q=self.block_q,
-                        block_k=self.block_k,
-                        is_tiled=self.is_tiled,
-                        is_first=self.is_first,
-                    )
+                if not cutlass.const_expr(self.oldest_boundary):
+                    if bin_count > Int32(_SMEM_CANDS):
+                        _exact_overflow_fallback(
+                            tx,
+                            total_len,
+                            topk_static,
+                            s_hist0,
+                            s_hist1,
+                            s_out,
+                            h0,
+                            ctr,
+                            thr,
+                            ni0,
+                            ni1,
+                            lr,
+                            flat=False,
+                            flat_values=input_tensor,
+                            input_tensor=input_tensor,
+                            carry_values=carry_values,
+                            row_base=row_base,
+                            row_start=row_start,
+                            carry_base=out_base,
+                            chunk_len=length,
+                            block_q=self.block_q,
+                            block_k=self.block_k,
+                            is_tiled=self.is_tiled,
+                            is_first=self.is_first,
+                        )
 
             cute.arch.sync_threads()
             idx0 = Int32(tx)
@@ -1543,7 +1706,8 @@ def run_tiled_topk(
             dynamic_strides=(0,),
         ),
         (
-            "tiled_topk_v26_wide_coarse",
+            "tiled_topk_v27_selection_policy",
+            _SELECTION_POLICY,
             topk,
             block_q,
             block_k,
@@ -1713,7 +1877,8 @@ def run_row_topk(
             "carry_indices", carry_indices_key_tensor, dynamic=True
         ),
         (
-            "row_topk_v6",
+            "row_topk_v7_selection_policy",
+            _SELECTION_POLICY,
             topk,
             output_gather_table is not None,
         ),

--- a/tests/attention/test_nsa_topk_selection_policy.py
+++ b/tests/attention/test_nsa_topk_selection_policy.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from sparkinfer.attention.nsa_indexer.tiled_topk import (
+    _resolve_selection_policy,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "exact"),
+        ("", "exact"),
+        ("exact", "exact"),
+        (" EXACT ", "exact"),
+        ("oldest_boundary", "oldest_boundary"),
+        (" OLDEST_BOUNDARY ", "oldest_boundary"),
+    ],
+)
+def test_resolve_selection_policy(raw: str | None, expected: str) -> None:
+    assert _resolve_selection_policy(raw) == expected
+
+
+def test_resolve_selection_policy_rejects_unknown_value() -> None:
+    with pytest.raises(
+        ValueError,
+        match="SPARKINFER_NSA_TOPK_SELECTION_POLICY must be one of",
+    ):
+        _resolve_selection_policy("legacy")


### PR DESCRIPTION
## Summary

Adds an opt-in `oldest_boundary` selection policy to the NSA tiled top-k
indexer. The policy provides deterministic, bounds-safe handling of candidates
that share the coarse Kth-score bucket.

`exact` remains the default policy.

Closes the SparkInfer portion of
[`local-inference-lab/vllm#182`](https://github.com/local-inference-lab/vllm/issues/182).

## Background

GLM-5.2 uses a learned sparse indexer to choose 2,048 historical token
positions for attention. A token that is not selected cannot contribute to
that sparse-attention layer, so selector membership is directly observable as
long-context retrieval quality.

The reproduction uses a deterministic long document of financial-record
prose. It inserts one sentence stating that the Facility 27 maintenance ticket
number is `738216` at 40% of the document, then asks for that number at the end.
Each prompt and its chat-rendered token IDs are SHA-256 pinned. Requests use
temperature 0, thinking disabled, and a 2,000-token output limit. A request
passes only when:

- `cached_tokens == 0`;
- `finish_reason == "stop"`;
- finalized `content.strip() == "738216"`.

On the GLM-5.2 NF3/NVFP4-MLA-KV/FP8-RoPE configuration, the current v20
`exact` policy passes the pinned 245,497-token control and fails all three
pinned 343,727-token prompts. The failed requests stop normally and produce
coherent finalized output, but the target is absent.

Layer-level captures of the same 350k inputs show that the default selector
does not contain the complete three-token target value together until layer
74. With `oldest_boundary`, the complete target was selected by layer 38 and
the final answer was restored in all three cases.

## Why the policies differ

The indexer first reduces scores to a coarse radix bucket and then refines the
candidates around the Kth bucket. At long context, many positions can share
that boundary bucket. The choice of which boundary candidates enter full-score
refinement changes the 2,048-token sparse-attention set.

`exact` resolves the full quantized score field. `oldest_boundary` limits a
large tied coarse bucket by logical position before applying full-score
refinement. This produces a different, deterministic candidate set for the
learned indexer. This PR makes that choice explicit and checkpoint-selectable
without changing the default selector.

## Selection contract

With `SPARKINFER_NSA_TOPK_SELECTION_POLICY=oldest_boundary`, the selector:

1. computes an 8-bit coarse score histogram;
2. retains every candidate in a bucket strictly above the Kth bucket;
3. enumerates candidates in the Kth bucket in ascending logical-position
   order;
4. retains the first 4,096 candidates from that boundary bucket;
5. applies the existing four-pass full 32-bit radix refinement;
6. emits exactly `topk` indices.

The boundary scan uses tile-ordered warp-prefix compaction. It records the full
boundary population while writing only ordinals in `[0, 4096)`, so candidate
writes cannot exceed the allocated buffer.

## Configuration and scope

```text
SPARKINFER_NSA_TOPK_SELECTION_POLICY=exact            # default
SPARKINFER_NSA_TOPK_SELECTION_POLICY=oldest_boundary  # opt-in
```

The value is normalized and validated at module initialization. Unsupported
values fail immediately with `ValueError`.

The policy is included in the compilation-cache key. It is server-static and
must not be changed inside a running process.

This PR does not change `exact`, does not select `oldest_boundary`
automatically for other checkpoints, and does not add an overflow or
out-of-bounds compatibility path.

## Validation

### Frozen end-to-end retrieval gate

All requests were cold (`cached_tokens=0`) and required finalized content
`738216` with `finish_reason=stop`.

| Cell | Default `exact` | `oldest_boundary` |
|---|---|---|
| 250k control | pass | pass |
| 350k seed 1 | target absent | pass |
| 350k seed 2 | target absent | pass |
| 350k seed 3 | target absent | pass |

The current-v20 result summary is pinned by SHA-256:

```text
dda7bddd33919d0947bcf45e0731c7fe07e1d4918944781fca9928cafe1d18f6
```

### Randomized cold ladder

The same current-v20 process passed 50k, 150k, 250k, 300k, 350k, and 475k.
The deepest prompt contained 466,493 tokens. Every cell:

- reported `cached_tokens=0`;
- returned finalized content `738216`;
- stopped normally;
- passed arithmetic, coherence, and degeneration checks.

The ladder summary is pinned by SHA-256:

```text
b855f1febae880a6ae146797fbf37707e3ea02bccd213578d41ec5ba19ae6268
```

### Selector and capacity checks

- Captured selector rows reconstruct at 97.0%--99.3% set overlap.
- A model-free 3,072-row production-shape test
  (`lengths=1..3072`, `topk=2048`, `block_q=32`, `block_k=256`) reports the
  correct valid count for every row and no out-of-range index.
- The current-v20 integration image serves a 480,000-token maximum with a
  545,280-token KV pool and zero restarts.
- Unit tests cover the default, normalization, both supported values, and
  rejection of unsupported values.

### Matched KLD comparison

Three runs per policy were compared with the same pinned BF16 reference logits
(2,047 token positions):

| Policy | Runs | Mean KLD ± SD | Min | Max |
|---|---:|---:|---:|---:|
| `exact` | 3 | 0.15823696 ± 0.00468419 | 0.15539664 | 0.16364348 |
| `oldest_boundary` | 3 | 0.16044075 ± 0.00297924 | 0.15700885 | 0.16236257 |

The paired `oldest_boundary - exact` deltas were `-0.00663463`,
`+0.00655420`, and `+0.00669180`. Their mean was `+0.00220379` (+1.39%
of the exact-policy mean), with sample SD `0.00765461`. The mixed signs and
variance larger than the mean delta do not show a large shallow
distribution-level regression at n=3.

This is a 2,048-token no-regression gate, not a selector-sensitive comparison:
the selector budget is also 2,048, so both policies select every eligible
token. Deep-context efficacy is covered by the frozen 350k gate and randomized
50k–475k ladder.

## Qualification status

The long-context retrieval, selector-safety, and KV-capacity gates pass on the
current v20 base (`vLLM 0c79e41db4`, SparkInfer `e603f74bb6`). The matched
three-run shallow KLD comparison passes without a large regression.
Prefill/decode performance comparison remains integration-qualification work
and is not claimed as complete by this PR.

The pinned image, A/B configuration, test procedure, and evidence links are
available in the
[community validation specification](https://gist.github.com/yatesdr/a2e84aa3171ee0b355649704f04f96a8).
