### PR TITLE
test(indexer): cover i64 packed-page offsets and value/index pairing

### DIFF
--- a/tests/attention/test_fused_indexer.py
+++ b/tests/attention/test_fused_indexer.py
@@ -532,3 +532,74 @@ def test_fused_indexer_mla_matches_reference(rows):
         logit = (torch.relu(torch.einsum("hd,td->ht", qf[r], kf[a:b])) * weights[r].unsqueeze(1)).sum(0) * k_scales[a:b]
         gset = set((torch.topk(logit, topk).indices + a).tolist())  # absolute index
         assert set(idx[r].tolist()) == gset
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
+    """Direct-K addressing stays exact after the packed-page Int32 boundary."""
+    device = torch.device("cuda")
+    record_bytes = 1_077_120
+    pid_lo, pages_used = 2000, 64
+    pool_pages = pid_lo + pages_used + 4
+    need = pool_pages * record_bytes + (1 << 29)
+    free, _ = torch.cuda.mem_get_info(device)
+    if free < need:
+        pytest.skip(f"needs ~{need / 2**30:.1f} GiB free device memory")
+
+    rows, heads, topk = 4, 64, 512
+    seqlen = pages_used * _PS
+    g = torch.Generator(device="cpu").manual_seed(7)
+    pool = torch.zeros(pool_pages * record_bytes, dtype=torch.uint8, device=device)
+    k_quant = pool.as_strided((pool_pages, _PS, 128), (record_bytes, 128, 1))
+    k_scales = pool.view(torch.float32).as_strided(
+        (pool_pages, _PS), (record_bytes // 4, 1), storage_offset=2048
+    )
+    k_fp8 = (torch.randn((pages_used, _PS, 128), generator=g) / 3).to(
+        torch.float8_e4m3fn
+    )
+    k_quant[pid_lo : pid_lo + pages_used] = k_fp8.view(torch.uint8).to(device)
+    k_scales[pid_lo : pid_lo + pages_used] = (
+        torch.rand((pages_used, _PS), generator=g) + 0.1
+    ).to(device)
+
+    q_fp8 = (torch.randn((rows, heads, 128), generator=g) / 3).to(
+        torch.float8_e4m3fn
+    ).to(device)
+    weights = torch.randn((rows, heads), generator=g, dtype=torch.float32).to(device)
+    page_table = (
+        torch.arange(pid_lo, pid_lo + pages_used, dtype=torch.int32, device=device)
+        .repeat(rows, 1)
+        .contiguous()
+    )
+    seqlens = torch.full((rows,), seqlen, dtype=torch.int32, device=device)
+
+    idx, val = run_fused_paged_indexer(
+        q_bytes=q_fp8.view(torch.uint8),
+        weights=weights,
+        k_quant_bytes=k_quant,
+        k_scales=k_scales,
+        real_page_table=page_table,
+        seqlens=seqlens,
+        num_heads=heads,
+        topk=topk,
+        ctas_per_group=8,
+    )
+    torch.cuda.synchronize(device)
+
+    gold_vals, gold_idx_sets = _golden_topk(
+        q_fp8,
+        weights,
+        k_quant.view(torch.float8_e4m3fn)[pid_lo : pid_lo + pages_used],
+        k_scales[pid_lo : pid_lo + pages_used],
+        page_table - pid_lo,
+        seqlens,
+        topk,
+    )
+    assert torch.allclose(
+        torch.sort(val, dim=1, descending=True).values,
+        gold_vals,
+        atol=1e-2,
+        rtol=0,
+    )
+    for row in range(rows):
+        assert set(idx[row].tolist()) == gold_idx_sets[row]

--- a/tests/attention/test_fused_indexer.py
+++ b/tests/attention/test_fused_indexer.py
@@ -236,10 +236,12 @@ def _build_case(rows, heads, seqlen, topk, *, seed, device):
     return q_fp8, weights, k_fp8, k_scales, page_table, seqlens
 
 
-def _golden_topk(q_fp8, weights, k_fp8, k_scales, page_table, seqlens, topk):
+def _golden_topk(
+    q_fp8, weights, k_fp8, k_scales, page_table, seqlens, topk, return_scores=False
+):
     rows, seqlen = int(q_fp8.shape[0]), int(seqlens[0])
     qf, kf = q_fp8.float(), k_fp8.float()
-    vals, idxs = [], []
+    vals, idxs, scores = [], [], []
     for r in range(rows):
         pages = page_table[r].long()
         kr = kf[pages].reshape(-1, 128)[:seqlen]
@@ -248,6 +250,9 @@ def _golden_topk(q_fp8, weights, k_fp8, k_scales, page_table, seqlens, topk):
         tk = torch.topk(logit, topk, largest=True, sorted=True)
         vals.append(tk.values)
         idxs.append(set(tk.indices.tolist()))
+        scores.append(logit)
+    if return_scores:
+        return torch.stack(vals), idxs, torch.stack(scores)
     return torch.stack(vals), idxs
 
 
@@ -586,7 +591,7 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
     )
     torch.cuda.synchronize(device)
 
