### PR TITLE
fix(indexer): make page-table row stride a runtime kernel argument

### DIFF
--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -16,7 +16,7 @@ import os
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass import Float32, Int32, Uint32
+from cutlass import Float32, Int32, Int64, Uint32
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T, dsl_user_op
 from cutlass.cute.runtime import from_dlpack
@@ -211,11 +211,11 @@ def _emit_global_index_virtual(
         if gidx >= Int32(0):
             page_col = gidx // page_size
             page_offset = gidx - page_col * page_size
-            page_id = Int32(
-                output_page_table[
-                    row_idx * output_page_table_row_stride + page_col
-                ]
+            page_table_index = (
+                Int64(row_idx) * Int64(output_page_table_row_stride)
+                + Int64(page_col)
             )
+            page_id = Int32(output_page_table[page_table_index])
             if page_id >= Int32(0):
                 physical_idx = page_id * page_size + page_offset
         gidx = physical_idx

--- a/sparkinfer/attention/nsa_indexer/tiled_topk.py
+++ b/sparkinfer/attention/nsa_indexer/tiled_topk.py
@@ -180,6 +180,7 @@ def _load_value_virtual(
 def _emit_global_index_virtual(
     carry_indices,
     output_page_table,
+    output_page_table_row_stride: Int32,
     row_start: Int32,
     output_index_offset: Int32,
     carry_base: Int32,
@@ -210,7 +211,11 @@ def _emit_global_index_virtual(
         if gidx >= Int32(0):
             page_col = gidx // page_size
             page_offset = gidx - page_col * page_size
-            page_id = Int32(output_page_table[row_idx, page_col])
+            page_id = Int32(
+                output_page_table[
+                    row_idx * output_page_table_row_stride + page_col
+                ]
+            )
             if page_id >= Int32(0):
                 physical_idx = page_id * page_size + page_offset
         gidx = physical_idx
@@ -551,6 +556,7 @@ class SparseNSATiledTopkKernel:
         carry_values,
         carry_indices,
         output_page_table,
+        output_page_table_row_stride,
         batch_size,
         input_stride,
         num_k_tiles,
@@ -575,6 +581,7 @@ class SparseNSATiledTopkKernel:
             carry_values,
             carry_indices,
             output_page_table,
+            output_page_table_row_stride,
             batch_size,
             input_stride,
             num_k_tiles,
@@ -605,6 +612,7 @@ class SparseNSATiledTopkKernel:
         carry_values: cute.Tensor,
         carry_indices: cute.Tensor,
         output_page_table: cute.Tensor,
+        output_page_table_row_stride: Int32,
         batch_size: Int32,
         input_stride: Int32,
         num_k_tiles: Int32,
@@ -767,6 +775,7 @@ class SparseNSATiledTopkKernel:
                     _emit_global_index_virtual(
                         carry_indices,
                         output_page_table,
+                        output_page_table_row_stride,
                         row_start,
                         output_index_offset,
                         out_base,
@@ -1188,6 +1197,7 @@ class SparseNSATiledTopkKernel:
                 indices[out_base + idx0] = _emit_global_index_virtual(
                     carry_indices,
                     output_page_table,
+                    output_page_table_row_stride,
                     row_start,
                     output_index_offset,
                     out_base,
@@ -1217,6 +1227,7 @@ class SparseNSATiledTopkKernel:
                 indices[out_base + idx1] = _emit_global_index_virtual(
                     carry_indices,
                     output_page_table,
+                    output_page_table_row_stride,
                     row_start,
                     output_index_offset,
                     out_base,
@@ -1377,11 +1388,18 @@ def run_tiled_topk(
             raise ValueError(
                 f"output_page_size must be positive, got {output_page_size}"
             )
-        output_page_table_for_kernel = output_page_table
+        output_page_table_row_stride = int(output_page_table.stride(0))
+        if output_page_table_row_stride == 0:
+            # A row-shared expanded table has no flattenable multi-row view.
+            # Pass its single physical row and retain stride 0 in the kernel.
+            output_page_table_for_kernel = output_page_table[0].reshape(-1)
+        else:
+            output_page_table_for_kernel = output_page_table.reshape(-1)
     else:
         # The physical mapping branch is constexpr-elided. Reuse row metadata as
         # its dummy tensor so ordinary tiled top-k remains allocation-free.
         output_page_table_for_kernel = lengths
+        output_page_table_row_stride = 0
         output_page_size = 1
     num_q_tiles = (num_q_rows + block_q - 1) // block_q
     tile_size = block_q * block_k
@@ -1505,6 +1523,7 @@ def run_tiled_topk(
         _to_kernel_tensor(flat_carry_values, cutlass.Float32, assumed_align=4),
         _to_kernel_tensor(flat_carry_indices, cutlass.Int32, assumed_align=4),
         _to_kernel_tensor(output_page_table_for_kernel, cutlass.Int32, assumed_align=4),
+        Int32(output_page_table_row_stride),
         Int32(num_q_rows * extent_splits),
         input_stride,
         Int32(num_k_tiles),
@@ -1530,20 +1549,14 @@ def run_tiled_topk(
         _flat_tensor_compile_key(
             "carry_indices", carry_indices_key_tensor, dynamic=True
         ),
-        _tensor_compile_key(
-            "output_page_table",
-            output_page_table_key_tensor,
-            dynamic_dims=(0, 1),
-            # The kernel indexes output_page_table[row, page_col] at runtime
-            # (page_col = gidx // output_page_size); neither shape[1] (the live
-            # page-table width, which grows with KV-cache capacity) nor stride(0)
-            # (which is the same width for the contiguous view) is a compile-time
-            # input. Pinning either into the key re-links a fresh cubin on every
-            # capacity bump, per TP rank, on the first serving run.
-            dynamic_strides=(0,),
+        # The page table is passed as a flat pointer with an explicit runtime
+        # row stride. Keeping only its storage length dynamic lets one cubin
+        # serve changing KV capacities without baking a stale 2-D CuTe layout.
+        _flat_tensor_compile_key(
+            "output_page_table", output_page_table_key_tensor, dynamic=True
         ),
         (
-            "tiled_topk_v26_wide_coarse",
+            "tiled_topk_v27_runtime_page_stride",
             topk,
             block_q,
             block_k,
@@ -1664,6 +1677,11 @@ def run_row_topk(
             raise ValueError("output_gather_table must be contiguous")
         if output_gather_table.device != row_logits.device:
             raise ValueError("output_gather_table must be on the logits device")
+        output_gather_table_for_kernel = output_gather_table.reshape(-1)
+        output_gather_table_row_stride = width
+    else:
+        output_gather_table_for_kernel = lengths
+        output_gather_table_row_stride = 0
     carry_values = topk_values
     carry_indices = topk_indices
     flat_carry_values = carry_values.reshape(-1)
@@ -1684,10 +1702,11 @@ def run_row_topk(
         _to_kernel_tensor(flat_carry_values, cutlass.Float32, assumed_align=4),
         _to_kernel_tensor(flat_carry_indices, cutlass.Int32, assumed_align=4),
         _to_kernel_tensor(
-            output_gather_table if output_gather_table is not None else lengths,
+            output_gather_table_for_kernel,
             cutlass.Int32,
             assumed_align=4,
         ),
+        Int32(output_gather_table_row_stride),
         Int32(num_q_rows),
         Int32(width),
         Int32(0),
@@ -1712,8 +1731,11 @@ def run_row_topk(
         _flat_tensor_compile_key(
             "carry_indices", carry_indices_key_tensor, dynamic=True
         ),
+        _flat_tensor_compile_key(
+            "output_gather_table", output_gather_table_for_kernel, dynamic=True
+        ),
         (
-            "row_topk_v6",
+            "row_topk_v7_runtime_page_stride",
             topk,
             output_gather_table is not None,
         ),
@@ -1729,6 +1751,7 @@ def run_row_topk(
             "topk_indices",
             "carry_values",
             "carry_indices",
+            "output_gather_table",
             "policy",
         ),
     )

--- a/tests/attention/test_attention_nsa_indexer_api.py
+++ b/tests/attention/test_attention_nsa_indexer_api.py
@@ -1587,6 +1587,49 @@ def test_row_topk_live_rows_do_not_resolve_new_kernel(
 
 
 @pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for indexer compile-cache coverage",
+)
+def test_row_topk_gather_table_width_and_stride_are_runtime(monkeypatch) -> None:
+    monkeypatch.setenv("SPARKINFER_COMPILE_DISK_CACHE", "0")
+    monkeypatch.setenv("SPARKINFER_COMPILE_MEMORY_CACHE", "1")
+    clear_compile_cache()
+    clear_indexer_caches()
+
+    device = torch.device("cuda")
+    rows, topk = 17, 512
+
+    def select(width: int) -> None:
+        row_logits = torch.arange(
+            width, dtype=torch.float32, device=device
+        ).expand(rows, -1).contiguous()
+        lengths = torch.full((rows,), width, dtype=torch.int32, device=device)
+        gather_table = torch.arange(
+            rows * width, dtype=torch.int32, device=device
+        ).reshape(rows, width)
+        _, indices = run_row_topk(
+            row_logits=row_logits,
+            lengths=lengths,
+            topk=topk,
+            output_gather_table=gather_table,
+        )
+        torch.cuda.synchronize(device)
+        logical = torch.topk(
+            row_logits, k=topk, dim=1, largest=True, sorted=False
+        ).indices
+        expected = torch.gather(gather_table, 1, logical)
+        assert torch.equal(
+            torch.sort(indices, dim=1).values,
+            torch.sort(expected, dim=1).values,
+        )
+
+    select(512)
+    misses_after_narrow = compile_cache_info()["compile_misses"]
+    select(1024)
+    assert compile_cache_info()["compile_misses"] == misses_after_narrow
+
+
+@pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA required for BK512 prefill coverage"
 )
 def test_contiguous_logits_cuda_prefill512_sampled_logits(monkeypatch) -> None:

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -9,6 +9,7 @@ from sparkinfer.attention.nsa_indexer.scratch import (
     SPARKINFERIndexerPagedScratchCaps,
     plan_indexer_paged_scratch,
 )
+from sparkinfer.attention.nsa_indexer.tiled_topk import run_tiled_topk
 
 
 def _make_real_page_table(
@@ -475,6 +476,75 @@ def test_paged_tiled_indexer_emits_physical_slots_in_final_fold(
         torch.sort(actual, dim=1).values,
         torch.sort(expected, dim=1).values,
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
+    monkeypatch,
+) -> None:
+    """A cached cubin must support both narrow and full-capacity page tables."""
+    from sparkinfer._lib.compiler import clear_compile_cache, compile_cache_info
+
+    monkeypatch.setenv("SPARKINFER_COMPILE_DISK_CACHE", "0")
+    monkeypatch.setenv("SPARKINFER_COMPILE_MEMORY_CACHE", "1")
+    clear_compile_cache()
+
+    device = torch.device("cuda")
+    rows, block_q, block_k, topk = 17, 32, 512, 512
+    lengths = torch.full((rows,), 32, dtype=torch.int32, device=device)
+    page_ids = torch.arange(1000, 1000 + rows, dtype=torch.int32, device=device)
+    tile_logits = torch.zeros(
+        block_q * block_k,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def select(width: int, *, shared: bool = False) -> tuple[torch.Tensor, torch.Tensor]:
+        selected_page_ids = page_ids
+        if shared:
+            selected_page_ids = torch.full_like(page_ids, 2000)
+            page_table = torch.full(
+                (1, width), -1, dtype=torch.int32, device=device
+            )
+            page_table[:, 0] = selected_page_ids[0]
+            page_table = page_table.expand(rows, -1)
+        else:
+            page_table = torch.full(
+                (rows, width), -1, dtype=torch.int32, device=device
+            )
+            page_table[:, 0] = selected_page_ids
+        _, indices = run_tiled_topk(
+            tile_logits=tile_logits,
+            k_start=None,
+            lengths=lengths,
+            topk=topk,
+            block_q=block_q,
+            block_k=block_k,
+            num_k_tiles=1,
+            zero_row_start=True,
+            output_page_table=page_table,
+            output_page_size=64,
+        )
+        torch.cuda.synchronize(device)
+        return indices, selected_page_ids
+
+    narrow, narrow_page_ids = select(1)
+    misses_after_narrow = compile_cache_info()["compile_misses"]
+    wide, wide_page_ids = select(8192)
+    shared, shared_page_ids = select(8192, shared=True)
+    misses_after_reuse = compile_cache_info()["compile_misses"]
+
+    def expected(selected_page_ids: torch.Tensor) -> torch.Tensor:
+        result = torch.full((rows, topk), -1, dtype=torch.int32, device=device)
+        result[:, :32] = selected_page_ids[:, None] * 64 + torch.arange(
+            32, dtype=torch.int32, device=device
+        )[None, :]
+        return torch.sort(result, dim=1).values
+
+    assert torch.equal(torch.sort(narrow, dim=1).values, expected(narrow_page_ids))
+    assert torch.equal(torch.sort(wide, dim=1).values, expected(wide_page_ids))
+    assert torch.equal(torch.sort(shared, dim=1).values, expected(shared_page_ids))
+    assert misses_after_reuse == misses_after_narrow
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for graph capture")


### PR DESCRIPTION
## Summary

Pass the page-table row stride to the tiled top-k kernel as an explicit runtime
argument instead of relying on a cached two-dimensional CuTe tensor layout.

The page table and the row-top-k gather table are now passed as flat views. A
single cubin still serves changing KV-cache capacities, but every launch uses
the actual row stride of its current table.

## Root cause

Commit [`d4f82a6`](https://github.com/local-inference-lab/sparkinfer/commit/d4f82a648f641a531db4b2600a46897ae4add22c)
made the page-table width and row stride dynamic in the compile-cache key. Its
goal was valid: changing KV-cache capacity should not compile and link another
tiled top-k cubin on every TP rank.

The cache key became dynamic, but the kernel still received a two-dimensional
CuTe tensor and indexed it as `output_page_table[row, column]`. CuTe retained
the row stride from the first compiled layout. Reusing that cubin with another
page-table width therefore used the old stride:

- row 0 remained correct;
- later rows read adjacent columns rather than their own page-table rows;
- the failure became visible when serving crossed the 16-row tiled-path
  boundary;
- cache population and launch order made the symptom appear configuration- or
  restart-dependent.

This affected the SparkInfer revisions used by GLM-5.2 v20. The v19 SparkInfer
predecessor does not contain `d4f82a6`.

## Fix

- Flatten contiguous physical page tables before creating the kernel tensor.
- Preserve row-shared expanded tables without a copy by passing their single
  physical row and runtime stride `0`.
- Pass the real row stride as an `Int32` kernel argument and perform explicit
  linear addressing.
- Apply the same contract to the two-level `run_row_topk` gather-table path.
- Keep tensor lengths dynamic in the compile key, preserving one-cubin reuse
  across KV capacities.
- Bump both kernel policy identities so an old cubin cannot be reused with the
  new argument contract.

No persistent workspace, padding, or tensor copy is added on the supported
contiguous and row-shared paths.

## Regression coverage

Two focused GPU tests protect the runtime-layout contract:

1. `test_tiled_topk_physical_slots_use_runtime_page_table_row_stride`
   compiles at width 1, reuses the cubin at width 8192 with 17 distinct rows,
   then reuses it for a row-shared stride-0 table. It verifies every physical
   slot and asserts that no additional compile miss occurs.
2. `test_row_topk_gather_table_width_and_stride_are_runtime` reuses one
   row-top-k cubin across gather-table strides 512 and 1024, verifies all 17
   rows, and also requires zero additional compile misses.

The existing long-context two-level-fold tests additionally verify that the
gather path emits unique, in-range indices at top-k 2048.

## Validation

- Relevant GPU suite: **51 passed**
  - `tests/attention/test_paged_prefill_topk_long_context.py`
  - `tests/attention/test_attention_nsa_indexer_api.py`
  - `tests/attention/test_paged_indexer_integration.py`
- GLM-5.2 v20 TP8/DCP1/MTP3, standard CUDA graphs and async scheduling:
  - final branch CC32: **64/64 exact responses** across two runs;
  - the same fix was also exercised at CC6 and CC17 without a mismatch.
- Direct 30-second CC1 A/B with identical runtime settings:
  - original mean: **136.115 tok/s**;
  - patched mean: **136.192 tok/s**;
  - delta: **+0.06%** (no measurable regression).
- Fast speculative-extend mode remained functional; a repeated final run
  measured **156.73 tok/s** on the slower GPU 8-15 group.
- `ruff check`, `py_compile`, and `git diff --check` pass.

The performance A/B intentionally used identical speculative-attention policy
on both sides. `VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE` is independent of this
correctness fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row-wise and tiled top-k indexing to correctly handle page-table (and gather-table) widths via runtime row-stride values.
  * Ensured physical slot/selected index mapping remains accurate across shared and per-row table layouts without needing recompilation.

* **Tests**
  * Added CUDA-only coverage verifying runtime handling of gather-table and page-table strides and that compile cache misses do not increase when switching widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->