### PR TITLE
indexer: bound two-level fold workspace

### DIFF
--- a/sparkinfer/attention/nsa_indexer/paged.py
+++ b/sparkinfer/attention/nsa_indexer/paged.py
@@ -35,6 +35,9 @@ from sparkinfer.attention.nsa_indexer.tiled_topk import (
 # row) at very long contexts.
 _TWO_LEVEL_SLICE_TOKENS = 16384
 _TWO_LEVEL_MAX_SLICES = 32
+_TWO_LEVEL_FOLD_MODE_ENV = "SPARKINFER_INDEXER_TWO_LEVEL_FOLD"
+_TWO_LEVEL_FOLD_MAX_MIB_ENV = "SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB"
+_TWO_LEVEL_FOLD_MAX_MIB_DEFAULT = 256
 from sparkinfer.attention.nsa_indexer.reference import (
     pack_index_k_cache_reference,
     paged_decode_logits_reference,
@@ -49,6 +52,130 @@ _PAGED_INDEX_SUPERTILE_K_DEFAULT = 32768
 _PAGED_INDEX_TILE_BLOCK_Q = 32
 _PAGED_INDEX_TILE_BLOCK_K = 512
 _PAGED_INDEX_CACHE_DATA_BYTES = PAGED_INDEX_PAGE_SIZE * INDEX_HEAD_DIM
+
+
+@dataclass(frozen=True)
+class _TwoLevelFoldPlan:
+    """Runtime choice between the parallel fold and exact streaming carry."""
+
+    slices: tuple[tuple[int, int], ...] = ()
+    candidate_nbytes: int = 0
+    budget_nbytes: int = 0
+    reason: str = "carry"
+
+
+def _read_two_level_fold_policy() -> tuple[str, int]:
+    raw_mode = os.getenv(_TWO_LEVEL_FOLD_MODE_ENV, "auto").strip().lower()
+    disabled_modes = {"0", "false", "off", "no"}
+    forced_modes = {"1", "true", "on", "yes"}
+    if raw_mode == "auto":
+        mode = "auto"
+    elif raw_mode in disabled_modes:
+        mode = "off"
+    elif raw_mode in forced_modes:
+        mode = "on"
+    else:
+        raise ValueError(
+            f"{_TWO_LEVEL_FOLD_MODE_ENV} must be auto, 0, or 1, got "
+            f"{raw_mode!r}"
+        )
+
+    raw_limit_mib = os.getenv(
+        _TWO_LEVEL_FOLD_MAX_MIB_ENV,
+        str(_TWO_LEVEL_FOLD_MAX_MIB_DEFAULT),
+    )
+    try:
+        limit_mib = int(raw_limit_mib)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_TWO_LEVEL_FOLD_MAX_MIB_ENV} must be a non-negative integer, "
+            f"got {raw_limit_mib!r}"
+        ) from exc
+    if limit_mib < 0:
+        raise ValueError(
+            f"{_TWO_LEVEL_FOLD_MAX_MIB_ENV} must be a non-negative integer, "
+            f"got {raw_limit_mib!r}"
+        )
+    return mode, limit_mib * 1024 * 1024
+
+
+def _plan_two_level_fold(
+    *,
+    q_rows: int,
+    topk: int,
+    page_size: int,
+    page_table_width: int,
+    supertile_pages: int,
+    output_physical_slots: bool,
+) -> _TwoLevelFoldPlan:
+    """Use the parallel fold only while its transient candidate slab fits.
+
+    Both routes are exact. The two-level route exposes more parallelism but its
+    FP32-value/int32-index candidate slab scales with query rows. Streaming
+    carry uses the fixed scratch double-buffer when that slab exceeds the
+    configured runtime budget.
+    """
+
+    dimensions = {
+        "q_rows": q_rows,
+        "topk": topk,
+        "page_size": page_size,
+        "page_table_width": page_table_width,
+        "supertile_pages": supertile_pages,
+    }
+    invalid = {name: value for name, value in dimensions.items() if value < 1}
+    if invalid:
+        raise ValueError(f"two-level fold dimensions must be positive, got {invalid}")
+
+    mode, budget_nbytes = _read_two_level_fold_policy()
+    width_tokens = page_table_width * page_size
+    if output_physical_slots:
+        return _TwoLevelFoldPlan(
+            budget_nbytes=budget_nbytes,
+            reason="physical output requires streaming carry",
+        )
+    if width_tokens < 2 * _TWO_LEVEL_SLICE_TOKENS:
+        return _TwoLevelFoldPlan(
+            budget_nbytes=budget_nbytes,
+            reason="context is below the two-level threshold",
+        )
+    if mode == "off":
+        return _TwoLevelFoldPlan(
+            budget_nbytes=budget_nbytes,
+            reason="two-level fold is disabled",
+        )
+
+    slice_tokens = _TWO_LEVEL_SLICE_TOKENS
+    min_slice = -(-width_tokens // _TWO_LEVEL_MAX_SLICES)
+    if min_slice > slice_tokens:
+        slice_tokens = -(-min_slice // page_size) * page_size
+
+    num_chunks = -(-page_table_width // supertile_pages)
+    slices: list[tuple[int, int]] = []
+    total_slices = 0
+    for chunk_idx in range(num_chunks):
+        page_begin = chunk_idx * supertile_pages
+        chunk_pages = min(supertile_pages, page_table_width - page_begin)
+        chunk_tokens = chunk_pages * page_size
+        chunk_slices = max(1, -(-chunk_tokens // slice_tokens))
+        slices.append((chunk_slices, total_slices))
+        total_slices += chunk_slices
+
+    # fold_values and fold_indices each use four bytes per candidate. The
+    # lengths vector contributes one int32 per query row.
+    candidate_nbytes = q_rows * (total_slices * topk * 8 + 4)
+    if mode == "auto" and candidate_nbytes > budget_nbytes:
+        return _TwoLevelFoldPlan(
+            candidate_nbytes=candidate_nbytes,
+            budget_nbytes=budget_nbytes,
+            reason="candidate slab exceeds the memory budget",
+        )
+    return _TwoLevelFoldPlan(
+        slices=tuple(slices),
+        candidate_nbytes=candidate_nbytes,
+        budget_nbytes=budget_nbytes,
+        reason="forced" if mode == "on" else "within memory budget",
+    )
 
 
 @triton.jit(
@@ -779,27 +906,20 @@ def index_topk_fp8(
     # the last chunk. The per-chunk tile-logits scratch stays at the supertile
     # ceiling. Physical-slot output keeps the legacy carry chain (the fold
     # gather emits logical indices).
-    width_tokens = page_table_width * page_size
-    two_level_slices: list[tuple[int, int]] = []
-    total_slices = 0
+    fold_plan = _plan_two_level_fold(
+        q_rows=q_rows,
+        topk=topk,
+        page_size=page_size,
+        page_table_width=page_table_width,
+        supertile_pages=supertile_pages,
+        output_physical_slots=output_physical_slots,
+    )
+    two_level_slices = fold_plan.slices
+    total_slices = sum(chunk_slices for chunk_slices, _ in two_level_slices)
     fold_values = None
     fold_indices = None
     fold_lengths = None
-    if not output_physical_slots and width_tokens >= 2 * _TWO_LEVEL_SLICE_TOKENS:
-        slice_tokens = _TWO_LEVEL_SLICE_TOKENS
-        min_slice = -(-width_tokens // _TWO_LEVEL_MAX_SLICES)
-        if min_slice > slice_tokens:
-            slice_tokens = -(-min_slice // page_size) * page_size
-        base = 0
-        for c in range(num_chunks):
-            c_pages = (
-                min((c + 1) * supertile_pages, page_table_width) - c * supertile_pages
-            )
-            c_tokens = c_pages * page_size
-            splits_c = max(1, -(-c_tokens // slice_tokens))
-            two_level_slices.append((splits_c, base))
-            base += splits_c
-        total_slices = base
+    if two_level_slices:
         fold_values = torch.empty(
             (q_rows * total_slices, topk), dtype=torch.float32, device=q_fp8.device
         )

--- a/sparkinfer/attention/nsa_indexer/paged.py
+++ b/sparkinfer/attention/nsa_indexer/paged.py
@@ -59,9 +59,38 @@ class _TwoLevelFoldPlan:
     """Runtime choice between the parallel fold and exact streaming carry."""
 
     slices: tuple[tuple[int, int], ...] = ()
+    total_slices: int = 0
     candidate_nbytes: int = 0
     budget_nbytes: int = 0
     reason: str = "carry"
+
+
+@dataclass(frozen=True)
+class _PagedIndexerChunkGeometry:
+    page_begin: int
+    page_end: int
+    page_count: int
+    token_begin: int
+    token_count: int
+
+
+def _paged_indexer_chunk_geometry(
+    *,
+    chunk_idx: int,
+    page_table_width: int,
+    supertile_pages: int,
+    page_size: int,
+) -> _PagedIndexerChunkGeometry:
+    page_begin = chunk_idx * supertile_pages
+    page_end = min(page_begin + supertile_pages, page_table_width)
+    page_count = page_end - page_begin
+    return _PagedIndexerChunkGeometry(
+        page_begin=page_begin,
+        page_end=page_end,
+        page_count=page_count,
+        token_begin=page_begin * page_size,
+        token_count=page_count * page_size,
+    )
 
 
 def _read_two_level_fold_policy() -> tuple[str, int]:
@@ -76,8 +105,8 @@ def _read_two_level_fold_policy() -> tuple[str, int]:
         mode = "on"
     else:
         raise ValueError(
-            f"{_TWO_LEVEL_FOLD_MODE_ENV} must be auto, 0, or 1, got "
-            f"{raw_mode!r}"
+            f"{_TWO_LEVEL_FOLD_MODE_ENV} must be auto, 0/false/off/no, or "
+            f"1/true/on/yes, got {raw_mode!r}"
         )
 
     raw_limit_mib = os.getenv(
@@ -154,10 +183,13 @@ def _plan_two_level_fold(
     slices: list[tuple[int, int]] = []
     total_slices = 0
     for chunk_idx in range(num_chunks):
-        page_begin = chunk_idx * supertile_pages
-        chunk_pages = min(supertile_pages, page_table_width - page_begin)
-        chunk_tokens = chunk_pages * page_size
-        chunk_slices = max(1, -(-chunk_tokens // slice_tokens))
+        chunk = _paged_indexer_chunk_geometry(
+            chunk_idx=chunk_idx,
+            page_table_width=page_table_width,
+            supertile_pages=supertile_pages,
+            page_size=page_size,
+        )
+        chunk_slices = max(1, -(-chunk.token_count // slice_tokens))
         slices.append((chunk_slices, total_slices))
         total_slices += chunk_slices
 
@@ -172,6 +204,7 @@ def _plan_two_level_fold(
         )
     return _TwoLevelFoldPlan(
         slices=tuple(slices),
+        total_slices=total_slices,
         candidate_nbytes=candidate_nbytes,
         budget_nbytes=budget_nbytes,
         reason="forced" if mode == "on" else "within memory budget",
@@ -915,7 +948,7 @@ def index_topk_fp8(
         output_physical_slots=output_physical_slots,
     )
     two_level_slices = fold_plan.slices
-    total_slices = sum(chunk_slices for chunk_slices, _ in two_level_slices)
+    total_slices = fold_plan.total_slices
     fold_values = None
     fold_indices = None
     fold_lengths = None
@@ -988,11 +1021,16 @@ def index_topk_fp8(
             )
 
     for chunk_idx in range(num_chunks):
-        page_begin = chunk_idx * supertile_pages
-        page_end = min(page_begin + supertile_pages, page_table_width)
-        chunk_pages = page_end - page_begin
-        chunk_width_tokens = chunk_pages * page_size
-        chunk_start_token = page_begin * page_size
+        chunk = _paged_indexer_chunk_geometry(
+            chunk_idx=chunk_idx,
+            page_table_width=page_table_width,
+            supertile_pages=supertile_pages,
+            page_size=page_size,
+        )
+        page_begin = chunk.page_begin
+        chunk_pages = chunk.page_count
+        chunk_width_tokens = chunk.token_count
+        chunk_start_token = chunk.token_begin
         if not _env_indexer_stream_scorer_enabled() and uses_paged_mqa_schedule(
             q_rows=q_rows, max_pages=chunk_pages
         ):

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -5,6 +5,7 @@ import torch
 
 from sparkinfer.attention.nsa_indexer._impl import clear_indexer_caches
 from sparkinfer.attention.nsa_indexer.paged import (
+    _paged_indexer_chunk_geometry,
     _plan_two_level_fold,
     index_topk_fp8,
     pack_paged_index_k_cache_reference,
@@ -800,10 +801,12 @@ def test_two_level_fold_auto_respects_candidate_memory_boundary(
     above = _plan_two_level_fold(q_rows=64, **common)
 
     assert below.slices == ((1, 0), (1, 1), (1, 2), (1, 3))
+    assert below.total_slices == 4
     assert below.candidate_nbytes == 63 * (4 * 512 * 8 + 4)
     assert below.candidate_nbytes <= 1024 * 1024
     assert below.reason == "within memory budget"
     assert above.slices == ()
+    assert above.total_slices == 0
     assert above.candidate_nbytes == 64 * (4 * 512 * 8 + 4)
     assert above.candidate_nbytes > 1024 * 1024
     assert above.reason == "candidate slab exceeds the memory budget"
@@ -825,7 +828,23 @@ def test_two_level_fold_forced_mode_ignores_memory_boundary(
     )
 
     assert plan.slices == ((1, 0), (1, 1), (1, 2), (1, 3))
+    assert plan.total_slices == 4
     assert plan.reason == "forced"
+
+
+def test_paged_indexer_chunk_geometry_handles_partial_final_chunk() -> None:
+    chunk = _paged_indexer_chunk_geometry(
+        chunk_idx=4,
+        page_table_width=1025,
+        supertile_pages=256,
+        page_size=64,
+    )
+
+    assert chunk.page_begin == 1024
+    assert chunk.page_end == 1025
+    assert chunk.page_count == 1
+    assert chunk.token_begin == 65536
+    assert chunk.token_count == 64
 
 
 @pytest.mark.parametrize(

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -4,7 +4,14 @@ import pytest
 import torch
 
 from sparkinfer.attention.nsa_indexer._impl import clear_indexer_caches
-from sparkinfer.attention.nsa_indexer.paged import index_topk_fp8, pack_paged_index_k_cache_reference, paged_index_logits_reference, prepare_paged_indexer_metadata, resolve_replicated_num_q_heads
+from sparkinfer.attention.nsa_indexer.paged import (
+    _plan_two_level_fold,
+    index_topk_fp8,
+    pack_paged_index_k_cache_reference,
+    paged_index_logits_reference,
+    prepare_paged_indexer_metadata,
+    resolve_replicated_num_q_heads,
+)
 from sparkinfer.attention.nsa_indexer.scratch import (
     SPARKINFERIndexerPagedScratchCaps,
     plan_indexer_paged_scratch,
@@ -774,6 +781,123 @@ def test_paged_index_supertile_plan_records_launch_contract() -> None:
     assert plan.layout.supertile_tokens == 512
     assert plan.layout.max_chunks == 2
     assert plan.layout.tile_logits_elements == 32 * 512
+
+
+def test_two_level_fold_auto_respects_candidate_memory_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", "auto")
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB", "1")
+    common = {
+        "topk": 512,
+        "page_size": 64,
+        "page_table_width": 1024,
+        "supertile_pages": 256,
+        "output_physical_slots": False,
+    }
+
+    below = _plan_two_level_fold(q_rows=63, **common)
+    above = _plan_two_level_fold(q_rows=64, **common)
+
+    assert below.slices == ((1, 0), (1, 1), (1, 2), (1, 3))
+    assert below.candidate_nbytes == 63 * (4 * 512 * 8 + 4)
+    assert below.candidate_nbytes <= 1024 * 1024
+    assert below.reason == "within memory budget"
+    assert above.slices == ()
+    assert above.candidate_nbytes == 64 * (4 * 512 * 8 + 4)
+    assert above.candidate_nbytes > 1024 * 1024
+    assert above.reason == "candidate slab exceeds the memory budget"
+
+
+def test_two_level_fold_forced_mode_ignores_memory_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", "on")
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB", "0")
+
+    plan = _plan_two_level_fold(
+        q_rows=64,
+        topk=512,
+        page_size=64,
+        page_table_width=1024,
+        supertile_pages=256,
+        output_physical_slots=False,
+    )
+
+    assert plan.slices == ((1, 0), (1, 1), (1, 2), (1, 3))
+    assert plan.reason == "forced"
+
+
+@pytest.mark.parametrize(
+    ("output_physical_slots", "width", "mode", "reason"),
+    [
+        (True, 1024, "auto", "physical output requires streaming carry"),
+        (False, 128, "auto", "context is below the two-level threshold"),
+        (False, 1024, "off", "two-level fold is disabled"),
+    ],
+)
+def test_two_level_fold_ineligible_routes_use_streaming_carry(
+    monkeypatch: pytest.MonkeyPatch,
+    output_physical_slots: bool,
+    width: int,
+    mode: str,
+    reason: str,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", mode)
+
+    plan = _plan_two_level_fold(
+        q_rows=16,
+        topk=512,
+        page_size=64,
+        page_table_width=width,
+        supertile_pages=256,
+        output_physical_slots=output_physical_slots,
+    )
+
+    assert plan.slices == ()
+    assert plan.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", "sometimes"),
+        ("SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB", "-1"),
+        ("SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB", "many"),
+    ],
+)
+def test_two_level_fold_rejects_invalid_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+) -> None:
+    monkeypatch.setenv(name, value)
+
+    with pytest.raises(ValueError):
+        _plan_two_level_fold(
+            q_rows=1,
+            topk=512,
+            page_size=64,
+            page_table_width=1024,
+            supertile_pages=256,
+            output_physical_slots=False,
+        )
+
+
+def test_two_level_fold_rejects_invalid_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", "auto")
+
+    with pytest.raises(ValueError, match="q_rows"):
+        _plan_two_level_fold(
+            q_rows=0,
+            topk=512,
+            page_size=64,
+            page_table_width=1024,
+            supertile_pages=256,
+            output_physical_slots=False,
+        )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/tests/attention/test_paged_prefill_topk_long_context.py
+++ b/tests/attention/test_paged_prefill_topk_long_context.py
@@ -219,6 +219,18 @@ def test_paged_prefill_topk_logical_output_two_level_fold(monkeypatch) -> None:
     _assert_selects_true_topk(scene, selected, output_physical_slots=False)
 
 
+def test_paged_prefill_topk_logical_output_adaptive_carry(monkeypatch) -> None:
+    """A zero candidate budget selects the exact carry path for logical output."""
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD", "auto")
+    monkeypatch.setenv("SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB", "0")
+    device = torch.device("cuda")
+    scene = _build_scene(device, 32768, "monotonic")
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=8192, output_physical_slots=False
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=False)
+
+
 def test_paged_prefill_topk_carry_fold_overflow(monkeypatch) -> None:
     """supertile_k < context forces the multi-chunk carry fold (is_first=False path).
 


### PR DESCRIPTION
## Summary

- bound the existing logical-output two-level top-k fold by its full transient candidate allocation
- automatically use the existing exact streaming-carry route above a 256 MiB default budget
- keep explicit `auto`, forced two-level, and forced carry controls
- add planner boundary, validation, route-selection, and GPU correctness tests

This does not add a new selector or change top-k precision. Both routes are exact. It only chooses which existing fold implementation handles the intermediate candidates.

## Motivation

The parallel two-level fold allocates FP32 values plus int32 indices for every query row, fold slice, and top-k entry. On large logical-output DCP prefill profiles, that transient slab can reach several GiB per rank and is included in vLLM's peak non-KV memory profile. The resulting peak reduces the KV cache even though the allocation is not persistent.

Physical-slot output, including the current DCP1 route, already requires streaming carry and is unchanged.

The policy was inspired by [Josh Cartu's adaptive-fold study](https://github.com/jcartu/glm52-exl3-blackwell-inference-study). This PR ports the idea onto current SparkInfer `master`, derives the complete fold geometry internally, accounts for both candidate tensors and row lengths, validates configuration and dimensions, and adds current integration coverage.

## Controls

```text
SPARKINFER_INDEXER_TWO_LEVEL_FOLD=auto|0|1
SPARKINFER_INDEXER_TWO_LEVEL_FOLD_MAX_MIB=256
```

- `auto`: use two-level fold while the candidate allocation fits; otherwise use carry
- `0`: force streaming carry
- `1`: force historical two-level behavior

## E2E results

Paired runs used TP8/DCP4/MTP0, FP8 KV, A16, a 1,048,576-token model limit, GPUs 0-7, and otherwise identical source and configuration.

| Measurement | Baseline | Adaptive | Delta |
| --- | ---: | ---: | ---: |
| KV cache budget | 2,442,240 tokens | 2,578,944 tokens | +136,704 (+5.60%) |
| 64,511-token prefill | 5,760 tok/s | 5,741 tok/s | -0.33% |
| 399,988-token prefill | 4,104 tok/s | 4,119 tok/s | +0.35% |
| ~998.8k-token prefill | 3,715 tok/s | 3,730 tok/s | +0.40% |
| DCP4 CC1 decode, ctx0 | 73.1 tok/s | 73.1 tok/s | 0.00% |

The throughput deltas are within run noise. The KV capacity gain was stable across boots.

## Validation

- targeted planner and GPU route tests: 12 passed
- full long-context GPU suite: 8 passed
- planner/integration CPU suite: 15 passed, 6 skipped
- Ruff on touched files: passed
- paired 64k, 400k, and ~999k prefill plus CC1 decode E2E runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive two-level folding for paged top‑k indexing with environment-configurable mode and a memory budget cap.
  * Introduced improved chunk/page geometry handling for more consistent paged processing.
* **Bug Fixes**
  * Ensured top‑k accuracy is preserved when adaptively switching between folding and legacy streaming-carry behavior.
  * Added stricter validation for invalid folding policy and geometry inputs.
* **Tests**
  * Added CUDA-skipped integration/regression coverage for fold planning decisions, partial final chunk boundaries, and long-context correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->