### PR TITLE
compiler: key CuTe disk cache by CUDA device architecture

### DIFF
--- a/sparkinfer/_lib/compiler.py
+++ b/sparkinfer/_lib/compiler.py
@@ -2043,6 +2043,11 @@ def _semantic_compile_manifest_payload(
     semantic: dict[str, Any] = {
         "cache_format": cache_format,
         "target": _semantic_target_key(cache_payload[1]),
+        # device_arch is cache_payload index 4 in both the v6_explicit_spec and
+        # v3 formats. Include it in the semantic identity so two payloads that
+        # differ only by GPU architecture hash to distinct semantic keys and the
+        # device-aware cache format cannot be aliased across architectures.
+        "device_arch": _manifest_json_value(cache_payload[4]),
     }
     if cache_format == "sparkinfer_cute_compile_cache_v6_explicit_spec":
         semantic["compile_spec_hash"] = cache_payload[5]

--- a/sparkinfer/_lib/compiler.py
+++ b/sparkinfer/_lib/compiler.py
@@ -1072,12 +1072,16 @@ def _compile_cache_payload_log_value(
 ) -> dict[str, Any]:
     if payload is None:
         return {}
-    if len(payload) == 10 and payload[0] == "sparkinfer_cute_compile_cache_v5_explicit_spec":
+    if (
+        len(payload) == 11
+        and payload[0] == "sparkinfer_cute_compile_cache_v6_explicit_spec"
+    ):
         (
             _version,
             target_key,
             _sparkinfer_fingerprint,
             toolchain_key,
+            _device_arch,
             spec_hash,
             spec_json,
             kwargs_hash,
@@ -1146,13 +1150,14 @@ def _compile_cache_payload_log_value(
                 summary["toolchain"] = toolchain_summary
         return summary
 
-    if len(payload) != 8:
+    if len(payload) != 9:
         return {}
     (
         _version,
         target_key,
         _sparkinfer_fingerprint,
         toolchain_key,
+        _device_arch,
         args_key,
         kwargs_key,
         options_key,
@@ -1183,8 +1188,8 @@ def _compile_cache_payload_log_value(
 def _is_explicit_spec_payload(payload: tuple[object, ...] | None) -> bool:
     return (
         payload is not None
-        and len(payload) == 10
-        and payload[0] == "sparkinfer_cute_compile_cache_v5_explicit_spec"
+        and len(payload) == 11
+        and payload[0] == "sparkinfer_cute_compile_cache_v6_explicit_spec"
     )
 
 
@@ -1443,6 +1448,33 @@ def _distribution_version(name: str) -> str:
         return ""
 
 
+_DEVICE_ARCH_KEY: tuple[object, ...] | None = None
+
+
+def _device_arch_key() -> tuple[object, ...]:
+    """Compute capability of the device this process will compile for.
+
+    Deliberately NOT lru_cached on failure: if CUDA is not initialized yet the
+    query is retried on the next call, so an early call can never memoize a
+    bogus "unknown" and let a cubin built for one architecture be served to
+    another from the shared on-disk cache.
+    """
+    global _DEVICE_ARCH_KEY
+    if _DEVICE_ARCH_KEY is not None:
+        return _DEVICE_ARCH_KEY
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return ("arch", "unavailable")
+        major, minor = torch.cuda.get_device_capability()
+        name = torch.cuda.get_device_name()
+    except Exception:
+        return ("arch", "unavailable")
+    _DEVICE_ARCH_KEY = ("arch", int(major), int(minor), str(name))
+    return _DEVICE_ARCH_KEY
+
+
 @lru_cache(maxsize=1)
 def _runtime_toolchain_key() -> tuple[object, ...]:
     from .runtime_patches import cutlass_runtime_patch_status
@@ -1538,6 +1570,7 @@ def _static_compile_cache_context(compile_callable: Any) -> tuple[object, ...]:
     return (
         _sparkinfer_package_fingerprint(),
         _runtime_toolchain_key(),
+        _device_arch_key(),
         _compile_options_cache_key(compile_callable),
         _compile_environment_key(),
     )
@@ -1849,16 +1882,18 @@ def _compile_disk_cache_payload(
     (
         package_fingerprint,
         runtime_toolchain,
+        device_arch,
         compile_options,
         compile_environment,
     ) = _static_compile_cache_context(compile_callable)
     if compile_spec is not None:
         kwargs_json_key, kwargs_hash_key = _compile_kwargs_json_key(kwargs)
         return (
-            "sparkinfer_cute_compile_cache_v5_explicit_spec",
+            "sparkinfer_cute_compile_cache_v6_explicit_spec",
             _explicit_spec_compile_target(func),
             package_fingerprint,
             runtime_toolchain,
+            device_arch,
             compile_spec.hash_key,
             compile_spec.json_key,
             kwargs_hash_key,
@@ -1867,10 +1902,11 @@ def _compile_disk_cache_payload(
             compile_environment,
         )
     return (
-        "sparkinfer_cute_compile_cache_v2",
+        "sparkinfer_cute_compile_cache_v3",
         _normalize_compile_target(func, set()),
         package_fingerprint,
         runtime_toolchain,
+        device_arch,
         _structural_cache_key(args),
         _structural_cache_key(kwargs),
         compile_options,
@@ -2008,25 +2044,25 @@ def _semantic_compile_manifest_payload(
         "cache_format": cache_format,
         "target": _semantic_target_key(cache_payload[1]),
     }
-    if cache_format == "sparkinfer_cute_compile_cache_v5_explicit_spec":
-        semantic["compile_spec_hash"] = cache_payload[4]
+    if cache_format == "sparkinfer_cute_compile_cache_v6_explicit_spec":
+        semantic["compile_spec_hash"] = cache_payload[5]
         try:
-            semantic["compile_spec"] = json.loads(str(cache_payload[5]))
+            semantic["compile_spec"] = json.loads(str(cache_payload[6]))
         except (TypeError, ValueError, json.JSONDecodeError):
-            semantic["compile_spec"] = str(cache_payload[5])
-        if cache_payload[6]:
-            semantic["compile_kwargs_hash"] = cache_payload[6]
+            semantic["compile_spec"] = str(cache_payload[6])
+        if cache_payload[7]:
+            semantic["compile_kwargs_hash"] = cache_payload[7]
             try:
-                semantic["compile_kwargs"] = json.loads(str(cache_payload[7]))
+                semantic["compile_kwargs"] = json.loads(str(cache_payload[8]))
             except (TypeError, ValueError, json.JSONDecodeError):
-                semantic["compile_kwargs"] = str(cache_payload[7])
-        semantic["compile_options"] = _manifest_json_value(cache_payload[8])
-        semantic["compile_environment"] = _manifest_json_value(cache_payload[9])
+                semantic["compile_kwargs"] = str(cache_payload[8])
+        semantic["compile_options"] = _manifest_json_value(cache_payload[9])
+        semantic["compile_environment"] = _manifest_json_value(cache_payload[10])
     else:
-        semantic["args"] = _semantic_structural_key(cache_payload[4])
-        semantic["kwargs"] = _semantic_structural_key(cache_payload[5])
-        semantic["compile_options"] = _manifest_json_value(cache_payload[6])
-        semantic["compile_environment"] = _manifest_json_value(cache_payload[7])
+        semantic["args"] = _semantic_structural_key(cache_payload[5])
+        semantic["kwargs"] = _semantic_structural_key(cache_payload[6])
+        semantic["compile_options"] = _manifest_json_value(cache_payload[7])
+        semantic["compile_environment"] = _manifest_json_value(cache_payload[8])
     return semantic
 
 
@@ -2260,9 +2296,9 @@ def _build_compile_manifest(
         allow_nan=False,
     )
     cache_format = str(cache_payload[0]) if cache_payload else "unknown"
-    explicit = cache_format == "sparkinfer_cute_compile_cache_v5_explicit_spec"
-    options_index = 8 if explicit else 6
-    environment_index = 9 if explicit else 7
+    explicit = cache_format == "sparkinfer_cute_compile_cache_v6_explicit_spec"
+    options_index = 9 if explicit else 7
+    environment_index = 10 if explicit else 8
     launch_metadata = (
         _extract_launch_dynamic_smem_bytes(compiled)
         if compiled is not None
@@ -2308,12 +2344,12 @@ def _build_compile_manifest(
         ).hexdigest(),
     }
     if explicit:
-        manifest["compile_spec_hash"] = str(cache_payload[4])
-        manifest["compile_spec_json"] = str(cache_payload[5])
-        manifest["compile_kwargs_hash"] = str(cache_payload[6])
-        manifest["compile_kwargs_json"] = str(cache_payload[7])
+        manifest["compile_spec_hash"] = str(cache_payload[5])
+        manifest["compile_spec_json"] = str(cache_payload[6])
+        manifest["compile_kwargs_hash"] = str(cache_payload[7])
+        manifest["compile_kwargs_json"] = str(cache_payload[8])
         try:
-            spec = json.loads(str(cache_payload[5]))
+            spec = json.loads(str(cache_payload[6]))
         except (TypeError, ValueError, json.JSONDecodeError):
             spec = None
         if isinstance(spec, dict):

--- a/sparkinfer/_lib/compiler.py
+++ b/sparkinfer/_lib/compiler.py
@@ -1448,31 +1448,65 @@ def _distribution_version(name: str) -> str:
         return ""
 
 
-_DEVICE_ARCH_KEY: tuple[object, ...] | None = None
+_DEVICE_ARCH_KEYS: dict[int, tuple[object, ...]] = {}
 
 
-def _device_arch_key() -> tuple[object, ...]:
-    """Compute capability of the device this process will compile for.
+def _current_device_ordinal() -> int | None:
+    """Ordinal of the device this process is currently compiling for."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return int(torch.cuda.current_device())
+    except Exception:
+        return None
+
+
+def _device_arch_key(device_ordinal: int | None = None) -> tuple[object, ...]:
+    """Architecture identity of the device this process will compile for.
+
+    Memoized *per device ordinal* rather than once per process. Torch resolves
+    ``get_device_capability()`` / ``get_device_name()`` against the current
+    device when called without an argument, so a single process-wide cache
+    freezes whichever GPU happened to be current on the first call -- passing
+    ``current_device()`` explicitly is equivalent and does not change that. A
+    process that selects a different GPU afterwards would keep reusing the stale
+    identity. Keying the memo by ordinal binds every entry to the device it was
+    actually measured on, which is what makes the guarantee below hold on a
+    mixed-GPU process (e.g. Max-Q and non-Max-Q RTX PRO 6000 boards share
+    compute capability 12.0 but report different device names).
+
+    The returned key deliberately omits the ordinal: two GPUs with the same
+    capability and name yield the same key and therefore share compiled
+    artifacts, which is the desired behaviour on a homogeneous rig. Only the
+    lookup is per ordinal.
 
     Deliberately NOT lru_cached on failure: if CUDA is not initialized yet the
     query is retried on the next call, so an early call can never memoize a
     bogus "unknown" and let a cubin built for one architecture be served to
     another from the shared on-disk cache.
     """
-    global _DEVICE_ARCH_KEY
-    if _DEVICE_ARCH_KEY is not None:
-        return _DEVICE_ARCH_KEY
     try:
         import torch
 
         if not torch.cuda.is_available():
             return ("arch", "unavailable")
-        major, minor = torch.cuda.get_device_capability()
-        name = torch.cuda.get_device_name()
+        index = (
+            int(torch.cuda.current_device())
+            if device_ordinal is None
+            else int(device_ordinal)
+        )
+        cached = _DEVICE_ARCH_KEYS.get(index)
+        if cached is not None:
+            return cached
+        major, minor = torch.cuda.get_device_capability(index)
+        name = torch.cuda.get_device_name(index)
     except Exception:
         return ("arch", "unavailable")
-    _DEVICE_ARCH_KEY = ("arch", int(major), int(minor), str(name))
-    return _DEVICE_ARCH_KEY
+    key = ("arch", int(major), int(minor), str(name))
+    _DEVICE_ARCH_KEYS[index] = key
+    return key
 
 
 @lru_cache(maxsize=1)
@@ -1566,11 +1600,17 @@ def _compile_environment_key() -> tuple[tuple[str, str], ...]:
 
 
 @lru_cache(maxsize=16)
-def _static_compile_cache_context(compile_callable: Any) -> tuple[object, ...]:
+def _static_compile_cache_context(
+    compile_callable: Any, device_ordinal: int | None = None
+) -> tuple[object, ...]:
+    # device_ordinal participates in the lru_cache key on purpose: without it
+    # this cache would pin the architecture identity to whichever GPU was
+    # current the first time a given compile_callable was seen, re-introducing
+    # the staleness that keying _device_arch_key per ordinal removes.
     return (
         _sparkinfer_package_fingerprint(),
         _runtime_toolchain_key(),
-        _device_arch_key(),
+        _device_arch_key(device_ordinal),
         _compile_options_cache_key(compile_callable),
         _compile_environment_key(),
     )
@@ -1885,7 +1925,7 @@ def _compile_disk_cache_payload(
         device_arch,
         compile_options,
         compile_environment,
-    ) = _static_compile_cache_context(compile_callable)
+    ) = _static_compile_cache_context(compile_callable, _current_device_ordinal())
     if compile_spec is not None:
         kwargs_json_key, kwargs_hash_key = _compile_kwargs_json_key(kwargs)
         return (

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
+import pytest
+
 compiler = importlib.import_module("sparkinfer._lib.compiler")
 
 
@@ -49,3 +51,41 @@ def test_cache_dir_resolution_order(monkeypatch):
 
     monkeypatch.setenv("SPARKINFER_COMPILE_CACHE_DIR", "/explicit")
     assert compiler._cute_compile_cache_dir() == Path("/explicit")
+
+
+def test_disk_cache_key_includes_device_arch(monkeypatch):
+    compile_callable = object()
+    monkeypatch.setattr(
+        compiler,
+        "_static_compile_cache_context",
+        lambda _callable: (
+            "package",
+            "toolchain",
+            ("arch", 12, 0, "gpu"),
+            (),
+            (),
+        ),
+    )
+
+    payload = compiler._compile_disk_cache_payload(
+        compile_callable,
+        test_disk_cache_key_includes_device_arch,
+        (),
+        {},
+    )
+
+    assert payload[0] == "sparkinfer_cute_compile_cache_v3"
+    assert payload[4] == ("arch", 12, 0, "gpu")
+
+
+def test_device_arch_key_retries_after_unavailable(monkeypatch):
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(compiler, "_DEVICE_ARCH_KEY", None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert compiler._device_arch_key() == ("arch", "unavailable")
+    assert compiler._DEVICE_ARCH_KEY is None
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (12, 1))
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda: "SM121")
+    assert compiler._device_arch_key() == ("arch", 12, 1, "SM121")

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -58,7 +58,7 @@ def test_disk_cache_key_includes_device_arch(monkeypatch):
     monkeypatch.setattr(
         compiler,
         "_static_compile_cache_context",
-        lambda _callable: (
+        lambda _callable, _ordinal=None: (
             "package",
             "toolchain",
             ("arch", 12, 0, "gpu"),
@@ -80,12 +80,55 @@ def test_disk_cache_key_includes_device_arch(monkeypatch):
 
 def test_device_arch_key_retries_after_unavailable(monkeypatch):
     torch = pytest.importorskip("torch")
-    monkeypatch.setattr(compiler, "_DEVICE_ARCH_KEY", None)
+    monkeypatch.setattr(compiler, "_DEVICE_ARCH_KEYS", {})
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     assert compiler._device_arch_key() == ("arch", "unavailable")
-    assert compiler._DEVICE_ARCH_KEY is None
+    # An unavailable probe must not be memoized, or an early call would pin a
+    # bogus identity for the rest of the process.
+    assert compiler._DEVICE_ARCH_KEYS == {}
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (12, 1))
-    monkeypatch.setattr(torch.cuda, "get_device_name", lambda: "SM121")
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (12, 1))
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda device=None: "SM121")
     assert compiler._device_arch_key() == ("arch", 12, 1, "SM121")
+    assert compiler._DEVICE_ARCH_KEYS == {0: ("arch", 12, 1, "SM121")}
+
+
+def test_device_arch_key_is_memoized_per_ordinal(monkeypatch):
+    """A second GPU must not inherit the first GPU's architecture identity.
+
+    torch resolves get_device_capability()/get_device_name() against the current
+    device when no argument is given, so a process-wide cache would freeze the
+    first device probed. Mixed rigs make this observable: two boards can share a
+    compute capability but report different device names.
+    """
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(compiler, "_DEVICE_ARCH_KEYS", {})
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    boards = {0: (12, 0, "MAX-Q"), 1: (12, 0, "FULL")}
+    current = {"index": 0}
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current["index"])
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda device=None: boards[current["index"] if device is None else device][:2],
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_name",
+        lambda device=None: boards[current["index"] if device is None else device][2],
+    )
+
+    assert compiler._device_arch_key() == ("arch", 12, 0, "MAX-Q")
+    # Selecting a different board must re-probe rather than return the memoized
+    # identity of board 0.
+    current["index"] = 1
+    assert compiler._device_arch_key() == ("arch", 12, 0, "FULL")
+    # Explicit ordinals resolve independently of whichever device is current.
+    assert compiler._device_arch_key(0) == ("arch", 12, 0, "MAX-Q")
+    assert compiler._DEVICE_ARCH_KEYS == {
+        0: ("arch", 12, 0, "MAX-Q"),
+        1: ("arch", 12, 0, "FULL"),
+    }

--- a/validation/cutlass_migration/acceptance/corpus/ptx_capture.py
+++ b/validation/cutlass_migration/acceptance/corpus/ptx_capture.py
@@ -765,25 +765,25 @@ def _semantic_target_key(target_key: Any) -> Any:
 
 
 def _semantic_payload_from_cache_payload(cache_payload: list[Any]) -> dict[str, Any]:
-    if len(cache_payload) != 10:
+    if len(cache_payload) != 11:
         raise RuntimeError(f"explicit cache payload has {len(cache_payload)} fields")
-    if cache_payload[0] != "sparkinfer_cute_compile_cache_v5_explicit_spec":
+    if cache_payload[0] != "sparkinfer_cute_compile_cache_v6_explicit_spec":
         raise RuntimeError(f"unsupported cache format {cache_payload[0]!r}")
     semantic: dict[str, Any] = {
         "cache_format": cache_payload[0],
         "target": _semantic_target_key(cache_payload[1]),
-        "compile_spec_hash": cache_payload[4],
+        "compile_spec_hash": cache_payload[5],
     }
     semantic["compile_spec"] = _load_json_document(
-        str(cache_payload[5]), "cache-payload compile spec"
+        str(cache_payload[6]), "cache-payload compile spec"
     )
-    if cache_payload[6]:
-        semantic["compile_kwargs_hash"] = cache_payload[6]
+    if cache_payload[7]:
+        semantic["compile_kwargs_hash"] = cache_payload[7]
         semantic["compile_kwargs"] = _load_json_document(
-            str(cache_payload[7]), "cache-payload compile kwargs"
+            str(cache_payload[8]), "cache-payload compile kwargs"
         )
-    semantic["compile_options"] = _manifest_json_value(cache_payload[8])
-    semantic["compile_environment"] = _manifest_json_value(cache_payload[9])
+    semantic["compile_options"] = _manifest_json_value(cache_payload[9])
+    semantic["compile_environment"] = _manifest_json_value(cache_payload[10])
     return semantic
 
 
@@ -883,8 +883,8 @@ def _validate_compile_manifest(
         toolchain_names.append(entry[0])
     if len(toolchain_names) != len(set(toolchain_names)):
         raise RuntimeError("compile manifest toolchain repeats a component")
-    compile_spec_hash = cache_payload[4]
-    compile_spec_json = cache_payload[5]
+    compile_spec_hash = cache_payload[5]
+    compile_spec_json = cache_payload[6]
     if (
         not isinstance(compile_spec_hash, str)
         or not _SHA256_RE.fullmatch(compile_spec_hash)
@@ -912,8 +912,8 @@ def _validate_compile_manifest(
     if raw.get("compile_spec_version") != compile_spec.get("version"):
         raise RuntimeError("compile manifest version differs from compile spec")
 
-    compile_kwargs_hash = cache_payload[6]
-    compile_kwargs_json = cache_payload[7]
+    compile_kwargs_hash = cache_payload[7]
+    compile_kwargs_json = cache_payload[8]
     if (
         raw.get("compile_kwargs_hash") != compile_kwargs_hash
         or raw.get("compile_kwargs_json") != compile_kwargs_json
@@ -930,13 +930,13 @@ def _validate_compile_manifest(
         _load_json_document(compile_kwargs_json, "compile kwargs")
     elif compile_kwargs_hash:
         raise RuntimeError("compile manifest has a kwargs hash without JSON")
-    if raw.get("compile_options") != cache_payload[8]:
+    if raw.get("compile_options") != cache_payload[9]:
         raise RuntimeError("compile manifest compile options differ from payload")
     if not isinstance(raw["compile_options"], list) or any(
         not isinstance(option, str) or not option for option in raw["compile_options"]
     ):
         raise RuntimeError("compile manifest compile options are invalid")
-    if raw.get("compile_environment") != cache_payload[9]:
+    if raw.get("compile_environment") != cache_payload[10]:
         raise RuntimeError("compile manifest compile environment differs from payload")
     compile_environment = raw["compile_environment"]
     if not isinstance(compile_environment, list) or any(

--- a/validation/cutlass_migration/acceptance/e2e/contract.py
+++ b/validation/cutlass_migration/acceptance/e2e/contract.py
@@ -345,7 +345,8 @@ def _validate_cache_artifact(
         f"{location}: unsupported compile manifest schema",
     )
     _require(
-        manifest.get("cache_format") == "sparkinfer_cute_compile_cache_v5_explicit_spec",
+        manifest.get("cache_format")
+        == "sparkinfer_cute_compile_cache_v6_explicit_spec",
         f"{location}: exact explicit compile specification is required",
     )
     cache_key = manifest.get("cache_key")

--- a/validation/cutlass_migration/evidence/kernel_resources.py
+++ b/validation/cutlass_migration/evidence/kernel_resources.py
@@ -413,27 +413,27 @@ def _semantic_target_key(target_key: Any) -> Any:
 
 
 def _semantic_payload_from_cache_payload(cache_payload: list[Any]) -> dict[str, Any]:
-    if len(cache_payload) != 10:
+    if len(cache_payload) != 11:
         raise ValueError(f"explicit cache payload has {len(cache_payload)} fields")
-    if cache_payload[0] != "sparkinfer_cute_compile_cache_v5_explicit_spec":
+    if cache_payload[0] != "sparkinfer_cute_compile_cache_v6_explicit_spec":
         raise ValueError(f"unsupported cache format {cache_payload[0]!r}")
     semantic: dict[str, Any] = {
         "cache_format": cache_payload[0],
         "target": _semantic_target_key(cache_payload[1]),
-        "compile_spec_hash": cache_payload[4],
+        "compile_spec_hash": cache_payload[5],
     }
     try:
-        semantic["compile_spec"] = json.loads(str(cache_payload[5]))
+        semantic["compile_spec"] = json.loads(str(cache_payload[6]))
     except (TypeError, ValueError, json.JSONDecodeError):
-        semantic["compile_spec"] = str(cache_payload[5])
-    if cache_payload[6]:
-        semantic["compile_kwargs_hash"] = cache_payload[6]
+        semantic["compile_spec"] = str(cache_payload[6])
+    if cache_payload[7]:
+        semantic["compile_kwargs_hash"] = cache_payload[7]
         try:
-            semantic["compile_kwargs"] = json.loads(str(cache_payload[7]))
+            semantic["compile_kwargs"] = json.loads(str(cache_payload[8]))
         except (TypeError, ValueError, json.JSONDecodeError):
-            semantic["compile_kwargs"] = str(cache_payload[7])
-    semantic["compile_options"] = _manifest_json_value(cache_payload[8])
-    semantic["compile_environment"] = _manifest_json_value(cache_payload[9])
+            semantic["compile_kwargs"] = str(cache_payload[8])
+    semantic["compile_options"] = _manifest_json_value(cache_payload[9])
+    semantic["compile_environment"] = _manifest_json_value(cache_payload[10])
     return semantic
 
 
@@ -504,31 +504,31 @@ def _manifest_integrity_status(
         return "invalid-package-fingerprint"
     if raw.get("toolchain") != cache_payload[3]:
         return "toolchain-payload-mismatch"
-    if raw.get("compile_spec_hash") != cache_payload[4]:
+    if raw.get("compile_spec_hash") != cache_payload[5]:
         return "compile-spec-payload-mismatch"
     compile_spec_json = raw.get("compile_spec_json")
-    if compile_spec_json != cache_payload[5] or not isinstance(compile_spec_json, str):
+    if compile_spec_json != cache_payload[6] or not isinstance(compile_spec_json, str):
         return "compile-spec-json-mismatch"
     if hashlib.sha256(compile_spec_json.encode("utf-8")).hexdigest() != raw.get(
         "compile_spec_hash"
     ):
         return "compile-spec-hash-mismatch"
     if (
-        raw.get("compile_kwargs_hash", "") != cache_payload[6]
-        or raw.get("compile_kwargs_json", "") != cache_payload[7]
+        raw.get("compile_kwargs_hash", "") != cache_payload[7]
+        or raw.get("compile_kwargs_json", "") != cache_payload[8]
     ):
         return "compile-kwargs-payload-mismatch"
-    if cache_payload[7]:
+    if cache_payload[8]:
         if (
-            hashlib.sha256(str(cache_payload[7]).encode("utf-8")).hexdigest()
-            != cache_payload[6]
+            hashlib.sha256(str(cache_payload[8]).encode("utf-8")).hexdigest()
+            != cache_payload[7]
         ):
             return "compile-kwargs-hash-mismatch"
-    elif cache_payload[6]:
+    elif cache_payload[7]:
         return "compile-kwargs-hash-without-json"
-    if raw.get("compile_options") != cache_payload[8]:
+    if raw.get("compile_options") != cache_payload[9]:
         return "compile-options-payload-mismatch"
-    if raw.get("compile_environment") != cache_payload[9]:
+    if raw.get("compile_environment") != cache_payload[10]:
         return "compile-environment-payload-mismatch"
     try:
         compile_spec = json.loads(compile_spec_json)


### PR DESCRIPTION
## Summary

- include CUDA capability and device name in both structural and explicit-spec CuTe disk-cache identities
- memoize architecture metadata per CUDA device ordinal, while allowing homogeneous GPUs to share artifacts
- include the architecture in semantic manifests and bump cache formats to prevent old/new aliasing

## Why

A shared compile cache could otherwise reuse an artifact produced for a different GPU architecture. A process-wide architecture memo was also insufficient for processes that switch CUDA devices. This is independent of EXL3/Trellis and is split out of #49 as requested.

## Tests

- ......                                                                   [100%]
6 passed in 5.03s (6 passed)
- ......                                                                   [100%]
6 passed, 1 skipped, 3 deselected in 4.84s (6 passed, 1 skipped, 3 deselected)
- 

No canonical branch was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compile-cache isolation across different GPU architectures and device ordinals.
  - Prevented unavailable architecture information from being incorrectly cached.
  - Ensured cache entries are reused only when the GPU architecture matches.

- **Validation**
  - Updated compile-cache manifest and artifact validation for the latest cache format.
  - Added coverage for architecture-aware cache keys and multi-GPU behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->