-    gold_vals, gold_idx_sets = _golden_topk(
+    gold_vals, gold_idx_sets, gold_scores = _golden_topk(
         q_fp8,
         weights,
         k_quant.view(torch.float8_e4m3fn)[pid_lo : pid_lo + pages_used],
@@ -594,6 +599,7 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
         page_table - pid_lo,
         seqlens,
         topk,
+        return_scores=True,
     )
     assert torch.allclose(
         torch.sort(val, dim=1, descending=True).values,
@@ -603,3 +609,11 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
     )
     for row in range(rows):
         assert set(idx[row].tolist()) == gold_idx_sets[row]
+        # Value-to-index pairing. Comparing the sorted value list and the index set
+        # separately would still pass if correct values were emitted against the
+        # wrong indices, so gather the golden score for each index the kernel
+        # actually returned and compare position by position. Gathering by the
+        # returned index (rather than asserting an index order) keeps this robust
+        # to ties at the top-k boundary.
+        paired = gold_scores[row].index_select(0, idx[row].long())
+        assert torch.allclose(val[row].float(), paired.float(), atol=1e-2, rtol=0)

--- a/tests/attention/test_fused_indexer.py
+++ b/tests/attention/test_fused_indexer.py
@@ -545,6 +545,12 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
     device = torch.device("cuda")
     record_bytes = 1_077_120
     pid_lo, pages_used = 2000, 64
+    # Keep this case above the Int32 byte-offset boundary. If either constant
+    # is retuned, a green test must not silently stop exercising i64 offsets.
+    assert pid_lo * record_bytes >= (1 << 31), (
+        f"page base offset {pid_lo * record_bytes} no longer crosses the "
+        "Int32 boundary"
+    )
     pool_pages = pid_lo + pages_used + 4
     need = pool_pages * record_bytes + (1 << 29)
     free, _ = torch.cuda.mem_get_info(device)


### PR DESCRIPTION
## Summary

- cover direct-K packed-page lookup where the byte offset exceeds the signed Int32 range
- assert the fixture remains above that boundary
- verify returned top-k values stay paired with their original indices

## Why

This is independent validation extracted from #49. It protects the existing fused-indexer addressing path without coupling it to EXL3/Trellis integration.

## Tests

- CUDA SM120: 
==================================== ERRORS ====================================
____________ ERROR collecting tests/attention/test_fused_indexer.py ____________
ImportError while importing test module '/root/vllm/worktrees/sparkinfer-indexer-i64-test-20260729/tests/attention/test_fused_indexer.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/attention/test_fused_indexer.py:14: in <module>
    from sparkinfer.attention.nsa_indexer.fused_indexer import (
sparkinfer/attention/nsa_indexer/fused_indexer.py:28: in <module>
    import cutlass
E   ModuleNotFoundError: No module named 'cutlass'
=========================== short test summary info ============================
ERROR tests/attention/test_fused_indexer.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 0.68s (1 passed, 73 deselected)
- 

No canonical branch was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of indexed results when processing large page identifiers.
  * Added coverage to ensure returned values remain correctly paired with their corresponding indices in high-offset scenarios.

* **Tests**
  * Added CUDA regression coverage for direct-K indexing across Int32 byte-offset boundaries.
  * Enhanced result comparisons to verify both top-k values and selected index sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->