### PR TITLE
moe: integrate EXL3 Trellis into the fused W4A16 API

### DIFF
--- a/sparkinfer/__init__.py
+++ b/sparkinfer/__init__.py
@@ -50,6 +50,7 @@ _OPS: tuple[str, ...] = (
     "gemm.bmm",
     "gemm.mxfp8_linear",
     "gemm.mla_query_projection",
+    "gemm.trellis_linear",
     "gemm.wo_projection",
     "moe.fused_moe",
     "moe.ep_moe",

--- a/sparkinfer/_lib/intrinsics.py
+++ b/sparkinfer/_lib/intrinsics.py
@@ -6167,3 +6167,221 @@ def nf3_codebook_pools(codebook) -> tuple:
         lo[reg] |= (bf16 & 0xFF) << (8 * slot)
         hi[reg] |= ((bf16 >> 8) & 0xFF) << (8 * slot)
     return lo[0], lo[1], hi[0], hi[1]
+
+# ===== TRELLIS-3.0 (QTIP/EXL3 3INST cb=1) dequant — added for NF3->trellis swap =====
+_TRELLIS_MCG  = 0xCBAC1FED   # codebook.cuh:39  MCG multiplier (cb==1)
+_TRELLIS_MASK = 0x8FFF8FFF   # codebook.cuh:41  lop3 operand b
+_TRELLIS_OR   = 0x3B603B60   # codebook.cuh:41  lop3 operand c ; immLut 0x6a == (a & b) ^ c
+
+
+@dsl_user_op
+def packed_dequant_trellis_to_half2x4(
+    win_a, win_b, bits: int = 3, *, loc=None, ip=None
+):
+    """8 trellis windows -> 4 fp16x2 fragments for one compile-time bitrate.
+
+    win_a/win_b: two 32-bit funnel windows extracted from the staged unit by the
+    caller (_trellis_funnel32). Element/lane order matches the NF3 primitive:
+      o0=(dec w0, dec w1) o1=(dec w2, dec w3) o2=(dec w4, dec w5) o3=(dec w6, dec w7)
+    with w7=win_a, w6=win_a>>bits, ... w4=win_a>>(3*bits), and
+         w3=win_b, w2=win_b>>bits, ... w0=win_b>>(3*bits).
+
+    ``bits`` is a trace-time specialization in {3,4,5,6}, so the generated PTX
+    keeps the same immediate shifts as exl3's templated dq4/dq8 implementations.
+    The caller supplies independently valid four-weight windows for 5/6 bpw,
+    whose full eight-weight span can cross three ring words.
+    """
+    bits = int(bits)
+    if bits not in (3, 4, 5, 6):
+        raise ValueError(f"unsupported trellis bitrate {bits}; expected 3, 4, 5, or 6")
+    asm = """
+        {
+            .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7, lo, hi, M;
+            mov.b32 M, 0xCBAC1FED;
+            and.b32 w7, $4, 0xffff;
+            shr.u32 w6, $4, __B1__;  and.b32 w6, w6, 0xffff;
+            shr.u32 w5, $4, __B2__;  and.b32 w5, w5, 0xffff;
+            shr.u32 w4, $4, __B3__;  and.b32 w4, w4, 0xffff;
+            and.b32 w3, $5, 0xffff;
+            shr.u32 w2, $5, __B1__;  and.b32 w2, w2, 0xffff;
+            shr.u32 w1, $5, __B2__;  and.b32 w1, w1, 0xffff;
+            shr.u32 w0, $5, __B3__;  and.b32 w0, w0, 0xffff;
+            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, 0x8fff8fff, 0x3b603b60, 0x6a;
+            prmt.b32 lo, w0, w1, 0x5410;  prmt.b32 hi, w0, w1, 0x7632;  add.rn.f16x2 $0, lo, hi;
+            prmt.b32 lo, w2, w3, 0x5410;  prmt.b32 hi, w2, w3, 0x7632;  add.rn.f16x2 $1, lo, hi;
+            prmt.b32 lo, w4, w5, 0x5410;  prmt.b32 hi, w4, w5, 0x7632;  add.rn.f16x2 $2, lo, hi;
+            prmt.b32 lo, w6, w7, 0x5410;  prmt.b32 hi, w6, w7, 0x7632;  add.rn.f16x2 $3, lo, hi;
+        }
+        """
+    asm = (
+        asm.replace("__B1__", str(bits))
+        .replace("__B2__", str(2 * bits))
+        .replace("__B3__", str(3 * bits))
+    )
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Uint32(win_a).ir_value(loc=loc, ip=ip), Uint32(win_b).ir_value(loc=loc, ip=ip)],
+        asm,
+        "=r,=r,=r,=r,r,r",
+        has_side_effects=False, is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT, loc=loc, ip=ip,
+    )
+    o0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    o1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    o2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    o3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(o0), Uint32(o1), Uint32(o2), Uint32(o3)
+
+
+@dsl_user_op
+def packed_dequant_trellis_stream_to_half2x4(
+    stream_lo, stream_hi, bits: int, *, loc=None, ip=None
+):
+    """Decode eight windows from a bitrate-strided 64-bit aligned stream.
+
+    Bit zero of ``{stream_hi,stream_lo}`` begins w7; w6..w0 begin at successive
+    ``bits`` offsets. This is required at 6 bpw, where four 16-bit windows span
+    34 bits and cannot be represented by one 32-bit base window.
+    """
+    bits = int(bits)
+    if bits not in (3, 4, 5, 6):
+        raise ValueError(f"unsupported trellis bitrate {bits}; expected 3, 4, 5, or 6")
+    asm = """
+        {
+            .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7, lo, hi, M;
+            mov.b32 M, 0xCBAC1FED;
+            and.b32 w7, $4, 0xffff;
+            __I6__
+            __I5__
+            __I4__
+            __I3__
+            __I2__
+            __I1__
+            __I0__
+            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, 0x8fff8fff, 0x3b603b60, 0x6a;
+            prmt.b32 lo, w0, w1, 0x5410;  prmt.b32 hi, w0, w1, 0x7632;  add.rn.f16x2 $0, lo, hi;
+            prmt.b32 lo, w2, w3, 0x5410;  prmt.b32 hi, w2, w3, 0x7632;  add.rn.f16x2 $1, lo, hi;
+            prmt.b32 lo, w4, w5, 0x5410;  prmt.b32 hi, w4, w5, 0x7632;  add.rn.f16x2 $2, lo, hi;
+            prmt.b32 lo, w6, w7, 0x5410;  prmt.b32 hi, w6, w7, 0x7632;  add.rn.f16x2 $3, lo, hi;
+        }
+        """
+    for name, register, multiple in (
+        ("__I6__", "w6", 1), ("__I5__", "w5", 2),
+        ("__I4__", "w4", 3), ("__I3__", "w3", 4),
+        ("__I2__", "w2", 5), ("__I1__", "w1", 6),
+        ("__I0__", "w0", 7),
+    ):
+        shift = multiple * bits
+        if shift < 32:
+            instruction = (
+                f"shf.r.wrap.b32 {register}, $4, $5, {shift}; "
+                f"and.b32 {register}, {register}, 0xffff;"
+            )
+        else:
+            instruction = (
+                f"shr.u32 {register}, $5, {shift - 32}; "
+                f"and.b32 {register}, {register}, 0xffff;"
+            )
+        asm = asm.replace(name, instruction)
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [
+            Uint32(stream_lo).ir_value(loc=loc, ip=ip),
+            Uint32(stream_hi).ir_value(loc=loc, ip=ip),
+        ],
+        asm,
+        "=r,=r,=r,=r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    o0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    o1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    o2 = llvm.extractvalue(T.i32(), result, [2], loc=loc, ip=ip)
+    o3 = llvm.extractvalue(T.i32(), result, [3], loc=loc, ip=ip)
+    return Uint32(o0), Uint32(o1), Uint32(o2), Uint32(o3)
+
+
+@dsl_user_op
+def packed_dequant_trellis3_to_half2x4(win_a, win_b, *, loc=None, ip=None):
+    """Compatibility wrapper for the original 3-bpw primitive."""
+    return packed_dequant_trellis_to_half2x4(win_a, win_b, 3, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def _f16x2_to_bf16x2(p, *, loc=None, ip=None):
+    """{hi_f16, lo_f16} -> {hi_bf16, lo_bf16}, RNE, lane order preserved."""
+    r = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32()]),
+        [Uint32(p).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 hlo, hhi;
+            .reg .f32 flo, fhi;
+            mov.b32 {hlo, hhi}, $1;
+            cvt.f32.f16 flo, hlo;
+            cvt.f32.f16 fhi, hhi;
+            cvt.rn.bf16x2.f32 $0, fhi, flo;
+        }
+        """,
+        "=r,r", has_side_effects=False, is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT, loc=loc, ip=ip,
+    )
+    return Uint32(llvm.extractvalue(T.i32(), r, [0], loc=loc, ip=ip))
+
+
+@dsl_user_op
+def packed_dequant_trellis_to_bfloat2x4(
+    win_a, win_b, bits: int = 3, *, loc=None, ip=None
+):
+    """Diagnostic bf16 conversion of the generalized fp16 trellis decode.
+
+    Production trellis kernels should use the fp16 primitive and fp16 MMA arm:
+    that is bit-faithful to exl3 and saves 16 conversion instructions per
+    fragment.  This wrapper remains available for the D4 bf16 A/B gate.
+    """
+    h0, h1, h2, h3 = packed_dequant_trellis_to_half2x4(
+        win_a, win_b, bits, loc=loc, ip=ip
+    )
+    return (_f16x2_to_bf16x2(h0, loc=loc, ip=ip), _f16x2_to_bf16x2(h1, loc=loc, ip=ip),
+            _f16x2_to_bf16x2(h2, loc=loc, ip=ip), _f16x2_to_bf16x2(h3, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def packed_dequant_trellis_stream_to_bfloat2x4(
+    stream_lo, stream_hi, bits: int, *, loc=None, ip=None
+):
+    """Diagnostic bf16 conversion of the 64-bit-stream trellis decode."""
+    h0, h1, h2, h3 = packed_dequant_trellis_stream_to_half2x4(
+        stream_lo, stream_hi, bits, loc=loc, ip=ip
+    )
+    return (
+        _f16x2_to_bf16x2(h0, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h1, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h2, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h3, loc=loc, ip=ip),
+    )
+
+
+@dsl_user_op
+def packed_dequant_trellis3_to_bfloat2x4(win_a, win_b, *, loc=None, ip=None):
+    """Compatibility wrapper for the former 3-bpw bf16 primitive."""
+    return packed_dequant_trellis_to_bfloat2x4(
+        win_a, win_b, 3, loc=loc, ip=ip
+    )

--- a/sparkinfer/_lib/intrinsics.py
+++ b/sparkinfer/_lib/intrinsics.py
@@ -2601,9 +2601,7 @@ def pack_f32x2_to_half2(x0: Float32, x1: Float32, *, loc=None, ip=None) -> Uint3
 
 
 @dsl_user_op
-def cvt_bf16x2_to_f16x2_via_f32(
-    packed: Uint32, *, loc=None, ip=None
-) -> Uint32:
+def cvt_bf16x2_to_f16x2_via_f32(packed: Uint32, *, loc=None, ip=None) -> Uint32:
     """Convert packed bf16x2 to packed f16x2 through exact FP32 values."""
     return Uint32(
         llvm.inline_asm(
@@ -6168,10 +6166,19 @@ def nf3_codebook_pools(codebook) -> tuple:
         hi[reg] |= ((bf16 >> 8) & 0xFF) << (8 * slot)
     return lo[0], lo[1], hi[0], hi[1]
 
+
 # ===== TRELLIS-3.0 (QTIP/EXL3 3INST cb=1) dequant — added for NF3->trellis swap =====
-_TRELLIS_MCG  = 0xCBAC1FED   # codebook.cuh:39  MCG multiplier (cb==1)
-_TRELLIS_MASK = 0x8FFF8FFF   # codebook.cuh:41  lop3 operand b
-_TRELLIS_OR   = 0x3B603B60   # codebook.cuh:41  lop3 operand c ; immLut 0x6a == (a & b) ^ c
+_TRELLIS_MCG = 0xCBAC1FED  # codebook.cuh:39  MCG multiplier (cb==1)
+_TRELLIS_MASK = 0x8FFF8FFF  # codebook.cuh:41  lop3 operand b
+_TRELLIS_OR = 0x3B603B60  # codebook.cuh:41  lop3 operand c; immLut 0x6a == (a & b) ^ c
+
+
+def _trellis_mcg_asm_constants(asm: str) -> str:
+    return (
+        asm.replace("__MCG__", f"{_TRELLIS_MCG:#010x}")
+        .replace("__MASK__", f"{_TRELLIS_MASK:#010x}")
+        .replace("__OR__", f"{_TRELLIS_OR:#010x}")
+    )
 
 
 @dsl_user_op
@@ -6197,7 +6204,7 @@ def packed_dequant_trellis_to_half2x4(
     asm = """
         {
             .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7, lo, hi, M;
-            mov.b32 M, 0xCBAC1FED;
+            mov.b32 M, __MCG__;
             and.b32 w7, $4, 0xffff;
             shr.u32 w6, $4, __B1__;  and.b32 w6, w6, 0xffff;
             shr.u32 w5, $4, __B2__;  and.b32 w5, w5, 0xffff;
@@ -6206,32 +6213,38 @@ def packed_dequant_trellis_to_half2x4(
             shr.u32 w2, $5, __B1__;  and.b32 w2, w2, 0xffff;
             shr.u32 w1, $5, __B2__;  and.b32 w1, w1, 0xffff;
             shr.u32 w0, $5, __B3__;  and.b32 w0, w0, 0xffff;
-            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, __MASK__, __OR__, 0x6a;
             prmt.b32 lo, w0, w1, 0x5410;  prmt.b32 hi, w0, w1, 0x7632;  add.rn.f16x2 $0, lo, hi;
             prmt.b32 lo, w2, w3, 0x5410;  prmt.b32 hi, w2, w3, 0x7632;  add.rn.f16x2 $1, lo, hi;
             prmt.b32 lo, w4, w5, 0x5410;  prmt.b32 hi, w4, w5, 0x7632;  add.rn.f16x2 $2, lo, hi;
             prmt.b32 lo, w6, w7, 0x5410;  prmt.b32 hi, w6, w7, 0x7632;  add.rn.f16x2 $3, lo, hi;
         }
         """
-    asm = (
+    asm = _trellis_mcg_asm_constants(
         asm.replace("__B1__", str(bits))
         .replace("__B2__", str(2 * bits))
         .replace("__B3__", str(3 * bits))
     )
     result = llvm.inline_asm(
         llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
-        [Uint32(win_a).ir_value(loc=loc, ip=ip), Uint32(win_b).ir_value(loc=loc, ip=ip)],
+        [
+            Uint32(win_a).ir_value(loc=loc, ip=ip),
+            Uint32(win_b).ir_value(loc=loc, ip=ip),
+        ],
         asm,
         "=r,=r,=r,=r,r,r",
-        has_side_effects=False, is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT, loc=loc, ip=ip,
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
     o0 = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
     o1 = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
@@ -6256,7 +6269,7 @@ def packed_dequant_trellis_stream_to_half2x4(
     asm = """
         {
             .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7, lo, hi, M;
-            mov.b32 M, 0xCBAC1FED;
+            mov.b32 M, __MCG__;
             and.b32 w7, $4, 0xffff;
             __I6__
             __I5__
@@ -6265,14 +6278,14 @@ def packed_dequant_trellis_stream_to_half2x4(
             __I2__
             __I1__
             __I0__
-            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, 0x8fff8fff, 0x3b603b60, 0x6a;
-            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, 0x8fff8fff, 0x3b603b60, 0x6a;
+            mul.lo.u32 w0, w0, M;  lop3.b32 w0, w0, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w1, w1, M;  lop3.b32 w1, w1, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w2, w2, M;  lop3.b32 w2, w2, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w3, w3, M;  lop3.b32 w3, w3, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w4, w4, M;  lop3.b32 w4, w4, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w5, w5, M;  lop3.b32 w5, w5, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w6, w6, M;  lop3.b32 w6, w6, __MASK__, __OR__, 0x6a;
+            mul.lo.u32 w7, w7, M;  lop3.b32 w7, w7, __MASK__, __OR__, 0x6a;
             prmt.b32 lo, w0, w1, 0x5410;  prmt.b32 hi, w0, w1, 0x7632;  add.rn.f16x2 $0, lo, hi;
             prmt.b32 lo, w2, w3, 0x5410;  prmt.b32 hi, w2, w3, 0x7632;  add.rn.f16x2 $1, lo, hi;
             prmt.b32 lo, w4, w5, 0x5410;  prmt.b32 hi, w4, w5, 0x7632;  add.rn.f16x2 $2, lo, hi;
@@ -6280,9 +6293,12 @@ def packed_dequant_trellis_stream_to_half2x4(
         }
         """
     for name, register, multiple in (
-        ("__I6__", "w6", 1), ("__I5__", "w5", 2),
-        ("__I4__", "w4", 3), ("__I3__", "w3", 4),
-        ("__I2__", "w2", 5), ("__I1__", "w1", 6),
+        ("__I6__", "w6", 1),
+        ("__I5__", "w5", 2),
+        ("__I4__", "w4", 3),
+        ("__I3__", "w3", 4),
+        ("__I2__", "w2", 5),
+        ("__I1__", "w1", 6),
         ("__I0__", "w0", 7),
     ):
         shift = multiple * bits
@@ -6297,6 +6313,7 @@ def packed_dequant_trellis_stream_to_half2x4(
                 f"and.b32 {register}, {register}, 0xffff;"
             )
         asm = asm.replace(name, instruction)
+    asm = _trellis_mcg_asm_constants(asm)
     result = llvm.inline_asm(
         llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
         [
@@ -6340,8 +6357,12 @@ def _f16x2_to_bf16x2(p, *, loc=None, ip=None):
             cvt.rn.bf16x2.f32 $0, fhi, flo;
         }
         """,
-        "=r,r", has_side_effects=False, is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT, loc=loc, ip=ip,
+        "=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
     )
     return Uint32(llvm.extractvalue(T.i32(), r, [0], loc=loc, ip=ip))
 
@@ -6359,8 +6380,12 @@ def packed_dequant_trellis_to_bfloat2x4(
     h0, h1, h2, h3 = packed_dequant_trellis_to_half2x4(
         win_a, win_b, bits, loc=loc, ip=ip
     )
-    return (_f16x2_to_bf16x2(h0, loc=loc, ip=ip), _f16x2_to_bf16x2(h1, loc=loc, ip=ip),
-            _f16x2_to_bf16x2(h2, loc=loc, ip=ip), _f16x2_to_bf16x2(h3, loc=loc, ip=ip))
+    return (
+        _f16x2_to_bf16x2(h0, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h1, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h2, loc=loc, ip=ip),
+        _f16x2_to_bf16x2(h3, loc=loc, ip=ip),
+    )
 
 
 @dsl_user_op
@@ -6382,6 +6407,4 @@ def packed_dequant_trellis_stream_to_bfloat2x4(
 @dsl_user_op
 def packed_dequant_trellis3_to_bfloat2x4(win_a, win_b, *, loc=None, ip=None):
     """Compatibility wrapper for the former 3-bpw bf16 primitive."""
-    return packed_dequant_trellis_to_bfloat2x4(
-        win_a, win_b, 3, loc=loc, ip=ip
-    )
+    return packed_dequant_trellis_to_bfloat2x4(win_a, win_b, 3, loc=loc, ip=ip)

--- a/sparkinfer/gemm/__init__.py
+++ b/sparkinfer/gemm/__init__.py
@@ -6,6 +6,7 @@
 - ``block_fp8_linear``: DeepSeek-style serialized block-FP8 linear via MXFP8.
 - ``mxfp8_linear``: ModelOpt MXFP8 linear (one-shot).
 - ``mla_query_projection``: fused MXFP8 MLA query projection and assembly.
+- ``trellis_linear``: native EXL3 Trellis W4A16 dense linear.
 - ``wo_projection``: fused MLA WO-A/WO-B projections (+ inverse-RoPE variant).
 """
 
@@ -19,6 +20,7 @@ _OP_MODULES = (
     "block_fp8_linear",
     "mxfp8_linear",
     "mla_query_projection",
+    "trellis_linear",
     "wo_projection",
 )
 _FUNCTIONS = {

--- a/sparkinfer/gemm/trellis_linear/__init__.py
+++ b/sparkinfer/gemm/trellis_linear/__init__.py
@@ -1,0 +1,51 @@
+"""Native EXL3 Trellis W4A16 dense linear for SM12x.
+
+The operation consumes the checkpoint-native ``trellis3_t256`` payload and
+its two Hadamard sign vectors.  Preparation validates and records zero-copy
+views; execution performs input rotation, the W4A16 GEMM, and output rotation.
+Callers that need CUDA-graph capture must provide stable ``output``,
+``gemm_output``, and ``c_tmp`` tensors to :func:`run`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="trellis_linear",
+    group="gemm",
+    api_style="oneshot",
+    entry_points=(
+        "PreparedWeight",
+        "prepare_weight",
+        "run",
+        "is_supported",
+        "clear_caches",
+    ),
+    dtypes=("bf16", "fp16"),
+    recipes=("w4a16/exl3_trellis_mcg",),
+    provenance=Provenance(
+        repo="https://github.com/local-inference-lab/sparkinfer",
+        commit="c58a381",
+        paths=(
+            "sparkinfer/gemm/trellis_linear/",
+            "sparkinfer/moe/_shared/kernels/w4a16/",
+        ),
+    ),
+    test_path="tests/gemm/test_trellis_linear.py",
+    since="1.0.1",
+    notes="Zero-copy native EXL3 Trellis dense W4A16 linear.",
+)
+
+if TYPE_CHECKING:
+    from .api import (  # noqa: F401
+        PreparedWeight,
+        clear_caches,
+        is_supported,
+        prepare_weight,
+        run,
+    )
+
+install_lazy_api(globals(), META)

--- a/sparkinfer/gemm/trellis_linear/api.py
+++ b/sparkinfer/gemm/trellis_linear/api.py
@@ -51,15 +51,25 @@ def run(
     output: Optional[torch.Tensor] = None,
     gemm_output: Optional[torch.Tensor] = None,
     c_tmp: Optional[torch.Tensor] = None,
+    input_f16: Optional[torch.Tensor] = None,
+    rotated_f16: Optional[torch.Tensor] = None,
+    rotated_compute: Optional[torch.Tensor] = None,
+    gemm_output_f16: Optional[torch.Tensor] = None,
+    output_f16: Optional[torch.Tensor] = None,
     hadamard_128=None,
 ) -> torch.Tensor:
-    """Execute input rotation, native Trellis GEMM, and output rotation."""
+    """Execute Trellis GEMM, optionally reusing all capture-time storage."""
     return run_trellis256_dense(
         x,
         weight,
         output=output,
         gemm_output=gemm_output,
         c_tmp=c_tmp,
+        input_f16=input_f16,
+        rotated_f16=rotated_f16,
+        rotated_compute=rotated_compute,
+        gemm_output_f16=gemm_output_f16,
+        output_f16=output_f16,
         hadamard_128=hadamard_128,
     )
 

--- a/sparkinfer/gemm/trellis_linear/api.py
+++ b/sparkinfer/gemm/trellis_linear/api.py
@@ -1,0 +1,77 @@
+"""Public API for :mod:`sparkinfer.gemm.trellis_linear`."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ..._lib.gating import default_is_supported
+from ...moe._shared.kernels.w4a16.kernel import (
+    clear_w4a16_kernel_cache,
+    run_trellis256_dense,
+)
+from ...moe._shared.kernels.w4a16.prepare import (
+    PreparedTrellis256DenseWeight,
+    prepare_trellis256_dense_weight,
+)
+from . import META
+
+PreparedWeight = PreparedTrellis256DenseWeight
+
+
+def prepare_weight(
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    *,
+    mcg: Optional[torch.Tensor] = None,
+    mul1: Optional[torch.Tensor] = None,
+    codebook: Optional[str | int] = None,
+    params_dtype: torch.dtype = torch.float16,
+    dummy_scale: Optional[torch.Tensor] = None,
+) -> PreparedWeight:
+    """Validate one native EXL3 dense weight and retain zero-copy views."""
+    return prepare_trellis256_dense_weight(
+        trellis,
+        suh,
+        svh,
+        mcg=mcg,
+        mul1=mul1,
+        codebook=codebook,
+        params_dtype=params_dtype,
+        dummy_scale=dummy_scale,
+    )
+
+
+def run(
+    x: torch.Tensor,
+    weight: PreparedWeight,
+    *,
+    output: Optional[torch.Tensor] = None,
+    gemm_output: Optional[torch.Tensor] = None,
+    c_tmp: Optional[torch.Tensor] = None,
+    hadamard_128=None,
+) -> torch.Tensor:
+    """Execute input rotation, native Trellis GEMM, and output rotation."""
+    return run_trellis256_dense(
+        x,
+        weight,
+        output=output,
+        gemm_output=gemm_output,
+        c_tmp=c_tmp,
+        hadamard_128=hadamard_128,
+    )
+
+
+def is_supported(device=None) -> bool:
+    """True when the SM120/SM121 Trellis kernel stack is available."""
+    return default_is_supported(device, requires=META.requires)
+
+
+def clear_caches() -> None:
+    """Clear compiled W4A16 specializations shared with fused MoE."""
+    clear_w4a16_kernel_cache()
+
+
+__all__ = list(META.entry_points)

--- a/sparkinfer/moe/__init__.py
+++ b/sparkinfer/moe/__init__.py
@@ -1,7 +1,8 @@
 """MoE ops for sparkinfer.
 
 - ``fused_moe``: fused tensor-parallel routed-expert FFN (route -> FC1 ->
-  activation -> FC2 -> scatter); recipes nvfp4/mxfp4/w4a8_mx/w4a8_nvfp4/w4a16.
+  activation -> FC2 -> scatter); recipes nvfp4/mxfp4/w4a8_mx/w4a8_nvfp4/w4a16,
+  including the ``exl3_trellis_mcg`` W4A16 source format.
 - ``ep_moe``: expert-parallel MoE (replicated input -> local partial;
   cross-rank reduction is the caller's job, typically ``comm.pcie``).
 """

--- a/sparkinfer/moe/_shared/execution.py
+++ b/sparkinfer/moe/_shared/execution.py
@@ -44,6 +44,7 @@ class OperandEncoding(_StringEnum):
 
 class ScaleEncoding(_StringEnum):
     E4M3_K16 = "e4m3_k16"
+    E4M3_K32 = "e4m3_k32"
     E8M0_K32 = "e8m0_k32"
     E8M0_K32_X_E4M3_K16_RESIDUAL = "e8m0_k32_x_e4m3_k16_residual"
 
@@ -96,6 +97,7 @@ class GemmEngine(_StringEnum):
 
 class PreparedWeightLayout(_StringEnum):
     SOURCE_NATIVE = "source_native"
+    TRELLIS_NATIVE = "trellis_native"
     MMA_VIEW = "mma_view"
     MMA_PACKED = "mma_packed"
     QMMA_REPACKED = "qmma_repacked"
@@ -116,6 +118,7 @@ class WeightPreparationTransform(_StringEnum):
     RUNTIME_ALPHAS = "runtime_alphas"
     W4A16_NATIVE = "w4a16_native"
     W4A16_PACKED = "w4a16_packed"
+    W4A16_TRELLIS = "w4a16_trellis"
     W4A8_QMMA = "w4a8_qmma"
     W6A8_MXFP6 = "w6a8_mxfp6"
 
@@ -150,6 +153,7 @@ _SOURCE_FORMATS = {
     "fp4_e8m0_k32",
     "compressed_tensors",
     "mxfp6_e2m3",
+    "exl3_trellis_mcg",
 }
 _SOURCES_BY_QUANT_MODE = {
     "nvfp4": frozenset({"modelopt_nvfp4"}),
@@ -158,7 +162,12 @@ _SOURCES_BY_QUANT_MODE = {
     # W4A16 deliberately keeps its historical FP4 source trio; the packed
     # MX-FP6 source is exclusive to the w6a8_mx recipe.
     "w4a16": frozenset(
-        {"modelopt_nvfp4", "fp4_e8m0_k32", "compressed_tensors"}
+        {
+            "modelopt_nvfp4",
+            "fp4_e8m0_k32",
+            "compressed_tensors",
+            "exl3_trellis_mcg",
+        }
     ),
     "w6a8_mx": frozenset({"mxfp6_e2m3"}),
 }
@@ -260,6 +269,8 @@ class MoEWeightPreparationPlan:
     weight_layouts: frozenset[PreparedWeightLayout]
     scale_layouts: frozenset[PreparedScaleLayout]
     storage_policy: WeightStoragePolicy
+    trellis_bits: int | None = None
+    trellis_tile_config: tuple[int, int, int, int] | None = None
 
     def __post_init__(self) -> None:
         specs = tuple(self.specs)
@@ -287,6 +298,25 @@ class MoEWeightPreparationPlan:
         object.__setattr__(
             self, "storage_policy", WeightStoragePolicy(self.storage_policy)
         )
+        if self.source_format == "exl3_trellis_mcg":
+            bits = 3 if self.trellis_bits is None else int(self.trellis_bits)
+            if bits not in (3, 4, 5, 6):
+                raise ValueError(f"trellis_bits must be one of 3, 4, 5, 6; got {bits}")
+            tile_config = self.trellis_tile_config or (64, 256, 64, 256)
+            tile_config = tuple(int(value) for value in tile_config)
+            if len(tile_config) != 4 or any(
+                value <= 0 or value % 16 != 0 for value in tile_config
+            ):
+                raise ValueError(
+                    "trellis_tile_config must contain four positive multiples of 16"
+                )
+            object.__setattr__(self, "trellis_bits", bits)
+            object.__setattr__(self, "trellis_tile_config", tile_config)
+        elif self.trellis_bits is not None or self.trellis_tile_config is not None:
+            raise ValueError(
+                "trellis_bits/trellis_tile_config require "
+                "source_format='exl3_trellis_mcg'"
+            )
         for name in ("num_experts", "hidden_size", "intermediate_size"):
             if getattr(self, name) <= 0:
                 raise ValueError(f"{name} must be positive, got {getattr(self, name)}")
@@ -357,6 +387,8 @@ class MoEWeightPreparationPlan:
 
     @property
     def w4a16_weight_layout(self) -> str | None:
+        if WeightPreparationTransform.W4A16_TRELLIS in self.transforms:
+            return "trellis3_t256"
         if WeightPreparationTransform.W4A16_NATIVE in self.transforms:
             return "modelopt"
         if WeightPreparationTransform.W4A16_PACKED in self.transforms:
@@ -383,6 +415,8 @@ class MoEWeightPreparationPlan:
                 f"quant_mode={quant_mode!r} is absent from this preparation plan"
             )
         if quant_mode == "w4a16":
+            if WeightPreparationTransform.W4A16_TRELLIS in self.transforms:
+                return PreparedWeightLayout.TRELLIS_NATIVE
             return (
                 PreparedWeightLayout.SOURCE_NATIVE
                 if WeightPreparationTransform.W4A16_NATIVE in self.transforms
@@ -510,11 +544,14 @@ def make_moe_spec(
         quant_mode=quant_mode,
     )
 
-    source_scale = (
-        ScaleEncoding.E8M0_K32
-        if source_format in ("fp4_e8m0_k32", "mxfp6_e2m3")
-        else ScaleEncoding.E4M3_K16
-    )
+    if source_format == "exl3_trellis_mcg":
+        # Trellis stores codebook indices without a per-weight scale grid. The
+        # W4A16 ABI still carries a four-byte dummy E4M3 K/32 scale pointer.
+        source_scale = ScaleEncoding.E4M3_K32
+    elif source_format in ("fp4_e8m0_k32", "mxfp6_e2m3"):
+        source_scale = ScaleEncoding.E8M0_K32
+    else:
+        source_scale = ScaleEncoding.E4M3_K16
     if quant_mode == "w4a16":
         activation_encoding = OperandEncoding.BF16
         activation_scale = None
@@ -558,6 +595,8 @@ def plan_moe_weight_preparation(
     hidden_size: int,
     intermediate_size: int,
     w4a16_layout: PreparedWeightLayout | str | None = None,
+    trellis_bits: int | None = None,
+    trellis_tile_config: tuple[int, int, int, int] | None = None,
 ) -> MoEWeightPreparationPlan:
     """Choose the minimal representation set for the requested recipes.
 
@@ -593,9 +632,18 @@ def plan_moe_weight_preparation(
         None,
         PreparedWeightLayout.SOURCE_NATIVE,
         PreparedWeightLayout.MMA_PACKED,
+        PreparedWeightLayout.TRELLIS_NATIVE,
     }:
         raise ValueError(
-            "W4A16 preparation requires source_native or mma_packed layout"
+            "W4A16 preparation requires source_native, mma_packed, or "
+            "trellis_native layout"
+        )
+    if (
+        requested_w4a16_layout is PreparedWeightLayout.TRELLIS_NATIVE
+        and source_format != "exl3_trellis_mcg"
+    ):
+        raise ValueError(
+            "trellis_native layout requires source_format='exl3_trellis_mcg'"
         )
 
     transforms: set[WeightPreparationTransform] = set()
@@ -620,9 +668,7 @@ def plan_moe_weight_preparation(
             continue
         if spec.quant_mode == "w4a8_mx":
             if spec.activation not in {"silu", "situ"}:
-                raise ValueError(
-                    "W4A8-MX preparation currently requires silu or situ"
-                )
+                raise ValueError("W4A8-MX preparation currently requires silu or situ")
             # The rp storage ceil-tiles partial 256/128 tiles (zero-filled),
             # so 32-aligned shards (352 = 2048/TP6, 192 = 3072/TP16) prepare
             # fine; consumers bound their reads by the logical sizes.
@@ -659,6 +705,22 @@ def plan_moe_weight_preparation(
             )
             continue
         if spec.quant_mode == "w4a16":
+            if source_format == "exl3_trellis_mcg":
+                if spec.activation not in {"silu", "situ"}:
+                    raise ValueError(
+                        "EXL3 Trellis W4A16 currently requires silu or situ"
+                    )
+                if requested_w4a16_layout not in {
+                    None,
+                    PreparedWeightLayout.TRELLIS_NATIVE,
+                }:
+                    raise ValueError(
+                        "EXL3 Trellis W4A16 requires trellis_native layout"
+                    )
+                transforms.add(WeightPreparationTransform.W4A16_TRELLIS)
+                weight_layouts.add(PreparedWeightLayout.TRELLIS_NATIVE)
+                scale_layouts.add(PreparedScaleLayout.SOURCE_NATIVE)
+                continue
             layout = requested_w4a16_layout
             if layout is None:
                 # The packed MMA kernels only have tile configs for
@@ -702,6 +764,7 @@ def plan_moe_weight_preparation(
     )
     native_representation = (
         WeightPreparationTransform.W4A16_NATIVE in transforms
+        or WeightPreparationTransform.W4A16_TRELLIS in transforms
         # W6A8-MXFP6 keeps the packed FP6 bytes unchanged and transfers
         # ownership to the prepared representation (swizzled scales replace
         # the source grids), mirroring the native W4A16 storage policy.
@@ -735,6 +798,8 @@ def plan_moe_weight_preparation(
         weight_layouts=frozenset(weight_layouts),
         scale_layouts=frozenset(scale_layouts),
         storage_policy=storage_policy,
+        trellis_bits=trellis_bits,
+        trellis_tile_config=trellis_tile_config,
     )
 
 

--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
@@ -38,6 +38,9 @@ class W4A16PackedBuffers:
     block_expert_ids: torch.Tensor | None = None
     packed_route_count: torch.Tensor | None = None
     expert_offsets: torch.Tensor | None = None
+    expert_counts: torch.Tensor | None = None
+    rotation_a_gate: torch.Tensor | None = None
+    rotation_a_up: torch.Tensor | None = None
 
 
 @dataclass(frozen=True)
@@ -50,6 +53,8 @@ class W4A16BufferPlan:
     fc2_c_tmp_elements: int
     intermediate_cache13_elements: int
     intermediate_cache2_elements: int
+    block_size_m: int
+    rotation_a_elements: int = 0
 
 
 def validate_activation(activation: str) -> bool:
@@ -272,6 +277,8 @@ def plan_w4a16_buffers(
     topk: int,
     route_num_experts: int | None = None,
     sms: int,
+    full_rotation: bool = False,
+    block_size_m: int | None = None,
 ) -> W4A16BufferPlan:
     routed_rows = int(m) * int(topk)
     route_num_experts = (
@@ -282,7 +289,15 @@ def plan_w4a16_buffers(
     intermediate_size = int(prepared.intermediate_size)
     hidden_size = int(prepared.hidden_size)
     fc1_cols = (2 if prepared.is_gated else 1) * intermediate_size
-    block_size_m = select_route_block_size_m(m, topk, route_num_experts)
+    if block_size_m is None:
+        block_size_m = select_route_block_size_m(m, topk, route_num_experts)
+    else:
+        block_size_m = int(block_size_m)
+        if block_size_m not in _W4A16_ALLOWED_ROUTED_SIZES:
+            raise ValueError(
+                "block_size_m must be one of "
+                f"{_W4A16_ALLOWED_ROUTED_SIZES}, got {block_size_m}"
+            )
     route_slots = max_packed_route_slots(routed_rows, block_size_m, route_num_experts)
     route_blocks = (route_slots + block_size_m - 1) // block_size_m
     scratch_sms = int(sms)
@@ -305,6 +320,8 @@ def plan_w4a16_buffers(
         ),
         intermediate_cache13_elements=routed_rows * max(fc1_cols, hidden_size),
         intermediate_cache2_elements=routed_rows * intermediate_size,
+        block_size_m=block_size_m,
+        rotation_a_elements=(routed_rows * hidden_size if full_rotation else 0),
     )
 
 
@@ -316,6 +333,8 @@ def make_w4a16_packed_buffers(
     dtype: torch.dtype,
     device: torch.device,
     route_num_experts: int | None = None,
+    full_rotation: bool = False,
+    block_size_m: int | None = None,
 ) -> W4A16PackedBuffers:
     route_num_experts = (
         int(prepared.num_experts)
@@ -329,6 +348,8 @@ def make_w4a16_packed_buffers(
         topk=topk,
         route_num_experts=route_num_experts,
         sms=sms,
+        full_rotation=full_rotation,
+        block_size_m=block_size_m,
     )
     fc1_c_tmp = torch.empty(
         (plan.fc1_c_tmp_elements,),
@@ -351,7 +372,11 @@ def make_w4a16_packed_buffers(
             dtype=dtype,
             device=device,
         ),
-        output=torch.empty((m, prepared.hidden_size), dtype=dtype, device=device),
+        output=torch.empty(
+            (m, prepared.hidden_size),
+            dtype=torch.float32 if full_rotation else dtype,
+            device=device,
+        ),
         fc1_c_tmp=fc1_c_tmp,
         fc2_c_tmp=fc2_c_tmp,
         packed_route_indices=torch.empty(
@@ -363,6 +388,27 @@ def make_w4a16_packed_buffers(
         packed_route_count=torch.empty((1,), dtype=torch.int32, device=device),
         expert_offsets=torch.empty(
             (route_num_experts + 1,), dtype=torch.int32, device=device
+        ),
+        expert_counts=torch.empty(
+            (route_num_experts,), dtype=torch.int32, device=device
+        ),
+        rotation_a_gate=(
+            torch.empty(
+                (plan.routed_rows, int(prepared.hidden_size)),
+                dtype=torch.float16,
+                device=device,
+            )
+            if full_rotation
+            else None
+        ),
+        rotation_a_up=(
+            torch.empty(
+                (plan.routed_rows, int(prepared.hidden_size)),
+                dtype=torch.float16,
+                device=device,
+            )
+            if full_rotation
+            else None
         ),
     )
 

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -3429,9 +3429,9 @@ class W4A16GemmKernel:
                     smem_base + Int32(self.sh_rd_route_off * 16) + row * Int32(4)
                 )
             a_int4 = (
-                route_index * a_gl_stride
-                + tile_idx * Int32(self.a_gl_rd_delta_o)
-                + a_gl_rd_col0
+                Int64(route_index) * Int64(a_gl_stride)
+                + Int64(tile_idx) * Int64(self.a_gl_rd_delta_o)
+                + Int64(a_gl_rd_col0)
             )
             a_dst = self._int4_addr(
                 smem_base,
@@ -3441,7 +3441,7 @@ class W4A16GemmKernel:
                     Int32(i * self.a_sh_wr_delta) + a_sh_wr
                 ),
             )
-            a_src = get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8))
+            a_src = get_ptr_as_int64(a_bf16_flat, a_int4 * Int64(8))
             if cutlass.const_expr(self.dual_a):
                 # Projection-major FC1 validates that each CTA N tile is wholly
                 # gate or wholly up.  Select the matching pre-rotated A operand
@@ -3989,7 +3989,9 @@ class W4A16GemmKernel:
                 route_index = ld_shared_i32_relaxed(
                     smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
                 )
-                true_idx = route_index * c_gl_stride + (c_gl_wr % c_gl_stride)
+                true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(
+                    c_gl_wr % c_gl_stride
+                )
                 q0, q1, q2, q3 = ld_shared_v4_u32(
                     self._int4_addr(smem_base, Int32(self.sh_red_off) + c_sh_rd)
                 )
@@ -4013,15 +4015,17 @@ class W4A16GemmKernel:
                     # to token = route_index // top_k.  bf16x2 add lands two
                     # consecutive hidden lanes per word.
                     token_idx = route_index // Int32(self.fused_sum_topk)
-                    out_idx = token_idx * c_gl_stride + (c_gl_wr % c_gl_stride)
-                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int32(8))
+                    out_idx = Int64(token_idx) * Int64(c_gl_stride) + Int64(
+                        c_gl_wr % c_gl_stride
+                    )
+                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int64(8))
                     red_add_global_bf16x2(out_addr, q0)
                     red_add_global_bf16x2(out_addr + Int64(4), q1)
                     red_add_global_bf16x2(out_addr + Int64(8), q2)
                     red_add_global_bf16x2(out_addr + Int64(12), q3)
                 else:
                     st_global_v4_u32(
-                        get_ptr_as_int64(c_bf16_flat, true_idx * Int32(8)),
+                        get_ptr_as_int64(c_bf16_flat, true_idx * Int64(8)),
                         q0,
                         q1,
                         q2,
@@ -4052,7 +4056,7 @@ class W4A16GemmKernel:
                 route_index = ld_shared_i32_relaxed(
                     smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
                 )
-                true_idx = route_index * c_gl_stride + col_word
+                true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(col_word)
                 q0, q1, q2, q3 = ld_shared_v4_u32(
                     self._int4_addr(smem_base, Int32(self.sh_red_off) + c_sh_rd)
                 )
@@ -4071,15 +4075,15 @@ class W4A16GemmKernel:
                     q3 = self._relu2_elem2(q3)
                 if cutlass.const_expr(self.fused_topk_sum):
                     token_idx = route_index // Int32(self.fused_sum_topk)
-                    out_idx = token_idx * c_gl_stride + col_word
-                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int32(8))
+                    out_idx = Int64(token_idx) * Int64(c_gl_stride) + Int64(col_word)
+                    out_addr = get_ptr_as_int64(c_bf16_flat, out_idx * Int64(8))
                     red_add_global_bf16x2(out_addr, q0)
                     red_add_global_bf16x2(out_addr + Int64(4), q1)
                     red_add_global_bf16x2(out_addr + Int64(8), q2)
                     red_add_global_bf16x2(out_addr + Int64(12), q3)
                 else:
                     st_global_v4_u32(
-                        get_ptr_as_int64(c_bf16_flat, true_idx * Int32(8)),
+                        get_ptr_as_int64(c_bf16_flat, true_idx * Int64(8)),
                         q0,
                         q1,
                         q2,
@@ -4672,7 +4676,7 @@ class W4A16FusedMoeKernel:
                 )
             if not is_gated or self.activation_is_swigluoai or self.has_swiglu_limit:
                 raise ValueError(
-                    "intermediate_rotation requires plain gated silu "
+                    "intermediate_rotation requires unclamped gated silu or situ "
                     "(no swiglu limit/oai)"
                 )
             if int(intermediate_size) % 128 != 0:
@@ -4860,24 +4864,28 @@ class W4A16FusedMoeKernel:
         grid_x: cutlass.Int32,
         stream: cuda.CUstream,
     ):
-        a_rows = active_m
+        a_rows = Int64(active_m)
         if cutlass.const_expr(self.full_rotation):
-            a_rows = active_m * Int32(self.top_k)
+            a_rows = Int64(active_m) * Int64(self.top_k)
         a_bf16_flat = cute.make_tensor(
             a_bf16_ptr,
-            layout=cute.make_layout((a_rows * Int32(self.hidden_size),), stride=(1,)),
+            layout=cute.make_layout((a_rows * Int64(self.hidden_size),), stride=(1,)),
         )
         a_alt_bf16_flat = cute.make_tensor(
             a_alt_bf16_ptr,
-            layout=cute.make_layout((a_rows * Int32(self.hidden_size),), stride=(1,)),
+            layout=cute.make_layout((a_rows * Int64(self.hidden_size),), stride=(1,)),
         )
         rotation_input_flat = cute.make_tensor(
             rotation_input_ptr,
-            layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
+            layout=cute.make_layout(
+                (Int64(active_m) * Int64(self.hidden_size),), stride=(1,)
+            ),
         )
         topk_weights_flat = cute.make_tensor(
             topk_weights_ptr,
-            layout=cute.make_layout((active_m * Int32(self.top_k),), stride=(1,)),
+            layout=cute.make_layout(
+                (Int64(active_m) * Int64(self.top_k),), stride=(1,)
+            ),
         )
         grid = (grid_x, 1, 1)
         self.kernel(
@@ -8413,6 +8421,11 @@ def _rot_scales_dummy(device: torch.device) -> torch.Tensor:
     const_expr-gated kernel; keeps one compiled signature across all layouts)."""
     t = _ROT_SCALES_DUMMY.get(device)
     if t is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "W4A16 rotation placeholder is not initialized for CUDA graph "
+                "capture; prewarm the planned launch before capturing"
+            )
         t = torch.zeros(1, dtype=torch.float16, device=device)
         _ROT_SCALES_DUMMY[device] = t
     return t
@@ -9260,7 +9273,7 @@ def _compile_w4a16_gemm_launch(
             tile_n=tile_n,
             tile_k=tile_k,
             cta_threads=cta_threads,
-            max_shared_mem=max_shared_mem,
+            max_shared_mem=max_shared_mem - 512,
             scale_format=scale_format,
             weight_layout=weight_layout,
             weight_bits=planner_weight_bits,
@@ -9375,6 +9388,36 @@ def _resolve_exl3_hadamard_128(hadamard_128):
     return hadamard_128
 
 
+def _trellis_dense_buffer(
+    name: str,
+    buffer: torch.Tensor | None,
+    *,
+    shape: tuple[int, int],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Validate caller-owned dense scratch or allocate it before capture."""
+    if buffer is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"Trellis dense {name} is not initialized for CUDA graph capture; "
+                "provide caller-owned storage"
+            )
+        return torch.empty(shape, dtype=dtype, device=device)
+    if (
+        tuple(buffer.shape) != shape
+        or buffer.dtype != dtype
+        or buffer.device != device
+        or not buffer.is_contiguous()
+        or int(buffer.data_ptr()) % 16 != 0
+    ):
+        raise ValueError(
+            f"{name} must be contiguous, 16-byte-aligned {dtype} with shape "
+            f"{shape} on {device}"
+        )
+    return buffer
+
+
 def _run_trellis256_dense_current_device(
     x: torch.Tensor,
     prepared_dense,
@@ -9382,6 +9425,11 @@ def _run_trellis256_dense_current_device(
     output: torch.Tensor | None = None,
     gemm_output: torch.Tensor | None = None,
     c_tmp: torch.Tensor | None = None,
+    input_f16: torch.Tensor | None = None,
+    rotated_f16: torch.Tensor | None = None,
+    rotated_compute: torch.Tensor | None = None,
+    gemm_output_f16: torch.Tensor | None = None,
+    output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
 ) -> torch.Tensor:
@@ -9431,42 +9479,55 @@ def _run_trellis256_dense_current_device(
         )
     if prepared_dense.trellis.device != x.device:
         raise ValueError("x and prepared dense weight must be on the same CUDA device")
-    if output is None:
-        output = torch.empty((m, size_n), dtype=x.dtype, device=x.device)
-    elif (
-        tuple(output.shape) != (m, size_n)
-        or output.dtype != x.dtype
-        or output.device != x.device
-        or not output.is_contiguous()
-    ):
-        raise ValueError(
-            f"output must be contiguous {x.dtype} with shape {(m, size_n)} on {x.device}"
-        )
-    if gemm_output is None:
-        gemm_output = torch.empty((m, size_n), dtype=compute_dtype, device=x.device)
-    elif (
-        tuple(gemm_output.shape) != (m, size_n)
-        or gemm_output.dtype != compute_dtype
-        or gemm_output.device != x.device
-        or not gemm_output.is_contiguous()
-        or int(gemm_output.data_ptr()) % 16 != 0
-    ):
-        raise ValueError(
-            f"gemm_output must be contiguous, 16-byte-aligned {compute_dtype} with shape "
-            f"{(m, size_n)} on {x.device}"
-        )
+    output = _trellis_dense_buffer(
+        "output",
+        output,
+        shape=(m, size_n),
+        dtype=x.dtype,
+        device=x.device,
+    )
+    gemm_output = _trellis_dense_buffer(
+        "gemm_output",
+        gemm_output,
+        shape=(m, size_n),
+        dtype=compute_dtype,
+        device=x.device,
+    )
     if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
         raise ValueError("c_tmp must be at least 16-byte aligned")
 
     hadamard_128 = _resolve_exl3_hadamard_128(hadamard_128)
-    x_f16 = x if x.dtype == torch.float16 else x.to(torch.float16)
-    rotated_f16 = torch.empty_like(x_f16)
-    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
-    rotated_compute = (
-        rotated_f16
-        if compute_dtype == torch.float16
-        else rotated_f16.to(torch.bfloat16)
+    if x.dtype == torch.float16:
+        x_f16 = x
+    else:
+        input_f16 = _trellis_dense_buffer(
+            "input_f16",
+            input_f16,
+            shape=(m, size_k),
+            dtype=torch.float16,
+            device=x.device,
+        )
+        input_f16.copy_(x)
+        x_f16 = input_f16
+    rotated_f16 = _trellis_dense_buffer(
+        "rotated_f16",
+        rotated_f16,
+        shape=(m, size_k),
+        dtype=torch.float16,
+        device=x.device,
     )
+    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
+    if compute_dtype == torch.float16:
+        rotated_compute = rotated_f16
+    else:
+        rotated_compute = _trellis_dense_buffer(
+            "rotated_compute",
+            rotated_compute,
+            shape=(m, size_k),
+            dtype=torch.bfloat16,
+            device=x.device,
+        )
+        rotated_compute.copy_(rotated_f16)
 
     props = torch.cuda.get_device_properties(x.device)
     sms = int(props.multi_processor_count)
@@ -9540,13 +9601,28 @@ def _run_trellis256_dense_current_device(
         stream,
     )
 
-    gemm_f16 = (
-        gemm_output if compute_dtype == torch.float16 else gemm_output.to(torch.float16)
-    )
+    if compute_dtype == torch.float16:
+        gemm_f16 = gemm_output
+    else:
+        gemm_output_f16 = _trellis_dense_buffer(
+            "gemm_output_f16",
+            gemm_output_f16,
+            shape=(m, size_n),
+            dtype=torch.float16,
+            device=x.device,
+        )
+        gemm_output_f16.copy_(gemm_output)
+        gemm_f16 = gemm_output_f16
     if output.dtype == torch.float16:
         hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
     else:
-        output_f16 = torch.empty_like(gemm_f16)
+        output_f16 = _trellis_dense_buffer(
+            "output_f16",
+            output_f16,
+            shape=(m, size_n),
+            dtype=torch.float16,
+            device=x.device,
+        )
         hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
         output.copy_(output_f16)
     return output
@@ -9559,6 +9635,11 @@ def run_trellis256_dense(
     output: torch.Tensor | None = None,
     gemm_output: torch.Tensor | None = None,
     c_tmp: torch.Tensor | None = None,
+    input_f16: torch.Tensor | None = None,
+    rotated_f16: torch.Tensor | None = None,
+    rotated_compute: torch.Tensor | None = None,
+    gemm_output_f16: torch.Tensor | None = None,
+    output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
 ) -> torch.Tensor:
@@ -9584,6 +9665,11 @@ def run_trellis256_dense(
             output=output,
             gemm_output=gemm_output,
             c_tmp=c_tmp,
+            input_f16=input_f16,
+            rotated_f16=rotated_f16,
+            rotated_compute=rotated_compute,
+            gemm_output_f16=gemm_output_f16,
+            output_f16=output_f16,
             hadamard_128=hadamard_128,
             stream=None,
         )

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -14,7 +14,7 @@ import cutlass.cute as cute
 import torch
 from cutlass.base_dsl.compiler import OptLevel
 from cutlass._mlir.dialects import llvm
-from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, dsl_user_op
+from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, Uint64, dsl_user_op
 
 from sparkinfer._lib.compiler import (
     KernelCompileSpec,
@@ -56,6 +56,10 @@ from sparkinfer._lib.intrinsics import (
     packed_dequant_e8m0x4_to_bfloat2x2,
     packed_dequant_e8m0x4_to_half2x2,
     packed_dequant_nf3x8_to_bfloat2x4,
+    packed_dequant_trellis_to_bfloat2x4,
+    packed_dequant_trellis_to_half2x4,
+    packed_dequant_trellis_stream_to_bfloat2x4,
+    packed_dequant_trellis_stream_to_half2x4,
     nf3_codebook_pools,
     pack_f32x2_to_bfloat2,
     pack_f32x2_to_f16x2,
@@ -114,12 +118,16 @@ _E8M0_LOGICAL_TAIL_SCALE_N_ALIGNMENT = 64
 _DEVICE_MAX_REG_BYTES = 255 * 1024
 _DEFAULT_MAX_SHARED_MEM = 101_376
 _SCALAR_ACC_FRAGMENT_WIDTH = 1
-_WEIGHT_LAYOUTS = {"packed", "modelopt", "nf3_2p1"}
+_WEIGHT_LAYOUTS = {"packed", "modelopt", "nf3_2p1", "trellis3_t256"}
 _MODEL_OPT_W13_LAYOUTS = {"w13", "w31"}
+_TRELLIS256_W13_LAYOUTS = {"packed", "trellis3_t256_proj"}
 # NF3 codebook: 8 bf16 codepoints for the 3-bit ("nf3_2p1") weight layout. The
 # device dequant reads these as prmt pools (see nf3_codebook_pools); the host
 # injects the 4 pool words as compile-time constants into the GEMM.
 _NF3_CODEBOOK = (-1.0, -0.6047, -0.3563, -0.1275, 0.1275, 0.3563, 0.6047, 1.0)
+# Native EXL3 t256 tiles contain 256 tail-biting codes at one compile-time
+# bitrate. Their exact storage is [16*bits] int16 == [8*bits] uint32 per tile.
+_TRELLIS256_BITS = (3, 4, 5, 6)
 _SCALE_FORMATS = {
     "e4m3_k16": "e4m3_k16",
     "e8m0_k32": "e8m0_k32",
@@ -284,17 +292,15 @@ def _shared_memory_footprint(
     tile_k: int,
     scale_format: str = "e4m3_k16",
     weight_layout: str = "packed",
+    weight_bits: int = 4,
 ) -> int:
     cta_m = int(cta_m_blocks) * 16
     cta_n = int(tile_n)
     cta_k = int(tile_k)
     sh_block_meta_size = cta_m * 16
     sh_a_size = _STAGES * (cta_m * cta_k) * 2
-    sh_b_size = _STAGES * (cta_k * cta_n // _PACK_FACTOR) * 4
-    if weight_layout == "nf3_2p1":
-        # NF3 stages 12-byte triples per 32-code unit instead of 16-byte int4
-        # units (see b_unit_bytes) -- 3/4 of the packed B stage footprint.
-        sh_b_size = sh_b_size * 3 // 4
+    staged_weight_bits = 3 if weight_layout == "nf3_2p1" else int(weight_bits)
+    sh_b_size = _STAGES * (cta_k * cta_n * staged_weight_bits // 8)
     sh_red_size = cta_m * (cta_n + 8) * 2
     sh_bias_size = cta_n * 2
     tmp_size = min(sh_b_size, sh_red_size) + sh_bias_size
@@ -319,6 +325,7 @@ def _determine_blocks_per_sm(
     max_shared_mem: int,
     scale_format: str = "e4m3_k16",
     weight_layout: str = "packed",
+    weight_bits: int = 4,
 ) -> int:
     num_regs = _w4a16_num_regs(
         cta_threads=cta_threads,
@@ -335,6 +342,7 @@ def _determine_blocks_per_sm(
         tile_k=tile_k,
         scale_format=scale_format,
         weight_layout=weight_layout,
+        weight_bits=weight_bits,
     )
     blocks_per_sm_limit = min(
         _DEVICE_MAX_REG_BYTES // register_bytes,
@@ -373,6 +381,7 @@ def _candidate_tile_fits(
     max_shared_mem: int,
     scale_format: str = "e4m3_k16",
     weight_layout: str = "packed",
+    weight_bits: int = 4,
     allow_logical_tail: bool = False,
 ) -> bool:
     if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
@@ -402,6 +411,7 @@ def _candidate_tile_fits(
         tile_k=tile_k,
         scale_format=scale_format,
         weight_layout=weight_layout,
+        weight_bits=weight_bits,
     )
     return smem_bytes <= int(max_shared_mem)
 
@@ -418,6 +428,7 @@ def _select_tile_config(
     required_cta_threads: int | None = None,
     scale_format: str = "e4m3_k16",
     weight_layout: str = "packed",
+    weight_bits: int = 4,
     allow_logical_tail: bool = False,
 ) -> tuple[int, int, int, int]:
     cta_m_blocks = _covering_count(moe_block_size, 16)
@@ -442,6 +453,7 @@ def _select_tile_config(
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
             allow_logical_tail=allow_logical_tail,
         ):
             continue
@@ -463,6 +475,7 @@ def _select_tile_config(
             max_shared_mem=max_shared_mem,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
         )
         if blocks_per_sm_limit > best_blocks_per_sm:
             best_blocks_per_sm = blocks_per_sm_limit
@@ -492,6 +505,8 @@ class W4A16GemmCompileResult:
     weight_layout: str = "packed"
     scale_format: str = "e4m3_k16"
     w13_layout: str = "w13"
+    dense_route_fast_path: bool = False
+    trellis_bits: int = 3
 
 
 @dataclass(frozen=True)
@@ -511,6 +526,11 @@ class W4A16TopKSumCompileResult:
     m: int
     topk: int
     hidden_size: int
+    full_rotation: bool = False
+    num_experts: int = 0
+    route_num_experts: int = 0
+    route_ids_dtype: torch.dtype = torch.int32
+    use_expert_map: bool = False
 
 
 @dataclass(frozen=True)
@@ -542,6 +562,12 @@ class W4A16FusedMoeCompileResult:
     scale_format: str = "e4m3_k16"
     tc_decode_fused_sum: bool = False
     collect_activation_amax: bool = False
+    schedule_whole_tiles: bool = False
+    intermediate_rotation: bool = False
+    dual_a: bool = False
+    trellis_bits: int = 3
+    full_rotation: bool = False
+    rotation_input_dtype: str = "fp16"
 
 
 @dataclass(frozen=True)
@@ -665,9 +691,13 @@ class W4A16GemmKernel:
         weight_layout: str = "packed",
         scale_format: str = "e4m3_k16",
         w13_layout: str = "w13",
+        trellis_bits: int = 3,
         source_n_rotation: int = 0,
         single_token_route_fast_path: bool = False,
         direct_topk_routes: bool = False,
+        dense_route_fast_path: bool = False,
+        dual_a: bool = False,
+        route_major_a: bool = False,
         fused_topk_sum: bool = False,
         fused_sum_topk: int = 1,
         schedule_whole_tiles: bool = False,
@@ -676,10 +706,14 @@ class W4A16GemmKernel:
             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
         if weight_layout not in _WEIGHT_LAYOUTS:
             raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+        trellis_bits = int(trellis_bits)
         scale_format = _normalize_scale_format(scale_format)
         if weight_layout == "modelopt":
             if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
                 raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        elif weight_layout == "trellis3_t256":
+            if w13_layout not in _TRELLIS256_W13_LAYOUTS:
+                raise ValueError(f"unsupported trellis3_t256 w13_layout {w13_layout!r}")
         else:
             w13_layout = "packed"
             source_n_rotation = 0
@@ -690,6 +724,18 @@ class W4A16GemmKernel:
                 )
             if element_dtype != "bf16":
                 raise ValueError("nf3_2p1 W4A16 weights are bf16-activation only (v1)")
+        if weight_layout == "trellis3_t256":
+            if trellis_bits not in _TRELLIS256_BITS:
+                raise ValueError(
+                    "trellis3_t256 bits must be one of "
+                    f"{_TRELLIS256_BITS}, got {trellis_bits}"
+                )
+            if scale_format != "e4m3_k32":
+                raise ValueError(
+                    "trellis3_t256 W4A16 weights require scale_format='e4m3_k32'"
+                )
+        elif trellis_bits != 3:
+            raise ValueError("trellis_bits is only valid for trellis3_t256 weights")
         if epilogue_activation not in (None, "relu2"):
             raise ValueError(
                 "W4A16 GEMM epilogue activation currently supports only relu2"
@@ -753,7 +799,20 @@ class W4A16GemmKernel:
         self.is_fp16 = element_dtype == "fp16"
         self.epilogue_relu2 = epilogue_activation == "relu2"
         self.weight_layout = weight_layout
+        self.trellis_bits = trellis_bits
         self.weight_layout_nf3 = weight_layout == "nf3_2p1"
+        self.weight_layout_trellis256 = weight_layout == "trellis3_t256"
+        self.weight_layout_trellis256_proj = (
+            self.weight_layout_trellis256 and w13_layout == "trellis3_t256_proj"
+        )
+        if self.weight_layout_trellis256_proj and (
+            self.size_n % 2 != 0 or (self.size_n // 2) % self.tile_n != 0
+        ):
+            raise ValueError(
+                "trellis3_t256_proj requires each FC1 projection to contain "
+                "an integral number of CTA N tiles"
+            )
+        self.b_region_variable = self.weight_layout_nf3 or self.weight_layout_trellis256
         self.scale_format = scale_format
         self.scale_format_e8m0_k32 = scale_format == "e8m0_k32"
         # k32 scale cadence (two K16 rows share one scale group). Shared by the
@@ -790,6 +849,26 @@ class W4A16GemmKernel:
         self.source_n_rotation = int(source_n_rotation)
         self.single_token_route_fast_path = bool(single_token_route_fast_path)
         self.direct_topk_routes = bool(direct_topk_routes)
+        self.dense_route_fast_path = bool(dense_route_fast_path)
+        if self.dense_route_fast_path and (
+            self.direct_topk_routes
+            or self.single_token_route_fast_path
+            or self.num_experts != 1
+            or self.top_k != 1
+            or self.mul_topk_weights
+        ):
+            raise ValueError(
+                "dense_route_fast_path requires E=1, top_k=1, no top-k weights, "
+                "and no other route fast path"
+            )
+        self.dual_a = bool(dual_a)
+        if self.dual_a and not self.weight_layout_trellis256_proj:
+            raise ValueError(
+                "dual_a is only valid for projection-major trellis3_t256 FC1"
+            )
+        self.route_major_a = bool(route_major_a)
+        if self.route_major_a and not self.dual_a:
+            raise ValueError("route_major_a requires the exact dual-A FC1 path")
         self.fused_topk_sum = bool(fused_topk_sum)
         self.fused_sum_topk = int(fused_sum_topk)
         # Whole-tile persistent scheduling: every mn-tile is computed by one
@@ -797,8 +876,14 @@ class W4A16GemmKernel:
         # the split-K tail machinery entirely. Requires the host to bound the
         # wave count; used by the exact-geometry hybrid decode schedule.
         self.schedule_whole_tiles = bool(schedule_whole_tiles)
-        if self.schedule_whole_tiles and not self.direct_topk_routes:
-            raise ValueError("schedule_whole_tiles requires direct_topk_routes")
+        if (
+            self.schedule_whole_tiles
+            and not self.direct_topk_routes
+            and not self.weight_layout_trellis256
+        ):
+            raise ValueError(
+                "schedule_whole_tiles requires direct_topk_routes or trellis3_t256"
+            )
         if self.fused_topk_sum and not self.direct_topk_routes:
             raise ValueError("fused_topk_sum requires direct_topk_routes")
         if self.fused_topk_sum and self.fused_sum_topk < 1:
@@ -828,6 +913,9 @@ class W4A16GemmKernel:
             max_shared_mem=max_shared_mem,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=(
+                max(4, self.trellis_bits) if self.weight_layout_trellis256 else 4
+            ),
         )
 
         # W4A16 shared-memory geometry, in int4 units unless noted.
@@ -845,15 +933,20 @@ class W4A16GemmKernel:
         self.b_sh_stride_threads = self.b_sh_stride
         self.b_sh_stage = self.b_sh_stride * self.cta_k_blocks
         self.b_sh_wr_iters = self.b_sh_stage // self.cta_threads
-        # NF3 ("nf3_2p1") stages 12-byte triples per 32-code unit instead of the
-        # 16-byte int4 unit; the per-thread unit count is unchanged, only the
-        # bytes-per-unit and the 16-byte cp.async chunk count differ.
-        self.b_unit_bytes = 12 if self.weight_layout_nf3 else 16
+        # Native t256 uses 4*bits bytes per 32 codes; NF3 uses 12 bytes and
+        # packed/modelopt use 16 bytes for the same logical unit.
+        self.b_unit_bytes = (
+            4 * self.trellis_bits
+            if self.weight_layout_trellis256
+            else 12
+            if self.weight_layout_nf3
+            else 16
+        )
         self.b_sh_stage_bytes = self.b_sh_stage * self.b_unit_bytes
-        if self.weight_layout_nf3:
+        if self.b_region_variable:
             if self.b_sh_stage_bytes % 16 != 0:
                 raise ValueError(
-                    "nf3_2p1 B stage bytes must be a multiple of 16; "
+                    "nf3/trellis B stage bytes must be a multiple of 16; "
                     f"got {self.b_sh_stage_bytes}"
                 )
             self.b_sh_chunks = self.b_sh_stage_bytes // 16
@@ -895,6 +988,12 @@ class W4A16GemmKernel:
         self.sh_a_off = self.sh_s_off + _STAGES * self.s_sh_stage
         self.shared_int4 = self.sh_a_off + _STAGES * self.a_sh_stage
         self.shared_words = self.shared_int4 * 4
+        if self.shared_words * 4 > int(max_shared_mem):
+            raise ValueError(
+                "W4A16 shared-memory footprint exceeds device opt-in limit: "
+                f"{self.shared_words * 4} > {int(max_shared_mem)} bytes "
+                f"(layout={self.weight_layout})"
+            )
 
     @property
     def __cache_key__(self) -> tuple[object, ...]:
@@ -915,15 +1014,20 @@ class W4A16GemmKernel:
             self.element_dtype,
             self.epilogue_relu2,
             self.weight_layout,
+            self.trellis_bits,
             self.scale_format,
             self.w13_layout,
             self.source_n_rotation,
             self.single_token_route_fast_path,
             self.direct_topk_routes,
+            self.dense_route_fast_path,
+            self.dual_a,
+            self.route_major_a,
             self.fused_topk_sum,
             self.fused_sum_topk,
             self.cta_m_blocks,
             self.uses_m_block_8,
+            self.max_m_blocks,
             self.shared_words,
             # Launch bounds are part of the compiled kernel.  Keep binaries
             # planned for different residency targets out of the same cache
@@ -1048,9 +1152,10 @@ class W4A16GemmKernel:
     @cute.jit
     def __call__(
         self,
-        a_bf16_flat: cute.Tensor,
+        a_bf16_ptr: cute.Pointer,
+        a_alt_bf16_ptr: cute.Pointer,
         b_i32_flat: cute.Tensor,
-        c_bf16_flat: cute.Tensor,
+        c_bf16_ptr: cute.Pointer,
         scales_i32_flat: cute.Tensor,
         global_scale: cute.Tensor,
         packed_route_indices: cute.Tensor,
@@ -1063,9 +1168,24 @@ class W4A16GemmKernel:
         grid_x: cutlass.Int32,
         stream: cuda.CUstream,
     ):
+        a_bf16_flat = cute.make_tensor(
+            a_bf16_ptr,
+            layout=cute.make_layout((active_m * Int32(self.size_k),), stride=(1,)),
+        )
+        a_alt_bf16_flat = cute.make_tensor(
+            a_alt_bf16_ptr,
+            layout=cute.make_layout((active_m * Int32(self.size_k),), stride=(1,)),
+        )
+        c_bf16_flat = cute.make_tensor(
+            c_bf16_ptr,
+            layout=cute.make_layout(
+                (active_m * Int32(self.top_k) * Int32(self.size_n),), stride=(1,)
+            ),
+        )
         grid = (grid_x, 1, 1)
         self.kernel(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             c_bf16_flat,
             scales_i32_flat,
@@ -1088,6 +1208,7 @@ class W4A16GemmKernel:
     def kernel(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         c_bf16_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
@@ -1120,6 +1241,7 @@ class W4A16GemmKernel:
         grid_x, _, _ = cute.arch.grid_dim()
         self._run_persistent_gemm(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             c_bf16_flat,
             scales_i32_flat,
@@ -1141,6 +1263,7 @@ class W4A16GemmKernel:
     def _run_persistent_gemm(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         c_bf16_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
@@ -1160,7 +1283,11 @@ class W4A16GemmKernel:
     ):
         n_tiles = Int32(self.n_tiles)
         route_blocks = active_size_m * Int32(self.top_k)
-        if cutlass.const_expr(not self.direct_topk_routes):
+        if cutlass.const_expr(self.dense_route_fast_path):
+            route_blocks = (
+                active_size_m + Int32(self.moe_block_size) - Int32(1)
+            ) // Int32(self.moe_block_size)
+        elif cutlass.const_expr(not self.direct_topk_routes):
             route_blocks = packed_route_count[Int32(0)].to(Int32) // Int32(
                 self.moe_block_size
             )
@@ -1309,13 +1436,16 @@ class W4A16GemmKernel:
                         lock_slot,
                     )
                 else:
-                    if cutlass.const_expr(self.direct_topk_routes):
+                    if cutlass.const_expr(self.dense_route_fast_path):
+                        expert_idx = Int32(0)
+                    elif cutlass.const_expr(self.direct_topk_routes):
                         expert_idx = packed_route_indices[route_block_idx].to(Int32)
                     else:
                         expert_idx = block_expert_ids[route_block_idx].to(Int32)
                     if expert_idx >= Int32(0):
                         self._run_tile(
                             a_bf16_flat,
+                            a_alt_bf16_flat,
                             b_i32_flat,
                             c_bf16_flat,
                             scales_i32_flat,
@@ -1359,6 +1489,26 @@ class W4A16GemmKernel:
         global_scale_f32: cutlass.Float32,
         active_size_m: Int32,
     ) -> Int32:
+        if cutlass.const_expr(self.dense_route_fast_path):
+            block_row = route_block_idx * Int32(self.moe_block_size)
+            valid_rows = active_size_m - block_row
+            if valid_rows > Int32(self.moe_block_size):
+                valid_rows = Int32(self.moe_block_size)
+            if valid_rows < Int32(0):
+                valid_rows = Int32(0)
+            if tid < Int32(self.moe_block_size):
+                row = block_row + tid
+                st_shared_i32(
+                    smem_base + Int32(self.sh_route_off * 16) + tid * Int32(4),
+                    row,
+                )
+                st_shared_i32(
+                    smem_base + Int32(self.sh_rd_route_off * 16) + tid * Int32(4),
+                    row,
+                )
+            cute.arch.sync_threads()
+            return valid_rows
+
         if cutlass.const_expr(self.direct_topk_routes):
             if tid == Int32(0):
                 idx = route_block_idx
@@ -1381,6 +1531,8 @@ class W4A16GemmKernel:
                 ].to(Int32)
                 st_shared_i32(smem_base + Int32(self.sh_route_off * 16), idx)
                 rd_row = idx // Int32(self.top_k)
+                if cutlass.const_expr(self.route_major_a):
+                    rd_row = idx
                 st_shared_i32(smem_base + Int32(self.sh_rd_route_off * 16), rd_row)
                 if cutlass.const_expr(self.mul_topk_weights):
                     safe_idx = idx
@@ -1434,6 +1586,8 @@ class W4A16GemmKernel:
                 smem_base + Int32(self.sh_route_off * 16) + tid * Int32(4)
             )
             rd_row = idx // Int32(self.top_k)
+            if cutlass.const_expr(self.route_major_a):
+                rd_row = idx
             st_shared_i32(
                 smem_base + Int32(self.sh_rd_route_off * 16) + tid * Int32(4),
                 rd_row,
@@ -1463,6 +1617,7 @@ class W4A16GemmKernel:
     def _run_tile(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         c_bf16_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
@@ -1486,6 +1641,7 @@ class W4A16GemmKernel:
         if cutlass.const_expr(self.uses_m_block_8):
             self._run_tile_m8(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 b_i32_flat,
                 c_bf16_flat,
                 scales_i32_flat,
@@ -1509,6 +1665,7 @@ class W4A16GemmKernel:
         else:
             self._run_tile_large_m(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 b_i32_flat,
                 c_bf16_flat,
                 scales_i32_flat,
@@ -1656,6 +1813,7 @@ class W4A16GemmKernel:
     def _run_tile_m8(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         c_bf16_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
@@ -1717,6 +1875,7 @@ class W4A16GemmKernel:
         k_tiles = reduce_tile_count
         self._prefetch_initial_tiles(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             scales_i32_flat,
             smem_base,
@@ -1760,6 +1919,7 @@ class W4A16GemmKernel:
         )
         self._run_mma_pipeline(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             scales_i32_flat,
             smem_base,
@@ -1815,6 +1975,7 @@ class W4A16GemmKernel:
     def _run_tile_large_m(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         c_bf16_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
@@ -1899,6 +2060,7 @@ class W4A16GemmKernel:
         k_tiles = reduce_tile_count
         self._prefetch_initial_tiles(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             scales_i32_flat,
             smem_base,
@@ -1942,6 +2104,7 @@ class W4A16GemmKernel:
         )
         self._run_mma_pipeline(
             a_bf16_flat,
+            a_alt_bf16_flat,
             b_i32_flat,
             scales_i32_flat,
             smem_base,
@@ -1997,6 +2160,7 @@ class W4A16GemmKernel:
     def _run_mma_pipeline(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
         smem_base: Int32,
@@ -2051,6 +2215,7 @@ class W4A16GemmKernel:
 
                         self._prefetch_pipeline_step(
                             a_bf16_flat,
+                            a_alt_bf16_flat,
                             b_i32_flat,
                             scales_i32_flat,
                             smem_base,
@@ -2075,7 +2240,13 @@ class W4A16GemmKernel:
                         )
 
                         for jj in cutlass.range_constexpr(4):
-                            if cutlass.const_expr(self.weight_layout_nf3):
+                            if cutlass.const_expr(self.weight_layout_trellis256):
+                                self._scaled_dequant_b_fragment_trellis256(
+                                    b_frag,
+                                    b_scale_cur[0, jj],
+                                    b_scale_cur[1, jj],
+                                )
+                            elif cutlass.const_expr(self.weight_layout_nf3):
                                 # NF3 triple: lo16 = half (jj % 2) of word
                                 # (jj // 2); hi8 = byte jj of the hi word; scale
                                 # register is the same per-jj lane as packed.
@@ -2621,6 +2792,10 @@ class W4A16GemmKernel:
         pipe: Int32,
         kk: Int32,
     ):
+        if cutlass.const_expr(self.weight_layout_trellis256):
+            # TRELLIS-256: no per-weight scale; the (2,4) bundle carries the 4
+            # jj-tiles' pre-funnelled windows -> regs[0,jj]=win_a, regs[1,jj]=win_b.
+            return self._load_b_registers_trellis256(smem_base, tid, pipe, kk)
         if cutlass.const_expr(self.weight_layout == "modelopt"):
             q0, q1, q2, q3 = self._load_b_registers_modelopt_shared(
                 smem_base,
@@ -2822,6 +2997,124 @@ class W4A16GemmKernel:
         frag[0, 1] = self._elem2_mul(o1, s_lane0)
         frag[1, 0] = self._elem2_mul(o2, s_lane1)
         frag[1, 1] = self._elem2_mul(o3, s_lane1)
+
+    @cute.jit
+    def _trellis256_lane_geom(
+        self,
+        lane: Int32,
+        weight_offset: cutlass.Constexpr[int],
+        weight_count: cutlass.Constexpr[int],
+    ):
+        bits = Int32(self.trellis_bits)
+        ring_u32 = Int32(8 * self.trellis_bits)
+        t_offset = Int32(8) * lane + Int32(weight_offset)
+        b1 = (t_offset + Int32(257)) * bits
+        b0 = b1 - Int32(16)
+        b2 = b1 + Int32((int(weight_count) - 1) * self.trellis_bits)
+        i0 = b0 >> Int32(5)
+        i2 = (b2 - Int32(1)) >> Int32(5)
+        ia = i0 - ring_u32 * (i0 >= ring_u32).to(Int32)
+        ib = i2 - ring_u32 * (i2 >= ring_u32).to(Int32)
+        s2 = (i2 + Int32(1)) * Int32(32) - b2
+        return ia, ib, s2, i2 - i0
+
+    @cute.jit
+    def _trellis_funnel256(self, a: Uint32, b: Uint32, s2: Int32):
+        merged = (Int64(a) << Int64(32)) | Int64(b)
+        return Uint32(merged >> Int64(s2))
+
+    @cute.jit
+    def _scaled_dequant_b_fragment_trellis256(
+        self,
+        frag: cute.Tensor,
+        win_a: Uint32,
+        win_b: Uint32,
+    ):
+        if cutlass.const_expr(self.trellis_bits == 6):
+            if cutlass.const_expr(self.is_fp16):
+                o0, o1, o2, o3 = packed_dequant_trellis_stream_to_half2x4(
+                    win_a, win_b, self.trellis_bits
+                )
+            else:
+                o0, o1, o2, o3 = packed_dequant_trellis_stream_to_bfloat2x4(
+                    win_a, win_b, self.trellis_bits
+                )
+        elif cutlass.const_expr(self.is_fp16):
+            o0, o1, o2, o3 = packed_dequant_trellis_to_half2x4(
+                win_a, win_b, self.trellis_bits
+            )
+        else:
+            o0, o1, o2, o3 = packed_dequant_trellis_to_bfloat2x4(
+                win_a, win_b, self.trellis_bits
+            )
+        frag[0, 0] = o0
+        frag[0, 1] = o1
+        frag[1, 0] = o2
+        frag[1, 1] = o3
+
+    @cute.jit
+    def _load_b_registers_trellis256(
+        self,
+        smem_base: Int32,
+        tid: Int32,
+        pipe: Int32,
+        kk: Int32,
+    ):
+        lane = tid & Int32(31)
+        warp_id = tid >> Int32(5)
+        warp_row = warp_id // Int32(self.tb_n_warps)
+        w_n = warp_id % Int32(self.tb_n_warps)
+        kt_local = Int32(self.b_sh_wr_iters) * warp_row + kk
+        b_region = (
+            smem_base + Int32(self.sh_b_off * 16) + pipe * Int32(self.b_sh_stage_bytes)
+        )
+        tile_u32 = 8 * self.trellis_bits
+        base_u32 = (kt_local * Int32(self.cta_n_blocks) + Int32(4) * w_n) * Int32(
+            tile_u32
+        )
+        wa = [Uint32(0), Uint32(0), Uint32(0), Uint32(0)]
+        wb = [Uint32(0), Uint32(0), Uint32(0), Uint32(0)]
+        if cutlass.const_expr(self.trellis_bits <= 4):
+            ia, ib, s2, _ = self._trellis256_lane_geom(lane, 0, 8)
+            for jj in cutlass.range_constexpr(4):
+                tbase = base_u32 + Int32(jj * tile_u32)
+                a = ld_shared_u32(b_region + (tbase + ia) * Int32(4))
+                b = ld_shared_u32(b_region + (tbase + ib) * Int32(4))
+                wa[jj] = self._trellis_funnel256(a, b, s2)
+                wb[jj] = self._trellis_funnel256(
+                    a, b, s2 + Int32(4 * self.trellis_bits)
+                )
+        elif cutlass.const_expr(self.trellis_bits == 5):
+            ib0, ib1, sb, _ = self._trellis256_lane_geom(lane, 0, 4)
+            ia0, ia1, sa, _ = self._trellis256_lane_geom(lane, 4, 4)
+            for jj in cutlass.range_constexpr(4):
+                tbase = base_u32 + Int32(jj * tile_u32)
+                b0 = ld_shared_u32(b_region + (tbase + ib0) * Int32(4))
+                b1 = ld_shared_u32(b_region + (tbase + ib1) * Int32(4))
+                a0 = ld_shared_u32(b_region + (tbase + ia0) * Int32(4))
+                a1 = ld_shared_u32(b_region + (tbase + ia1) * Int32(4))
+                wb[jj] = self._trellis_funnel256(b0, b1, sb)
+                wa[jj] = self._trellis_funnel256(a0, a1, sa)
+        else:
+            i0, i2, s2, delta = self._trellis256_lane_geom(lane, 0, 8)
+            i1 = i0 + Int32(1)
+            i1 = i1 - Int32(tile_u32) * (i1 >= Int32(tile_u32)).to(Int32)
+            for jj in cutlass.range_constexpr(4):
+                tbase = base_u32 + Int32(jj * tile_u32)
+                z0 = ld_shared_u32(b_region + (tbase + i0) * Int32(4))
+                z1 = ld_shared_u32(b_region + (tbase + i1) * Int32(4))
+                z2 = ld_shared_u32(b_region + (tbase + i2) * Int32(4))
+                stream64 = Uint64(0)
+                if delta == Int32(1):
+                    stream64 = ((Uint64(z0) << Uint64(32)) | Uint64(z2)) >> Uint64(s2)
+                else:
+                    lower64 = (Uint64(z1) << Uint64(32)) | Uint64(z2)
+                    stream64 = (lower64 >> Uint64(s2)) | (
+                        Uint64(z0) << (Uint64(64) - Uint64(s2))
+                    )
+                wa[jj] = Uint32(stream64)
+                wb[jj] = Uint32(stream64 >> Uint64(32))
+        return wa[0], wa[1], wa[2], wa[3], wb[0], wb[1], wb[2], wb[3]
 
     @cute.jit
     def _mma_accumulate_m8(
@@ -3108,6 +3401,7 @@ class W4A16GemmKernel:
     def _stage_k_tile_async(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
         smem_base: Int32,
@@ -3147,20 +3441,77 @@ class W4A16GemmKernel:
                     Int32(i * self.a_sh_wr_delta) + a_sh_wr
                 ),
             )
+            a_src = get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8))
+            if cutlass.const_expr(self.dual_a):
+                # Projection-major FC1 validates that each CTA N tile is wholly
+                # gate or wholly up.  Select the matching pre-rotated A operand
+                # with the same logical projection boundary used by B staging.
+                # The selected source still lands in the one existing A SMEM
+                # stage, so this adds neither shared memory nor MMA work.
+                if output_n_tile >= Int32(self.n_tiles // 2):
+                    a_src = get_ptr_as_int64(a_alt_bf16_flat, a_int4 * Int32(8))
             if cutlass.const_expr(self.has_k_tile_tail):
                 a_k_int4 = tile_idx * Int32(self.a_gl_rd_delta_o) + a_gl_rd_col0
                 if row < block_valid_rows and a_k_int4 < a_gl_stride:
                     cp_async4_shared_global(
                         a_dst,
-                        get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8)),
+                        a_src,
                     )
                 else:
                     st_shared_v4_u32(a_dst, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
             else:
                 cp_async4_shared_global_pred(
                     a_dst,
-                    get_ptr_as_int64(a_bf16_flat, a_int4 * Int32(8)),
+                    a_src,
                     (row < block_valid_rows).to(Int32),
+                )
+
+        if cutlass.const_expr(self.weight_layout_trellis256):
+            t256_n16 = self.size_n // 16
+            t256_tile_u32 = 8 * self.trellis_bits
+            t256_expert_u32 = (self.size_k // 16) * t256_n16 * t256_tile_u32
+            t256_chunks_per_kt = self.cta_n_blocks * (2 * self.trellis_bits)
+            t256_total_chunks = self.cta_k_blocks * t256_chunks_per_kt
+            for i in cutlass.range_constexpr(self.b_sh_wr_iters_nf3):
+                t256_chunk = Int32(i * self.cta_threads) + tid
+                t256_kt = t256_chunk // Int32(t256_chunks_per_kt)
+                t256_in_kt = t256_chunk - t256_kt * Int32(t256_chunks_per_kt)
+                b_dst = (
+                    smem_base
+                    + Int32(self.sh_b_off * 16)
+                    + pipe * Int32(self.b_sh_stage_bytes)
+                    + t256_chunk * Int32(16)
+                )
+                if cutlass.const_expr(self.weight_layout_trellis256_proj):
+                    t256_half_n16 = t256_n16 // 2
+                    t256_out_n16 = output_n_tile * Int32(self.cta_n_blocks)
+                    t256_proj = (t256_out_n16 >= Int32(t256_half_n16)).to(Int32)
+                    t256_local_n16 = t256_out_n16 - t256_proj * Int32(t256_half_n16)
+                    t256_proj_expert_u32 = (
+                        (self.size_k // 16) * t256_half_n16 * t256_tile_u32
+                    )
+                    t256_plane_u32 = self.num_experts * t256_proj_expert_u32
+                    b_src_i64 = (
+                        Int64(t256_proj) * Int64(t256_plane_u32)
+                        + Int64(expert_idx) * Int64(t256_proj_expert_u32)
+                        + (Int64(tile_idx) * Int64(self.cta_k_blocks) + Int64(t256_kt))
+                        * Int64(t256_half_n16 * t256_tile_u32)
+                        + Int64(t256_local_n16) * Int64(t256_tile_u32)
+                        + Int64(t256_in_kt) * Int64(4)
+                    )
+                else:
+                    b_src_i64 = (
+                        Int64(t256_expert_u32) * Int64(expert_idx)
+                        + (Int64(tile_idx) * Int64(self.cta_k_blocks) + Int64(t256_kt))
+                        * Int64(t256_n16 * t256_tile_u32)
+                        + Int64(output_n_tile)
+                        * Int64(self.cta_n_blocks * t256_tile_u32)
+                        + Int64(t256_in_kt) * Int64(4)
+                    )
+                cp_async4_shared_global_pred(
+                    b_dst,
+                    get_ptr_as_int64(b_i32_flat, b_src_i64),
+                    (t256_chunk < Int32(t256_total_chunks)).to(Int32),
                 )
 
         if cutlass.const_expr(self.weight_layout_nf3):
@@ -3195,7 +3546,7 @@ class W4A16GemmKernel:
                 )
 
         for i in cutlass.range_constexpr(
-            0 if self.weight_layout_nf3 else self.b_sh_wr_iters
+            0 if self.b_region_variable else self.b_sh_wr_iters
         ):
             b_src_int4 = (
                 b_gl_rd_base
@@ -3224,40 +3575,47 @@ class W4A16GemmKernel:
                     Int32(i * self.cta_threads) + tid,
                 )
 
-        if tid < Int32(self.s_sh_stage):
-            s_k_group = tile_idx * Int32(self.s_tb_groups) + tid // Int32(
-                self.s_sh_stride
-            )
-            s_n_group = Int32(self.s_sh_stride) * output_n_tile + (
-                tid % Int32(self.s_sh_stride)
-            )
-            s_src_int4 = scales_expert_off + s_gl_stride * s_k_group + s_n_group
-            s_dst = self._int4_addr(
-                smem_base,
-                Int32(self.sh_s_off) + pipe * Int32(self.s_sh_stage) + tid,
-            )
-            if cutlass.const_expr(self.has_logical_tail):
-                if s_k_group < Int32(self.scale_k_groups) and s_n_group < Int32(
-                    self.scale_n_groups
-                ):
+        # trellis3_t256 has no per-weight scale and its register-load arm returns
+        # before touching scale SMEM.  Const-expr-elide the otherwise dead HBM
+        # reads so every layer can share a four-byte aligned dummy scale tensor
+        # instead of retaining 54 MiB of packed ones.
+        if cutlass.const_expr(not self.weight_layout_trellis256):
+            if tid < Int32(self.s_sh_stage):
+                s_k_group = tile_idx * Int32(self.s_tb_groups) + tid // Int32(
+                    self.s_sh_stride
+                )
+                s_n_group = Int32(self.s_sh_stride) * output_n_tile + (
+                    tid % Int32(self.s_sh_stride)
+                )
+                s_src_int4 = scales_expert_off + s_gl_stride * s_k_group + s_n_group
+                s_dst = self._int4_addr(
+                    smem_base,
+                    Int32(self.sh_s_off) + pipe * Int32(self.s_sh_stage) + tid,
+                )
+                if cutlass.const_expr(self.has_logical_tail):
+                    if s_k_group < Int32(self.scale_k_groups) and s_n_group < Int32(
+                        self.scale_n_groups
+                    ):
+                        cp_async4_shared_global(
+                            s_dst,
+                            get_ptr_as_int64(scales_i32_flat, s_src_int4 * Int32(4)),
+                        )
+                    else:
+                        st_shared_v4_u32(
+                            s_dst, Uint32(0), Uint32(0), Uint32(0), Uint32(0)
+                        )
+                else:
                     cp_async4_shared_global(
                         s_dst,
                         get_ptr_as_int64(scales_i32_flat, s_src_int4 * Int32(4)),
                     )
-                else:
-                    st_shared_v4_u32(s_dst, Uint32(0), Uint32(0), Uint32(0), Uint32(0))
-            else:
-                cp_async4_shared_global(
-                    s_dst,
-                    get_ptr_as_int64(scales_i32_flat, s_src_int4 * Int32(4)),
-                )
-
         cute.arch.cp_async_commit_group()
 
     @cute.jit
     def _prefetch_pipeline_step(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
         smem_base: Int32,
@@ -3283,6 +3641,7 @@ class W4A16GemmKernel:
         if cutlass.const_expr(kk == self.b_sh_wr_iters - 2):
             self._prefetch_lookahead_tile(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 b_i32_flat,
                 scales_i32_flat,
                 smem_base,
@@ -3309,6 +3668,7 @@ class W4A16GemmKernel:
     def _prefetch_initial_tiles(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
         smem_base: Int32,
@@ -3332,6 +3692,7 @@ class W4A16GemmKernel:
             if Int32(pipe) < k_tiles:
                 self._stage_k_tile_async(
                     a_bf16_flat,
+                    a_alt_bf16_flat,
                     b_i32_flat,
                     scales_i32_flat,
                     smem_base,
@@ -3360,6 +3721,7 @@ class W4A16GemmKernel:
     def _prefetch_lookahead_tile(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
         b_i32_flat: cute.Tensor,
         scales_i32_flat: cute.Tensor,
         smem_base: Int32,
@@ -3385,6 +3747,7 @@ class W4A16GemmKernel:
         if fetch_tile < k_tiles:
             self._stage_k_tile_async(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 b_i32_flat,
                 scales_i32_flat,
                 smem_base,
@@ -4226,11 +4589,15 @@ class W4A16FusedMoeKernel:
         weight_layout: str = "packed",
         scale_format: str = "e4m3_k16",
         w13_layout: str = "w13",
+        trellis_bits: int = 3,
         direct_topk_routes: bool = False,
         tc_decode_fused_sum: bool = False,
         tc_zero_output: bool = True,
         collect_activation_amax: bool = False,
         schedule_whole_tiles: bool = False,
+        intermediate_rotation: bool = False,
+        full_rotation: bool = False,
+        rotation_input_dtype: str = "fp16",
     ):
         activation = normalize_moe_activation(activation)
         is_gated = validate_activation(activation)
@@ -4246,6 +4613,9 @@ class W4A16FusedMoeKernel:
         if weight_layout == "modelopt":
             if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
                 raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+        elif weight_layout == "trellis3_t256":
+            if w13_layout not in _TRELLIS256_W13_LAYOUTS:
+                raise ValueError(f"unsupported trellis3_t256 w13_layout {w13_layout!r}")
         else:
             w13_layout = "packed"
         self.tc_decode_fused_sum = bool(tc_decode_fused_sum)
@@ -4282,6 +4652,7 @@ class W4A16FusedMoeKernel:
         self.swiglu_alpha = float(swiglu_alpha)
         self.swiglu_beta = float(swiglu_beta)
         self.weight_layout = weight_layout
+        self.trellis_bits = int(trellis_bits)
         self.scale_format = scale_format
         self.w13_layout = w13_layout
         self.apply_router_weight_on_input = bool(apply_router_weight_on_input)
@@ -4290,7 +4661,49 @@ class W4A16FusedMoeKernel:
         self.is_fp16 = element_dtype == "fp16"
         self.fast_math = bool(fast_math)
         self.direct_topk_routes = bool(direct_topk_routes)
-        self.schedule_whole_tiles = bool(schedule_whole_tiles)
+        self.schedule_whole_tiles = bool(
+            schedule_whole_tiles or weight_layout == "trellis3_t256"
+        )
+        self.intermediate_rotation = bool(intermediate_rotation)
+        if self.intermediate_rotation:
+            if weight_layout != "trellis3_t256":
+                raise ValueError(
+                    "intermediate_rotation is only supported for trellis3_t256"
+                )
+            if not is_gated or self.activation_is_swigluoai or self.has_swiglu_limit:
+                raise ValueError(
+                    "intermediate_rotation requires plain gated silu "
+                    "(no swiglu limit/oai)"
+                )
+            if int(intermediate_size) % 128 != 0:
+                raise ValueError(
+                    "intermediate_rotation requires intermediate_size % 128 == 0"
+                )
+        self.full_rotation = bool(full_rotation)
+        self.rotation_input_dtype = str(rotation_input_dtype)
+        self.rotation_input_is_fp16 = self.rotation_input_dtype == "fp16"
+        if self.full_rotation:
+            if not self.intermediate_rotation:
+                raise ValueError("full_rotation requires intermediate_rotation")
+            if element_dtype != "fp16":
+                raise ValueError("full_rotation requires fp16 GEMM operands")
+            if self.rotation_input_dtype not in {"bf16", "fp16"}:
+                raise ValueError("full_rotation input dtype must be 'bf16' or 'fp16'")
+            if self.direct_topk_routes or self.tc_decode_fused_sum:
+                raise ValueError(
+                    "full_rotation requires the route-packed non-TC-decode path"
+                )
+            if self.apply_router_weight_on_input:
+                raise ValueError(
+                    "full_rotation applies router weights only in the fp32 top-k sum"
+                )
+            if int(hidden_size) % 128 != 0:
+                raise ValueError("full_rotation requires hidden_size % 128 == 0")
+        self.dual_a = bool(
+            self.intermediate_rotation
+            and weight_layout == "trellis3_t256"
+            and w13_layout == "trellis3_t256_proj"
+        )
         fc1_source_n_rotation = (
             int(intermediate_size)
             if (weight_layout == "modelopt" and w13_layout == "w13" and is_gated)
@@ -4312,9 +4725,12 @@ class W4A16FusedMoeKernel:
             weight_layout=weight_layout,
             scale_format=scale_format,
             w13_layout=w13_layout,
+            trellis_bits=self.trellis_bits,
             source_n_rotation=fc1_source_n_rotation,
             single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
+            dual_a=self.dual_a,
+            route_major_a=self.full_rotation,
             schedule_whole_tiles=self.schedule_whole_tiles,
         )
         self.fc2 = W4A16GemmKernel(
@@ -4323,7 +4739,9 @@ class W4A16FusedMoeKernel:
             size_k=intermediate_size,
             num_experts=num_experts,
             top_k=1,
-            mul_topk_weights=not bool(apply_router_weight_on_input),
+            mul_topk_weights=(
+                not bool(apply_router_weight_on_input) and not self.full_rotation
+            ),
             tile_n=fc2_tile_n,
             tile_k=fc2_tile_k,
             moe_block_size=moe_block_size,
@@ -4331,7 +4749,8 @@ class W4A16FusedMoeKernel:
             element_dtype=element_dtype,
             weight_layout=weight_layout,
             scale_format=scale_format,
-            w13_layout=w13_layout,
+            w13_layout=("packed" if weight_layout == "trellis3_t256" else w13_layout),
+            trellis_bits=self.trellis_bits,
             single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
             fused_topk_sum=self.tc_decode_fused_sum,
@@ -4366,6 +4785,7 @@ class W4A16FusedMoeKernel:
             self.swiglu_alpha,
             self.swiglu_beta,
             self.weight_layout,
+            self.trellis_bits,
             self.scale_format,
             self.apply_router_weight_on_input,
             self.zero_fc2_output,
@@ -4374,6 +4794,10 @@ class W4A16FusedMoeKernel:
             self.direct_topk_routes,
             self.tc_zero_output,
             self.collect_activation_amax,
+            self.intermediate_rotation,
+            self.dual_a,
+            self.full_rotation,
+            self.rotation_input_dtype,
             self.fc1.__cache_key__,
             self.fc2.__cache_key__,
             self.cta_threads,
@@ -4409,6 +4833,8 @@ class W4A16FusedMoeKernel:
     def __call__(
         self,
         a_bf16_ptr: cute.Pointer,
+        a_alt_bf16_ptr: cute.Pointer,
+        rotation_input_ptr: cute.Pointer,
         w13_i32_flat: cute.Tensor,
         w2_i32_flat: cute.Tensor,
         fc1_bf16_flat: cute.Tensor,
@@ -4427,12 +4853,26 @@ class W4A16FusedMoeKernel:
         fc1_c_tmp_f32_flat: cute.Tensor,
         fc2_c_tmp_f32_flat: cute.Tensor,
         locks_i32_flat: cute.Tensor,
+        rot_scales_flat: cute.Tensor,
+        suh_gate_flat: cute.Tensor,
+        suh_up_flat: cute.Tensor,
         active_m: cutlass.Int32,
         grid_x: cutlass.Int32,
         stream: cuda.CUstream,
     ):
+        a_rows = active_m
+        if cutlass.const_expr(self.full_rotation):
+            a_rows = active_m * Int32(self.top_k)
         a_bf16_flat = cute.make_tensor(
             a_bf16_ptr,
+            layout=cute.make_layout((a_rows * Int32(self.hidden_size),), stride=(1,)),
+        )
+        a_alt_bf16_flat = cute.make_tensor(
+            a_alt_bf16_ptr,
+            layout=cute.make_layout((a_rows * Int32(self.hidden_size),), stride=(1,)),
+        )
+        rotation_input_flat = cute.make_tensor(
+            rotation_input_ptr,
             layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
         )
         topk_weights_flat = cute.make_tensor(
@@ -4442,6 +4882,8 @@ class W4A16FusedMoeKernel:
         grid = (grid_x, 1, 1)
         self.kernel(
             a_bf16_flat,
+            a_alt_bf16_flat,
+            rotation_input_flat,
             w13_i32_flat,
             w2_i32_flat,
             fc1_bf16_flat,
@@ -4460,6 +4902,9 @@ class W4A16FusedMoeKernel:
             fc1_c_tmp_f32_flat,
             fc2_c_tmp_f32_flat,
             locks_i32_flat,
+            rot_scales_flat,
+            suh_gate_flat,
+            suh_up_flat,
             active_m,
         ).launch(
             grid=grid,
@@ -4477,6 +4922,8 @@ class W4A16FusedMoeKernel:
     def kernel(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
+        rotation_input_flat: cute.Tensor,
         w13_i32_flat: cute.Tensor,
         w2_i32_flat: cute.Tensor,
         fc1_bf16_flat: cute.Tensor,
@@ -4495,6 +4942,9 @@ class W4A16FusedMoeKernel:
         fc1_c_tmp_f32_flat: cute.Tensor,
         fc2_c_tmp_f32_flat: cute.Tensor,
         locks_i32_flat: cute.Tensor,
+        rot_scales_flat: cute.Tensor,
+        suh_gate_flat: cute.Tensor,
+        suh_up_flat: cute.Tensor,
         active_m: cutlass.Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -4518,6 +4968,8 @@ class W4A16FusedMoeKernel:
 
         self._moe_body(
             a_bf16_flat,
+            a_alt_bf16_flat,
+            rotation_input_flat,
             w13_i32_flat,
             w2_i32_flat,
             fc1_bf16_flat,
@@ -4536,6 +4988,9 @@ class W4A16FusedMoeKernel:
             fc1_c_tmp_f32_flat,
             fc2_c_tmp_f32_flat,
             locks_i32_flat,
+            rot_scales_flat,
+            suh_gate_flat,
+            suh_up_flat,
             smem_base,
             tid,
             cta,
@@ -4547,6 +5002,8 @@ class W4A16FusedMoeKernel:
     def _moe_body(
         self,
         a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
+        rotation_input_flat: cute.Tensor,
         w13_i32_flat: cute.Tensor,
         w2_i32_flat: cute.Tensor,
         fc1_bf16_flat: cute.Tensor,
@@ -4565,6 +5022,9 @@ class W4A16FusedMoeKernel:
         fc1_c_tmp_f32_flat: cute.Tensor,
         fc2_c_tmp_f32_flat: cute.Tensor,
         locks_i32_flat: cute.Tensor,
+        rot_scales_flat: cute.Tensor,
+        suh_gate_flat: cute.Tensor,
+        suh_up_flat: cute.Tensor,
         smem_base: Int32,
         tid: Int32,
         cta: Int32,
@@ -4578,6 +5038,23 @@ class W4A16FusedMoeKernel:
         # barrier, FC2. The emit hooks delegate per-tile expert resolution and
         # dispatch (used by the hybrid route map); None keeps the single-tier
         # resolution inside _run_persistent_gemm.
+        if cutlass.const_expr(self.full_rotation):
+            self._run_input_rotation(
+                rotation_input_flat,
+                a_bf16_flat,
+                a_alt_bf16_flat,
+                suh_gate_flat,
+                suh_up_flat,
+                packed_route_indices,
+                block_expert_ids,
+                packed_route_count,
+                tid,
+                cta,
+                grid_x,
+                active_m,
+            )
+            self._grid_barrier(locks_i32_flat, tid, grid_x)
+
         if cutlass.const_expr(self.tc_decode_fused_sum):
             # The TC-decode FC2 epilogue atomically accumulates per-route
             # partials directly into the per-token output, so the output must be
@@ -4610,6 +5087,7 @@ class W4A16FusedMoeKernel:
         if cutlass.const_expr(self.activation_is_gated):
             self.fc1._run_persistent_gemm(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 w13_i32_flat,
                 fc1_bf16_flat,
                 w13_scales_i32_flat,
@@ -4628,17 +5106,33 @@ class W4A16FusedMoeKernel:
                 fc1_emit_tile,
             )
             self._grid_barrier(locks_i32_flat, tid, grid_x)
-            self._run_activation(
-                fc1_bf16_flat,
-                activated_bf16_flat,
-                tid,
-                cta,
-                grid_x,
-                active_m,
-            )
+            if cutlass.const_expr(self.full_rotation):
+                self._run_activation_compact(
+                    fc1_bf16_flat,
+                    activated_bf16_flat,
+                    rot_scales_flat,
+                    packed_route_indices,
+                    block_expert_ids,
+                    packed_route_count,
+                    tid,
+                    cta,
+                    grid_x,
+                    active_m,
+                )
+            else:
+                self._run_activation(
+                    fc1_bf16_flat,
+                    activated_bf16_flat,
+                    rot_scales_flat,
+                    tid,
+                    cta,
+                    grid_x,
+                    active_m,
+                )
         else:
             self.fc1._run_persistent_gemm(
                 a_bf16_flat,
+                a_alt_bf16_flat,
                 w13_i32_flat,
                 activated_bf16_flat,
                 w13_scales_i32_flat,
@@ -4676,6 +5170,7 @@ class W4A16FusedMoeKernel:
             self._zero_fc2_output(fc2_bf16_flat, tid, cta, grid_x, active_m)
             self._grid_barrier(locks_i32_flat, tid, grid_x)
         self.fc2._run_persistent_gemm(
+            activated_bf16_flat,
             activated_bf16_flat,
             w2_i32_flat,
             fc2_bf16_flat,
@@ -4717,6 +5212,213 @@ class W4A16FusedMoeKernel:
                 while sense == old_sense:
                     sense = ld_global_acquire_i32(sense_addr)
         cute.arch.sync_threads()
+
+    @cute.jit
+    def _run_input_rotation(
+        self,
+        x_input_flat: cute.Tensor,
+        a_gate_flat: cute.Tensor,
+        a_up_flat: cute.Tensor,
+        suh_gate_flat: cute.Tensor,
+        suh_up_flat: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+    ):
+        # One warp owns one (packed route, H128 block).  The packed route id is
+        # the logical flattened top-k route, so route//top_k is the source token
+        # and route is the row in each projection-specific A scratch.  Padding
+        # slots carry the live-route sentinel and are skipped.  Both scale
+        # multiplies are rounded to fp16 before the existing fp32-register
+        # H128 butterfly, and each H128 result is rounded to fp16 on store.
+        lane = tid & Int32(31)
+        warp_in_cta = tid >> Int32(5)
+        warps_per_cta = Int32(self.cta_threads // 32)
+        nblk = Int32(self.hidden_size // 128)
+        live_routes = active_m * Int32(self.top_k)
+        route_count = packed_route_count[Int32(0)].to(Int32)
+        gwarp = cta * warps_per_cta + warp_in_cta
+        gw_stride = grid_x * warps_per_cta
+        total_units = route_count * nblk
+        elem = lane * Int32(4)
+        unit = gwarp
+        while unit < total_units:
+            route_pos = unit // nblk
+            blk = unit - route_pos * nblk
+            route = packed_route_indices[route_pos].to(Int32)
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
+            if route >= Int32(0) and route < live_routes and expert >= Int32(0):
+                token = route // Int32(self.top_k)
+                col0 = blk * Int32(128) + elem
+                x_base = token * Int32(self.hidden_size) + col0
+                s_base = expert * Int32(self.hidden_size) + col0
+                out_base = route * Int32(self.hidden_size) + col0
+
+                x0 = cutlass.Float16(
+                    x_input_flat[x_base + Int32(0)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                x1 = cutlass.Float16(
+                    x_input_flat[x_base + Int32(1)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                x2 = cutlass.Float16(
+                    x_input_flat[x_base + Int32(2)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                x3 = cutlass.Float16(
+                    x_input_flat[x_base + Int32(3)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                sg0 = suh_gate_flat[s_base + Int32(0)].to(cutlass.Float32)
+                sg1 = suh_gate_flat[s_base + Int32(1)].to(cutlass.Float32)
+                sg2 = suh_gate_flat[s_base + Int32(2)].to(cutlass.Float32)
+                sg3 = suh_gate_flat[s_base + Int32(3)].to(cutlass.Float32)
+                su0 = suh_up_flat[s_base + Int32(0)].to(cutlass.Float32)
+                su1 = suh_up_flat[s_base + Int32(1)].to(cutlass.Float32)
+                su2 = suh_up_flat[s_base + Int32(2)].to(cutlass.Float32)
+                su3 = suh_up_flat[s_base + Int32(3)].to(cutlass.Float32)
+
+                g0 = cutlass.Float16(x0 * sg0).to(cutlass.Float32)
+                g1 = cutlass.Float16(x1 * sg1).to(cutlass.Float32)
+                g2 = cutlass.Float16(x2 * sg2).to(cutlass.Float32)
+                g3 = cutlass.Float16(x3 * sg3).to(cutlass.Float32)
+                u0 = cutlass.Float16(x0 * su0).to(cutlass.Float32)
+                u1 = cutlass.Float16(x1 * su1).to(cutlass.Float32)
+                u2 = cutlass.Float16(x2 * su2).to(cutlass.Float32)
+                u3 = cutlass.Float16(x3 * su3).to(cutlass.Float32)
+                gh0, gh1, gh2, gh3 = self._had128_quad(g0, g1, g2, g3, lane)
+                uh0, uh1, uh2, uh3 = self._had128_quad(u0, u1, u2, u3, lane)
+                a_gate_flat[out_base + Int32(0)] = cutlass.Float16(gh0)
+                a_gate_flat[out_base + Int32(1)] = cutlass.Float16(gh1)
+                a_gate_flat[out_base + Int32(2)] = cutlass.Float16(gh2)
+                a_gate_flat[out_base + Int32(3)] = cutlass.Float16(gh3)
+                a_up_flat[out_base + Int32(0)] = cutlass.Float16(uh0)
+                a_up_flat[out_base + Int32(1)] = cutlass.Float16(uh1)
+                a_up_flat[out_base + Int32(2)] = cutlass.Float16(uh2)
+                a_up_flat[out_base + Int32(3)] = cutlass.Float16(uh3)
+            unit += gw_stride
+
+    @cute.jit
+    def _run_activation_compact(
+        self,
+        fc1_bf16_flat: cute.Tensor,
+        activated_bf16_flat: cute.Tensor,
+        rot_scales_flat: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        tid: Int32,
+        cta: Int32,
+        grid_x: Int32,
+        active_m: cutlass.Int32,
+    ):
+        # A9: traverse the already-packed expert blocks and index the persistent
+        # [E,3I] table directly.  FC1/activation rows stay at their logical
+        # flattened route ids, so packing order cannot change arithmetic or the
+        # per-row output location.
+        lane = tid & Int32(31)
+        warp_in_cta = tid >> Int32(5)
+        warps_per_cta = Int32(self.cta_threads // 32)
+        nblk = Int32(self.intermediate_size // 128)
+        live_routes = active_m * Int32(self.top_k)
+        route_count = packed_route_count[Int32(0)].to(Int32)
+        fc1_cols = Int32(self.fc1_cols)
+        isz = Int32(self.intermediate_size)
+        rot_row = Int32(3 * self.intermediate_size)
+        gwarp = cta * warps_per_cta + warp_in_cta
+        gw_stride = grid_x * warps_per_cta
+        total_units = route_count * nblk
+        elem = lane * Int32(4)
+        unit = gwarp
+        while unit < total_units:
+            route_pos = unit // nblk
+            blk = unit - route_pos * nblk
+            row = packed_route_indices[route_pos].to(Int32)
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
+            if row >= Int32(0) and row < live_routes and expert >= Int32(0):
+                col0 = blk * Int32(128) + elem
+                g_base = row * fc1_cols + col0
+                u_base = g_base + isz
+                s_base = expert * rot_row + col0
+                g0 = fc1_bf16_flat[g_base + Int32(0)].to(cutlass.Float32)
+                g1 = fc1_bf16_flat[g_base + Int32(1)].to(cutlass.Float32)
+                g2 = fc1_bf16_flat[g_base + Int32(2)].to(cutlass.Float32)
+                g3 = fc1_bf16_flat[g_base + Int32(3)].to(cutlass.Float32)
+                u0 = fc1_bf16_flat[u_base + Int32(0)].to(cutlass.Float32)
+                u1 = fc1_bf16_flat[u_base + Int32(1)].to(cutlass.Float32)
+                u2 = fc1_bf16_flat[u_base + Int32(2)].to(cutlass.Float32)
+                u3 = fc1_bf16_flat[u_base + Int32(3)].to(cutlass.Float32)
+                gh0, gh1, gh2, gh3 = self._had128_quad(g0, g1, g2, g3, lane)
+                uh0, uh1, uh2, uh3 = self._had128_quad(u0, u1, u2, u3, lane)
+                svg0 = rot_scales_flat[s_base + Int32(0)].to(cutlass.Float32)
+                svg1 = rot_scales_flat[s_base + Int32(1)].to(cutlass.Float32)
+                svg2 = rot_scales_flat[s_base + Int32(2)].to(cutlass.Float32)
+                svg3 = rot_scales_flat[s_base + Int32(3)].to(cutlass.Float32)
+                svu0 = rot_scales_flat[s_base + isz + Int32(0)].to(cutlass.Float32)
+                svu1 = rot_scales_flat[s_base + isz + Int32(1)].to(cutlass.Float32)
+                svu2 = rot_scales_flat[s_base + isz + Int32(2)].to(cutlass.Float32)
+                svu3 = rot_scales_flat[s_base + isz + Int32(3)].to(cutlass.Float32)
+                ig0 = gh0 * svg0
+                ig1 = gh1 * svg1
+                ig2 = gh2 * svg2
+                ig3 = gh3 * svg3
+                iu0 = uh0 * svu0
+                iu1 = uh1 * svu1
+                iu2 = uh2 * svu2
+                iu3 = uh3 * svu3
+                down = isz + isz
+                sd0 = rot_scales_flat[s_base + down + Int32(0)].to(cutlass.Float32)
+                sd1 = rot_scales_flat[s_base + down + Int32(1)].to(cutlass.Float32)
+                sd2 = rot_scales_flat[s_base + down + Int32(2)].to(cutlass.Float32)
+                sd3 = rot_scales_flat[s_base + down + Int32(3)].to(cutlass.Float32)
+                if cutlass.const_expr(self.activation_is_situ):
+                    beta = cutlass.Float32(SITU_DEFAULT_BETA)
+                    linear_beta = cutlass.Float32(SITU_DEFAULT_LINEAR_BETA)
+                    a0 = (
+                        beta
+                        * cute.math.tanh(ig0 / beta, fastmath=self.fast_math)
+                        * self._sigmoid_f32(ig0)
+                        * linear_beta
+                        * cute.math.tanh(iu0 / linear_beta, fastmath=self.fast_math)
+                        * sd0
+                    )
+                    a1 = (
+                        beta
+                        * cute.math.tanh(ig1 / beta, fastmath=self.fast_math)
+                        * self._sigmoid_f32(ig1)
+                        * linear_beta
+                        * cute.math.tanh(iu1 / linear_beta, fastmath=self.fast_math)
+                        * sd1
+                    )
+                    a2 = (
+                        beta
+                        * cute.math.tanh(ig2 / beta, fastmath=self.fast_math)
+                        * self._sigmoid_f32(ig2)
+                        * linear_beta
+                        * cute.math.tanh(iu2 / linear_beta, fastmath=self.fast_math)
+                        * sd2
+                    )
+                    a3 = (
+                        beta
+                        * cute.math.tanh(ig3 / beta, fastmath=self.fast_math)
+                        * self._sigmoid_f32(ig3)
+                        * linear_beta
+                        * cute.math.tanh(iu3 / linear_beta, fastmath=self.fast_math)
+                        * sd3
+                    )
+                else:
+                    a0 = self._silu_f32(ig0) * iu0 * sd0
+                    a1 = self._silu_f32(ig1) * iu1 * sd1
+                    a2 = self._silu_f32(ig2) * iu2 * sd2
+                    a3 = self._silu_f32(ig3) * iu3 * sd3
+                o0, o1, o2, o3 = self._had128_quad(a0, a1, a2, a3, lane)
+                out_base = row * isz + col0
+                activated_bf16_flat[out_base + Int32(0)] = self._cast_elem(o0)
+                activated_bf16_flat[out_base + Int32(1)] = self._cast_elem(o1)
+                activated_bf16_flat[out_base + Int32(2)] = self._cast_elem(o2)
+                activated_bf16_flat[out_base + Int32(3)] = self._cast_elem(o3)
+            unit += gw_stride
 
     @cute.jit
     def _zero_fc2_output(
@@ -4847,15 +5549,145 @@ class W4A16FusedMoeKernel:
             expert_idx += grid_x
 
     @cute.jit
+    def _had128_quad(
+        self,
+        v0: cutlass.Float32,
+        v1: cutlass.Float32,
+        v2: cutlass.Float32,
+        v3: cutlass.Float32,
+        lane: Int32,
+    ):
+        # Blockwise-128 Walsh-Hadamard (Sylvester/natural order) across ONE warp,
+        # bit-identical in structure to exllamav3 had_hf_r_128_inner: lane `t`
+        # owns the 4 consecutive elements [4t..4t+3], so element index within the
+        # 128-block is 4*lane + reg.  H_128 = H_4(reg, in-register) (x) H_32(lane,
+        # warp butterfly), then * r_scale = 1/sqrt(128).
+        s0 = v0 + v1
+        d0 = v0 - v1
+        s1 = v2 + v3
+        d1 = v2 - v3
+        h0 = s0 + s1
+        h1 = d0 + d1
+        h2 = s0 - s1
+        h3 = d0 - d1
+        for i in cutlass.range_constexpr(5):
+            st = 1 << i
+            p0 = cute.arch.shuffle_sync_bfly(h0, offset=st)
+            p1 = cute.arch.shuffle_sync_bfly(h1, offset=st)
+            p2 = cute.arch.shuffle_sync_bfly(h2, offset=st)
+            p3 = cute.arch.shuffle_sync_bfly(h3, offset=st)
+            if (lane & Int32(st)) != Int32(0):
+                h0 = p0 - h0
+                h1 = p1 - h1
+                h2 = p2 - h2
+                h3 = p3 - h3
+            else:
+                h0 = p0 + h0
+                h1 = p1 + h1
+                h2 = p2 + h2
+                h3 = p3 + h3
+        rs = cutlass.Float32(0.088388347648)  # scale / sqrt(128), scale = 1
+        return h0 * rs, h1 * rs, h2 * rs, h3 * rs
+
+    @cute.jit
+    def _sigmoid_f32(self, x: cutlass.Float32) -> cutlass.Float32:
+        if cutlass.const_expr(self.fast_math):
+            e = cute.math.exp(-x, fastmath=True)
+        else:
+            e = cute.math.exp(-x, fastmath=False)
+        return cutlass.Float32(1.0) / (cutlass.Float32(1.0) + e)
+
+    @cute.jit
+    def _silu_f32(self, x: cutlass.Float32) -> cutlass.Float32:
+        return x * self._sigmoid_f32(x)
+
+    @cute.jit
     def _run_activation(
         self,
         fc1_bf16_flat: cute.Tensor,
         activated_bf16_flat: cute.Tensor,
+        rot_scales_flat: cute.Tensor,
         tid: Int32,
         cta: Int32,
         grid_x: Int32,
         active_m: cutlass.Int32,
     ):
+        if cutlass.const_expr(self.intermediate_rotation):
+            # Rotation-aware epilogue (trellis3_t256 tail).  Warp-cooperative over
+            # (routed-row, 128-block) units; each warp owns one 128-wide block of
+            # a row's intermediate.  Per row r the FC1 output is [gate(I) | up(I)]
+            # (fc1_cols = 2I) and rot_scales_flat[r] = [svh_gate(I)|svh_up(I)|
+            # suh_down(I)] (3I fp16).  Applies:
+            #   ig2 = had128(gate) * svh_gate ;  iu2 = had128(up) * svh_up
+            #   ia  = silu(ig2) * iu2
+            #   ia2 = had128(ia * suh_down)           -> activated[r, block]
+            lane = tid & Int32(31)
+            warp_in_cta = tid >> Int32(5)
+            warps_per_cta = Int32(self.cta_threads // 32)
+            nblk = Int32(self.intermediate_size // 128)
+            fc1_cols = Int32(self.fc1_cols)
+            isz = Int32(self.intermediate_size)
+            rot_row = Int32(3 * self.intermediate_size)
+            gwarp = cta * warps_per_cta + warp_in_cta
+            gw_stride = grid_x * warps_per_cta
+            total_units = active_m * Int32(self.top_k) * nblk
+            e = lane * Int32(4)
+            unit = gwarp
+            while unit < total_units:
+                row = unit // nblk
+                blk = unit - row * nblk
+                col0 = blk * Int32(128) + e
+                g_base = row * fc1_cols + col0
+                u_base = g_base + isz
+                s_base = row * rot_row + col0
+                # load 4 gate + 4 up
+                g0 = fc1_bf16_flat[g_base + Int32(0)].to(cutlass.Float32)
+                g1 = fc1_bf16_flat[g_base + Int32(1)].to(cutlass.Float32)
+                g2 = fc1_bf16_flat[g_base + Int32(2)].to(cutlass.Float32)
+                g3 = fc1_bf16_flat[g_base + Int32(3)].to(cutlass.Float32)
+                u0 = fc1_bf16_flat[u_base + Int32(0)].to(cutlass.Float32)
+                u1 = fc1_bf16_flat[u_base + Int32(1)].to(cutlass.Float32)
+                u2 = fc1_bf16_flat[u_base + Int32(2)].to(cutlass.Float32)
+                u3 = fc1_bf16_flat[u_base + Int32(3)].to(cutlass.Float32)
+                # blockwise-128 Hadamard on gate and up (pre-silu, output side)
+                gh0, gh1, gh2, gh3 = self._had128_quad(g0, g1, g2, g3, lane)
+                uh0, uh1, uh2, uh3 = self._had128_quad(u0, u1, u2, u3, lane)
+                # post-scale svh_gate / svh_up
+                svg0 = rot_scales_flat[s_base + Int32(0)].to(cutlass.Float32)
+                svg1 = rot_scales_flat[s_base + Int32(1)].to(cutlass.Float32)
+                svg2 = rot_scales_flat[s_base + Int32(2)].to(cutlass.Float32)
+                svg3 = rot_scales_flat[s_base + Int32(3)].to(cutlass.Float32)
+                svu0 = rot_scales_flat[s_base + isz + Int32(0)].to(cutlass.Float32)
+                svu1 = rot_scales_flat[s_base + isz + Int32(1)].to(cutlass.Float32)
+                svu2 = rot_scales_flat[s_base + isz + Int32(2)].to(cutlass.Float32)
+                svu3 = rot_scales_flat[s_base + isz + Int32(3)].to(cutlass.Float32)
+                ig2_0 = gh0 * svg0
+                ig2_1 = gh1 * svg1
+                ig2_2 = gh2 * svg2
+                ig2_3 = gh3 * svg3
+                iu2_0 = uh0 * svu0
+                iu2_1 = uh1 * svu1
+                iu2_2 = uh2 * svu2
+                iu2_3 = uh3 * svu3
+                # silu(gate) * up, then pre-scale suh_down
+                d2 = isz + isz
+                sd0 = rot_scales_flat[s_base + d2 + Int32(0)].to(cutlass.Float32)
+                sd1 = rot_scales_flat[s_base + d2 + Int32(1)].to(cutlass.Float32)
+                sd2 = rot_scales_flat[s_base + d2 + Int32(2)].to(cutlass.Float32)
+                sd3 = rot_scales_flat[s_base + d2 + Int32(3)].to(cutlass.Float32)
+                a0 = self._silu_f32(ig2_0) * iu2_0 * sd0
+                a1 = self._silu_f32(ig2_1) * iu2_1 * sd1
+                a2 = self._silu_f32(ig2_2) * iu2_2 * sd2
+                a3 = self._silu_f32(ig2_3) * iu2_3 * sd3
+                # blockwise-128 Hadamard on the activation (post-silu, input side)
+                o0, o1, o2, o3 = self._had128_quad(a0, a1, a2, a3, lane)
+                out_base = row * isz + col0
+                activated_bf16_flat[out_base + Int32(0)] = self._cast_elem(o0)
+                activated_bf16_flat[out_base + Int32(1)] = self._cast_elem(o1)
+                activated_bf16_flat[out_base + Int32(2)] = self._cast_elem(o2)
+                activated_bf16_flat[out_base + Int32(3)] = self._cast_elem(o3)
+                unit += gw_stride
+            return
         idx = cta * Int32(self.cta_threads) + tid
         stride = grid_x * Int32(self.cta_threads)
         total = active_m * Int32(self.top_k * self.intermediate_size)
@@ -4878,9 +5710,7 @@ class W4A16FusedMoeKernel:
                     exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=True)
                 else:
                     exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=False)
-                sigmoid = cutlass.Float32(1.0) / (
-                    cutlass.Float32(1.0) + exp_neg_gate
-                )
+                sigmoid = cutlass.Float32(1.0) / (cutlass.Float32(1.0) + exp_neg_gate)
                 silu = gate * sigmoid
                 if cutlass.const_expr(self.activation_is_situ):
                     beta = cutlass.Float32(SITU_DEFAULT_BETA)
@@ -4894,9 +5724,7 @@ class W4A16FusedMoeKernel:
                         up / linear_beta,
                         fastmath=self.fast_math,
                     )
-                    activated_bf16_flat[idx] = self._cast_elem(
-                        situ_gate * situ_up
-                    )
+                    activated_bf16_flat[idx] = self._cast_elem(situ_gate * situ_up)
                 elif cutlass.const_expr(self.activation_is_swigluoai):
                     activated_bf16_flat[idx] = self._cast_elem(silu * up_term)
                 else:
@@ -4948,6 +5776,10 @@ class W4A16FusedMoeHybridKernel:
             if moe.collect_activation_amax:
                 raise ValueError(
                     f"hybrid W4A16 {name} is incompatible with activation amax"
+                )
+            if moe.intermediate_rotation or moe.dual_a or moe.full_rotation:
+                raise ValueError(
+                    f"hybrid W4A16 {name} forbids trellis rotation features"
                 )
             if moe.zero_fc2_output:
                 raise ValueError(f"hybrid W4A16 {name} forbids zero_fc2_output")
@@ -5081,6 +5913,7 @@ class W4A16FusedMoeHybridKernel:
                         if cutlass.const_expr(is_fc1):
                             self.tier0.fc1._run_tile(
                                 a_bf16_flat,
+                                a_bf16_flat,
                                 t0_b_i32_flat,
                                 c_bf16_flat,
                                 t0_scales_i32_flat,
@@ -5103,6 +5936,7 @@ class W4A16FusedMoeHybridKernel:
                             )
                         else:
                             self.tier0.fc2._run_tile(
+                                a_bf16_flat,
                                 a_bf16_flat,
                                 t0_b_i32_flat,
                                 c_bf16_flat,
@@ -5130,6 +5964,7 @@ class W4A16FusedMoeHybridKernel:
                             if cutlass.const_expr(is_fc1):
                                 self.tier1.fc1._run_tile(
                                     a_bf16_flat,
+                                    a_bf16_flat,
                                     t1_b_i32_flat,
                                     c_bf16_flat,
                                     t1_scales_i32_flat,
@@ -5152,6 +5987,7 @@ class W4A16FusedMoeHybridKernel:
                                 )
                             else:
                                 self.tier1.fc2._run_tile(
+                                    a_bf16_flat,
                                     a_bf16_flat,
                                     t1_b_i32_flat,
                                     c_bf16_flat,
@@ -5337,6 +6173,8 @@ class W4A16FusedMoeHybridKernel:
         # route + no-amax const_expr configuration never reads.
         self.tier0._moe_body(
             a_bf16_flat,
+            a_bf16_flat,
+            a_bf16_flat,
             t0_w13_i32_flat,
             t0_w2_i32_flat,
             fc1_bf16_flat,
@@ -5355,6 +6193,9 @@ class W4A16FusedMoeHybridKernel:
             fc1_c_tmp_f32_flat,
             fc2_c_tmp_f32_flat,
             locks_i32_flat,
+            global_topk_ids_i32_flat,
+            global_topk_ids_i32_flat,
+            global_topk_ids_i32_flat,
             smem_base,
             tid,
             cta,
@@ -5491,9 +6332,7 @@ class W4A16ActivationKernel:
                     exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=True)
                 else:
                     exp_neg_gate = cute.math.exp(-sigmoid_arg, fastmath=False)
-                sigmoid = cutlass.Float32(1.0) / (
-                    cutlass.Float32(1.0) + exp_neg_gate
-                )
+                sigmoid = cutlass.Float32(1.0) / (cutlass.Float32(1.0) + exp_neg_gate)
                 silu = gate * sigmoid
                 if cutlass.const_expr(self.is_situ):
                     beta = cutlass.Float32(SITU_DEFAULT_BETA)
@@ -5507,9 +6346,7 @@ class W4A16ActivationKernel:
                         up / linear_beta,
                         fastmath=self.fast_math,
                     )
-                    activated_flat[idx] = self._cast_elem(
-                        situ_gate * situ_up
-                    )
+                    activated_flat[idx] = self._cast_elem(situ_gate * situ_up)
                 elif cutlass.const_expr(self.is_swigluoai):
                     activated_flat[idx] = self._cast_elem(silu * up_term)
                 else:
@@ -5524,7 +6361,17 @@ class W4A16ActivationKernel:
 
 
 class W4A16TopKSumKernel:
-    def __init__(self, *, topk: int, hidden_size: int, element_dtype: str = "bf16"):
+    def __init__(
+        self,
+        *,
+        topk: int,
+        hidden_size: int,
+        element_dtype: str = "bf16",
+        full_rotation: bool = False,
+        num_experts: int = 0,
+        route_num_experts: int = 0,
+        use_expert_map: bool = False,
+    ):
         if element_dtype not in {"bf16", "fp16"}:
             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
         if topk <= 0 or hidden_size <= 0:
@@ -5533,6 +6380,21 @@ class W4A16TopKSumKernel:
         self.hidden_size = int(hidden_size)
         self.element_dtype = element_dtype
         self.is_fp16 = element_dtype == "fp16"
+        self.full_rotation = bool(full_rotation)
+        self.num_experts = int(num_experts)
+        self.route_num_experts = int(route_num_experts)
+        self.use_expert_map = bool(use_expert_map)
+        if self.full_rotation:
+            if self.element_dtype != "fp16":
+                raise ValueError("full-rotation top-k sum requires fp16 route values")
+            if self.hidden_size % 128 != 0:
+                raise ValueError(
+                    "full-rotation top-k sum requires hidden_size % 128 == 0"
+                )
+            if self.num_experts <= 0:
+                raise ValueError("full-rotation top-k sum requires num_experts > 0")
+            if self.use_expert_map and self.route_num_experts <= 0:
+                raise ValueError("expert-map top-k sum requires route_num_experts > 0")
         self.cta_threads = 256
 
     @cute.jit
@@ -5546,6 +6408,10 @@ class W4A16TopKSumKernel:
         self,
         fc2_ptr: cute.Pointer,
         output_ptr: cute.Pointer,
+        topk_weights_ptr: cute.Pointer,
+        route_expert_ids_ptr: cute.Pointer,
+        expert_map_ptr: cute.Pointer,
+        svh_ptr: cute.Pointer,
         active_m: cutlass.Int32,
         stream: cuda.CUstream,
     ):
@@ -5559,9 +6425,39 @@ class W4A16TopKSumKernel:
             output_ptr,
             layout=cute.make_layout((active_m * Int32(self.hidden_size),), stride=(1,)),
         )
-        total = active_m * Int32(self.hidden_size)
-        grid = (_covering_count(total, self.cta_threads), 1, 1)
-        self.kernel(fc2_flat, output_flat, active_m).launch(
+        topk_weights_flat = cute.make_tensor(
+            topk_weights_ptr,
+            layout=cute.make_layout((active_m * Int32(self.topk),), stride=(1,)),
+        )
+        route_expert_ids_flat = cute.make_tensor(
+            route_expert_ids_ptr,
+            layout=cute.make_layout((active_m * Int32(self.topk),), stride=(1,)),
+        )
+        expert_map_flat = cute.make_tensor(
+            expert_map_ptr,
+            layout=cute.make_layout((max(self.route_num_experts, 1),), stride=(1,)),
+        )
+        svh_flat = cute.make_tensor(
+            svh_ptr,
+            layout=cute.make_layout(
+                (max(self.num_experts * self.hidden_size, 1),), stride=(1,)
+            ),
+        )
+        if cutlass.const_expr(self.full_rotation):
+            total = active_m * Int32(self.hidden_size // 128)
+            grid = (_covering_count(total, self.cta_threads // 32), 1, 1)
+        else:
+            total = active_m * Int32(self.hidden_size)
+            grid = (_covering_count(total, self.cta_threads), 1, 1)
+        self.kernel(
+            fc2_flat,
+            output_flat,
+            topk_weights_flat,
+            route_expert_ids_flat,
+            expert_map_flat,
+            svh_flat,
+            active_m,
+        ).launch(
             grid=grid,
             block=[self.cta_threads, 1, 1],
             stream=stream,
@@ -5572,10 +6468,64 @@ class W4A16TopKSumKernel:
         self,
         fc2_flat: cute.Tensor,
         output_flat: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        route_expert_ids_flat: cute.Tensor,
+        expert_map_flat: cute.Tensor,
+        svh_flat: cute.Tensor,
         active_m: cutlass.Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
+        if cutlass.const_expr(self.full_rotation):
+            tid = Int32(tidx)
+            lane = tid & Int32(31)
+            warp = tid >> Int32(5)
+            unit = Int32(bidx) * Int32(self.cta_threads // 32) + warp
+            nblk = Int32(self.hidden_size // 128)
+            total_units = active_m * nblk
+            if unit < total_units:
+                token = unit // nblk
+                blk = unit - token * nblk
+                col0 = blk * Int32(128) + lane * Int32(4)
+                acc0 = cutlass.Float32(0.0)
+                acc1 = cutlass.Float32(0.0)
+                acc2 = cutlass.Float32(0.0)
+                acc3 = cutlass.Float32(0.0)
+                for route in cutlass.range_constexpr(self.topk):
+                    row = token * Int32(self.topk) + Int32(route)
+                    raw_expert = route_expert_ids_flat[row].to(Int32)
+                    expert = raw_expert
+                    if cutlass.const_expr(self.use_expert_map):
+                        expert = Int32(-1)
+                        if raw_expert >= Int32(0) and raw_expert < Int32(
+                            self.route_num_experts
+                        ):
+                            expert = expert_map_flat[raw_expert].to(Int32)
+                    if expert >= Int32(0) and expert < Int32(self.num_experts):
+                        base = row * Int32(self.hidden_size) + col0
+                        v0 = fc2_flat[base + Int32(0)].to(cutlass.Float32)
+                        v1 = fc2_flat[base + Int32(1)].to(cutlass.Float32)
+                        v2 = fc2_flat[base + Int32(2)].to(cutlass.Float32)
+                        v3 = fc2_flat[base + Int32(3)].to(cutlass.Float32)
+                        h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
+                        sbase = expert * Int32(self.hidden_size) + col0
+                        s0 = svh_flat[sbase + Int32(0)].to(cutlass.Float32)
+                        s1 = svh_flat[sbase + Int32(1)].to(cutlass.Float32)
+                        s2 = svh_flat[sbase + Int32(2)].to(cutlass.Float32)
+                        s3 = svh_flat[sbase + Int32(3)].to(cutlass.Float32)
+                        weight = topk_weights_flat[row].to(cutlass.Float32)
+                        # Deliberate fp32-C ordering: raw route H128, fp32(svh),
+                        # then router weight, with no intermediate fp16 round.
+                        acc0 += h0 * s0 * weight
+                        acc1 += h1 * s1 * weight
+                        acc2 += h2 * s2 * weight
+                        acc3 += h3 * s3 * weight
+                out_base = token * Int32(self.hidden_size) + col0
+                output_flat[out_base + Int32(0)] = acc0
+                output_flat[out_base + Int32(1)] = acc1
+                output_flat[out_base + Int32(2)] = acc2
+                output_flat[out_base + Int32(3)] = acc3
+            return
         idx = Int32(bidx) * Int32(self.cta_threads) + Int32(tidx)
         total = active_m * Int32(self.hidden_size)
         if idx < total:
@@ -5589,6 +6539,42 @@ class W4A16TopKSumKernel:
                 )
                 acc += _materialize_w4a16_topk_route_f32(route_value)
             output_flat[idx] = self._cast_elem(acc)
+
+    @cute.jit
+    def _had128_quad(
+        self,
+        v0: cutlass.Float32,
+        v1: cutlass.Float32,
+        v2: cutlass.Float32,
+        v3: cutlass.Float32,
+        lane: Int32,
+    ):
+        s0 = v0 + v1
+        d0 = v0 - v1
+        s1 = v2 + v3
+        d1 = v2 - v3
+        h0 = s0 + s1
+        h1 = d0 + d1
+        h2 = s0 - s1
+        h3 = d0 - d1
+        for i in cutlass.range_constexpr(5):
+            st = 1 << i
+            p0 = cute.arch.shuffle_sync_bfly(h0, offset=st)
+            p1 = cute.arch.shuffle_sync_bfly(h1, offset=st)
+            p2 = cute.arch.shuffle_sync_bfly(h2, offset=st)
+            p3 = cute.arch.shuffle_sync_bfly(h3, offset=st)
+            if (lane & Int32(st)) != Int32(0):
+                h0 = p0 - h0
+                h1 = p1 - h1
+                h2 = p2 - h2
+                h3 = p3 - h3
+            else:
+                h0 = p0 + h0
+                h1 = p1 + h1
+                h2 = p2 + h2
+                h3 = p3 + h3
+        rs = cutlass.Float32(0.088388347648)
+        return h0 * rs, h1 * rs, h2 * rs, h3 * rs
 
 
 _CACHE: dict[tuple, W4A16GemmCompileResult] = {}
@@ -5856,7 +6842,11 @@ def compile_w4a16_gemm(
     moe_block_size: int,
     max_m_blocks: int,
     element_dtype: str = "bf16",
+    weight_layout: str = "packed",
     scale_format: str = "e4m3_k16",
+    w13_layout: str = "packed",
+    trellis_bits: int = 3,
+    dense_route_fast_path: bool = False,
 ) -> W4A16GemmCompileResult:
     scale_format = _normalize_scale_format(scale_format)
     cutlass_dtype = _cutlass_element_dtype(element_dtype)
@@ -5876,7 +6866,12 @@ def compile_w4a16_gemm(
         moe_block_size=moe_block_size,
         max_m_blocks=max_m_blocks,
         element_dtype=element_dtype,
+        weight_layout=weight_layout,
         scale_format=scale_format,
+        w13_layout=w13_layout,
+        trellis_bits=trellis_bits,
+        dense_route_fast_path=bool(dense_route_fast_path),
+        schedule_whole_tiles=weight_layout == "trellis3_t256",
     )
     cache_key = (
         "w4a16_gemm",
@@ -5894,21 +6889,19 @@ def compile_w4a16_gemm(
     compile_size_m = _fake_m_for_specialization(size_m)
     compile_route_blocks = 1
     compile_route_slots = compile_route_blocks * int(moe_block_size)
-    a_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass_dtype,
-        (compile_size_m * size_k,),
-        assumed_align=16,
-    )
+    a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    if weight_layout == "trellis3_t256":
+        b_fake_elements = (
+            num_experts * (size_k // 16) * (size_n // 16) * (8 * int(trellis_bits))
+        )
+    else:
+        b_fake_elements = num_experts * (size_k // 16) * (size_n // 16 * 32)
     b_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (num_experts * (size_k // 16) * (size_n // 16 * 32),),
+        (b_fake_elements,),
         assumed_align=16,
     )
-    c_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass_dtype,
-        (compile_size_m * top_k * size_n,),
-        assumed_align=16,
-    )
+    c_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     scales_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
         (
@@ -5968,6 +6961,7 @@ def compile_w4a16_gemm(
     compiled = sparkinfer_compile(
         kernel,
         a_fake,
+        a_fake,
         b_fake,
         c_fake,
         scales_fake,
@@ -5983,7 +6977,7 @@ def compile_w4a16_gemm(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "moe.w4a16.gemm",
-            1,
+            3,
             cache_key,
         ),
     )
@@ -5994,7 +6988,11 @@ def compile_w4a16_gemm(
         moe_block_size=moe_block_size,
         max_m_blocks=max_m_blocks,
         blocks_per_sm=kernel.blocks_per_sm,
+        weight_layout=weight_layout,
         scale_format=scale_format,
+        w13_layout=w13_layout,
+        dense_route_fast_path=bool(dense_route_fast_path),
+        trellis_bits=int(trellis_bits),
     )
     _CACHE[cache_key] = result
     return result
@@ -6022,12 +7020,21 @@ def compile_w4a16_fused_moe(
     weight_layout: str = "packed",
     scale_format: str = "e4m3_k16",
     w13_layout: str = "w13",
+    trellis_bits: int = 3,
     direct_topk_routes: bool = False,
     tc_decode_fused_sum: bool = False,
     collect_activation_amax: bool = False,
     force_tile_config: tuple[int, int, int, int] | None = None,
+    intermediate_rotation: bool = False,
+    full_rotation: bool = False,
+    rotation_input_dtype: str | None = None,
 ) -> W4A16FusedMoeCompileResult:
     scale_format = _normalize_scale_format(scale_format)
+    intermediate_rotation = bool(intermediate_rotation)
+    full_rotation = bool(full_rotation)
+    rotation_input_dtype = (
+        element_dtype if rotation_input_dtype is None else str(rotation_input_dtype)
+    )
     cutlass_dtype = _cutlass_element_dtype(element_dtype)
     device = int(torch.cuda.current_device()) if torch.cuda.is_available() else None
     activation = normalize_moe_activation(activation)
@@ -6040,9 +7047,29 @@ def compile_w4a16_fused_moe(
     )
     if weight_layout not in _WEIGHT_LAYOUTS:
         raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    trellis_bits = int(trellis_bits)
+    if weight_layout == "trellis3_t256":
+        if trellis_bits not in _TRELLIS256_BITS:
+            raise ValueError(
+                f"trellis3_t256 bits must be one of {_TRELLIS256_BITS}, got {trellis_bits}"
+            )
+    elif trellis_bits != 3:
+        raise ValueError("trellis_bits is only valid for trellis3_t256 weights")
+    # Existing 3-bpw scheduling was conservatively planned as 4 bpw. Keep that
+    # grid contract stable for D6; widen only the 5/6-bpw specializations.
+    weight_bits = max(4, trellis_bits) if weight_layout == "trellis3_t256" else 4
+    # GATE 5: the PRODUCTION 256-weight-tile fused-megakernel B-staging is now
+    # wired (per-warp native [K/16,N/16,8*bits u32] tile staging + the per-lane
+    # bitrate-specialized read) and ADMITTED at 3 bpw against a full-GEMM
+    # numeric oracle (megakernel FC1->silu->FC2 vs a torch reference over tiles;
+    # tests/test_trellis256_fullgemm_oracle.py, max rel-err <= 2^-6).  The GATE-4
+    # NotImplementedError gate is therefore lifted.  See GATE5_RESULT.md.
     if weight_layout == "modelopt":
         if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
             raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    elif weight_layout == "trellis3_t256":
+        if w13_layout not in _TRELLIS256_W13_LAYOUTS:
+            raise ValueError(f"unsupported trellis3_t256 w13_layout {w13_layout!r}")
     else:
         w13_layout = "packed"
     direct_topk_routes = bool(direct_topk_routes)
@@ -6051,6 +7078,34 @@ def compile_w4a16_fused_moe(
     if collect_activation_amax and (direct_topk_routes or tc_decode_fused_sum):
         raise ValueError(
             "W4A16 activation amax collection requires the route-packed fused path"
+        )
+    if collect_activation_amax and intermediate_rotation:
+        raise ValueError(
+            "W4A16 activation amax collection is incompatible with intermediate rotation"
+        )
+    if full_rotation:
+        if not intermediate_rotation:
+            raise ValueError("full_rotation requires intermediate_rotation")
+        if weight_layout != "trellis3_t256":
+            raise ValueError("full_rotation is only supported for trellis3_t256")
+        if element_dtype != "fp16":
+            raise ValueError("full_rotation requires element_dtype='fp16'")
+        if rotation_input_dtype not in {"bf16", "fp16"}:
+            raise ValueError(
+                "rotation_input_dtype must be 'bf16' or 'fp16' for full_rotation"
+            )
+        if direct_topk_routes or tc_decode_fused_sum:
+            raise ValueError(
+                "full_rotation requires route packing and cannot use TC decode"
+            )
+        if apply_router_weight_on_input:
+            raise ValueError(
+                "full_rotation requires apply_router_weight_on_input=False"
+            )
+    if collect_activation_amax and weight_layout == "trellis3_t256":
+        raise NotImplementedError(
+            "trellis3_t256 activation-amax collection is not exposed through the "
+            "registered launch ABI; refusing to compile a bitrate-ambiguous kernel"
         )
     # The TC-decode path validates M in {1,2,4,8} itself and uses direct-topk
     # routing for the whole {1,2,4,8} range, so it lifts the default decode cap.
@@ -6087,6 +7142,7 @@ def compile_w4a16_fused_moe(
         max_shared_mem=max_shared_mem,
         scale_format=scale_format,
         weight_layout=weight_layout,
+        weight_bits=weight_bits,
         allow_logical_tail=allow_native_logical_tail,
     )
     fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
@@ -6099,6 +7155,7 @@ def compile_w4a16_fused_moe(
         max_shared_mem=max_shared_mem,
         scale_format=scale_format,
         weight_layout=weight_layout,
+        weight_bits=weight_bits,
         allow_logical_tail=allow_native_logical_tail,
     )
     if fc1_cta_threads != fc2_cta_threads:
@@ -6114,6 +7171,7 @@ def compile_w4a16_fused_moe(
             required_cta_threads=common_cta_threads,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
             allow_logical_tail=allow_native_logical_tail,
         )
         fc2_tile_k, fc2_tile_n, fc2_cta_threads, _ = _select_tile_config(
@@ -6127,6 +7185,7 @@ def compile_w4a16_fused_moe(
             required_cta_threads=common_cta_threads,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
             allow_logical_tail=allow_native_logical_tail,
         )
         if fc1_cta_threads != fc2_cta_threads:
@@ -6176,6 +7235,7 @@ def compile_w4a16_fused_moe(
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
         ):
             fc1_tile_n = 256
             fc1_tile_k = wide_fc1_tile_k
@@ -6207,6 +7267,7 @@ def compile_w4a16_fused_moe(
             max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
         ):
             fc2_tile_n = 256
             fc2_tile_k = wide_fc2_tile_k
@@ -6252,6 +7313,7 @@ def compile_w4a16_fused_moe(
             tile_k=ultra_fc2_tile_k,
             scale_format=scale_format,
             weight_layout=weight_layout,
+            weight_bits=weight_bits,
         )
         if (
             int(intermediate_size) % ultra_fc2_tile_k == 0
@@ -6291,6 +7353,7 @@ def compile_w4a16_fused_moe(
                 max_shared_mem=int(max_shared_mem) - 512,
                 scale_format=scale_format,
                 weight_layout=weight_layout,
+                weight_bits=weight_bits,
                 allow_logical_tail=allow_native_logical_tail,
             ):
                 raise ValueError(
@@ -6322,9 +7385,13 @@ def compile_w4a16_fused_moe(
         weight_layout=weight_layout,
         scale_format=scale_format,
         w13_layout=w13_layout,
+        trellis_bits=trellis_bits,
         direct_topk_routes=direct_topk_routes,
         tc_decode_fused_sum=tc_decode_fused_sum,
         collect_activation_amax=collect_activation_amax,
+        intermediate_rotation=intermediate_rotation,
+        full_rotation=full_rotation,
+        rotation_input_dtype=rotation_input_dtype,
     )
     cache_key = (
         "w4a16_fused_moe",
@@ -6382,6 +7449,12 @@ def compile_w4a16_fused_moe(
         compile_routed_rows if direct_topk_routes else compile_route_slots
     )
     a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    rotation_input_fake = make_ptr(
+        _cutlass_element_dtype(rotation_input_dtype),
+        16,
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
     if weight_layout == "modelopt":
         w13_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Uint8,
@@ -6391,6 +7464,27 @@ def compile_w4a16_fused_moe(
         w2_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Uint8,
             (num_experts * hidden_size * (intermediate_size // 2),),
+            assumed_align=16,
+        )
+    elif weight_layout == "trellis3_t256":
+        w13_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (
+                num_experts
+                * (hidden_size // 16)
+                * (fc1_cols // 16)
+                * (8 * trellis_bits),
+            ),
+            assumed_align=16,
+        )
+        w2_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (
+                num_experts
+                * (intermediate_size // 16)
+                * (hidden_size // 16)
+                * (8 * trellis_bits),
+            ),
             assumed_align=16,
         )
     elif weight_layout == "nf3_2p1":
@@ -6513,6 +7607,24 @@ def compile_w4a16_fused_moe(
         (4 * 256 + 2,),
         assumed_align=16,
     )
+    # Legacy mode supplies per-route [R,3I]; full rotation indexes the compact
+    # persistent [E,3I] table by the packed block's expert id.
+    rot_rows = num_experts if full_rotation else compile_routed_rows
+    rot_scales_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float16,
+        (max(rot_rows * 3 * intermediate_size, 1),),
+        assumed_align=16,
+    )
+    suh_gate_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float16,
+        (max(num_experts * hidden_size, 1),),
+        assumed_align=16,
+    )
+    suh_up_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float16,
+        (max(num_experts * hidden_size, 1),),
+        assumed_align=16,
+    )
 
     raise_if_kernel_resolution_frozen(
         "cute.compile", target=kernel, cache_key=cache_key
@@ -6520,6 +7632,8 @@ def compile_w4a16_fused_moe(
     compiled = sparkinfer_compile(
         kernel,
         a_fake,
+        a_fake,
+        rotation_input_fake,
         w13_fake,
         w2_fake,
         fc1_fake,
@@ -6538,12 +7652,15 @@ def compile_w4a16_fused_moe(
         fc1_c_tmp_fake,
         fc2_c_tmp_fake,
         locks_fake,
+        rot_scales_fake,
+        suh_gate_fake,
+        suh_up_fake,
         1,
         1,
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "moe.w4a16.fused_moe",
-            1,
+            4,
             cache_key,
         ),
         dsl_compile_options=OptLevel(2),
@@ -6576,6 +7693,12 @@ def compile_w4a16_fused_moe(
         scale_format=scale_format,
         tc_decode_fused_sum=bool(tc_decode_fused_sum),
         collect_activation_amax=collect_activation_amax,
+        schedule_whole_tiles=kernel.schedule_whole_tiles,
+        intermediate_rotation=intermediate_rotation,
+        dual_a=kernel.dual_a,
+        trellis_bits=trellis_bits,
+        full_rotation=full_rotation,
+        rotation_input_dtype=rotation_input_dtype,
     )
     _FUSED_CACHE[cache_key] = result
     return result
@@ -7024,19 +8147,58 @@ def compile_w4a16_topk_sum(
     topk: int,
     hidden_size: int,
     element_dtype: str = "bf16",
+    full_rotation: bool = False,
+    num_experts: int = 0,
+    route_num_experts: int = 0,
+    route_ids_dtype: torch.dtype = torch.int32,
+    use_expert_map: bool = False,
 ) -> W4A16TopKSumCompileResult:
     cutlass_dtype = _cutlass_element_dtype(element_dtype)
-    cache_key = ("w4a16_topk_sum", element_dtype, topk, hidden_size)
+    if route_ids_dtype not in (torch.int32, torch.int64):
+        raise TypeError("top-k route expert ids must be int32 or int64")
+    route_cutlass_dtype = (
+        cutlass.Int32 if route_ids_dtype == torch.int32 else cutlass.Int64
+    )
+    cache_key = (
+        "w4a16_topk_sum",
+        element_dtype,
+        topk,
+        hidden_size,
+        bool(full_rotation),
+        int(num_experts),
+        int(route_num_experts),
+        str(route_ids_dtype),
+        bool(use_expert_map),
+    )
     cached = _SUM_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
     fc2_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
-    output_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    output_dtype = cutlass.Float32 if full_rotation else cutlass_dtype
+    output_fake = make_ptr(output_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
+    topk_weights_fake = make_ptr(
+        cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    route_ids_align = 4 if route_ids_dtype == torch.int32 else 8
+    route_ids_fake = make_ptr(
+        route_cutlass_dtype,
+        route_ids_align,
+        cute.AddressSpace.gmem,
+        assumed_align=route_ids_align,
+    )
+    expert_map_fake = make_ptr(
+        cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4
+    )
+    svh_fake = make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16)
     kernel = W4A16TopKSumKernel(
         topk=topk,
         hidden_size=hidden_size,
         element_dtype=element_dtype,
+        full_rotation=full_rotation,
+        num_experts=num_experts,
+        route_num_experts=route_num_experts,
+        use_expert_map=use_expert_map,
     )
     raise_if_kernel_resolution_frozen(
         "cute.compile", target=kernel, cache_key=cache_key
@@ -7045,11 +8207,15 @@ def compile_w4a16_topk_sum(
         kernel,
         fc2_fake,
         output_fake,
+        topk_weights_fake,
+        route_ids_fake,
+        expert_map_fake,
+        svh_fake,
         1,
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "moe.w4a16.topk_sum",
-            1,
+            2,
             cache_key,
         ),
     )
@@ -7058,6 +8224,11 @@ def compile_w4a16_topk_sum(
         m=0,
         topk=topk,
         hidden_size=hidden_size,
+        full_rotation=bool(full_rotation),
+        num_experts=int(num_experts),
+        route_num_experts=int(route_num_experts),
+        route_ids_dtype=route_ids_dtype,
+        use_expert_map=bool(use_expert_map),
     )
     _SUM_CACHE[cache_key] = result
     return result
@@ -7233,6 +8404,20 @@ def _w4a16_small_m_direct_launch_fake(
     return None
 
 
+_ROT_SCALES_DUMMY: dict[object, torch.Tensor] = {}
+
+
+def _rot_scales_dummy(device: torch.device) -> torch.Tensor:
+    """Tiny fp16 placeholder for the rot_scales kernel slot when the
+    intermediate-rotation epilogue is disabled (never dereferenced by the
+    const_expr-gated kernel; keeps one compiled signature across all layouts)."""
+    t = _ROT_SCALES_DUMMY.get(device)
+    if t is None:
+        t = torch.zeros(1, dtype=torch.float16, device=device)
+        _ROT_SCALES_DUMMY[device] = t
+    return t
+
+
 def _w4a16_fused_moe_launch_flat(
     a_input: torch.Tensor,
     w13_arg: torch.Tensor,
@@ -7283,14 +8468,52 @@ def _w4a16_fused_moe_launch_flat(
     tc_decode_fused_sum: bool,
     collect_activation_amax: bool,
     stream_int: int,
+    rot_scales: torch.Tensor | None = None,
+    intermediate_rotation: bool = False,
+    a_input_up: torch.Tensor | None = None,
+    trellis_bits: int = 3,
+    full_rotation: bool = False,
+    rotation_input: torch.Tensor | None = None,
+    suh_gate_table: torch.Tensor | None = None,
+    suh_up_table: torch.Tensor | None = None,
 ) -> None:
     swiglu_limit = float(swiglu_limit_value) if has_swiglu_limit else None
     collect_activation_amax = bool(collect_activation_amax)
+    intermediate_rotation = bool(intermediate_rotation)
+    full_rotation = bool(full_rotation)
     if collect_activation_amax and activation_amax is None:
         raise ValueError("activation_amax is required for calibrated W4A16 launch")
     activation_amax_arg = (
         activation_amax.view(-1) if activation_amax is not None else w13_global_scale
     )
+    if intermediate_rotation:
+        if rot_scales is None:
+            raise ValueError("intermediate_rotation launch requires rot_scales")
+        rot_scales_arg = rot_scales.view(-1)
+    else:
+        rot_scales_arg = _rot_scales_dummy(w13_global_scale.device)
+    if full_rotation and a_input_up is None:
+        raise ValueError("full_rotation launch requires a distinct up A scratch")
+    if a_input_up is None:
+        a_input_up = a_input
+    if full_rotation and a_input_up.data_ptr() == a_input.data_ptr():
+        raise ValueError("full_rotation gate/up A scratches must not alias")
+    if full_rotation and rotation_input is None:
+        raise ValueError("full_rotation launch requires the raw rotation input")
+    if rotation_input is None:
+        rotation_input = a_input
+    if full_rotation:
+        if suh_gate_table is None or suh_up_table is None:
+            raise ValueError(
+                "full_rotation launch requires suh_gate_table and suh_up_table"
+            )
+        suh_gate_arg = suh_gate_table.reshape(-1)
+        suh_up_arg = suh_up_table.reshape(-1)
+        rotation_input_dtype = _normalize_element_dtype(rotation_input.dtype)
+    else:
+        suh_gate_arg = _rot_scales_dummy(w13_global_scale.device)
+        suh_up_arg = suh_gate_arg
+        rotation_input_dtype = element_dtype
     fused = compile_w4a16_fused_moe(
         size_m=size_m,
         hidden_size=hidden_size,
@@ -7312,6 +8535,7 @@ def _w4a16_fused_moe_launch_flat(
         weight_layout=weight_layout,
         scale_format=scale_format,
         w13_layout=w13_layout,
+        trellis_bits=trellis_bits,
         direct_topk_routes=bool(direct_topk_routes),
         tc_decode_fused_sum=bool(tc_decode_fused_sum),
         collect_activation_amax=collect_activation_amax,
@@ -7319,11 +8543,26 @@ def _w4a16_fused_moe_launch_flat(
         # its selected geometry so tile-specific packs (notably NF3) resolve the
         # identical cache entry instead of silently recompiling with auto tiles.
         force_tile_config=(fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n),
+        intermediate_rotation=intermediate_rotation,
+        full_rotation=full_rotation,
+        rotation_input_dtype=rotation_input_dtype,
     )
     fused.compiled(
         make_ptr(
             _cutlass_element_dtype(element_dtype),
             a_input.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            _cutlass_element_dtype(element_dtype),
+            a_input_up.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            _cutlass_element_dtype(rotation_input_dtype),
+            rotation_input.data_ptr(),
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
@@ -7350,6 +8589,9 @@ def _w4a16_fused_moe_launch_flat(
         fc1_scratch,
         fc2_scratch,
         workspace,
+        rot_scales_arg,
+        suh_gate_arg,
+        suh_up_arg,
         m,
         _w4a16_fused_persistent_grid_x(
             fused=fused,
@@ -7754,13 +8996,41 @@ def _w4a16_topk_sum_launch_flat(
     hidden_size: int,
     element_dtype: str,
     stream_int: int,
+    *,
+    full_rotation: bool = False,
+    num_experts: int = 0,
+    topk_weights: torch.Tensor | None = None,
+    route_expert_ids: torch.Tensor | None = None,
+    expert_map: torch.Tensor | None = None,
+    svh_table: torch.Tensor | None = None,
 ) -> None:
+    full_rotation = bool(full_rotation)
+    route_ids_dtype = (
+        torch.int32 if route_expert_ids is None else route_expert_ids.dtype
+    )
+    route_num_experts = 0 if expert_map is None else int(expert_map.numel())
     sum_kernel = compile_w4a16_topk_sum(
         m=m,
         topk=topk,
         hidden_size=hidden_size,
         element_dtype=element_dtype,
+        full_rotation=full_rotation,
+        num_experts=num_experts,
+        route_num_experts=route_num_experts,
+        route_ids_dtype=route_ids_dtype,
+        use_expert_map=expert_map is not None,
     )
+    dummy_addr = output.data_ptr()
+    weights_addr = dummy_addr if topk_weights is None else topk_weights.data_ptr()
+    route_ids_addr = (
+        dummy_addr if route_expert_ids is None else route_expert_ids.data_ptr()
+    )
+    expert_map_addr = dummy_addr if expert_map is None else expert_map.data_ptr()
+    svh_addr = dummy_addr if svh_table is None else svh_table.data_ptr()
+    route_cutlass_dtype = (
+        cutlass.Int32 if route_ids_dtype == torch.int32 else cutlass.Int64
+    )
+    route_align = 4 if route_ids_dtype == torch.int32 else 8
     sum_kernel.compiled(
         make_ptr(
             _cutlass_element_dtype(element_dtype),
@@ -7769,8 +9039,32 @@ def _w4a16_topk_sum_launch_flat(
             assumed_align=16,
         ),
         make_ptr(
-            _cutlass_element_dtype(element_dtype),
+            cutlass.Float32 if full_rotation else _cutlass_element_dtype(element_dtype),
             output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            weights_addr,
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            route_cutlass_dtype,
+            route_ids_addr,
+            cute.AddressSpace.gmem,
+            assumed_align=route_align,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            expert_map_addr,
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            svh_addr,
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
@@ -7927,23 +9221,54 @@ def _compile_w4a16_gemm_launch(
     moe_block_size: int,
     max_m_blocks: int,
     element_dtype: str,
-    packed_route_indices: torch.Tensor,
+    packed_route_indices: torch.Tensor | None,
     sms: int,
     max_shared_mem: int,
     device: torch.device,
     c_tmp: torch.Tensor | None = None,
+    weight_layout: str = "packed",
     scale_format: str = "e4m3_k16",
+    w13_layout: str = "packed",
+    trellis_bits: int = 3,
+    dense_route_fast_path: bool = False,
+    route_slots: int | None = None,
+    force_tile_config: tuple[int, int] | None = None,
 ) -> _W4A16GemmLaunch:
-    tile_k, tile_n, _, _ = _select_tile_config(
-        problem_m=size_m,
-        problem_n=size_n,
-        problem_k=size_k,
-        top_k=top_k,
-        moe_block_size=moe_block_size,
-        sms=sms,
-        max_shared_mem=max_shared_mem,
-        scale_format=scale_format,
+    planner_weight_bits = (
+        max(4, int(trellis_bits)) if weight_layout == "trellis3_t256" else 4
     )
+    if force_tile_config is None:
+        tile_k, tile_n, _, _ = _select_tile_config(
+            problem_m=size_m,
+            problem_n=size_n,
+            problem_k=size_k,
+            top_k=top_k,
+            moe_block_size=moe_block_size,
+            sms=sms,
+            max_shared_mem=max_shared_mem,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+            weight_bits=planner_weight_bits,
+        )
+    else:
+        tile_k, tile_n = (int(v) for v in force_tile_config)
+        cta_threads = tile_n * tile_k // 64
+        if not _candidate_tile_fits(
+            problem_n=size_n,
+            problem_k=size_k,
+            cta_m_blocks=_covering_count(moe_block_size, 16),
+            tile_n=tile_n,
+            tile_k=tile_k,
+            cta_threads=cta_threads,
+            max_shared_mem=max_shared_mem,
+            scale_format=scale_format,
+            weight_layout=weight_layout,
+            weight_bits=planner_weight_bits,
+        ):
+            raise ValueError(
+                "forced standalone W4A16 tile does not fit: "
+                f"tile_k/tile_n={tile_k}/{tile_n}, N/K={size_n}/{size_k}"
+            )
     kernel = compile_w4a16_gemm(
         size_m=size_m,
         size_n=size_n,
@@ -7956,12 +9281,22 @@ def _compile_w4a16_gemm_launch(
         moe_block_size=moe_block_size,
         max_m_blocks=max_m_blocks,
         element_dtype=element_dtype,
+        weight_layout=weight_layout,
         scale_format=scale_format,
+        w13_layout=w13_layout,
+        trellis_bits=trellis_bits,
+        dense_route_fast_path=bool(dense_route_fast_path),
     )
+    if route_slots is None:
+        if packed_route_indices is None:
+            raise ValueError(
+                "standalone W4A16 launch requires route_slots or packed_route_indices"
+            )
+        route_slots = int(packed_route_indices.numel())
     c_tmp = _get_c_tmp(
         packed_gemm_scratch_elements(
             size_n=size_n,
-            route_slots=int(packed_route_indices.numel()),
+            route_slots=int(route_slots),
             moe_block_size=moe_block_size,
             sms=sms,
         ),
@@ -7981,6 +9316,7 @@ def pack_topk_routes_by_expert(
     block_expert_ids: torch.Tensor | None = None,
     packed_route_count: torch.Tensor | None = None,
     expert_offsets: torch.Tensor | None = None,
+    expert_counts: torch.Tensor | None = None,
     stream: cuda.CUstream | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Group top-k routes by expert and pad each group to the GEMM M-block size."""
@@ -8000,7 +9336,257 @@ def pack_topk_routes_by_expert(
         block_expert_ids=block_expert_ids,
         packed_route_count=packed_route_count,
         expert_offsets=expert_offsets,
+        expert_counts=expert_counts,
     )
+
+
+def _trellis256_dense_tile_config(size_k: int, size_n: int) -> tuple[int, int]:
+    """Return an m-invariant t256 tile so dense row bits cannot drift with m."""
+    if int(size_k) % 64 != 0:
+        raise ValueError(f"trellis3_t256 dense K must be divisible by 64, got {size_k}")
+    if int(size_n) % 256 == 0:
+        return (64, 256)
+    if int(size_n) % 128 == 0:
+        # With dense M=64, (tile_k=64,tile_n=128) maps to the measured
+        # (cta_threads=128, cta_m/n/k_blocks=4/8/4) register specialization.
+        # The superficially symmetric 128x128 tile would need a missing
+        # 256-thread 4/8/8 register entry and fail before compilation.
+        return (64, 128)
+    raise ValueError(
+        "trellis3_t256 dense N must be divisible by 128 (or 256 for the wide tile), "
+        f"got N={size_n}"
+    )
+
+
+def _resolve_exl3_hadamard_128(hadamard_128):
+    if hadamard_128 is None:
+        try:
+            import exllamav3_ext
+        except ImportError as exc:
+            raise RuntimeError(
+                "run_trellis256_dense requires exllamav3_ext.had_r_128 for the "
+                "EXL3 input/output rotations"
+            ) from exc
+        hadamard_128 = exllamav3_ext.had_r_128
+    elif not callable(hadamard_128):
+        hadamard_128 = getattr(hadamard_128, "had_r_128", None)
+    if not callable(hadamard_128):
+        raise TypeError("hadamard_128 must be callable or expose had_r_128")
+    return hadamard_128
+
+
+def _run_trellis256_dense_current_device(
+    x: torch.Tensor,
+    prepared_dense,
+    *,
+    output: torch.Tensor | None = None,
+    gemm_output: torch.Tensor | None = None,
+    c_tmp: torch.Tensor | None = None,
+    hadamard_128=None,
+    stream: cuda.CUstream | None = None,
+) -> torch.Tensor:
+    """Run one native EXL3 linear on the already-selected CUDA device.
+
+    This is a true dense entry: E=1 and contiguous row identities are synthesized
+    inside the kernel, so no top-k tensors or route-packing kernels are created.
+    Outer rotations follow EXL3 order exactly: fp16 ``suh`` multiply before the
+    input H128, and fp16 ``svh`` multiply after the output H128.  The current
+    device decode is MCG-only and rejects other codebook metadata fail-closed.
+    """
+    if getattr(prepared_dense, "weight_layout", None) != "trellis3_t256":
+        raise ValueError("run_trellis256_dense requires prepared trellis3_t256 weights")
+    if int(getattr(prepared_dense, "num_experts", 0)) != 1:
+        raise ValueError("run_trellis256_dense requires an honest E=1 prepared weight")
+    if getattr(prepared_dense, "trellis_codebook", None) != "mcg":
+        raise NotImplementedError(
+            "run_trellis256_dense currently decodes only the MCG codebook; "
+            f"got {getattr(prepared_dense, 'trellis_codebook', None)!r}"
+        )
+    trellis_bits = int(getattr(prepared_dense, "trellis_bits", 0))
+    if trellis_bits not in _TRELLIS256_BITS:
+        raise ValueError(
+            f"prepared dense weight has invalid trellis_bits={trellis_bits}"
+        )
+    compute_dtype = getattr(prepared_dense, "params_dtype", None)
+    if compute_dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(
+            "prepared dense weight must select fp16 or bf16 compute, got "
+            f"{compute_dtype}"
+        )
+    element_dtype = "fp16" if compute_dtype == torch.float16 else "bf16"
+    cutlass_dtype = (
+        cutlass.Float16 if compute_dtype == torch.float16 else cutlass.BFloat16
+    )
+    if x.ndim != 2 or int(x.shape[0]) <= 0:
+        raise ValueError(f"x must be a non-empty rank-2 tensor, got {tuple(x.shape)}")
+    if x.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"x must be fp16 or bf16, got {x.dtype}")
+    if not x.is_cuda or not x.is_contiguous():
+        raise ValueError("x must be a contiguous CUDA tensor")
+    m, size_k = (int(v) for v in x.shape)
+    size_n = int(prepared_dense.out_features)
+    if size_k != int(prepared_dense.in_features):
+        raise ValueError(
+            f"x has K={size_k}, prepared dense weight expects {prepared_dense.in_features}"
+        )
+    if prepared_dense.trellis.device != x.device:
+        raise ValueError("x and prepared dense weight must be on the same CUDA device")
+    if output is None:
+        output = torch.empty((m, size_n), dtype=x.dtype, device=x.device)
+    elif (
+        tuple(output.shape) != (m, size_n)
+        or output.dtype != x.dtype
+        or output.device != x.device
+        or not output.is_contiguous()
+    ):
+        raise ValueError(
+            f"output must be contiguous {x.dtype} with shape {(m, size_n)} on {x.device}"
+        )
+    if gemm_output is None:
+        gemm_output = torch.empty((m, size_n), dtype=compute_dtype, device=x.device)
+    elif (
+        tuple(gemm_output.shape) != (m, size_n)
+        or gemm_output.dtype != compute_dtype
+        or gemm_output.device != x.device
+        or not gemm_output.is_contiguous()
+        or int(gemm_output.data_ptr()) % 16 != 0
+    ):
+        raise ValueError(
+            f"gemm_output must be contiguous, 16-byte-aligned {compute_dtype} with shape "
+            f"{(m, size_n)} on {x.device}"
+        )
+    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
+        raise ValueError("c_tmp must be at least 16-byte aligned")
+
+    hadamard_128 = _resolve_exl3_hadamard_128(hadamard_128)
+    x_f16 = x if x.dtype == torch.float16 else x.to(torch.float16)
+    rotated_f16 = torch.empty_like(x_f16)
+    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
+    rotated_compute = (
+        rotated_f16
+        if compute_dtype == torch.float16
+        else rotated_f16.to(torch.bfloat16)
+    )
+
+    props = torch.cuda.get_device_properties(x.device)
+    sms = int(props.multi_processor_count)
+    max_shared_mem = int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+    moe_block_size = 64
+    route_blocks = (m + moe_block_size - 1) // moe_block_size
+    route_slots = route_blocks * moe_block_size
+    tile_k, tile_n = _trellis256_dense_tile_config(size_k, size_n)
+    launch = _compile_w4a16_gemm_launch(
+        size_m=m,
+        size_n=size_n,
+        size_k=size_k,
+        num_experts=1,
+        top_k=1,
+        mul_topk_weights=False,
+        moe_block_size=moe_block_size,
+        max_m_blocks=route_blocks,
+        element_dtype=element_dtype,
+        packed_route_indices=None,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        device=x.device,
+        c_tmp=c_tmp,
+        weight_layout="trellis3_t256",
+        scale_format="e4m3_k32",
+        w13_layout="packed",
+        trellis_bits=trellis_bits,
+        dense_route_fast_path=True,
+        route_slots=route_slots,
+        force_tile_config=(tile_k, tile_n),
+    )
+    dummy_i32 = prepared_dense.workspace[:1]
+    stream = current_cuda_stream() if stream is None else stream
+    n_tiles = size_n // tile_n
+    grid_x = min(
+        sms * int(launch.kernel.blocks_per_sm),
+        max(route_blocks * n_tiles, 1),
+    )
+    launch.kernel.compiled(
+        make_ptr(
+            cutlass_dtype,
+            rotated_compute.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass_dtype,
+            rotated_compute.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        prepared_dense.trellis,
+        make_ptr(
+            cutlass_dtype,
+            gemm_output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        prepared_dense.scale.view(torch.uint8).view(torch.int32).view(-1),
+        prepared_dense.global_scale,
+        dummy_i32,
+        dummy_i32,
+        dummy_i32,
+        prepared_dense.global_scale,
+        launch.c_tmp,
+        prepared_dense.workspace,
+        m,
+        grid_x,
+        stream,
+    )
+
+    gemm_f16 = (
+        gemm_output if compute_dtype == torch.float16 else gemm_output.to(torch.float16)
+    )
+    if output.dtype == torch.float16:
+        hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
+    else:
+        output_f16 = torch.empty_like(gemm_f16)
+        hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
+        output.copy_(output_f16)
+    return output
+
+
+def run_trellis256_dense(
+    x: torch.Tensor,
+    prepared_dense,
+    *,
+    output: torch.Tensor | None = None,
+    gemm_output: torch.Tensor | None = None,
+    c_tmp: torch.Tensor | None = None,
+    hadamard_128=None,
+    stream: cuda.CUstream | None = None,
+) -> torch.Tensor:
+    """Run one native 3/4/5/6-bpw EXL3 linear through the fused t256 GEMM.
+
+    The whole input-rotation -> GEMM -> output-rotation chain is device-guarded
+    and runs on the current Torch stream for ``x.device``.  To use a non-default
+    stream, enter ``torch.cuda.stream(...)`` around this call; accepting a raw
+    driver stream here would leave the surrounding Torch/EXL3 rotations on a
+    different stream and create an unsynchronized race.
+    """
+    if not isinstance(x, torch.Tensor) or not x.is_cuda:
+        raise ValueError("x must be a CUDA tensor")
+    if stream is not None:
+        raise ValueError(
+            "run_trellis256_dense does not accept a raw CUDA stream; select a "
+            "Torch stream with torch.cuda.stream(...) around the call"
+        )
+    with torch.cuda.device(x.device):
+        return _run_trellis256_dense_current_device(
+            x,
+            prepared_dense,
+            output=output,
+            gemm_output=gemm_output,
+            c_tmp=c_tmp,
+            hadamard_128=hadamard_128,
+            stream=None,
+        )
 
 
 def run_w4a16_moe(
@@ -8019,7 +9605,9 @@ def run_w4a16_moe(
     block_expert_ids: torch.Tensor | None = None,
     packed_route_count: torch.Tensor | None = None,
     expert_offsets: torch.Tensor | None = None,
+    expert_counts: torch.Tensor | None = None,
     expert_map: torch.Tensor | None = None,
+    output_expert_map: torch.Tensor | None = None,
     activation_amax: torch.Tensor | None = None,
     layer_idx: int | None = None,
     apply_router_weight_on_input: bool = False,
@@ -8029,6 +9617,14 @@ def run_w4a16_moe(
     swiglu_beta: float | None = None,
     fused_launch: W4A16FusedMoeCompileResult | None = None,
     topk_sum_launch: W4A16TopKSumCompileResult | None = None,
+    intermediate_rotation_scales: torch.Tensor | None = None,
+    a_input_up: torch.Tensor | None = None,
+    full_rotation: bool = False,
+    suh_gate_table: torch.Tensor | None = None,
+    suh_up_table: torch.Tensor | None = None,
+    svh_table: torch.Tensor | None = None,
+    rotation_a_gate: torch.Tensor | None = None,
+    rotation_a_up: torch.Tensor | None = None,
     stream: cuda.CUstream | None = None,
 ) -> torch.Tensor:
     activation = normalize_moe_activation(activation)
@@ -8039,17 +9635,48 @@ def run_w4a16_moe(
         swiglu_alpha,
         swiglu_beta,
     )
-    element_dtype = _normalize_element_dtype(a_input.dtype)
-    if output.dtype != a_input.dtype:
-        raise TypeError(f"output must have dtype {a_input.dtype}, got {output.dtype}")
+    full_rotation = bool(full_rotation)
+    rotation_input_dtype = _normalize_element_dtype(a_input.dtype)
     prepared_dtype = getattr(prepared, "params_dtype", a_input.dtype)
-    if prepared_dtype != a_input.dtype:
-        raise TypeError(
-            f"prepared weights were built for {prepared_dtype}, but a_input has dtype {a_input.dtype}"
-        )
+    if full_rotation:
+        element_dtype = _normalize_element_dtype(prepared_dtype)
+        if element_dtype != "fp16":
+            raise TypeError("full_rotation requires fp16 prepared weights/scratch")
+        if output.dtype != torch.float32:
+            raise TypeError(
+                f"full_rotation output must be torch.float32, got {output.dtype}"
+            )
+    else:
+        element_dtype = rotation_input_dtype
+        if output.dtype != a_input.dtype:
+            raise TypeError(
+                f"output must have dtype {a_input.dtype}, got {output.dtype}"
+            )
+        if prepared_dtype != a_input.dtype:
+            raise TypeError(
+                f"prepared weights were built for {prepared_dtype}, but a_input has dtype {a_input.dtype}"
+            )
     weight_layout = getattr(prepared, "weight_layout", "packed")
     if weight_layout not in _WEIGHT_LAYOUTS:
         raise ValueError(f"unsupported W4A16 weight_layout {weight_layout!r}")
+    trellis_bits = int(getattr(prepared, "trellis_bits", 3))
+    if weight_layout == "trellis3_t256":
+        if trellis_bits not in _TRELLIS256_BITS:
+            raise ValueError(
+                f"prepared trellis3_t256 bitrate must be in {_TRELLIS256_BITS}, "
+                f"got {trellis_bits}"
+            )
+        if getattr(prepared, "trellis_codebook", None) != "mcg":
+            raise NotImplementedError(
+                "trellis3_t256 execution currently requires the MCG codebook"
+            )
+        if activation_amax is not None:
+            raise NotImplementedError(
+                "trellis3_t256 activation-amax collection is not exposed through "
+                "the registered launch ABI"
+            )
+    elif trellis_bits != 3:
+        raise ValueError("trellis_bits is only valid for trellis3_t256 weights")
     scale_format = _normalize_scale_format(
         getattr(prepared, "scale_format", None)
         or (
@@ -8066,8 +9693,41 @@ def run_w4a16_moe(
     if weight_layout == "modelopt":
         if w13_layout not in _MODEL_OPT_W13_LAYOUTS:
             raise ValueError(f"unsupported W4A16 w13_layout {w13_layout!r}")
+    elif weight_layout == "trellis3_t256":
+        if w13_layout not in _TRELLIS256_W13_LAYOUTS:
+            raise ValueError(f"unsupported trellis3_t256 w13_layout {w13_layout!r}")
     else:
         w13_layout = "packed"
+    dual_a_required = bool(
+        intermediate_rotation_scales is not None
+        and weight_layout == "trellis3_t256"
+        and w13_layout == "trellis3_t256_proj"
+    )
+    if full_rotation and not dual_a_required:
+        raise ValueError(
+            "full_rotation requires projection-major trellis intermediate rotation"
+        )
+    if dual_a_required and a_input_up is None and not full_rotation:
+        raise ValueError(
+            "exact projection-major trellis3_t256 rotation requires a_input_up"
+        )
+    if a_input_up is not None and (not dual_a_required or full_rotation):
+        raise ValueError(
+            "a_input_up is only valid for exact projection-major trellis3_t256 rotation"
+        )
+    if a_input_up is not None:
+        if (
+            a_input_up.shape != a_input.shape
+            or a_input_up.dtype != a_input.dtype
+            or a_input_up.device != a_input.device
+        ):
+            raise ValueError(
+                "a_input_up must match a_input shape, dtype, and device; got "
+                f"{tuple(a_input_up.shape)}/{a_input_up.dtype}/{a_input_up.device} "
+                f"vs {tuple(a_input.shape)}/{a_input.dtype}/{a_input.device}"
+            )
+        if not a_input_up.is_contiguous():
+            raise ValueError("a_input_up must be contiguous")
     if topk_weights.dtype != torch.float32:
         raise TypeError("topk_weights must be torch.float32")
     _validate_topk_ids(topk_ids, require_cuda=False, require_contiguous=False)
@@ -8078,6 +9738,9 @@ def run_w4a16_moe(
     ):
         raise ValueError("a_input, topk_weights, and topk_ids must be contiguous")
     _validate_expert_map(expert_map, device=a_input.device)
+    _validate_expert_map(output_expert_map, device=a_input.device)
+    if output_expert_map is not None and not full_rotation:
+        raise ValueError("output_expert_map is only valid with full_rotation")
 
     m, hidden_size = a_input.shape
     topk = int(topk_ids.shape[1])
@@ -8091,6 +9754,73 @@ def run_w4a16_moe(
         raise ValueError(f"output must have shape {(m, hidden_size)}")
     if expert_map is not None and int(expert_map.numel()) < int(prepared.num_experts):
         raise ValueError("expert_map cannot be shorter than the local expert count")
+    if output_expert_map is not None and int(output_expert_map.numel()) < int(
+        prepared.num_experts
+    ):
+        raise ValueError(
+            "output_expert_map cannot be shorter than the local expert count"
+        )
+    if full_rotation:
+        if apply_router_weight_on_input:
+            raise ValueError(
+                "full_rotation applies router weights only in the fp32 top-k sum"
+            )
+        num_local_experts = int(prepared.num_experts)
+        intermediate_size_full = int(prepared.intermediate_size)
+        for name, table, shape in (
+            ("suh_gate_table", suh_gate_table, (num_local_experts, hidden_size)),
+            ("suh_up_table", suh_up_table, (num_local_experts, hidden_size)),
+            ("svh_table", svh_table, (num_local_experts, hidden_size)),
+            (
+                "intermediate_rotation_scales",
+                intermediate_rotation_scales,
+                (num_local_experts, 3 * intermediate_size_full),
+            ),
+        ):
+            if table is None:
+                raise ValueError(f"full_rotation requires {name}")
+            if (
+                table.dtype != torch.float16
+                or table.device != a_input.device
+                or tuple(table.shape) != shape
+                or not table.is_contiguous()
+            ):
+                raise ValueError(
+                    f"{name} must be contiguous fp16 {shape} on {a_input.device}; "
+                    f"got {tuple(table.shape)}/{table.dtype}/{table.device}/"
+                    f"contiguous={table.is_contiguous()}"
+                )
+        required_a = m * topk * hidden_size
+        for name, scratch in (
+            ("rotation_a_gate", rotation_a_gate),
+            ("rotation_a_up", rotation_a_up),
+        ):
+            if scratch is None:
+                raise ValueError(f"full_rotation requires preallocated {name}")
+            if (
+                scratch.dtype != torch.float16
+                or scratch.device != a_input.device
+                or not scratch.is_contiguous()
+                or int(scratch.numel()) < required_a
+            ):
+                raise ValueError(
+                    f"{name} must be contiguous fp16 on {a_input.device} with at least "
+                    f"{required_a} elements"
+                )
+        assert rotation_a_gate is not None and rotation_a_up is not None
+        if rotation_a_gate.data_ptr() == rotation_a_up.data_ptr():
+            raise ValueError("full_rotation gate/up A scratches must not alias")
+    elif any(
+        value is not None
+        for value in (
+            suh_gate_table,
+            suh_up_table,
+            svh_table,
+            rotation_a_gate,
+            rotation_a_up,
+        )
+    ):
+        raise ValueError("full-rotation tables/scratch require full_rotation=True")
     layer_idx_int = _validate_activation_amax(
         activation_amax,
         layer_idx=layer_idx,
@@ -8297,6 +10027,7 @@ def run_w4a16_moe(
                 block_expert_ids=block_expert_ids,
                 packed_route_count=packed_route_count,
                 expert_offsets=expert_offsets,
+                expert_counts=expert_counts,
                 stream=stream,
             )
         )
@@ -8314,6 +10045,8 @@ def run_w4a16_moe(
         topk=topk,
         route_num_experts=route_num_experts,
         sms=sms,
+        full_rotation=full_rotation,
+        block_size_m=block_size_m,
     )
     intermediate_size = int(prepared.intermediate_size)
     fc1_cols = buffer_plan.fc1_cols
@@ -8328,11 +10061,12 @@ def run_w4a16_moe(
             f"intermediate_cache2 has {intermediate_cache2.numel()} elements; "
             f"need at least {buffer_plan.intermediate_cache2_elements}"
         )
+    cache_dtype = prepared_dtype if full_rotation else a_input.dtype
     if (
-        intermediate_cache13.dtype != a_input.dtype
-        or intermediate_cache2.dtype != a_input.dtype
+        intermediate_cache13.dtype != cache_dtype
+        or intermediate_cache2.dtype != cache_dtype
     ):
-        raise TypeError(f"intermediate caches must be {a_input.dtype}")
+        raise TypeError(f"intermediate caches must be {cache_dtype}")
     if (
         not intermediate_cache13.is_contiguous()
         or not intermediate_cache2.is_contiguous()
@@ -8354,7 +10088,7 @@ def run_w4a16_moe(
             top_k=topk,
             activation=activation,
             apply_router_weight_on_input=bool(apply_router_weight_on_input),
-            zero_fc2_output=expert_map is not None,
+            zero_fc2_output=expert_map is not None and not full_rotation,
             moe_block_size=block_size_m,
             max_m_blocks=int(required_m_blocks),
             element_dtype=element_dtype,
@@ -8367,9 +10101,13 @@ def run_w4a16_moe(
             weight_layout=weight_layout,
             scale_format=scale_format,
             w13_layout=w13_layout,
+            trellis_bits=trellis_bits,
             direct_topk_routes=use_direct_topk_routes,
             tc_decode_fused_sum=use_tc_decode,
             collect_activation_amax=collect_activation_amax,
+            intermediate_rotation=intermediate_rotation_scales is not None,
+            full_rotation=full_rotation,
+            rotation_input_dtype=rotation_input_dtype,
         )
     else:
         if int(fused_launch.size_m) < m:
@@ -8384,7 +10122,7 @@ def run_w4a16_moe(
             topk,
             activation,
             bool(apply_router_weight_on_input),
-            expert_map is not None,
+            expert_map is not None and not full_rotation,
             element_dtype,
             bool(fast_math),
             swiglu_limit,
@@ -8393,9 +10131,14 @@ def run_w4a16_moe(
             weight_layout,
             scale_format,
             w13_layout,
+            trellis_bits,
             bool(use_direct_topk_routes),
             bool(collect_activation_amax),
             block_size_m,
+            bool(intermediate_rotation_scales is not None),
+            dual_a_required,
+            full_rotation,
+            rotation_input_dtype,
         )
         actual_fused = (
             int(fused_launch.hidden_size),
@@ -8419,9 +10162,14 @@ def run_w4a16_moe(
                 if getattr(fused_launch, "weight_layout", "packed") == "modelopt"
                 else "packed",
             ),
+            int(getattr(fused_launch, "trellis_bits", 3)),
             bool(getattr(fused_launch, "direct_topk_routes", False)),
             bool(getattr(fused_launch, "collect_activation_amax", False)),
             int(fused_launch.moe_block_size),
+            bool(getattr(fused_launch, "intermediate_rotation", False)),
+            bool(getattr(fused_launch, "dual_a", False)),
+            bool(getattr(fused_launch, "full_rotation", False)),
+            getattr(fused_launch, "rotation_input_dtype", fused_launch.element_dtype),
         )
         if actual_fused != expected_fused or int(fused_launch.max_m_blocks) < int(
             required_m_blocks
@@ -8526,7 +10274,7 @@ def run_w4a16_moe(
         topk,
         activation,
         bool(apply_router_weight_on_input),
-        expert_map is not None,
+        expert_map is not None and not full_rotation,
         block_size_m,
         int(fused.max_m_blocks),
         element_dtype,
@@ -8545,6 +10293,34 @@ def run_w4a16_moe(
         int(fused.fc2_tile_k),
         int(fused.fc2_tile_n),
     )
+    _intermediate_rotation = intermediate_rotation_scales is not None
+    if _intermediate_rotation and (
+        collect_activation_amax
+        or use_tc_decode
+        or use_direct_topk_routes
+        or weight_layout != "trellis3_t256"
+    ):
+        raise ValueError(
+            "intermediate_rotation_scales requires the packed trellis3_t256 fused "
+            "path (no calibration / tc-decode / direct-topk)"
+        )
+    if _intermediate_rotation:
+        need = (
+            int(prepared.num_experts) * 3 * intermediate_size
+            if full_rotation
+            else int(m) * topk * 3 * intermediate_size
+        )
+        rot_arg = intermediate_rotation_scales.reshape(-1)
+        if int(rot_arg.numel()) < need or rot_arg.dtype != torch.float16:
+            raise ValueError(
+                "intermediate_rotation_scales must be fp16 with >= "
+                f"{need} elements ({'experts' if full_rotation else 'routes'}"
+                "*3*intermediate); got "
+                f"numel={int(rot_arg.numel())} dtype={rot_arg.dtype}"
+            )
+        rot_arg = rot_arg[:need]
+    else:
+        rot_arg = None
     if collect_activation_amax:
         assert activation_amax is not None
         assert layer_idx_int is not None
@@ -8554,6 +10330,119 @@ def run_w4a16_moe(
             int(layer_idx_int),
             *launch_tail,
             int(stream),
+        )
+    elif _intermediate_rotation or weight_layout == "trellis3_t256":
+        # Native t256 bypasses the registered torch op so its shape-derived
+        # bitrate reaches compilation without widening the stable public op ABI.
+        # Other production layouts keep the registered path byte-identical.
+        (
+            _rc_a,
+            _rc_w13,
+            _rc_w2,
+            _rc_fc1,
+            _rc_act,
+            _rc_fc2,
+            _rc_w13s,
+            _rc_w2s,
+            _rc_w13g,
+            _rc_w2g,
+            _rc_pri,
+            _rc_bei,
+            _rc_prc,
+        ) = launch_common
+        (
+            _lt_tw,
+            _lt_fc1s,
+            _lt_fc2s,
+            _lt_ws,
+            _lt_m,
+            _lt_capm,
+            _lt_h,
+            _lt_i,
+            _lt_ne,
+            _lt_tk,
+            _lt_act,
+            _lt_arwi,
+            _lt_zfo,
+            _lt_bsm,
+            _lt_mmb,
+            _lt_edt,
+            _lt_fm,
+            _lt_sms,
+            _lt_msm,
+            _lt_hsl,
+            _lt_slv,
+            _lt_sa,
+            _lt_sb,
+            _lt_wl,
+            _lt_sf,
+            _lt_w13l,
+            _lt_fc1tk,
+            _lt_fc1tn,
+            _lt_fc2tk,
+            _lt_fc2tn,
+        ) = launch_tail
+        launch_a = rotation_a_gate if full_rotation else _rc_a
+        launch_a_up = rotation_a_up if full_rotation else a_input_up
+        assert launch_a is not None
+        _w4a16_fused_moe_launch_flat(
+            a_input=launch_a,
+            w13_arg=_rc_w13,
+            w2_arg=_rc_w2,
+            fc1_out=_rc_fc1,
+            activated=_rc_act,
+            fc2_out=_rc_fc2,
+            w13_scale_i32=_rc_w13s,
+            w2_scale_i32=_rc_w2s,
+            w13_global_scale=_rc_w13g,
+            w2_global_scale=_rc_w2g,
+            packed_route_indices=_rc_pri,
+            block_expert_ids=_rc_bei,
+            packed_route_count=_rc_prc,
+            activation_amax=None,
+            layer_idx=0,
+            topk_weights=_lt_tw,
+            fc1_scratch=_lt_fc1s,
+            fc2_scratch=_lt_fc2s,
+            workspace=_lt_ws,
+            m=_lt_m,
+            size_m=_lt_capm,
+            hidden_size=_lt_h,
+            intermediate_size=_lt_i,
+            num_experts=_lt_ne,
+            topk=_lt_tk,
+            activation=_lt_act,
+            apply_router_weight_on_input=_lt_arwi,
+            zero_fc2_output=_lt_zfo,
+            moe_block_size=_lt_bsm,
+            max_m_blocks=_lt_mmb,
+            element_dtype=_lt_edt,
+            fast_math=_lt_fm,
+            sms=_lt_sms,
+            max_shared_mem=_lt_msm,
+            has_swiglu_limit=_lt_hsl,
+            swiglu_limit_value=_lt_slv,
+            swiglu_alpha=_lt_sa,
+            swiglu_beta=_lt_sb,
+            weight_layout=_lt_wl,
+            scale_format=_lt_sf,
+            w13_layout=_lt_w13l,
+            fc1_tile_k=_lt_fc1tk,
+            fc1_tile_n=_lt_fc1tn,
+            fc2_tile_k=_lt_fc2tk,
+            fc2_tile_n=_lt_fc2tn,
+            direct_topk_routes=bool(use_direct_topk_routes),
+            tc_decode_fused_sum=bool(use_tc_decode),
+            collect_activation_amax=False,
+            stream_int=int(stream),
+            rot_scales=rot_arg,
+            intermediate_rotation=_intermediate_rotation,
+            a_input_up=launch_a_up,
+            trellis_bits=trellis_bits,
+            full_rotation=full_rotation,
+            rotation_input=_rc_a,
+            suh_gate_table=suh_gate_table,
+            suh_up_table=suh_up_table,
         )
     else:
         torch.ops.sparkinfer.w4a16_fused_moe_launch(
@@ -8568,26 +10457,58 @@ def run_w4a16_moe(
         # FC2 already wrote the top-k-summed result into `output`.
         return output
 
+    sum_expert_map = output_expert_map if output_expert_map is not None else expert_map
     if topk_sum_launch is not None:
-        expected_sum = (topk, hidden_size)
+        expected_sum = (
+            topk,
+            hidden_size,
+            full_rotation,
+            int(prepared.num_experts) if full_rotation else 0,
+            0 if sum_expert_map is None else int(sum_expert_map.numel()),
+            topk_ids.dtype if full_rotation else torch.int32,
+            bool(sum_expert_map is not None) if full_rotation else False,
+        )
         actual_sum = (
             int(topk_sum_launch.topk),
             int(topk_sum_launch.hidden_size),
+            bool(getattr(topk_sum_launch, "full_rotation", False)),
+            int(getattr(topk_sum_launch, "num_experts", 0)),
+            int(getattr(topk_sum_launch, "route_num_experts", 0)),
+            getattr(topk_sum_launch, "route_ids_dtype", torch.int32),
+            bool(getattr(topk_sum_launch, "use_expert_map", False)),
         )
         if actual_sum != expected_sum:
             raise RuntimeError(
                 "preplanned W4A16 top-k sum launch does not match requested contract: "
                 f"requested={expected_sum}, planned={actual_sum}"
             )
-    torch.ops.sparkinfer.w4a16_topk_sum_launch(
-        fc2_out,
-        output,
-        m,
-        topk,
-        hidden_size,
-        element_dtype,
-        int(stream),
-    )
+    if full_rotation:
+        assert svh_table is not None
+        _w4a16_topk_sum_launch_flat(
+            fc2_out,
+            output,
+            m,
+            topk,
+            hidden_size,
+            element_dtype,
+            int(stream),
+            full_rotation=True,
+            num_experts=int(prepared.num_experts),
+            topk_weights=topk_weights,
+            route_expert_ids=topk_ids,
+            expert_map=sum_expert_map,
+            svh_table=svh_table,
+        )
+    else:
+        torch.ops.sparkinfer.w4a16_topk_sum_launch(
+            fc2_out,
+            output,
+            m,
+            topk,
+            hidden_size,
+            element_dtype,
+            int(stream),
+        )
     return output
 
 
@@ -9337,6 +11258,7 @@ __all__ = [
     "compile_w4a16_gemm",
     "compile_w4a16_topk_sum",
     "pack_topk_routes_by_expert",
+    "run_trellis256_dense",
     "run_w4a16_moe",
     "run_w4a16_moe_hybrid",
 ]

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -9675,6 +9675,30 @@ def run_trellis256_dense(
         )
 
 
+def _resolve_route_block_size_m(
+    *,
+    m: int,
+    topk: int,
+    route_num_experts: int,
+    planned_block_size_m: int | None,
+    fused_launch: W4A16FusedMoeCompileResult | None,
+) -> int:
+    """Resolve one route geometry shared by scratch, packing, and GEMM."""
+    planned = None if planned_block_size_m is None else int(planned_block_size_m)
+    if planned is not None and planned not in _ALLOWED_ROUTED_SIZES:
+        raise ValueError(f"unsupported planned W4A16 moe_block_size={planned}")
+    if fused_launch is None:
+        return planned or select_route_block_size_m(m, topk, route_num_experts)
+
+    compiled = int(fused_launch.moe_block_size)
+    if planned is not None and compiled != planned:
+        raise RuntimeError(
+            "preplanned W4A16 route geometry does not match the fused launch: "
+            f"planned_block_size_m={planned}, launch_block_size_m={compiled}"
+        )
+    return compiled
+
+
 def run_w4a16_moe(
     a_input: torch.Tensor,
     prepared,
@@ -9703,6 +9727,7 @@ def run_w4a16_moe(
     swiglu_beta: float | None = None,
     fused_launch: W4A16FusedMoeCompileResult | None = None,
     topk_sum_launch: W4A16TopKSumCompileResult | None = None,
+    route_block_size_m: int | None = None,
     intermediate_rotation_scales: torch.Tensor | None = None,
     a_input_up: torch.Tensor | None = None,
     full_rotation: bool = False,
@@ -9918,10 +9943,13 @@ def run_w4a16_moe(
     route_num_experts = (
         int(expert_map.numel()) if expert_map is not None else int(prepared.num_experts)
     )
-    if fused_launch is None:
-        block_size_m = select_route_block_size_m(m, topk, route_num_experts)
-    else:
-        block_size_m = int(fused_launch.moe_block_size)
+    block_size_m = _resolve_route_block_size_m(
+        m=m,
+        topk=topk,
+        route_num_experts=route_num_experts,
+        planned_block_size_m=route_block_size_m,
+        fused_launch=fused_launch,
+    )
     if block_size_m not in _ALLOWED_ROUTED_SIZES:
         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
 

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -1562,8 +1562,8 @@ def _trellis256_flat_native_view(
     device: torch.device,
 ) -> torch.Tensor:
     trellis_bits = int(trellis_bits)
-    expected_i16_shape = expected_prefix_shape + (16 * trellis_bits,)
-    expected_i32_shape = expected_prefix_shape + (8 * trellis_bits,)
+    expected_i16_shape = (*expected_prefix_shape, 16 * trellis_bits)
+    expected_i32_shape = (*expected_prefix_shape, 8 * trellis_bits)
     if tensor.device != device:
         raise ValueError(
             f"trellis3_t256 {name} must be on {device}, got {tensor.device}"

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -11,6 +11,7 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     W4A16PackedBuffers,
     make_w4a16_packed_buffers as _make_w4a16_packed_buffers,
     unswizzle_expert_scales,
+    validate_activation,
     validate_nf3_moe_inputs,
     validate_w4a16_packed_inputs,
 )
@@ -97,16 +98,12 @@ class W4A16ModelOptWeights:
 
 
 @dataclass(frozen=True)
-class PreparedNF3MoeWeights:
-    """Runtime NF3 ("nf3_2p1") hybrid-expert W4A16 weights.
+class PreparedW4A16MoeWeights:
+    """Runtime native-codebook W4A16 expert weights.
 
-    Mirrors W4A16PackedWeights so run_w4a16_moe consumes it identically. The
-    packed planes are int32 (3 words per 32-code unit); the K/32 scales are
-    e4m3-style bytes viewed uint8; the global scales carry the 2**116 the NF3
-    scale convention defers out of the codebook. fc1_tile_n / fc2_tile_n record
-    the CTA N-tile the flat-span packing was built for -- the kernel MUST be
-    compiled/launched with the SAME tile_n (read them back from the compiled
-    W4A16FusedMoeCompileResult).
+    NF3 uses packed code planes plus K/32 scales. EXL3 Trellis keeps native
+    codebook tiles and persistent full-rotation tables. Both share the same
+    W4A16 host ABI and must retain the tile configuration used at preparation.
     """
 
     w13: torch.Tensor
@@ -127,6 +124,55 @@ class PreparedNF3MoeWeights:
     w13_layout: str = "packed"
     weight_layout: str = "nf3_2p1"
     scale_format: str = "e4m3_k32"
+    # Native trellis tiles are codebook-agnostic storage.  The current
+    # trellis3_t256 decoder is still MCG-only, but retaining the checkpoint
+    # codebook here lets callers fail closed instead of silently mis-decoding a
+    # MUL1 (or default-codebook) tensor.
+    trellis_codebook: str | None = None
+    trellis_bits: int = 3
+    # Projection-specific EXL3 input incoherence scales.  They remain optional
+    # for non-trellis and synthetic oracle preparation, but the coherent
+    # projection-major runtime binds both so gate/up can stage distinct rotated
+    # A operands without copying either table.
+    gate_suh: torch.Tensor | None = None
+    up_suh: torch.Tensor | None = None
+    intermediate_rotations: torch.Tensor | None = None
+    down_svh: torch.Tensor | None = None
+    tile_config: tuple[int, int, int, int] | None = None
+
+
+# Compatibility for internal callers that still use the historical NF3 name.
+PreparedNF3MoeWeights = PreparedW4A16MoeWeights
+
+
+@dataclass(frozen=True)
+class PreparedTrellis256DenseWeight:
+    """Zero-copy native EXL3 tensor plus its outer rotations.
+
+    ``trellis`` is the flattened int32 view of one native
+    ``[K/16,N/16,16*bits]i16`` payload. ``suh`` and ``svh`` retain the
+    checkpoint tensors by reference. The current compute decoder is MCG-only;
+    MUL1 is preserved as metadata so execution can reject it rather than
+    misdecode it.
+    """
+
+    trellis: torch.Tensor
+    suh: torch.Tensor
+    svh: torch.Tensor
+    scale: torch.Tensor
+    global_scale: torch.Tensor
+    workspace: torch.Tensor
+    in_features: int
+    out_features: int
+    params_dtype: torch.dtype
+    trellis_bits: int
+    trellis_codebook: str
+    mcg: torch.Tensor | None = None
+    mul1: torch.Tensor | None = None
+    num_experts: int = 1
+    weight_layout: str = "trellis3_t256"
+    scale_format: str = "e4m3_k32"
+    w13_layout: str = "packed"
 
 
 def _make_workspace(
@@ -1371,7 +1417,7 @@ def prepare_nf3_moe_weights(
     fc1_tile_n: int,
     fc2_tile_n: int,
     params_dtype: torch.dtype = torch.bfloat16,
-) -> PreparedNF3MoeWeights:
+) -> PreparedW4A16MoeWeights:
     """Pack NF3 codes/scales into the runtime "nf3_2p1" W4A16 layout.
 
     Inputs are per-expert integer codes (0..7) in kernel-native output order
@@ -1410,7 +1456,7 @@ def prepare_nf3_moe_weights(
     global_scale = torch.full(
         (shape.num_experts,), _NF3_SCALE_GLOBAL, dtype=torch.float32, device=device
     )
-    return PreparedNF3MoeWeights(
+    return PreparedW4A16MoeWeights(
         w13=packed_w13,
         w13_scale=packed_w13_scale,
         w13_global_scale=global_scale,
@@ -1425,6 +1471,652 @@ def prepare_nf3_moe_weights(
         params_dtype=params_dtype,
         fc1_tile_n=int(fc1_tile_n),
         fc2_tile_n=int(fc2_tile_n),
+    )
+
+
+_TRELLIS256_W13_LAYOUTS = {"packed", "trellis3_t256_proj"}
+_TRELLIS256_CODEBOOKS = {
+    "default": "default",
+    "cb0": "default",
+    "mcg": "mcg",
+    "cb1": "mcg",
+    "mul1": "mul1",
+    "cb2": "mul1",
+}
+_TRELLIS256_CODEBOOK_SENTINELS = {
+    0: "default",
+    0xCBAC1FED: "mcg",
+    0x83DCD12D: "mul1",
+}
+
+
+def _normalize_trellis256_codebook(codebook: str | int) -> str:
+    if isinstance(codebook, int):
+        normalized = _TRELLIS256_CODEBOOK_SENTINELS.get(int(codebook) & 0xFFFFFFFF)
+        if normalized is None:
+            raise ValueError(
+                "unsupported trellis256 codebook sentinel "
+                f"{int(codebook) & 0xFFFFFFFF:#010x}; expected default "
+                "0x00000000, MCG 0xcbac1fed, or MUL1 0x83dcd12d"
+            )
+        return normalized
+    normalized = _TRELLIS256_CODEBOOKS.get(str(codebook).strip().lower())
+    if normalized is None:
+        raise ValueError(
+            f"unsupported trellis256 codebook {codebook!r}; expected "
+            "'default', 'mcg', or 'mul1'"
+        )
+    return normalized
+
+
+def _trellis256_random_native_tensor(
+    shape: tuple[int, ...],
+    *,
+    device: torch.device,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    """Generate all 32-bit native tile words without changing their bit pattern."""
+    raw = torch.randint(
+        0,
+        1 << 32,
+        shape,
+        dtype=torch.int64,
+        device=device,
+        generator=generator,
+    )
+    raw = torch.where(raw >= 2**31, raw - 2**32, raw)
+    return raw.to(torch.int32).contiguous()
+
+
+def _trellis256_bits_from_native_tensor(tensor: torch.Tensor, *, name: str) -> int:
+    """Recover the EXL3 bitrate from the native tile's final dimension."""
+    if tensor.ndim < 1:
+        raise ValueError(f"trellis3_t256 {name} must have at least one dimension")
+    words_per_bit = 16 if tensor.dtype == torch.int16 else 8
+    if tensor.dtype not in (torch.int16, torch.int32):
+        raise TypeError(
+            f"trellis3_t256 {name} must use native int16 or int32 storage, "
+            f"got {tensor.dtype}"
+        )
+    last = int(tensor.shape[-1])
+    if last % words_per_bit != 0:
+        raise ValueError(
+            f"trellis3_t256 {name} final dimension {last} is not a native "
+            f"{tensor.dtype} tile width"
+        )
+    bits = last // words_per_bit
+    if bits not in (3, 4, 5, 6):
+        raise ValueError(
+            f"trellis3_t256 {name} encodes unsupported {bits}-bpw storage; "
+            "expected 3, 4, 5, or 6"
+        )
+    return bits
+
+
+def _trellis256_flat_native_view(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    expected_prefix_shape: tuple[int, ...],
+    trellis_bits: int,
+    device: torch.device,
+) -> torch.Tensor:
+    trellis_bits = int(trellis_bits)
+    expected_i16_shape = expected_prefix_shape + (16 * trellis_bits,)
+    expected_i32_shape = expected_prefix_shape + (8 * trellis_bits,)
+    if tensor.device != device:
+        raise ValueError(
+            f"trellis3_t256 {name} must be on {device}, got {tensor.device}"
+        )
+    if tensor.dtype == torch.int16:
+        expected_shape = expected_i16_shape
+    elif tensor.dtype == torch.int32:
+        expected_shape = expected_i32_shape
+    else:
+        raise TypeError(
+            f"trellis3_t256 {name} must be native int16 tiles ({16 * trellis_bits} words) "
+            f"or the identical int32 view ({8 * trellis_bits} words), got {tensor.dtype}"
+        )
+    if tuple(tensor.shape) != expected_shape:
+        raise ValueError(
+            f"trellis3_t256 {name} requires native {trellis_bits}-bit EXL3 shape "
+            f"{expected_shape} for dtype {tensor.dtype}, got {tuple(tensor.shape)}"
+        )
+    if not tensor.is_contiguous():
+        raise ValueError(f"trellis3_t256 {name} must be contiguous")
+    if int(tensor.data_ptr()) % 16 != 0:
+        raise ValueError(
+            f"trellis3_t256 {name} must be at least 16-byte aligned for cp.async"
+        )
+    return tensor.view(torch.int32).reshape(-1)
+
+
+def prepare_trellis256_moe_weights(
+    w13: torch.Tensor | None = None,
+    w2: torch.Tensor | None = None,
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    activation: str,
+    fc1_tile_n: int,
+    fc2_tile_n: int,
+    device: torch.device | str | int | None = None,
+    seed: int = 0,
+    params_dtype: torch.dtype = torch.bfloat16,
+    w13_layout: str = "packed",
+    trellis_bits: int | None = None,
+    dummy_scale: torch.Tensor | None = None,
+    codebook: str | int = "mcg",
+    gate_suh: torch.Tensor | None = None,
+    up_suh: torch.Tensor | None = None,
+    intermediate_rotations: torch.Tensor | None = None,
+    down_svh: torch.Tensor | None = None,
+    tile_config: tuple[int, int, int, int] | None = None,
+    workspace: torch.Tensor | None = None,
+) -> PreparedW4A16MoeWeights:
+    """Wrap or synthesize native EXL3 tiles for ``trellis3_t256``.
+
+    Supplying both ``w13`` and ``w2`` is the production path: no bytes are
+    copied or permuted; each tensor is only viewed as contiguous int32 words and
+    flattened.  Omitting both tensors is the deterministic full-GEMM-oracle
+    path selected by ``device`` and ``seed``.  ``gate_suh`` and ``up_suh`` are
+    optional zero-copy bindings for the two projection-specific EXL3 input
+    rotations; when supplied, both must be contiguous fp16 ``[E,H]`` tensors on
+    the weight device.
+
+    Plain FC1 storage is expert-major
+    ``[E,H/16,FC1_N/16,16*bits]i16``. ``trellis3_t256_proj`` instead requires one
+    projection-major backing ``[2,E,H/16,I/16,16*bits]i16`` so gate/up fallback views
+    can continue to alias the same live storage.  FC2 is always the plain native
+    ``[E,I/16,H/16,16*bits]i16`` layout.
+    """
+    hidden_size = int(hidden_size)
+    intermediate_size = int(intermediate_size)
+    num_experts = int(num_experts)
+    fc1_tile_n = int(fc1_tile_n)
+    fc2_tile_n = int(fc2_tile_n)
+    if params_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError("trellis3_t256 W4A16 weights require fp16 or bf16 activations")
+    requested_trellis_bits = None if trellis_bits is None else int(trellis_bits)
+    if requested_trellis_bits is not None and requested_trellis_bits not in (
+        3,
+        4,
+        5,
+        6,
+    ):
+        raise ValueError(
+            "trellis3_t256 bits must be one of 3, 4, 5, or 6, "
+            f"got {requested_trellis_bits}"
+        )
+    if num_experts <= 0:
+        raise ValueError(f"trellis3_t256 requires num_experts > 0, got {num_experts}")
+    if hidden_size <= 0 or intermediate_size <= 0:
+        raise ValueError(
+            "trellis3_t256 requires positive hidden_size and intermediate_size, "
+            f"got H={hidden_size} I={intermediate_size}"
+        )
+    if hidden_size % 16 != 0 or intermediate_size % 16 != 0:
+        raise ValueError(
+            "native EXL3 tiles require hidden_size and intermediate_size to be "
+            f"multiples of 16, got H={hidden_size} I={intermediate_size}"
+        )
+    if hidden_size % 32 != 0 or intermediate_size % 32 != 0:
+        raise ValueError(
+            "trellis3_t256 uses E4M3 K/32 kernel plumbing and therefore requires "
+            "hidden_size and intermediate_size to be multiples of 32; "
+            f"got H={hidden_size} I={intermediate_size}"
+        )
+    for name, tile_n in (("fc1_tile_n", fc1_tile_n), ("fc2_tile_n", fc2_tile_n)):
+        if tile_n < 64 or tile_n % 16 != 0:
+            raise ValueError(
+                f"trellis3_t256 {name} must be a multiple of 16 and at least "
+                f"64 for the current W4A16 kernel, got {tile_n}"
+            )
+
+    is_gated = validate_activation(activation)
+    w13_rows = intermediate_size * (2 if is_gated else 1)
+    if w13_layout not in _TRELLIS256_W13_LAYOUTS:
+        raise ValueError(
+            f"unsupported trellis3_t256 w13_layout {w13_layout!r}; expected "
+            "'packed' or 'trellis3_t256_proj'"
+        )
+    if w13_layout == "trellis3_t256_proj":
+        if not is_gated:
+            raise ValueError(
+                "trellis3_t256_proj requires a gated activation with separate "
+                "gate/up FC1 projections"
+            )
+        if intermediate_size % fc1_tile_n != 0:
+            raise ValueError(
+                "trellis3_t256_proj requires each FC1 projection to contain an "
+                f"integral number of CTA N tiles: I={intermediate_size}, "
+                f"fc1_tile_n={fc1_tile_n}"
+            )
+    elif w13_rows % fc1_tile_n != 0:
+        raise ValueError(
+            "trellis3_t256 has no FC1 logical-tail path: "
+            f"FC1_N={w13_rows} must be divisible by fc1_tile_n={fc1_tile_n}"
+        )
+    if hidden_size % fc2_tile_n != 0:
+        raise ValueError(
+            "trellis3_t256 has no FC2 logical-tail path: "
+            f"FC2_N={hidden_size} must be divisible by fc2_tile_n={fc2_tile_n}"
+        )
+    normalized_codebook = _normalize_trellis256_codebook(codebook)
+
+    have_w13 = w13 is not None
+    have_w2 = w2 is not None
+    if have_w13 != have_w2:
+        raise ValueError("trellis3_t256 requires both w13 and w2, or neither")
+    synthetic = not have_w13
+    if synthetic:
+        resolved_trellis_bits = requested_trellis_bits or 3
+        if device is None:
+            raise ValueError(
+                "device is required when synthesizing trellis3_t256 oracle weights"
+            )
+        if isinstance(device, int):
+            resolved_device = torch.device("cuda", int(device))
+        else:
+            resolved_device = torch.device(device)
+        if resolved_device.type != "cuda":
+            raise ValueError(
+                "trellis3_t256 W4A16 weights require a CUDA device, got "
+                f"{resolved_device}"
+            )
+        if resolved_device.index is None:
+            resolved_device = torch.device("cuda", torch.cuda.current_device())
+        generator = torch.Generator(device=resolved_device)
+        generator.manual_seed(int(seed))
+        if w13_layout == "trellis3_t256_proj":
+            w13_i32_shape = (
+                2,
+                num_experts,
+                hidden_size // 16,
+                intermediate_size // 16,
+                8 * resolved_trellis_bits,
+            )
+        else:
+            w13_i32_shape = (
+                num_experts,
+                hidden_size // 16,
+                w13_rows // 16,
+                8 * resolved_trellis_bits,
+            )
+        w2_i32_shape = (
+            num_experts,
+            intermediate_size // 16,
+            hidden_size // 16,
+            8 * resolved_trellis_bits,
+        )
+        packed_w13 = _trellis256_random_native_tensor(
+            w13_i32_shape, device=resolved_device, generator=generator
+        ).reshape(-1)
+        packed_w2 = _trellis256_random_native_tensor(
+            w2_i32_shape, device=resolved_device, generator=generator
+        ).reshape(-1)
+    else:
+        assert w13 is not None and w2 is not None
+        w13_bits = _trellis256_bits_from_native_tensor(w13, name="w13")
+        w2_bits = _trellis256_bits_from_native_tensor(w2, name="w2")
+        if w13_bits != w2_bits:
+            raise ValueError(
+                f"trellis3_t256 w13/w2 bitrate mismatch: {w13_bits} vs {w2_bits}"
+            )
+        resolved_trellis_bits = w13_bits
+        if (
+            requested_trellis_bits is not None
+            and requested_trellis_bits != resolved_trellis_bits
+        ):
+            raise ValueError(
+                "explicit trellis_bits disagrees with native tensor shape: "
+                f"requested={requested_trellis_bits}, inferred={resolved_trellis_bits}"
+            )
+        resolved_device = w13.device
+        if resolved_device.type != "cuda":
+            raise ValueError(
+                "trellis3_t256 W4A16 weights require CUDA storage, got "
+                f"{resolved_device}"
+            )
+        if device is not None:
+            requested_device = (
+                torch.device("cuda", int(device))
+                if isinstance(device, int)
+                else torch.device(device)
+            )
+            device_matches = requested_device.type == resolved_device.type and (
+                requested_device.index is None
+                or requested_device.index == resolved_device.index
+            )
+            if not device_matches:
+                raise ValueError(
+                    "explicit trellis3_t256 device does not match supplied weights: "
+                    f"device={requested_device}, weights={resolved_device}"
+                )
+        if w13_layout == "trellis3_t256_proj":
+            expected_w13_prefix = (
+                2,
+                num_experts,
+                hidden_size // 16,
+                intermediate_size // 16,
+            )
+        else:
+            expected_w13_prefix = (
+                num_experts,
+                hidden_size // 16,
+                w13_rows // 16,
+            )
+        expected_w2_prefix = (
+            num_experts,
+            intermediate_size // 16,
+            hidden_size // 16,
+        )
+        packed_w13 = _trellis256_flat_native_view(
+            w13,
+            name="w13",
+            expected_prefix_shape=expected_w13_prefix,
+            trellis_bits=resolved_trellis_bits,
+            device=resolved_device,
+        )
+        packed_w2 = _trellis256_flat_native_view(
+            w2,
+            name="w2",
+            expected_prefix_shape=expected_w2_prefix,
+            trellis_bits=resolved_trellis_bits,
+            device=resolved_device,
+        )
+
+    have_gate_suh = gate_suh is not None
+    have_up_suh = up_suh is not None
+    if have_gate_suh != have_up_suh:
+        raise ValueError(
+            "trellis3_t256 projection input scales require both gate_suh and up_suh"
+        )
+    if have_gate_suh:
+        if w13_layout != "trellis3_t256_proj":
+            raise ValueError(
+                "trellis3_t256 gate_suh/up_suh bindings require "
+                "w13_layout='trellis3_t256_proj'"
+            )
+        assert gate_suh is not None and up_suh is not None
+        for name, scale in (("gate_suh", gate_suh), ("up_suh", up_suh)):
+            if scale.device != resolved_device:
+                raise ValueError(
+                    f"trellis3_t256 {name} must be on {resolved_device}, got {scale.device}"
+                )
+            if scale.dtype != torch.float16:
+                raise TypeError(
+                    f"trellis3_t256 {name} must be torch.float16, got {scale.dtype}"
+                )
+            if tuple(scale.shape) != (num_experts, hidden_size):
+                raise ValueError(
+                    f"trellis3_t256 {name} must have shape "
+                    f"{(num_experts, hidden_size)}, got {tuple(scale.shape)}"
+                )
+            if not scale.is_contiguous():
+                raise ValueError(f"trellis3_t256 {name} must be contiguous")
+
+    have_full_rotation = any(
+        value is not None
+        for value in (gate_suh, up_suh, intermediate_rotations, down_svh)
+    )
+    if have_full_rotation and not all(
+        value is not None
+        for value in (gate_suh, up_suh, intermediate_rotations, down_svh)
+    ):
+        raise ValueError(
+            "full-rotation trellis3_t256 requires gate_suh, up_suh, "
+            "intermediate_rotations, and down_svh"
+        )
+    if have_full_rotation:
+        assert intermediate_rotations is not None and down_svh is not None
+        for name, scale, shape in (
+            (
+                "intermediate_rotations",
+                intermediate_rotations,
+                (num_experts, 3 * intermediate_size),
+            ),
+            ("down_svh", down_svh, (num_experts, hidden_size)),
+        ):
+            if scale.device != resolved_device:
+                raise ValueError(
+                    f"trellis3_t256 {name} must be on {resolved_device}, got {scale.device}"
+                )
+            if scale.dtype != torch.float16:
+                raise TypeError(
+                    f"trellis3_t256 {name} must be torch.float16, got {scale.dtype}"
+                )
+            if tuple(scale.shape) != shape:
+                raise ValueError(
+                    f"trellis3_t256 {name} must have shape {shape}, got {tuple(scale.shape)}"
+                )
+            if not scale.is_contiguous():
+                raise ValueError(f"trellis3_t256 {name} must be contiguous")
+
+    if tile_config is not None:
+        tile_config = tuple(int(value) for value in tile_config)
+        if len(tile_config) != 4 or any(
+            value <= 0 or value % 16 != 0 for value in tile_config
+        ):
+            raise ValueError(
+                "trellis3_t256 tile_config must contain four positive multiples of 16"
+            )
+        fc1_tile_k, configured_fc1_n, fc2_tile_k, configured_fc2_n = tile_config
+        if configured_fc1_n != fc1_tile_n or configured_fc2_n != fc2_tile_n:
+            raise ValueError(
+                "trellis3_t256 tile_config N dimensions disagree with preparation: "
+                f"tile_config={tile_config}, fc1_tile_n={fc1_tile_n}, "
+                f"fc2_tile_n={fc2_tile_n}"
+            )
+        if hidden_size % fc1_tile_k != 0 or intermediate_size % fc2_tile_k != 0:
+            raise ValueError(
+                "trellis3_t256 tile_config K dimensions must divide the model geometry"
+            )
+
+    if dummy_scale is None:
+        dummy_scale = torch.zeros(4, dtype=torch.uint8, device=resolved_device)
+    else:
+        if dummy_scale.device != resolved_device:
+            raise ValueError(
+                "trellis3_t256 dummy_scale must share the weight device, got "
+                f"{dummy_scale.device} and {resolved_device}"
+            )
+        if dummy_scale.dtype != torch.uint8:
+            raise TypeError(
+                f"trellis3_t256 dummy_scale must be torch.uint8, got {dummy_scale.dtype}"
+            )
+        if not dummy_scale.is_contiguous() or tuple(dummy_scale.shape) != (4,):
+            raise ValueError(
+                "trellis3_t256 dummy_scale must be a contiguous four-byte "
+                f"tensor with shape (4,), got {tuple(dummy_scale.shape)}"
+            )
+        if int(dummy_scale.data_ptr()) % 16 != 0:
+            raise ValueError(
+                "trellis3_t256 dummy_scale must be at least 16-byte aligned"
+            )
+
+    global_scale = torch.ones(
+        (num_experts,), dtype=torch.float32, device=resolved_device
+    )
+    if workspace is None:
+        workspace = _make_workspace(resolved_device, max_blocks_per_sm=4)
+    elif workspace.device != resolved_device or workspace.dtype != torch.int32:
+        raise ValueError("trellis3_t256 workspace must be int32 on the weight device")
+    return PreparedW4A16MoeWeights(
+        w13=packed_w13,
+        w13_scale=dummy_scale,
+        w13_global_scale=global_scale,
+        w2=packed_w2,
+        w2_scale=dummy_scale,
+        w2_global_scale=global_scale,
+        workspace=workspace,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=is_gated,
+        params_dtype=params_dtype,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_n=fc2_tile_n,
+        source_format="trellis3_t256",
+        w13_layout=w13_layout,
+        weight_layout="trellis3_t256",
+        scale_format="e4m3_k32",
+        trellis_codebook=normalized_codebook,
+        trellis_bits=resolved_trellis_bits,
+        gate_suh=gate_suh,
+        up_suh=up_suh,
+        intermediate_rotations=intermediate_rotations,
+        down_svh=down_svh,
+        tile_config=tile_config,
+    )
+
+
+def _trellis256_marker_codebook(
+    *,
+    mcg: torch.Tensor | None,
+    mul1: torch.Tensor | None,
+    codebook: str | int | None,
+) -> str:
+    if mcg is not None and mul1 is not None:
+        raise ValueError("trellis256 accepts exactly one of mcg or mul1, not both")
+    marker_codebook: str | None = None
+    marker = mcg if mcg is not None else mul1
+    if marker is not None:
+        name = "mcg" if mcg is not None else "mul1"
+        if marker.numel() != 1 or marker.dtype not in (torch.int32, torch.uint32):
+            raise ValueError(
+                f"trellis256 {name} marker must be a scalar int32/uint32 tensor"
+            )
+        marker_value = int(marker.item()) & 0xFFFFFFFF
+        marker_codebook = _normalize_trellis256_codebook(marker_value)
+        if marker_codebook != name:
+            raise ValueError(
+                f"trellis256 {name} marker has unexpected value {marker_value:#010x}"
+            )
+    explicit = None if codebook is None else _normalize_trellis256_codebook(codebook)
+    if (
+        marker_codebook is not None
+        and explicit is not None
+        and marker_codebook != explicit
+    ):
+        raise ValueError(
+            "trellis256 codebook metadata disagrees: "
+            f"marker={marker_codebook!r}, codebook={explicit!r}"
+        )
+    normalized = marker_codebook or explicit
+    if normalized is None:
+        raise ValueError(
+            "trellis256 dense preparation requires mcg=, mul1=, or explicit codebook="
+        )
+    return normalized
+
+
+def prepare_trellis256_dense_weight(
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    *,
+    mcg: torch.Tensor | None = None,
+    mul1: torch.Tensor | None = None,
+    codebook: str | int | None = None,
+    params_dtype: torch.dtype = torch.float16,
+    dummy_scale: torch.Tensor | None = None,
+) -> PreparedTrellis256DenseWeight:
+    """Prepare one native EXL3 linear for the dense trellis256 entry point.
+
+    The native payload is ``[K/16,N/16,16*bits]i16`` (or the byte-identical
+    ``[...,8*bits]i32`` view), optionally with a leading singleton expert axis.
+    The bitrate is inferred from that final dimension. No trellis or rotation
+    bytes are copied, permuted, stacked, or concatenated.
+    """
+    if params_dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError("trellis3_t256 dense compute requires fp16 or bf16 MMA inputs")
+    if trellis.ndim not in (3, 4):
+        raise ValueError(
+            "trellis3_t256 dense payload must have rank 3 or a leading E=1 axis"
+        )
+    if trellis.ndim == 4:
+        if int(trellis.shape[0]) != 1:
+            raise ValueError(
+                f"trellis3_t256 dense payload requires E=1, got {int(trellis.shape[0])}"
+            )
+        k16, n16 = int(trellis.shape[1]), int(trellis.shape[2])
+    else:
+        k16, n16 = int(trellis.shape[0]), int(trellis.shape[1])
+    trellis_bits = _trellis256_bits_from_native_tensor(trellis, name="dense trellis")
+    in_features = k16 * 16
+    out_features = n16 * 16
+    if in_features <= 0 or out_features <= 0:
+        raise ValueError(
+            f"trellis3_t256 dense dimensions must be positive, got {in_features}x{out_features}"
+        )
+    if in_features % 128 != 0 or out_features % 128 != 0:
+        raise ValueError(
+            "trellis3_t256 dense rotations require K and N divisible by 128; "
+            f"got K={in_features} N={out_features}"
+        )
+    expected_prefix_shape = (1, k16, n16) if trellis.ndim == 4 else (k16, n16)
+    device = trellis.device
+    if device.type != "cuda":
+        raise ValueError(
+            f"trellis3_t256 dense weights require CUDA storage, got {device}"
+        )
+    packed = _trellis256_flat_native_view(
+        trellis,
+        name="dense trellis",
+        expected_prefix_shape=expected_prefix_shape,
+        trellis_bits=trellis_bits,
+        device=device,
+    )
+    for name, scale, width in (
+        ("suh", suh, in_features),
+        ("svh", svh, out_features),
+    ):
+        if scale.device != device:
+            raise ValueError(f"trellis3_t256 dense {name} must be on {device}")
+        if scale.dtype != torch.float16:
+            raise TypeError(
+                f"trellis3_t256 dense {name} must be torch.float16, got {scale.dtype}"
+            )
+        if tuple(scale.shape) != (width,):
+            raise ValueError(
+                f"trellis3_t256 dense {name} must have shape {(width,)}, "
+                f"got {tuple(scale.shape)}"
+            )
+        if not scale.is_contiguous():
+            raise ValueError(f"trellis3_t256 dense {name} must be contiguous")
+    normalized_codebook = _trellis256_marker_codebook(
+        mcg=mcg, mul1=mul1, codebook=codebook
+    )
+    if dummy_scale is None:
+        dummy_scale = torch.zeros(4, dtype=torch.uint8, device=device)
+    else:
+        if (
+            dummy_scale.device != device
+            or dummy_scale.dtype != torch.uint8
+            or tuple(dummy_scale.shape) != (4,)
+            or not dummy_scale.is_contiguous()
+            or int(dummy_scale.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                "trellis3_t256 dense dummy_scale must be a contiguous, 16-byte-"
+                "aligned four-byte uint8 tensor on the weight device"
+            )
+    return PreparedTrellis256DenseWeight(
+        trellis=packed,
+        suh=suh,
+        svh=svh,
+        scale=dummy_scale,
+        global_scale=torch.ones(1, dtype=torch.float32, device=device),
+        workspace=_make_workspace(device, max_blocks_per_sm=4),
+        in_features=in_features,
+        out_features=out_features,
+        params_dtype=params_dtype,
+        trellis_bits=trellis_bits,
+        trellis_codebook=normalized_codebook,
+        mcg=mcg,
+        mul1=mul1,
     )
 
 
@@ -1544,11 +2236,15 @@ def _nf3_pack_selftest() -> None:
 
 __all__ = [
     "PreparedNF3MoeWeights",
+    "PreparedW4A16MoeWeights",
+    "PreparedTrellis256DenseWeight",
     "W4A16PackedBuffers",
     "W4A16ModelOptWeights",
     "W4A16PackedWeights",
     "make_w4a16_packed_buffers",
     "prepare_nf3_moe_weights",
+    "prepare_trellis256_moe_weights",
+    "prepare_trellis256_dense_weight",
     "prepare_w4a16_compressed_tensors_weights",
     "prepare_w4a16_e8m0_native_weights",
     "prepare_w4a16_fp4_e8m0_k32_weights",

--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
@@ -302,6 +302,7 @@ def pack_topk_routes_by_expert(
     block_expert_ids: torch.Tensor | None = None,
     packed_route_count: torch.Tensor | None = None,
     expert_offsets: torch.Tensor | None = None,
+    expert_counts: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     numel = int(topk_ids.numel())
     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
@@ -406,7 +407,35 @@ def pack_topk_routes_by_expert(
                 triton.cdiv(max_route_blocks, _POST_PREFIX_BLOCK_T),
             ),
         )
-        if not torch.cuda.is_current_stream_capturing():
+        if expert_counts is not None:
+            expert_counts = _workspace_slice(
+                expert_counts,
+                name="expert_counts",
+                elements=int(num_experts),
+                dtype=torch.int32,
+                device=topk_ids.device,
+            )
+            expert_counts.zero_()
+            _w4a16_route_count_kernel[(triton.cdiv(numel, _FAST_COUNT_BLOCK_T),)](
+                topk_ids,
+                expert_map_tensor,
+                expert_counts,
+                numel,
+                NUM_EXPERTS=int(num_experts),
+                HAS_EXPERT_MAP=expert_map is not None,
+                BLOCK_T=_FAST_COUNT_BLOCK_T,
+                num_warps=4,
+            )
+            _w4a16_route_prefix_from_counts_kernel[(1,)](
+                expert_counts,
+                packed_route_count,
+                expert_offsets,
+                BLOCK_SIZE=int(block_size),
+                NUM_EXPERTS=int(num_experts),
+                BLOCK_E=block_e,
+                num_warps=4,
+            )
+        elif not torch.cuda.is_current_stream_capturing():
             # FAST (eager prefill): parallel atomic count + tiny over-experts
             # block-padded prefix, replacing the single-CTA count+prefix
             # (~7-31x measured at prefill). Only the large path (routes > 4096,

--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
@@ -330,6 +330,29 @@ def pack_topk_routes_by_expert(
     max_packed_routes = max(max_packed_routes, 1)
     max_route_blocks = max(max_route_blocks, 1)
 
+    provided_routes = (
+        None if packed_route_indices is None else int(packed_route_indices.numel())
+    )
+    provided_blocks = (
+        None if block_expert_ids is None else int(block_expert_ids.numel())
+    )
+    if (
+        provided_routes is not None
+        and provided_blocks is not None
+        and (
+            provided_routes < max_packed_routes
+            or provided_blocks < max_route_blocks
+        )
+    ):
+        raise ValueError(
+            "W4A16 route-packing workspace is too small: "
+            f"topk_shape={tuple(topk_ids.shape)}, live_routes={numel}, "
+            f"capacity_routes={numel_capacity}, block_size={int(block_size)}, "
+            f"num_experts={int(num_experts)}, "
+            f"packed_route_indices={provided_routes}/{max_packed_routes}, "
+            f"block_expert_ids={provided_blocks}/{max_route_blocks}"
+        )
+
     packed_route_indices = _workspace_slice(
         packed_route_indices,
         name="packed_route_indices",

--- a/sparkinfer/moe/fused_moe/__init__.py
+++ b/sparkinfer/moe/fused_moe/__init__.py
@@ -65,7 +65,7 @@ META = OpMeta(
         "is_supported",
         "clear_caches",
     ),
-    dtypes=("bf16",),
+    dtypes=("bf16", "fp16"),
     recipes=(
         "nvfp4",
         "mxfp4",

--- a/sparkinfer/moe/fused_moe/__init__.py
+++ b/sparkinfer/moe/fused_moe/__init__.py
@@ -2,8 +2,9 @@
 scatter, in one launch family.
 
 Recipes (``META.recipes``) are arguments, not separate ops: nvfp4, mxfp4,
-w4a8_mx, w4a8_nvfp4, w4a16 (weight layouts packed/modelopt/nf3_2p1).  Activations:
-silu, situ, relu2, swigluoai_uninterleave.  Kernel
+w4a8_mx, w4a8_nvfp4, w4a16 (weight layouts packed/modelopt/nf3_2p1 and the
+``exl3_trellis_mcg`` full-rotation source). Activations: silu, situ, relu2,
+swigluoai_uninterleave. Kernel
 regimes (micro / dynamic / tiny-decode / w4a16) are selected declaratively by
 ``plan_execution``.
 
@@ -65,7 +66,14 @@ META = OpMeta(
         "clear_caches",
     ),
     dtypes=("bf16",),
-    recipes=("nvfp4", "mxfp4", "w4a8_mx", "w4a8_nvfp4", "w4a16"),
+    recipes=(
+        "nvfp4",
+        "mxfp4",
+        "w4a8_mx",
+        "w4a8_nvfp4",
+        "w4a16",
+        "w4a16/exl3_trellis_mcg",
+    ),
     requires=("triton",),
     provenance=Provenance(
         repo="https://github.com/lukealonso/sparkinfer",

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -1026,6 +1026,10 @@ class TPMoEFP4Binding:
     rotation_a_gate: torch.Tensor | None = None
     rotation_a_up: torch.Tensor | None = None
     kernel_workspace: torch.Tensor | None = None
+    # Preserve the route geometry selected by the caller-owned scratch plan.
+    # Re-running the live-batch heuristic here can select a smaller block than
+    # the arena was sized for (for example, planned 64 versus live 48).
+    route_block_size_m: int | None = None
     route_expert_map: torch.Tensor | None = None
     output_expert_map: torch.Tensor | None = None
     fused_launch: object | None = None
@@ -2378,6 +2382,7 @@ def _build_tp_moe_fp4_binding_from_views(
             rotation_a_gate=tensors.get("rotation_a_gate"),
             rotation_a_up=tensors.get("rotation_a_up"),
             kernel_workspace=tensors.get("kernel_workspace"),
+            route_block_size_m=plan.route_block_size_m,
             route_expert_map=route_expert_map,
             output_expert_map=output_expert_map,
         )
@@ -6963,6 +6968,7 @@ def build_tp_moe_fp4_binding(
             rotation_a_gate=workspace.rotation_a_gate,
             rotation_a_up=workspace.rotation_a_up,
             kernel_workspace=workspace.kernel_workspace,
+            route_block_size_m=workspace.route_block_size_m,
             fused_launch=fused_launch,
             topk_sum_launch=topk_sum_launch,
         )
@@ -9780,6 +9786,7 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
             swiglu_beta=swiglu_beta,
             fused_launch=fused_launch,
             topk_sum_launch=topk_sum_launch,
+            route_block_size_m=binding.route_block_size_m,
             intermediate_rotation_scales=(
                 prepared.intermediate_rotations if full_rotation else None
             ),

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -859,6 +859,11 @@ class TPMoEScratchPlan:
     _core_workspace_plan: _TPCoreWorkspacePlan
     _scratch_specs: tuple[ScratchBufferSpec, ...]
 
+    @property
+    def full_rotation(self) -> bool:
+        """Whether this plan owns the EXL3 full-rotation execution path."""
+        return self._core_workspace_plan.full_rotation
+
     def scratch_specs(self) -> tuple[ScratchBufferSpec, ...]:
         return self._scratch_specs
 
@@ -2278,6 +2283,12 @@ def _build_tp_moe_fp4_binding_from_views(
         raise ValueError(
             f"scratch plan routed-row capacity {plan.routed_rows} cannot bind "
             f"{m * num_topk} routed rows"
+        )
+    if not plan.full_rotation and (
+        route_expert_map is not None or output_expert_map is not None
+    ):
+        raise ValueError(
+            "route_expert_map/output_expert_map require a full-rotation Trellis plan"
         )
     if plan.full_rotation:
         if topk_weights.dtype != torch.float32:
@@ -4842,16 +4853,20 @@ def prepare_sparkinfer_fp4_moe_weights(
     if plan.source_format == "exl3_trellis_mcg":
         if plan.quant_modes != frozenset({"w4a16"}):
             raise ValueError("EXL3 Trellis weights support only quant_mode='w4a16'")
-        if trellis_mcg is not None:
-            marker = (
-                int(trellis_mcg.item())
-                if isinstance(trellis_mcg, torch.Tensor)
-                else int(trellis_mcg)
-            ) & 0xFFFFFFFF
-            if marker != 0xCBAC1FED:
-                raise ValueError(
-                    f"unexpected EXL3 MCG marker {marker:#010x}; expected 0xcbac1fed"
-                )
+        if trellis_mcg is None:
+            raise ValueError(
+                "EXL3 Trellis preparation requires the checkpoint's trellis_mcg "
+                "marker; the runtime decoder is MCG-only and must fail closed"
+            )
+        marker = (
+            int(trellis_mcg.item())
+            if isinstance(trellis_mcg, torch.Tensor)
+            else int(trellis_mcg)
+        ) & 0xFFFFFFFF
+        if marker != 0xCBAC1FED:
+            raise ValueError(
+                f"unexpected EXL3 MCG marker {marker:#010x}; expected 0xcbac1fed"
+            )
         if not all(
             value is not None
             for value in (gate_suh, up_suh, intermediate_rotations, down_svh)
@@ -6235,6 +6250,7 @@ def _prewarm_w4a16_planned_launches(
     )
     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
         _DEFAULT_MAX_SHARED_MEM,
+        _rot_scales_dummy,
         _TC_DECODE_MAX_M,
         compile_w4a16_fused_moe,
         compile_w4a16_topk_sum,
@@ -6250,6 +6266,7 @@ def _prewarm_w4a16_planned_launches(
     t0 = time.perf_counter() if _SPARKINFER_TIMING else 0.0
     with torch.cuda.device(workspace.device):
         is_capturing = torch.cuda.is_current_stream_capturing()
+        _rot_scales_dummy(workspace.device)
         props = torch.cuda.get_device_properties(workspace.device)
         sms = int(props.multi_processor_count)
         max_shared_mem = int(

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, Tuple
 
 import cuda.bindings.driver as cuda
@@ -129,9 +129,13 @@ _FP4_SOURCE_FORMATS = {
     # Packed MX-FP6 E2M3 codes with UE8M0 K/32 grids; exclusive to the
     # w6a8_mx recipe (see _validate_fp4_source_format_for_quant_mode).
     "mxfp6_e2m3": "mxfp6_e2m3",
+    # Native EXL3 Trellis tiles using the MCG codebook. They are consumed
+    # zero-copy by the full-rotation W4A16 recipe.
+    "exl3_trellis_mcg": "exl3_trellis_mcg",
 }
 _W4A16_SCALE_FORMATS = {
     "e4m3_k16": "e4m3_k16",
+    "e4m3_k32": "e4m3_k32",
     "e8m0_k32": "e8m0_k32",
 }
 _W13_LAYOUTS = {
@@ -141,6 +145,7 @@ _W13_LAYOUTS = {
     # in-place W13 row rotation ("w13"), "gate_up" is already kernel-native.
     "up_gate": "w13",
     "gate_up": "w31",
+    "trellis3_t256_proj": "trellis3_t256_proj",
 }
 
 _DEVICE_CAPABILITY_CACHE: dict[int, tuple[int, int]] = {}
@@ -242,6 +247,7 @@ class TPW4A16Workspace:
     activation: str
     state_E: int
     weight_E: int
+    route_E: int
     max_rows: int
     k: int
     n: int
@@ -257,6 +263,15 @@ class TPW4A16Workspace:
     block_expert_ids: torch.Tensor
     packed_route_count: torch.Tensor
     expert_offsets: torch.Tensor
+    expert_counts: torch.Tensor | None = None
+    full_rotation_output: torch.Tensor | None = None
+    rotation_a_gate: torch.Tensor | None = None
+    rotation_a_up: torch.Tensor | None = None
+    kernel_workspace: torch.Tensor | None = None
+    full_rotation: bool = False
+    trellis_bits: int = 3
+    trellis_tile_config: tuple[int, int, int, int] | None = None
+    route_block_size_m: int | None = None
     planned_token_counts: frozenset[int] = field(default_factory=frozenset)
     planned_apply_router_weight_on_input: bool = False
     planned_swiglu_limit: float | None = None
@@ -265,7 +280,7 @@ class TPW4A16Workspace:
     planned_scale_format: str = "e4m3_k16"
     planned_collect_activation_amax: bool = False
     planned_fused_moe_launches: dict[object, object] = field(default_factory=dict)
-    planned_topk_sum_launches: dict[int, object] = field(default_factory=dict)
+    planned_topk_sum_launches: dict[object, object] = field(default_factory=dict)
     # TC-decode fused-sum launches, keyed by exact token count (only the small-M
     # decode sizes in TC-decode's supported set, packed layout only).
     planned_tc_decode_launches: dict[int, object] = field(default_factory=dict)
@@ -657,6 +672,7 @@ class _TPCoreWorkspacePlan:
     swiglu_beta: float = 0.0
     state_E: int
     weight_E: int
+    route_E: int
     routed_rows: int
     max_rows: int
     k: int
@@ -667,6 +683,10 @@ class _TPCoreWorkspacePlan:
     deterministic_output: bool = False
     dynamic_physical_tiles: int | None = None
     dynamic_task_capacity: int | None = None
+    full_rotation: bool = False
+    trellis_bits: int = 3
+    trellis_tile_config: tuple[int, int, int, int] | None = None
+    route_block_size_m: int | None = None
     tensor_specs: Tuple[_TensorAllocSpec, ...] = ()
 
 
@@ -731,6 +751,8 @@ class TPMoEScratchCaps:
     swiglu_beta: float | None = None
     collect_activation_amax: bool = False
     deterministic_output: bool | None = None
+    w4a16_block_size_m: int | None = None
+    w4a16_fast_math: bool = True
     frozen: bool = True
 
     def __post_init__(self) -> None:
@@ -776,6 +798,12 @@ class TPMoEScratchCaps:
             object.__setattr__(
                 self, "deterministic_output", bool(self.deterministic_output)
             )
+        if self.w4a16_block_size_m is not None:
+            block_size_m = int(self.w4a16_block_size_m)
+            if block_size_m not in (8, 16, 32, 48, 64):
+                raise ValueError("w4a16_block_size_m must be one of 8, 16, 32, 48, 64")
+            object.__setattr__(self, "w4a16_block_size_m", block_size_m)
+        object.__setattr__(self, "w4a16_fast_math", bool(self.w4a16_fast_math))
         object.__setattr__(self, "frozen", bool(self.frozen))
 
     @property
@@ -851,6 +879,8 @@ class TPMoEScratchPlan:
         unit_scale_contract: bool = False,
         activation_amax: torch.Tensor | None = None,
         layer_idx: int | None = None,
+        route_expert_map: torch.Tensor | None = None,
+        output_expert_map: torch.Tensor | None = None,
     ) -> "TPMoEFP4Binding":
         if not isinstance(experts, SPARKINFERFP4ExpertWeights):
             raise TypeError("experts must come from prepare_sparkinfer_fp4_moe_weights")
@@ -889,6 +919,8 @@ class TPMoEScratchPlan:
             capacity_nbytes=self.layout.core_workspace_nbytes,
             do_init=False,
         )
+        if fast_math is None and self.caps.quant_mode == "w4a16":
+            fast_math = self.caps.w4a16_fast_math
         return _build_tp_moe_fp4_binding_from_views(
             plan=self._core_workspace_plan,
             tensors=tensors,
@@ -907,6 +939,8 @@ class TPMoEScratchPlan:
             swiglu_beta=self.caps.swiglu_beta,
             activation_amax=activation_amax,
             layer_idx=layer_idx,
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
         )
 
 
@@ -983,6 +1017,12 @@ class TPMoEFP4Binding:
     block_expert_ids: torch.Tensor | None = None
     packed_route_count: torch.Tensor | None = None
     expert_offsets: torch.Tensor | None = None
+    expert_counts: torch.Tensor | None = None
+    rotation_a_gate: torch.Tensor | None = None
+    rotation_a_up: torch.Tensor | None = None
+    kernel_workspace: torch.Tensor | None = None
+    route_expert_map: torch.Tensor | None = None
+    output_expert_map: torch.Tensor | None = None
     fused_launch: object | None = None
     topk_sum_launch: object | None = None
 
@@ -1254,7 +1294,8 @@ def _normalize_fp4_source_format(source_format: str) -> str:
     except KeyError as exc:
         raise ValueError(
             "source_format must be one of 'modelopt_nvfp4', "
-            "'fp4_e8m0_k32', 'compressed_tensors', or 'mxfp6_e2m3', "
+            "'fp4_e8m0_k32', 'compressed_tensors', 'mxfp6_e2m3', or "
+            "'exl3_trellis_mcg', "
             f"got {source_format!r}"
         ) from exc
 
@@ -1277,13 +1318,16 @@ def _normalize_w4a16_scale_format(scale_format: str) -> str:
         return _W4A16_SCALE_FORMATS[scale_format.lower()]
     except KeyError as exc:
         raise ValueError(
-            "scale_format must be one of 'e4m3_k16' or 'e8m0_k32', "
+            "scale_format must be one of 'e4m3_k16', 'e4m3_k32', or "
+            "'e8m0_k32', "
             f"got {scale_format!r}"
         ) from exc
 
 
 def _w4a16_scale_format_for_source(source_format: str) -> str:
     source_format = _normalize_fp4_source_format(source_format)
+    if source_format == "exl3_trellis_mcg":
+        return "e4m3_k32"
     return "e8m0_k32" if source_format == "fp4_e8m0_k32" else "e4m3_k16"
 
 
@@ -1298,11 +1342,11 @@ def _w4a16_weight_layout_for_source(source_format: str) -> str:
     decode kernel remain reachable for offline/benchmark use via the prepare API,
     just not auto-routed here.)
     """
-    _normalize_fp4_source_format(source_format)
-    return "packed"
+    source_format = _normalize_fp4_source_format(source_format)
+    return "trellis3_t256" if source_format == "exl3_trellis_mcg" else "packed"
 
 
-_W4A16_WEIGHT_LAYOUTS = {"packed", "modelopt"}
+_W4A16_WEIGHT_LAYOUTS = {"packed", "modelopt", "trellis3_t256"}
 
 
 def _normalize_w4a16_weight_layout(weight_layout: str) -> str:
@@ -1974,11 +2018,7 @@ def _dynamic_rows_padded_limit(k: int, *, quant_mode: str = "nvfp4") -> int:
     _qm = _normalize_quant_mode(quant_mode)
     input_cols = (
         k
-        if (
-            _qm == "w4a16"
-            or _is_w4a8_quant_mode(_qm)
-            or _qm in _W6A8_QUANT_MODES
-        )
+        if (_qm == "w4a16" or _is_w4a8_quant_mode(_qm) or _qm in _W6A8_QUANT_MODES)
         else k // 2
     )
     rows_padded_limit = min(
@@ -2143,6 +2183,8 @@ def _build_tp_moe_fp4_binding_from_views(
     swiglu_beta: float | None = None,
     activation_amax: torch.Tensor | None = None,
     layer_idx: int | None = None,
+    route_expert_map: torch.Tensor | None = None,
+    output_expert_map: torch.Tensor | None = None,
 ) -> TPMoEFP4Binding:
     if not isinstance(experts, SPARKINFERFP4ExpertWeights):
         raise TypeError("experts must come from prepare_sparkinfer_fp4_moe_weights")
@@ -2237,6 +2279,50 @@ def _build_tp_moe_fp4_binding_from_views(
             f"scratch plan routed-row capacity {plan.routed_rows} cannot bind "
             f"{m * num_topk} routed rows"
         )
+    if plan.full_rotation:
+        if topk_weights.dtype != torch.float32:
+            raise TypeError("full-rotation Trellis topk_weights must be float32")
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError("full-rotation Trellis topk_ids must be int32 or int64")
+        for name, expert_map in (
+            ("route_expert_map", route_expert_map),
+            ("output_expert_map", output_expert_map),
+        ):
+            if expert_map is None:
+                continue
+            if (
+                expert_map.dtype != torch.int32
+                or expert_map.device != a.device
+                or tuple(expert_map.shape) != (plan.route_E,)
+                or not expert_map.is_contiguous()
+            ):
+                raise ValueError(
+                    f"{name} must be contiguous int32[{plan.route_E}] on {a.device}"
+                )
+        if output is None:
+            output = tensors["full_rotation_output"][:m]
+        elif (
+            output.dtype != torch.float32
+            or output.device != a.device
+            or output.ndim != 2
+            or tuple(output.shape)
+            not in {
+                (m, k),
+                tuple(tensors["full_rotation_output"].shape),
+            }
+            or not output.is_contiguous()
+        ):
+            raise ValueError(
+                "full-rotation Trellis output must be a contiguous FP32 live "
+                "or capacity buffer on the input device"
+            )
+        output = output[:m]
+        # The persistent fused kernel uses this scratch for grid-barrier state.
+        # Unlike the ordinary W4A16 prepared object, this arena is caller-owned
+        # and may contain arbitrary bytes on its first bind. Record one zero-fill
+        # in the same stream as the launch; when bind occurs during CUDA graph
+        # capture the initialization is replayed with the graph as required.
+        tensors["kernel_workspace"].zero_()
 
     common_kwargs = dict(
         a=a,
@@ -2277,6 +2363,12 @@ def _build_tp_moe_fp4_binding_from_views(
             block_expert_ids=tensors["block_expert_ids"],
             packed_route_count=tensors["packed_route_count"],
             expert_offsets=tensors["expert_offsets"],
+            expert_counts=tensors.get("expert_counts"),
+            rotation_a_gate=tensors.get("rotation_a_gate"),
+            rotation_a_up=tensors.get("rotation_a_up"),
+            kernel_workspace=tensors.get("kernel_workspace"),
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
         )
 
     if plan.implementation == "micro":
@@ -2388,6 +2480,10 @@ def _plan_core_workspace(
     w13_layout: str = "w13",
     w4a16_weight_layout: str | None = None,
     w4a16_scale_format: str | None = None,
+    route_num_experts: int | None = None,
+    w4a16_block_size_m: int | None = None,
+    trellis_bits: int = 3,
+    trellis_tile_config: tuple[int, int, int, int] | None = None,
     apply_router_weight_on_input: bool = False,
     deterministic_output: bool = False,
     swiglu_limit: float | None = None,
@@ -2425,6 +2521,21 @@ def _plan_core_workspace(
             if w4a16_weight_layout is not None
             else _w4a16_weight_layout_for_source(source_format)
         )
+        route_E = int(route_num_experts or weight_E)
+        full_rotation = weight_layout == "trellis3_t256"
+        if full_rotation:
+            if source_format != "exl3_trellis_mcg":
+                raise ValueError(
+                    "trellis3_t256 workspace requires source_format='exl3_trellis_mcg'"
+                )
+            if int(k) % 128 != 0 or int(n) % 128 != 0:
+                raise ValueError(
+                    "full-rotation Trellis requires hidden and intermediate "
+                    "dimensions divisible by 128"
+                )
+            if int(trellis_bits) not in (3, 4, 5, 6):
+                raise ValueError("trellis_bits must be one of 3, 4, 5, 6")
+            trellis_tile_config = trellis_tile_config or (64, 256, 64, 256)
         routed_capacity = max(int(routed_rows), 1)
         fc1_cols = _activation_w1_rows(activation, int(n))
         route_slots_capacity = 1
@@ -2432,11 +2543,16 @@ def _plan_core_workspace(
         fc1_c_tmp_elements = 1
         fc2_c_tmp_elements = 1
         sms = max(1, int(get_num_sm(device)))
-        for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+        block_sizes = (
+            (int(w4a16_block_size_m),)
+            if w4a16_block_size_m is not None
+            else _W4A16_ALLOWED_ROUTED_SIZES
+        )
+        for block_size in block_sizes:
             route_slots = max_packed_route_slots(
                 routed_capacity,
                 int(block_size),
-                int(weight_E),
+                route_E,
             )
             route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
             route_slots_capacity = max(route_slots_capacity, route_slots)
@@ -2461,22 +2577,26 @@ def _plan_core_workspace(
             )
         intermediate_cache2_elements = routed_capacity * int(n)
         direct_m = routed_capacity // max(int(num_topk), 1)
-        if routed_capacity == direct_m * int(num_topk) and _small_m_direct_supported(
-            m=direct_m,
-            hidden_size=int(k),
-            intermediate_size=int(n),
-            num_experts=int(weight_E),
-            topk=int(num_topk),
-            activation=activation,
-            apply_router_weight_on_input=bool(apply_router_weight_on_input),
-            swiglu_limit=swiglu_limit,
-            swiglu_alpha=swiglu_alpha,
-            swiglu_beta=swiglu_beta,
-            element_dtype=_w4a16_element_dtype(dtype),
-            weight_layout=weight_layout,
-            w13_layout=w13_layout,
-            scale_format=scale_format,
-            expert_map=None,
+        if (
+            not full_rotation
+            and routed_capacity == direct_m * int(num_topk)
+            and _small_m_direct_supported(
+                m=direct_m,
+                hidden_size=int(k),
+                intermediate_size=int(n),
+                num_experts=route_E,
+                topk=int(num_topk),
+                activation=activation,
+                apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                element_dtype=_w4a16_element_dtype(dtype),
+                weight_layout=weight_layout,
+                w13_layout=w13_layout,
+                scale_format=scale_format,
+                expert_map=None,
+            )
         ):
             fc2_n_chunks = ((int(n) // 2) + 127) // 128
             direct_cache2_u32 = direct_m * fc2_n_chunks * 128 * int(num_topk)
@@ -2485,6 +2605,50 @@ def _plan_core_workspace(
                 intermediate_cache2_elements,
                 align_up(direct_cache2_nbytes, _dtype_nbytes(dtype))
                 // _dtype_nbytes(dtype),
+            )
+        cache_dtype = torch.float16 if full_rotation else dtype
+        tensor_specs = [
+            _TensorAllocSpec(
+                "intermediate_cache13",
+                (routed_capacity * max(fc1_cols, int(k)),),
+                cache_dtype,
+            ),
+            _TensorAllocSpec(
+                "intermediate_cache2",
+                (intermediate_cache2_elements,),
+                cache_dtype,
+            ),
+            _TensorAllocSpec("fc1_c_tmp", (fc1_c_tmp_elements,), torch.float32),
+            _TensorAllocSpec("fc2_c_tmp", (fc2_c_tmp_elements,), torch.float32),
+            _TensorAllocSpec(
+                "packed_route_indices", (route_slots_capacity,), torch.int32
+            ),
+            _TensorAllocSpec("block_expert_ids", (route_blocks_capacity,), torch.int32),
+            _TensorAllocSpec("packed_route_count", (1,), torch.int32),
+            _TensorAllocSpec("expert_offsets", (route_E + 1,), torch.int32),
+        ]
+        if full_rotation:
+            max_tokens = max(routed_capacity // max(int(num_topk), 1), 1)
+            tensor_specs.extend(
+                (
+                    _TensorAllocSpec("expert_counts", (route_E,), torch.int32),
+                    _TensorAllocSpec(
+                        "full_rotation_output",
+                        (max_tokens, int(k)),
+                        torch.float32,
+                    ),
+                    _TensorAllocSpec(
+                        "rotation_a_gate",
+                        (routed_capacity, int(k)),
+                        torch.float16,
+                    ),
+                    _TensorAllocSpec(
+                        "rotation_a_up",
+                        (routed_capacity, int(k)),
+                        torch.float16,
+                    ),
+                    _TensorAllocSpec("kernel_workspace", (sms * 4 + 2,), torch.int32),
+                )
             )
         return _TPCoreWorkspacePlan(
             implementation=implementation,
@@ -2495,6 +2659,7 @@ def _plan_core_workspace(
             swiglu_beta=swiglu_beta,
             state_E=state_E,
             weight_E=weight_E,
+            route_E=route_E,
             routed_rows=routed_capacity,
             max_rows=max(max_rows, routed_capacity),
             k=k,
@@ -2503,28 +2668,11 @@ def _plan_core_workspace(
             device=device,
             dtype=dtype,
             deterministic_output=False,
-            tensor_specs=(
-                _TensorAllocSpec(
-                    "intermediate_cache13",
-                    (routed_capacity * max(fc1_cols, int(k)),),
-                    dtype,
-                ),
-                _TensorAllocSpec(
-                    "intermediate_cache2",
-                    (intermediate_cache2_elements,),
-                    dtype,
-                ),
-                _TensorAllocSpec("fc1_c_tmp", (fc1_c_tmp_elements,), torch.float32),
-                _TensorAllocSpec("fc2_c_tmp", (fc2_c_tmp_elements,), torch.float32),
-                _TensorAllocSpec(
-                    "packed_route_indices", (route_slots_capacity,), torch.int32
-                ),
-                _TensorAllocSpec(
-                    "block_expert_ids", (route_blocks_capacity,), torch.int32
-                ),
-                _TensorAllocSpec("packed_route_count", (1,), torch.int32),
-                _TensorAllocSpec("expert_offsets", (int(weight_E) + 1,), torch.int32),
-            ),
+            full_rotation=full_rotation,
+            trellis_bits=int(trellis_bits),
+            trellis_tile_config=trellis_tile_config,
+            route_block_size_m=w4a16_block_size_m,
+            tensor_specs=tuple(tensor_specs),
         )
 
     activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
@@ -2581,6 +2729,7 @@ def _plan_core_workspace(
             swiglu_beta=swiglu_beta,
             state_E=state_E,
             weight_E=weight_E,
+            route_E=weight_E,
             routed_rows=routed_rows,
             max_rows=max_rows,
             k=k,
@@ -2707,6 +2856,7 @@ def _plan_core_workspace(
         swiglu_beta=swiglu_beta,
         state_E=state_E,
         weight_E=weight_E,
+        route_E=weight_E,
         routed_rows=routed_rows,
         max_rows=max_rows,
         k=k,
@@ -2918,6 +3068,7 @@ def _materialize_workspace_from_core_arena(
             planned_swiglu_beta=plan.swiglu_beta,
             state_E=plan.state_E,
             weight_E=plan.weight_E,
+            route_E=plan.route_E,
             max_rows=plan.max_rows,
             k=plan.k,
             n=plan.n,
@@ -2933,6 +3084,15 @@ def _materialize_workspace_from_core_arena(
             block_expert_ids=tensors["block_expert_ids"],
             packed_route_count=tensors["packed_route_count"],
             expert_offsets=tensors["expert_offsets"],
+            expert_counts=tensors.get("expert_counts"),
+            full_rotation_output=tensors.get("full_rotation_output"),
+            rotation_a_gate=tensors.get("rotation_a_gate"),
+            rotation_a_up=tensors.get("rotation_a_up"),
+            kernel_workspace=tensors.get("kernel_workspace"),
+            full_rotation=plan.full_rotation,
+            trellis_bits=plan.trellis_bits,
+            trellis_tile_config=plan.trellis_tile_config,
+            route_block_size_m=plan.route_block_size_m,
             volatile_launch_state=bool(volatile_launch_state),
         )
     if a1_gscale is None or a2_gscale is None:
@@ -4616,6 +4776,8 @@ def plan_sparkinfer_fp4_moe_weights(
     intermediate_size: int,
     w13_layout: str = "w13",
     w4a16_layout: PreparedWeightLayout | str | None = None,
+    trellis_bits: int | None = None,
+    trellis_tile_config: tuple[int, int, int, int] | None = None,
 ) -> MoEWeightPreparationPlan:
     """Plan the one canonical weight allocation used by selected recipes."""
 
@@ -4641,21 +4803,29 @@ def plan_sparkinfer_fp4_moe_weights(
         hidden_size=hidden_size,
         intermediate_size=intermediate_size,
         w4a16_layout=w4a16_layout,
+        trellis_bits=trellis_bits,
+        trellis_tile_config=trellis_tile_config,
     )
 
 
 def prepare_sparkinfer_fp4_moe_weights(
     *,
     plan: MoEWeightPreparationPlan,
-    w1_global_scale: torch.Tensor,
-    w2_global_scale: torch.Tensor,
-    w1_fp4: torch.Tensor,
-    w1_blockscale: torch.Tensor,
-    w2_fp4: torch.Tensor,
-    w2_blockscale: torch.Tensor,
-    a1_gscale: torch.Tensor,
-    a2_gscale: torch.Tensor,
     params_dtype: torch.dtype,
+    w1_fp4: torch.Tensor | None = None,
+    w2_fp4: torch.Tensor | None = None,
+    w1_global_scale: torch.Tensor | None = None,
+    w2_global_scale: torch.Tensor | None = None,
+    w1_blockscale: torch.Tensor | None = None,
+    w2_blockscale: torch.Tensor | None = None,
+    a1_gscale: torch.Tensor | None = None,
+    a2_gscale: torch.Tensor | None = None,
+    gate_suh: torch.Tensor | None = None,
+    up_suh: torch.Tensor | None = None,
+    intermediate_rotations: torch.Tensor | None = None,
+    down_svh: torch.Tensor | None = None,
+    trellis_mcg: torch.Tensor | int | None = None,
+    dummy_scale: torch.Tensor | None = None,
 ) -> SPARKINFERFP4ExpertWeights:
     """Transfer source tensors into the planner-selected runtime owner."""
 
@@ -4666,6 +4836,119 @@ def prepare_sparkinfer_fp4_moe_weights(
         raise ValueError(
             f"params_dtype={actual_dtype!r} does not match plan dtype={plan.io_dtype!r}"
         )
+    if w1_fp4 is None or w2_fp4 is None:
+        raise ValueError("weight preparation requires both w1_fp4 and w2_fp4")
+
+    if plan.source_format == "exl3_trellis_mcg":
+        if plan.quant_modes != frozenset({"w4a16"}):
+            raise ValueError("EXL3 Trellis weights support only quant_mode='w4a16'")
+        if trellis_mcg is not None:
+            marker = (
+                int(trellis_mcg.item())
+                if isinstance(trellis_mcg, torch.Tensor)
+                else int(trellis_mcg)
+            ) & 0xFFFFFFFF
+            if marker != 0xCBAC1FED:
+                raise ValueError(
+                    f"unexpected EXL3 MCG marker {marker:#010x}; expected 0xcbac1fed"
+                )
+        if not all(
+            value is not None
+            for value in (gate_suh, up_suh, intermediate_rotations, down_svh)
+        ):
+            raise ValueError(
+                "EXL3 Trellis preparation requires gate_suh, up_suh, "
+                "intermediate_rotations, and down_svh"
+            )
+        assert gate_suh is not None and up_suh is not None
+        assert intermediate_rotations is not None and down_svh is not None
+        for name, tensor, shape in (
+            ("gate_suh", gate_suh, (plan.num_experts, plan.hidden_size)),
+            ("up_suh", up_suh, (plan.num_experts, plan.hidden_size)),
+            (
+                "intermediate_rotations",
+                intermediate_rotations,
+                (plan.num_experts, 3 * plan.intermediate_size),
+            ),
+            ("down_svh", down_svh, (plan.num_experts, plan.hidden_size)),
+        ):
+            if tensor.dtype != torch.float16:
+                raise TypeError(f"{name} must be torch.float16, got {tensor.dtype}")
+            if tuple(tensor.shape) != shape:
+                raise ValueError(
+                    f"{name} must have shape {shape}, got {tuple(tensor.shape)}"
+                )
+            if tensor.device != w1_fp4.device:
+                raise ValueError(
+                    f"{name} must be on {w1_fp4.device}, got {tensor.device}"
+                )
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+        from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+            prepare_trellis256_moe_weights,
+        )
+
+        tile_config = plan.trellis_tile_config or (64, 256, 64, 256)
+        value = prepare_trellis256_moe_weights(
+            w1_fp4,
+            w2_fp4,
+            hidden_size=plan.hidden_size,
+            intermediate_size=plan.intermediate_size,
+            num_experts=plan.num_experts,
+            activation=plan.activation,
+            params_dtype=torch.float16,
+            fc1_tile_n=tile_config[1],
+            fc2_tile_n=tile_config[3],
+            w13_layout="trellis3_t256_proj",
+            trellis_bits=plan.trellis_bits,
+            dummy_scale=dummy_scale,
+            codebook="mcg",
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate_rotations,
+            down_svh=down_svh,
+            tile_config=tile_config,
+            # The live kernel workspace is carved from the caller-owned MoE
+            # scratch arena at bind time. Keep only a zero-copy placeholder in
+            # the persistent prepared-weight object.
+            workspace=w1_fp4.view(torch.int32).reshape(-1)[:1],
+        )
+        representation = _PreparedWeightRepresentation(
+            quant_mode="w4a16",
+            layout=PreparedWeightLayout.TRELLIS_NATIVE,
+            value=value,
+        )
+        input_scale = torch.ones((), dtype=torch.float32, device=w1_fp4.device)
+        return SPARKINFERFP4ExpertWeights(
+            plan=plan,
+            a1_gscale=a1_gscale if a1_gscale is not None else input_scale,
+            w1_fp4=value.w13,
+            w1_blockscale=value.w13_scale,
+            w1_alphas=value.w13_global_scale,
+            a2_gscale=a2_gscale if a2_gscale is not None else input_scale,
+            w2_fp4=value.w2,
+            w2_blockscale=value.w2_scale,
+            w2_alphas=value.w2_global_scale,
+            representation=representation,
+        )
+
+    required_tensors = {
+        "w1_global_scale": w1_global_scale,
+        "w2_global_scale": w2_global_scale,
+        "w1_blockscale": w1_blockscale,
+        "w2_blockscale": w2_blockscale,
+        "a1_gscale": a1_gscale,
+        "a2_gscale": a2_gscale,
+    }
+    missing = sorted(name for name, value in required_tensors.items() if value is None)
+    if missing:
+        raise ValueError(
+            "non-Trellis weight preparation is missing: " + ", ".join(missing)
+        )
+    assert w1_global_scale is not None and w2_global_scale is not None
+    assert w1_blockscale is not None and w2_blockscale is not None
+    assert a1_gscale is not None and a2_gscale is not None
+
     if int(w1_fp4.shape[0]) != plan.num_experts:
         raise ValueError(
             f"w1 expert count {int(w1_fp4.shape[0])} does not match "
@@ -5437,7 +5720,13 @@ def _validate_frozen_w4a16_launch(
             f"scale_format={scale_format!r}, "
             f"collect_activation_amax={bool(collect_activation_amax)}"
         )
-    if planned_capacity not in workspace.planned_topk_sum_launches:
+    has_topk_sum = planned_capacity in workspace.planned_topk_sum_launches
+    if workspace.full_rotation:
+        has_topk_sum = any(
+            isinstance(key, tuple) and key[0] == planned_capacity
+            for key in workspace.planned_topk_sum_launches
+        )
+    if not has_topk_sum:
         raise RuntimeError(
             "frozen W4A16 MoE workspace is missing its preplanned top-k sum launch "
             f"for capacity={planned_capacity}"
@@ -5451,6 +5740,8 @@ def _w4a16_preplanned_launches(
     weight_layout: str,
     scale_format: str = "e4m3_k16",
     collect_activation_amax: bool = False,
+    route_ids_dtype: torch.dtype = torch.int32,
+    use_expert_map: bool = False,
 ) -> tuple[object | None, object | None]:
     token_count = int(token_count)
     scale_format = _normalize_w4a16_scale_format(scale_format)
@@ -5488,7 +5779,10 @@ def _w4a16_preplanned_launches(
     fused = workspace.planned_fused_moe_launches.get(
         (weight_layout, scale_format, planned_capacity, collect_activation_amax)
     )
-    topk_sum = workspace.planned_topk_sum_launches.get(planned_capacity)
+    topk_sum_key: object = planned_capacity
+    if workspace.full_rotation:
+        topk_sum_key = (planned_capacity, route_ids_dtype, bool(use_expert_map))
+    topk_sum = workspace.planned_topk_sum_launches.get(topk_sum_key)
     if fused is None or topk_sum is None:
         raise RuntimeError(
             "W4A16 MoE workspace is missing preplanned launches for "
@@ -5701,6 +5995,7 @@ def plan_tp_moe_arena_layout(
     swiglu_beta: float | None = None,
     collect_activation_amax: bool = False,
     deterministic_output: bool | None = None,
+    w4a16_block_size_m: int | None = None,
 ) -> TPMoEArenaLayout:
     """Compute the byte layout needed by one lane-owned MoE pool."""
     if not isinstance(weight_plan, MoEWeightPreparationPlan):
@@ -5785,6 +6080,10 @@ def plan_tp_moe_arena_layout(
             w13_layout=w13_layout,
             w4a16_weight_layout=w4a16_weight_layout,
             w4a16_scale_format=w4a16_scale_format,
+            route_num_experts=route_num_experts,
+            w4a16_block_size_m=w4a16_block_size_m,
+            trellis_bits=weight_plan.trellis_bits or 3,
+            trellis_tile_config=weight_plan.trellis_tile_config,
             apply_router_weight_on_input=apply_router_weight_on_input,
             deterministic_output=plan.deterministic_output,
             swiglu_limit=plan.swiglu_limit,
@@ -5832,6 +6131,7 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         swiglu_beta=caps.swiglu_beta,
         collect_activation_amax=caps.collect_activation_amax,
         deterministic_output=deterministic_output,
+        w4a16_block_size_m=caps.w4a16_block_size_m,
     )
     capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
     launch_plan = plan_tp_moe_execution(
@@ -5865,6 +6165,10 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         w13_layout=caps.w13_layout,
         w4a16_weight_layout=caps.w4a16_weight_layout,
         w4a16_scale_format=caps.w4a16_scale_format,
+        route_num_experts=caps.route_num_experts,
+        w4a16_block_size_m=caps.w4a16_block_size_m,
+        trellis_bits=caps.weight_plan.trellis_bits or 3,
+        trellis_tile_config=caps.weight_plan.trellis_tile_config,
         apply_router_weight_on_input=caps.apply_router_weight_on_input,
         deterministic_output=launch_plan.deterministic_output,
         swiglu_limit=launch_plan.swiglu_limit,
@@ -5918,7 +6222,11 @@ def _prewarm_w4a16_planned_launches(
         raise RuntimeError("W4A16 MoE launch planning requires a CUDA device")
     scale_format = _normalize_w4a16_scale_format(scale_format)
     weight_layout = _normalize_w4a16_weight_layout(weight_layout)
-    w13_layout = _normalize_w13_layout(w13_layout)
+    full_rotation = bool(workspace.full_rotation)
+    if full_rotation:
+        w13_layout = "trellis3_t256_proj"
+    else:
+        w13_layout = _normalize_w13_layout(w13_layout)
     collect_activation_amax = bool(collect_activation_amax)
 
     from sparkinfer.moe._shared.kernels.w4a16.host import (
@@ -5947,7 +6255,8 @@ def _prewarm_w4a16_planned_launches(
         max_shared_mem = int(
             getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
         )
-        element_dtype = _w4a16_element_dtype(workspace.dtype)
+        input_element_dtype = _w4a16_element_dtype(workspace.dtype)
+        element_dtype = "fp16" if full_rotation else input_element_dtype
         fused_launches: dict[object, object] = {}
         topk_sum_launches: dict[int, object] = {}
         tc_decode_launches: dict[int, object] = {}
@@ -5961,16 +6270,14 @@ def _prewarm_w4a16_planned_launches(
         )
         for token_count in token_counts:
             t_token = time.perf_counter() if _SPARKINFER_TIMING else 0.0
-            block_size_m = select_route_block_size_m(
-                token_count,
-                workspace.num_topk,
-                workspace.weight_E,
+            block_size_m = workspace.route_block_size_m or select_route_block_size_m(
+                token_count, workspace.num_topk, workspace.route_E
             )
             routed_rows = int(token_count) * int(workspace.num_topk)
             route_slots = max_packed_route_slots(
                 routed_rows,
                 block_size_m,
-                workspace.weight_E,
+                workspace.route_E,
             )
             max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
@@ -5997,14 +6304,36 @@ def _prewarm_w4a16_planned_launches(
                 scale_format=scale_format,
                 w13_layout=w13_layout,
                 collect_activation_amax=collect_activation_amax,
+                trellis_bits=workspace.trellis_bits,
+                force_tile_config=workspace.trellis_tile_config,
+                intermediate_rotation=full_rotation,
+                full_rotation=full_rotation,
+                rotation_input_dtype=input_element_dtype,
             )
             t_fused = time.perf_counter() if _SPARKINFER_TIMING else 0.0
-            topk_sum_launches[token_count] = compile_w4a16_topk_sum(
-                m=token_count,
-                topk=workspace.num_topk,
-                hidden_size=workspace.k,
-                element_dtype=element_dtype,
-            )
+            if full_rotation:
+                for ids_dtype in (torch.int32, torch.int64):
+                    for mapped in (False, True):
+                        topk_sum_launches[(token_count, ids_dtype, mapped)] = (
+                            compile_w4a16_topk_sum(
+                                m=token_count,
+                                topk=workspace.num_topk,
+                                hidden_size=workspace.k,
+                                element_dtype=element_dtype,
+                                full_rotation=True,
+                                num_experts=workspace.weight_E,
+                                route_num_experts=(workspace.route_E if mapped else 0),
+                                route_ids_dtype=ids_dtype,
+                                use_expert_map=mapped,
+                            )
+                        )
+            else:
+                topk_sum_launches[token_count] = compile_w4a16_topk_sum(
+                    m=token_count,
+                    topk=workspace.num_topk,
+                    hidden_size=workspace.k,
+                    element_dtype=element_dtype,
+                )
             t_sum = time.perf_counter() if _SPARKINFER_TIMING else 0.0
 
             # The real route-pack launch happens in run_w4a16_moe. During CUDA
@@ -6032,7 +6361,7 @@ def _prewarm_w4a16_planned_launches(
                 int(torch.cuda.current_device()),
                 int(token_count) * int(workspace.num_topk),
                 int(block_size_m),
-                int(workspace.weight_E),
+                int(workspace.route_E),
                 bool(False),
             )
             if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
@@ -6062,7 +6391,7 @@ def _prewarm_w4a16_planned_launches(
             pack_topk_routes_by_expert(
                 dummy_topk_ids,
                 block_size_m,
-                workspace.weight_E,
+                workspace.route_E,
                 packed_route_indices=workspace.packed_route_indices,
                 block_expert_ids=workspace.block_expert_ids,
                 packed_route_count=workspace.packed_route_count,
@@ -6210,6 +6539,10 @@ def materialize_tp_moe_arena_workspaces(
             w13_layout=w13_layout,
             w4a16_weight_layout=w4a16_weight_layout,
             w4a16_scale_format=w4a16_scale_format,
+            route_num_experts=caps.route_num_experts,
+            w4a16_block_size_m=caps.w4a16_block_size_m,
+            trellis_bits=weight_plan.trellis_bits or 3,
+            trellis_tile_config=weight_plan.trellis_tile_config,
             apply_router_weight_on_input=apply_router_weight_on_input,
             deterministic_output=plan.deterministic_output,
             swiglu_limit=plan.swiglu_limit,
@@ -6384,6 +6717,8 @@ def build_tp_moe_fp4_binding(
     swiglu_beta: float | None = None,
     activation_amax: torch.Tensor | None = None,
     layer_idx: int | None = None,
+    route_expert_map: torch.Tensor | None = None,
+    output_expert_map: torch.Tensor | None = None,
 ) -> TPMoEFP4Binding:
     workspace = scratch
     if not isinstance(experts, SPARKINFERFP4ExpertWeights):
@@ -6512,6 +6847,8 @@ def build_tp_moe_fp4_binding(
         swiglu_beta=swiglu_beta,
         activation_amax=activation_amax,
         layer_idx=layer_idx,
+        route_expert_map=route_expert_map,
+        output_expert_map=output_expert_map,
     )
     if isinstance(workspace, TPW4A16Workspace):
         if quant_mode != "w4a16":
@@ -6536,12 +6873,54 @@ def build_tp_moe_fp4_binding(
         elif quant_mode == "w4a16":
             weight_layout = _w4a16_weight_layout_for_source(source_format)
             scale_format = _w4a16_scale_format_for_source(source_format)
+        if workspace.full_rotation:
+            if workspace.full_rotation_output is None:
+                raise RuntimeError("Trellis workspace is missing its FP32 output")
+            if output is None:
+                common_kwargs["output"] = workspace.full_rotation_output[:m]
+            else:
+                if (
+                    output.dtype != torch.float32
+                    or output.device != a.device
+                    or output.ndim != 2
+                    or tuple(output.shape)
+                    not in {
+                        (m, k),
+                        tuple(workspace.full_rotation_output.shape),
+                    }
+                    or not output.is_contiguous()
+                ):
+                    raise ValueError(
+                        "full-rotation Trellis output must be a contiguous FP32 "
+                        "live or capacity buffer on the input device"
+                    )
+                common_kwargs["output"] = output[:m]
+            if topk_ids.dtype not in (torch.int32, torch.int64):
+                raise TypeError("full-rotation Trellis topk_ids must be int32 or int64")
+            for name, expert_map in (
+                ("route_expert_map", route_expert_map),
+                ("output_expert_map", output_expert_map),
+            ):
+                if expert_map is None:
+                    continue
+                if (
+                    expert_map.dtype != torch.int32
+                    or expert_map.device != a.device
+                    or tuple(expert_map.shape) != (workspace.route_E,)
+                    or not expert_map.is_contiguous()
+                ):
+                    raise ValueError(
+                        f"{name} must be contiguous int32[{workspace.route_E}] "
+                        f"on {a.device}"
+                    )
         fused_launch, topk_sum_launch = _w4a16_preplanned_launches(
             workspace,
             token_count=m,
             weight_layout=weight_layout,
             scale_format=scale_format,
             collect_activation_amax=collect_activation_amax,
+            route_ids_dtype=topk_ids.dtype,
+            use_expert_map=output_expert_map is not None,
         )
         return TPMoEFP4Binding(
             **common_kwargs,
@@ -6563,6 +6942,10 @@ def build_tp_moe_fp4_binding(
             block_expert_ids=workspace.block_expert_ids,
             packed_route_count=workspace.packed_route_count,
             expert_offsets=workspace.expert_offsets,
+            expert_counts=workspace.expert_counts,
+            rotation_a_gate=workspace.rotation_a_gate,
+            rotation_a_up=workspace.rotation_a_up,
+            kernel_workspace=workspace.kernel_workspace,
             fused_launch=fused_launch,
             topk_sum_launch=topk_sum_launch,
         )
@@ -6832,9 +7215,7 @@ def _select_micro_mma_tiler_mn(
     resident_clusters: int | None = None,
 ) -> tuple[int, int]:
     if os.environ.get("SPARKINFER_MOE_TILE_MN"):
-        return tuple(
-            int(x) for x in os.environ["SPARKINFER_MOE_TILE_MN"].split("x")
-        )
+        return tuple(int(x) for x in os.environ["SPARKINFER_MOE_TILE_MN"].split("x"))
     sm_count = get_num_sm(torch.device("cuda"))
     coarse_tile = (128, 128)
     if max_rows <= 32 and n <= 256:
@@ -6914,9 +7295,7 @@ def _get_micro_kernel(
     last_kkey, last_kval = _LAST_KERNEL
     if last_kkey == cache_key:
         return last_kval, kernel.grid_x
-    reuse_compiled = (
-        os.environ.get("SPARKINFER_MICRO_REUSE_COMPILED", "1") != "0"
-    )
+    reuse_compiled = os.environ.get("SPARKINFER_MICRO_REUSE_COMPILED", "1") != "0"
     if reuse_compiled:
         cached = _MICRO_KERNEL_CACHE.get(cache_key)
         if cached is not None:
@@ -8086,12 +8465,8 @@ def _launch_dynamic_flat(
     # block scales (weight SFBs included); the FP4 recipes keep the FP4x2
     # packed view and E4M3 vec16 scale pointers.
     is_w6a8 = quant_mode in _W6A8_QUANT_MODES
-    packed_a_cutlass_dtype = (
-        cutlass.Float8E4M3FN if is_w6a8 else cutlass.Float4E2M1FN
-    )
-    sf_cutlass_dtype = (
-        cutlass.Float8E8M0FNU if is_w6a8 else cutlass.Float8E4M3FN
-    )
+    packed_a_cutlass_dtype = cutlass.Float8E4M3FN if is_w6a8 else cutlass.Float4E2M1FN
+    sf_cutlass_dtype = cutlass.Float8E8M0FNU if is_w6a8 else cutlass.Float8E4M3FN
     compiled(
         _gptr(cutlass.BFloat16, a),
         _gptr(ids_cutlass_dtype, flat_ids, ids_align),
@@ -9291,21 +9666,28 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
             run_w4a16_moe,
         )
 
+        prepared = prepared_payload
+        if prepared is None:
+            raise RuntimeError(
+                "the W4A16 weight plan did not materialize its required representation"
+            )
+        full_rotation = getattr(prepared, "weight_layout", "") == "trellis3_t256"
+        output_dtype = torch.float32 if full_rotation else a.dtype
         if output is None:
             if torch.cuda.is_current_stream_capturing():
                 raise ValueError(
                     "CUDA graph capture requires a caller-owned output buffer"
                 )
-            scatter_output = torch.empty(m, k, dtype=a.dtype, device=device)
+            scatter_output = torch.empty(m, k, dtype=output_dtype, device=device)
         else:
             scatter_output = output
         if scatter_output.shape != (m, k):
             raise ValueError(
                 f"output must have shape {(m, k)}, got {tuple(scatter_output.shape)}"
             )
-        if scatter_output.dtype != a.dtype:
+        if scatter_output.dtype != output_dtype:
             raise ValueError(
-                f"output must have dtype {a.dtype}, got {scatter_output.dtype}"
+                f"output must have dtype {output_dtype}, got {scatter_output.dtype}"
             )
         if scatter_output.device != device:
             raise ValueError(
@@ -9314,11 +9696,6 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
         if not scatter_output.is_contiguous():
             raise ValueError("output must be contiguous")
 
-        prepared = prepared_payload
-        if prepared is None:
-            raise RuntimeError(
-                "the W4A16 weight plan did not materialize its required representation"
-            )
         if binding.implementation != "w4a16":
             raise TypeError("expected a W4A16 TP MoE binding")
         if (binding.routed_rows_capacity or 0) < routed_rows:
@@ -9334,6 +9711,13 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
         block_expert_ids = _require_binding_field(binding, "block_expert_ids")
         packed_route_count = _require_binding_field(binding, "packed_route_count")
         expert_offsets = _require_binding_field(binding, "expert_offsets")
+        if full_rotation:
+            # Persistent weights retain only a zero-copy placeholder. The live
+            # barrier/counter storage is part of the caller-owned scratch plan.
+            prepared = replace(
+                prepared,
+                workspace=_require_binding_field(binding, "kernel_workspace"),
+            )
         fused_launch = binding.fused_launch
         topk_sum_launch = binding.topk_sum_launch
         if not topk_weights.is_contiguous():
@@ -9365,6 +9749,13 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
             block_expert_ids=block_expert_ids,
             packed_route_count=packed_route_count,
             expert_offsets=expert_offsets,
+            expert_counts=(
+                _require_binding_field(binding, "expert_counts")
+                if full_rotation
+                else None
+            ),
+            expert_map=binding.route_expert_map,
+            output_expert_map=binding.output_expert_map,
             activation_amax=activation_amax,
             layer_idx=layer_idx,
             swiglu_limit=swiglu_limit,
@@ -9372,6 +9763,23 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
             swiglu_beta=swiglu_beta,
             fused_launch=fused_launch,
             topk_sum_launch=topk_sum_launch,
+            intermediate_rotation_scales=(
+                prepared.intermediate_rotations if full_rotation else None
+            ),
+            full_rotation=full_rotation,
+            suh_gate_table=prepared.gate_suh if full_rotation else None,
+            suh_up_table=prepared.up_suh if full_rotation else None,
+            svh_table=prepared.down_svh if full_rotation else None,
+            rotation_a_gate=(
+                _require_binding_field(binding, "rotation_a_gate")
+                if full_rotation
+                else None
+            ),
+            rotation_a_up=(
+                _require_binding_field(binding, "rotation_a_up")
+                if full_rotation
+                else None
+            ),
         )
     activation_spec = _get_activation_kernel_spec(activation, quant_mode=quant_mode)
     plan = plan_tp_moe_execution(
@@ -9594,9 +10002,7 @@ def sparkinfer_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
                 activation in ("relu2", "silu")
                 and m == 1
                 and a1_gscale.numel() == 1
-                and os.environ.get(
-                    "SPARKINFER_MICRO_SHARE_INPUT_ACROSS_EXPERTS", "1"
-                )
+                and os.environ.get("SPARKINFER_MICRO_SHARE_INPUT_ACROSS_EXPERTS", "1")
                 != "0"
             ),
             share_expert_scales=(
@@ -9955,7 +10361,9 @@ def _select_experts_reference(
     )
 
 
-def sparkinfer_route_experts_fast(*, binding: TPMoERouteBinding) -> SPARKINFERTopKRouting:
+def sparkinfer_route_experts_fast(
+    *, binding: TPMoERouteBinding
+) -> SPARKINFERTopKRouting:
     """Public sparse-routing entrypoint for higher-level integrations.
 
     This is the optimization seam for future fast routing work. The current

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sparkinfer.gemm import trellis_linear
+from sparkinfer.gemm.trellis_linear import api
+
+
+def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
+    tensors = tuple(torch.empty(0) for _ in range(3))
+    expected = SimpleNamespace()
+    seen = {}
+
+    def fake_prepare(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return expected
+
+    monkeypatch.setattr(api, "prepare_trellis256_dense_weight", fake_prepare)
+    actual = trellis_linear.prepare_weight(
+        *tensors,
+        codebook="mcg",
+        params_dtype=torch.bfloat16,
+    )
+
+    assert actual is expected
+    assert seen["args"] == tensors
+    assert seen["kwargs"]["codebook"] == "mcg"
+    assert seen["kwargs"]["params_dtype"] == torch.bfloat16
+
+
+def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
+    x = torch.empty(0)
+    weight = SimpleNamespace()
+    output, gemm_output, c_tmp = (torch.empty(0) for _ in range(3))
+    seen = {}
+
+    def fake_run(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return output
+
+    monkeypatch.setattr(api, "run_trellis256_dense", fake_run)
+    actual = trellis_linear.run(
+        x,
+        weight,
+        output=output,
+        gemm_output=gemm_output,
+        c_tmp=c_tmp,
+    )
+
+    assert actual is output
+    assert seen["args"] == (x, weight)
+    assert seen["kwargs"]["output"] is output
+    assert seen["kwargs"]["gemm_output"] is gemm_output
+    assert seen["kwargs"]["c_tmp"] is c_tmp
+
+
+def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
+    seen = {}
+
+    def fake_gate(device, *, requires):
+        seen["device"] = device
+        seen["requires"] = requires
+        return True
+
+    monkeypatch.setattr(api, "default_is_supported", fake_gate)
+    assert trellis_linear.is_supported("cuda:3")
+    assert seen == {"device": "cuda:3", "requires": trellis_linear.META.requires}

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sparkinfer.gemm import trellis_linear
 from sparkinfer.gemm.trellis_linear import api
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major == 12 and minor in (0, 1)
 
 
 def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
@@ -26,7 +34,9 @@ def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
     )
 
     assert actual is expected
-    assert seen["args"] == tensors
+    assert all(
+        seen_arg is arg for seen_arg, arg in zip(seen["args"], tensors, strict=True)
+    )
     assert seen["kwargs"]["codebook"] == "mcg"
     assert seen["kwargs"]["params_dtype"] == torch.bfloat16
 
@@ -34,7 +44,17 @@ def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
 def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
     x = torch.empty(0)
     weight = SimpleNamespace()
-    output, gemm_output, c_tmp = (torch.empty(0) for _ in range(3))
+    buffers = tuple(torch.empty(0) for _ in range(8))
+    (
+        output,
+        gemm_output,
+        c_tmp,
+        input_f16,
+        rotated_f16,
+        rotated_compute,
+        gemm_output_f16,
+        output_f16,
+    ) = buffers
     seen = {}
 
     def fake_run(*args, **kwargs):
@@ -49,6 +69,11 @@ def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
         output=output,
         gemm_output=gemm_output,
         c_tmp=c_tmp,
+        input_f16=input_f16,
+        rotated_f16=rotated_f16,
+        rotated_compute=rotated_compute,
+        gemm_output_f16=gemm_output_f16,
+        output_f16=output_f16,
     )
 
     assert actual is output
@@ -56,6 +81,11 @@ def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
     assert seen["kwargs"]["output"] is output
     assert seen["kwargs"]["gemm_output"] is gemm_output
     assert seen["kwargs"]["c_tmp"] is c_tmp
+    assert seen["kwargs"]["input_f16"] is input_f16
+    assert seen["kwargs"]["rotated_f16"] is rotated_f16
+    assert seen["kwargs"]["rotated_compute"] is rotated_compute
+    assert seen["kwargs"]["gemm_output_f16"] is gemm_output_f16
+    assert seen["kwargs"]["output_f16"] is output_f16
 
 
 def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
@@ -69,3 +99,65 @@ def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
     monkeypatch.setattr(api, "default_is_supported", fake_gate)
     assert trellis_linear.is_supported("cuda:3")
     assert seen == {"device": "cuda:3", "requires": trellis_linear.META.requires}
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_dense_bf16_reuses_all_scratch_during_cuda_graph_capture() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    m = 2
+    features = 128
+    trellis = torch.randint(
+        -32768,
+        32767,
+        (features // 16, features // 16, 48),
+        dtype=torch.int16,
+        device=device,
+    )
+    scale = torch.ones((features,), dtype=torch.float16, device=device)
+    weight = trellis_linear.prepare_weight(
+        trellis,
+        scale,
+        scale.clone(),
+        mcg=torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device),
+        params_dtype=torch.bfloat16,
+    )
+    x = torch.randn((m, features), dtype=torch.bfloat16, device=device)
+    output = torch.empty_like(x)
+    gemm_output = torch.empty_like(x)
+    c_tmp = torch.empty((1 << 20,), dtype=torch.float32, device=device)
+    input_f16 = torch.empty_like(x, dtype=torch.float16)
+    rotated_f16 = torch.empty_like(input_f16)
+    rotated_compute = torch.empty_like(x)
+    gemm_output_f16 = torch.empty_like(input_f16)
+    output_f16 = torch.empty_like(input_f16)
+
+    def hadamard_128(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        _left_scale,
+        _right_scale,
+        _scale: float,
+    ) -> None:
+        destination.copy_(source)
+
+    kwargs = {
+        "output": output,
+        "gemm_output": gemm_output,
+        "c_tmp": c_tmp,
+        "input_f16": input_f16,
+        "rotated_f16": rotated_f16,
+        "rotated_compute": rotated_compute,
+        "gemm_output_f16": gemm_output_f16,
+        "output_f16": output_f16,
+        "hadamard_128": hadamard_128,
+    }
+    expected = trellis_linear.run(x, weight, **kwargs).clone()
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = trellis_linear.run(x, weight, **kwargs)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.equal(captured, expected)

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -1,0 +1,842 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from sparkinfer.moe import fused_moe
+from sparkinfer.moe._shared.kernels.w4a16.host import plan_w4a16_buffers
+from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+    PreparedW4A16MoeWeights,
+    prepare_nf3_moe_weights,
+)
+
+
+_MCG = np.uint64(0xCBAC1FED)
+_MASK = np.uint32(0x8FFF8FFF)
+_ORC = np.uint32(0x3B603B60)
+
+
+def _weight_plan(
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    input_dtype: torch.dtype,
+    activation: str = "silu",
+    trellis_bits: int = 3,
+    tile_config: tuple[int, int, int, int] = (64, 256, 64, 256),
+) -> fused_moe.WeightsPlan:
+    return fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="exl3_trellis_mcg",
+        activation=activation,
+        params_dtype=input_dtype,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w13_layout="w13",
+        trellis_bits=trellis_bits,
+        trellis_tile_config=tile_config,
+    )
+
+
+def _caps(**overrides) -> fused_moe.Caps:
+    values = {
+        "max_tokens": 32,
+        "num_topk": 8,
+        "num_experts": 192,
+        "hidden_size": 6144,
+        "intermediate_size": 512,
+        "route_num_experts": 256,
+        "w4a16_block_size_m": 8,
+        "input_dtype": torch.bfloat16,
+        "device": "cuda:0",
+    }
+    values.update(overrides)
+    weight_plan = _weight_plan(
+        num_experts=values.pop("num_experts"),
+        hidden_size=values.pop("hidden_size"),
+        intermediate_size=values.pop("intermediate_size"),
+        input_dtype=values.pop("input_dtype"),
+    )
+    return fused_moe.Caps(
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+        **values,
+    )
+
+
+def test_caps_preserve_exact_block_m_and_input_dtypes() -> None:
+    bf16 = _caps(w4a16_block_size_m=8, input_dtype=torch.bfloat16)
+    fp16 = _caps(w4a16_block_size_m=64, input_dtype=torch.float16)
+
+    assert bf16.w4a16_block_size_m == 8
+    assert bf16.route_num_experts == 256
+    assert bf16.dtype == torch.bfloat16
+    assert fp16.w4a16_block_size_m == 64
+    assert fp16.dtype == torch.float16
+
+
+@pytest.mark.parametrize("block_size_m", [0, 4, 12, 128])
+def test_caps_reject_unsupported_block_m(block_size_m: int) -> None:
+    with pytest.raises(ValueError, match="w4a16_block_size_m"):
+        _caps(w4a16_block_size_m=block_size_m)
+
+
+def _prepare_weights(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    gate_suh: torch.Tensor,
+    up_suh: torch.Tensor,
+    intermediate_rotations: torch.Tensor,
+    down_svh: torch.Tensor,
+    input_dtype: torch.dtype = torch.bfloat16,
+    activation: str = "silu",
+    codebook: str = "mcg",
+    mcg: torch.Tensor | int | None = None,
+    tile_config: tuple[int, int, int, int] = (64, 256, 64, 256),
+) -> fused_moe.ExpertWeights:
+    bits = int(w13.shape[-1]) // 16
+    plan = _weight_plan(
+        num_experts=int(w13.shape[1]),
+        hidden_size=int(w13.shape[2]) * 16,
+        intermediate_size=int(w13.shape[3]) * 16,
+        input_dtype=input_dtype,
+        activation=activation,
+        trellis_bits=bits,
+        tile_config=tile_config,
+    )
+    if codebook != "mcg":
+        # The unified planner records the only supported source codebook.
+        raise NotImplementedError(
+            "Trellis execution currently supports only the MCG codebook"
+        )
+    return fused_moe.prepare_weights(
+        plan=plan,
+        params_dtype=input_dtype,
+        w1_fp4=w13,
+        w2_fp4=w2,
+        gate_suh=gate_suh,
+        up_suh=up_suh,
+        intermediate_rotations=intermediate_rotations,
+        down_svh=down_svh,
+        trellis_mcg=mcg,
+    )
+
+
+def _plan(
+    weights: fused_moe.ExpertWeights,
+    *,
+    max_tokens: int,
+    num_topk: int,
+    route_num_experts: int,
+    block_size_m: int,
+    device: torch.device | str,
+) -> fused_moe.Plan:
+    return fused_moe.plan(
+        fused_moe.Caps(
+            max_tokens=max_tokens,
+            num_topk=num_topk,
+            route_num_experts=route_num_experts,
+            device=device,
+            weight_plan=weights.plan,
+            quant_mode="w4a16",
+            w4a16_block_size_m=block_size_m,
+        )
+    )
+
+
+def test_low_level_buffer_plan_honors_explicit_block_m() -> None:
+    prepared = SimpleNamespace(
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size=512,
+        is_gated=True,
+    )
+    automatic = plan_w4a16_buffers(
+        prepared,
+        m=1024,
+        topk=8,
+        route_num_experts=256,
+        sms=120,
+    )
+    exact = plan_w4a16_buffers(
+        prepared,
+        m=1024,
+        topk=8,
+        route_num_experts=256,
+        sms=120,
+        full_rotation=True,
+        block_size_m=8,
+    )
+
+    assert automatic.block_size_m != 8
+    assert exact.block_size_m == 8
+    assert exact.rotation_a_elements == 1024 * 8 * 6144
+    with pytest.raises(ValueError, match="block_size_m"):
+        plan_w4a16_buffers(
+            prepared,
+            m=1,
+            topk=8,
+            route_num_experts=256,
+            sms=120,
+            block_size_m=4,
+        )
+
+
+def _cpu_weight_tensors() -> tuple[torch.Tensor, ...]:
+    w13 = torch.zeros((2, 1, 8, 8, 48), dtype=torch.int16)
+    w2 = torch.zeros((1, 8, 8, 48), dtype=torch.int16)
+    edge = torch.ones((1, 128), dtype=torch.float16)
+    intermediate = torch.ones((1, 384), dtype=torch.float16)
+    return w13, w2, edge, edge.clone(), intermediate, edge.clone()
+
+
+def test_prepare_weights_rejects_non_mcg_before_cuda_work() -> None:
+    w13, w2, gate_suh, up_suh, intermediate, down_svh = _cpu_weight_tensors()
+    with pytest.raises(NotImplementedError, match="only the MCG"):
+        _prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate,
+            down_svh=down_svh,
+            codebook="mul1",
+            tile_config=(64, 128, 64, 128),
+        )
+    with pytest.raises(ValueError, match="unexpected .*MCG marker"):
+        _prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate,
+            down_svh=down_svh,
+            mcg=0x83DCD12D,
+            tile_config=(64, 128, 64, 128),
+        )
+
+
+def test_prepare_weights_validates_all_rotation_shapes() -> None:
+    w13, w2, gate_suh, up_suh, intermediate, down_svh = _cpu_weight_tensors()
+    with pytest.raises(ValueError, match="intermediate_rotations must have shape"):
+        _prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate[:, :-1].contiguous(),
+            down_svh=down_svh,
+            tile_config=(64, 128, 64, 128),
+        )
+
+
+def _decode_3inst_fp16(window: np.ndarray) -> np.ndarray:
+    value = window.astype(np.uint64)
+    value = ((value * _MCG) & np.uint64(0xFFFFFFFF)).astype(np.uint32)
+    value = np.uint32((value & _MASK) ^ _ORC)
+    low = (value & np.uint32(0xFFFF)).astype(np.uint16).view(np.float16)
+    high = (
+        ((value >> np.uint32(16)) & np.uint32(0xFFFF))
+        .astype(np.uint16)
+        .view(np.float16)
+    )
+    return (low.astype(np.float16) + high.astype(np.float16)).astype(np.float16)
+
+
+def _decode_lane(tile_words: np.ndarray, lane: int, bits: int) -> np.ndarray:
+    width = 8 * bits
+    values = []
+    for weight in range(8):
+        end_bit = (lane * 8 + weight + 257) * bits
+        start_bit = end_bit - 16
+        first_word = start_bit // 32
+        last_word = (end_bit - 1) // 32
+        shift = (last_word + 1) * 32 - end_bit
+        first = tile_words[..., first_word % width].astype(np.uint64)
+        last = tile_words[..., last_word % width].astype(np.uint64)
+        merged = (first << np.uint64(32)) | last
+        window = ((merged >> np.uint64(shift)) & np.uint64(0xFFFF)).astype(np.uint32)
+        values.append(_decode_3inst_fp16(window))
+    return np.stack(values, axis=-1).astype(np.float16)
+
+
+def _reconstruct_native(trellis: torch.Tensor) -> torch.Tensor:
+    native = trellis.detach().cpu().numpy()
+    bits = int(native.shape[-1]) // 16
+    k_tiles, n_tiles, _ = native.shape
+    packed = native.view(np.uint16).reshape(k_tiles, n_tiles, 8 * bits, 2)
+    words = packed[..., 0].astype(np.uint32) | (
+        packed[..., 1].astype(np.uint32) << np.uint32(16)
+    )
+    output = np.zeros((k_tiles * 16, n_tiles * 16), dtype=np.float16)
+    for k_tile in range(k_tiles):
+        for n_tile in range(n_tiles):
+            lanes = np.stack(
+                [_decode_lane(words[k_tile, n_tile], lane, bits) for lane in range(32)]
+            )
+            block = np.zeros((16, 16), dtype=np.float16)
+            for lane in range(32):
+                row0 = (lane % 4) * 2
+                rows = (row0, row0 + 1, row0 + 8, row0 + 9)
+                col0 = lane // 8
+                col1 = col0 + 4
+                parity = (lane >> 2) & 1
+                for weight in range(8):
+                    block[
+                        rows[weight % 4], 2 * (col0 if weight < 4 else col1) + parity
+                    ] = lanes[lane, weight]
+            output[
+                k_tile * 16 : (k_tile + 1) * 16,
+                n_tile * 16 : (n_tile + 1) * 16,
+            ] = block
+    return torch.from_numpy(output)
+
+
+def _hadamard_128(device: torch.device) -> torch.Tensor:
+    indices = torch.arange(128, dtype=torch.int64)
+    rows = []
+    for row in range(128):
+        parity = torch.tensor(
+            [(row & int(col)).bit_count() & 1 for col in indices],
+            dtype=torch.bool,
+        )
+        rows.append(torch.where(parity, -1.0, 1.0))
+    return (torch.stack(rows) / (128.0**0.5)).to(device)
+
+
+def _had128(
+    value: torch.Tensor,
+    hadamard: torch.Tensor,
+    *,
+    suh: torch.Tensor | None = None,
+    svh: torch.Tensor | None = None,
+    store_fp16: bool,
+) -> torch.Tensor:
+    work = value.float()
+    if suh is not None:
+        work = (work * suh.float()).to(torch.float16).float()
+    rows, width = work.shape
+    work = (work.view(rows, width // 128, 128) @ hadamard).view(rows, width)
+    if svh is not None:
+        work = work * svh.float()
+    return work.to(torch.float16) if store_fp16 else work
+
+
+def _reference_full_rotation(
+    x: torch.Tensor,
+    local_ids: torch.Tensor,
+    router_weights: torch.Tensor,
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    gate_suh: torch.Tensor,
+    up_suh: torch.Tensor,
+    intermediate_rotations: torch.Tensor,
+    down_svh: torch.Tensor,
+    *,
+    activation: str = "silu",
+) -> torch.Tensor:
+    device = x.device
+    experts = int(w2.shape[0])
+    intermediate = int(w2.shape[1]) * 16
+    hidden = int(w2.shape[2]) * 16
+    hadamard = _hadamard_128(device)
+    gate_weights = torch.stack(
+        [_reconstruct_native(w13[0, expert]) for expert in range(experts)]
+    ).to(device)
+    up_weights = torch.stack(
+        [_reconstruct_native(w13[1, expert]) for expert in range(experts)]
+    ).to(device)
+    down_weights = torch.stack(
+        [_reconstruct_native(w2[expert]) for expert in range(experts)]
+    ).to(device)
+    gate_svh = intermediate_rotations[:, :intermediate]
+    up_svh = intermediate_rotations[:, intermediate : 2 * intermediate]
+    down_suh = intermediate_rotations[:, 2 * intermediate :]
+    output = torch.zeros((int(x.shape[0]), hidden), dtype=torch.float32, device=device)
+    for token in range(int(x.shape[0])):
+        for slot in range(int(local_ids.shape[1])):
+            expert = int(local_ids[token, slot])
+            source = x[token : token + 1].to(torch.float16)
+            gate_a = _had128(
+                source,
+                hadamard,
+                suh=gate_suh[expert],
+                store_fp16=True,
+            )
+            up_a = _had128(
+                source,
+                hadamard,
+                suh=up_suh[expert],
+                store_fp16=True,
+            )
+            gate = (gate_a.float() @ gate_weights[expert].float()).to(torch.float16)
+            up = (up_a.float() @ up_weights[expert].float()).to(torch.float16)
+            gate = _had128(
+                gate,
+                hadamard,
+                svh=gate_svh[expert],
+                store_fp16=True,
+            )
+            up = _had128(
+                up,
+                hadamard,
+                svh=up_svh[expert],
+                store_fp16=True,
+            )
+            if activation == "situ":
+                activated = (
+                    4.0
+                    * torch.tanh(gate.float() / 4.0)
+                    * torch.sigmoid(gate.float())
+                    * 25.0
+                    * torch.tanh(up.float() / 25.0)
+                ).to(torch.float16)
+            else:
+                activated = (
+                    gate.float() * torch.sigmoid(gate.float()) * up.float()
+                ).to(torch.float16)
+            down_a = _had128(
+                activated,
+                hadamard,
+                suh=down_suh[expert],
+                store_fp16=True,
+            )
+            down = (down_a.float() @ down_weights[expert].float()).to(torch.float16)
+            route = _had128(
+                down,
+                hadamard,
+                svh=down_svh[expert],
+                store_fp16=False,
+            )
+            output[token] += router_weights[token, slot] * route[0]
+    return output
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+    return major == 12 and minor in (0, 1)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_nf3_and_trellis_share_the_w4a16_prepared_contract() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    experts, hidden, intermediate = 1, 128, 128
+    nf3 = prepare_nf3_moe_weights(
+        torch.zeros(
+            (experts, 2 * intermediate, hidden),
+            dtype=torch.int16,
+            device=device,
+        ),
+        torch.ones(
+            (experts, 2 * intermediate, hidden // 32),
+            dtype=torch.float32,
+            device=device,
+        ),
+        torch.zeros(
+            (experts, hidden, intermediate),
+            dtype=torch.int16,
+            device=device,
+        ),
+        torch.ones(
+            (experts, hidden, intermediate // 32),
+            dtype=torch.float32,
+            device=device,
+        ),
+        activation="silu",
+        fc1_tile_n=128,
+        fc2_tile_n=128,
+    )
+    rotations = torch.ones((experts, hidden), dtype=torch.float16, device=device)
+    trellis = _prepare_weights(
+        torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 48),
+            dtype=torch.int16,
+            device=device,
+        ),
+        torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 48),
+            dtype=torch.int16,
+            device=device,
+        ),
+        gate_suh=rotations,
+        up_suh=rotations.clone(),
+        intermediate_rotations=torch.ones(
+            (experts, 3 * intermediate), dtype=torch.float16, device=device
+        ),
+        down_svh=rotations.clone(),
+        tile_config=(64, 128, 64, 128),
+    ).representation_for("w4a16")
+
+    assert isinstance(nf3, PreparedW4A16MoeWeights)
+    assert isinstance(trellis, PreparedW4A16MoeWeights)
+    assert nf3.weight_layout == "nf3_2p1"
+    assert trellis.weight_layout == "trellis3_t256"
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("activation", ["silu", "situ"])
+def test_planned_full_rotation_matches_reference_and_captures(
+    input_dtype: torch.dtype,
+    activation: str,
+) -> None:
+    torch.manual_seed(20260721)
+    device = torch.device("cuda", torch.cuda.current_device())
+    experts, hidden, intermediate = 2, 128, 128
+    bits = 3
+    tile_config = (64, 128, 64, 128)
+    w13 = torch.randint(
+        -32768,
+        32767,
+        (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+    w2 = torch.randint(
+        -32768,
+        32767,
+        (experts, intermediate // 16, hidden // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+
+    def scales(shape: tuple[int, ...]) -> torch.Tensor:
+        return (0.875 + 0.25 * torch.rand(shape, device=device)).to(torch.float16)
+
+    gate_suh = scales((experts, hidden)).contiguous()
+    up_suh = scales((experts, hidden)).contiguous()
+    intermediate_rotations = scales((experts, 3 * intermediate)).contiguous()
+    down_svh = scales((experts, hidden)).contiguous()
+    weights = _prepare_weights(
+        w13,
+        w2,
+        gate_suh=gate_suh,
+        up_suh=up_suh,
+        intermediate_rotations=intermediate_rotations,
+        down_svh=down_svh,
+        codebook="mcg",
+        mcg=0xCBAC1FED,
+        tile_config=tile_config,
+        input_dtype=input_dtype,
+        activation=activation,
+    )
+    prepared = weights.representation_for("w4a16")
+    assert prepared.w13.data_ptr() == w13.data_ptr()
+    assert prepared.w2.data_ptr() == w2.data_ptr()
+
+    plan = _plan(
+        weights,
+        max_tokens=2,
+        num_topk=2,
+        route_num_experts=4,
+        block_size_m=8,
+        device=device,
+    )
+    assert plan.caps.w4a16_block_size_m == 8
+    assert plan._core_workspace_plan.full_rotation
+
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    x = (torch.randn((2, hidden), device=device) * 1.0e-3).to(input_dtype)
+    local_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32, device=device)
+    global_ids = torch.tensor([[1, 3], [3, 1]], dtype=torch.int64, device=device)
+    router_weights = torch.tensor(
+        [[0.65, 0.35], [0.2, 0.8]], dtype=torch.float32, device=device
+    )
+    route_map = torch.tensor([0, 0, 0, 1], dtype=torch.int32, device=device)
+    output_map = torch.tensor([-1, 0, -1, 1], dtype=torch.int32, device=device)
+    external_output = torch.empty((2, hidden), dtype=torch.float32, device=device)
+
+    mapped = fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=x,
+        experts=weights,
+        topk_weights=router_weights,
+        topk_ids=global_ids,
+        route_expert_map=route_map,
+        output_expert_map=output_map,
+        output=external_output,
+    )
+    mapped_output = fused_moe.run(binding=mapped)
+    torch.cuda.synchronize(device)
+    assert mapped_output.data_ptr() == external_output.data_ptr()
+    mapped_eager = mapped_output.clone()
+
+    identity = fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=x,
+        experts=weights,
+        topk_weights=router_weights,
+        topk_ids=local_ids,
+    )
+    identity_output = identity.run()
+    torch.cuda.synchronize(device)
+    assert identity_output.dtype == torch.float32
+    assert torch.allclose(identity_output, mapped_eager, rtol=2.0e-3, atol=2.0e-3)
+
+    reference = _reference_full_rotation(
+        x,
+        local_ids,
+        router_weights,
+        w13,
+        w2,
+        gate_suh,
+        up_suh,
+        intermediate_rotations,
+        down_svh,
+        activation=activation,
+    )
+    relative_error = (mapped_eager - reference).norm() / reference.norm().clamp_min(
+        1.0e-9
+    )
+    cosine = torch.nn.functional.cosine_similarity(
+        mapped_eager.flatten(), reference.flatten(), dim=0
+    )
+    assert float(relative_error) <= 2.0e-2
+    assert float(cosine) >= 0.999
+
+    mapped = fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=x,
+        experts=weights,
+        topk_weights=router_weights,
+        topk_ids=global_ids,
+        route_expert_map=route_map,
+        output_expert_map=output_map,
+        output=external_output,
+    )
+    mapped.run()
+    torch.cuda.synchronize(device)
+    allocated_before = torch.cuda.memory_allocated(device)
+    mapped.run()
+    torch.cuda.synchronize(device)
+    assert torch.cuda.memory_allocated(device) == allocated_before
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = mapped.run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert captured_output.data_ptr() == external_output.data_ptr()
+    assert torch.allclose(captured_output, mapped_eager, rtol=2.0e-3, atol=2.0e-3)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("m", [1, 2, 3, 4, 8])
+def test_planned_full_rotation_small_m_partial_blocks(m: int) -> None:
+    """Small-m coverage at production geometry, with m < plan capacity.
+
+    Motivated by vLLM issue #183, which reported that widening the Trellis window
+    (VLLM_EXL3_TRELLIS_MIN_M=1) so an MTP-N draft's m=1..N GEMMs stay on the fused
+    path silently corrupts output. m < moe_block_size means the route packer emits
+    mostly-padding blocks (at m=3, topk=8 roughly 1-3 real rows of 8), so padding
+    masking is load-bearing and was previously untested: the only numerical test on
+    this path ran m == max_tokens == 2 with topk=2 and a non-production tile.
+
+    Three oracles:
+      * per-token bitwise equality against an m=1 run of the same token. A token's
+        output depends only on its own routes, so batching must not change a bit.
+      * the scratch arena pre-filled with 0xFF (NaN in fp32/fp16) before every
+        bind, so any read of a padding/uninitialised slot surfaces as NaN.
+      * plan capacity 32 vs m, i.e. the window-widening regime itself.
+    """
+    torch.manual_seed(20260726)
+    device = torch.device("cuda", torch.cuda.current_device())
+    experts, hidden, intermediate = 32, 1024, 1024
+    bits, topk, capacity = 3, 8, 32
+    tile_config = (64, 256, 64, 256)
+
+    w13 = torch.randint(
+        -32768,
+        32767,
+        (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+    w2 = torch.randint(
+        -32768,
+        32767,
+        (experts, intermediate // 16, hidden // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+
+    def scales(shape: tuple[int, ...]) -> torch.Tensor:
+        return (0.875 + 0.25 * torch.rand(shape, device=device)).to(torch.float16)
+
+    weights = _prepare_weights(
+        w13,
+        w2,
+        gate_suh=scales((experts, hidden)).contiguous(),
+        up_suh=scales((experts, hidden)).contiguous(),
+        intermediate_rotations=scales((experts, 3 * intermediate)).contiguous(),
+        down_svh=scales((experts, hidden)).contiguous(),
+        codebook="mcg",
+        mcg=0xCBAC1FED,
+        tile_config=tile_config,
+    )
+    plan = _plan(
+        weights,
+        max_tokens=capacity,
+        num_topk=topk,
+        route_num_experts=experts,
+        block_size_m=8,
+        device=device,
+    )
+    assert plan.caps.w4a16_block_size_m == 8
+    assert plan._core_workspace_plan.full_rotation
+
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    ids = torch.stack(
+        [torch.randperm(experts, device=device)[:topk] for _ in range(m)]
+    ).to(torch.int32)
+    router_weights = torch.rand((m, topk), dtype=torch.float32, device=device)
+    router_weights /= router_weights.sum(dim=1, keepdim=True)
+
+    def _run(rows: slice) -> torch.Tensor:
+        # NaN-poison the arena so a padding-slot read cannot pass silently.
+        scratch.fill_(0xFF)
+        binding = fused_moe.bind(
+            plan,
+            scratch=scratch,
+            a=x[rows].contiguous(),
+            experts=weights,
+            topk_weights=router_weights[rows].contiguous(),
+            topk_ids=ids[rows].contiguous(),
+        )
+        out = fused_moe.run(binding=binding)
+        torch.cuda.synchronize(device)
+        return out.clone()
+
+    batched = _run(slice(0, m))
+    assert not torch.isnan(batched).any(), (
+        f"NaN in fused output at m={m}: a padding or uninitialised arena slot was read"
+    )
+
+    for row in range(m):
+        single = _run(slice(row, row + 1))
+        assert not torch.isnan(single).any()
+        assert torch.equal(batched[row], single[0]), (
+            f"row {row} of an m={m} batch differs from its own m=1 run; a token's "
+            "output must not depend on how many other tokens share the batch"
+        )
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("m", [1, 2, 3])
+def test_planned_full_rotation_capture_below_capacity(m: int) -> None:
+    """CUDA-graph capture and replay at m strictly below plan capacity.
+
+    This is the surface vLLM #183 actually leaves untested. The existing capture
+    test captures at ``m == max_tokens``, and a small-m eager check does not cover
+    capture: ``bind`` runs inside the captured region, so the route-pack grid, the
+    ``kernel_workspace`` zero-fill and the active-m constants are all baked into
+    the graph. If any of those were captured for the wrong m, replay would produce
+    stale or mismatched results while eager execution stayed correct -- which is
+    exactly a "short prompts pass, long context corrupts" signature once an
+    MTP-N draft replays its captured graph.
+
+    Asserts replay matches the eager result for the same inputs bit-for-bit, and
+    that a second replay is stable (no dependence on scratch left over from the
+    capture pass).
+    """
+    torch.manual_seed(20260726)
+    device = torch.device("cuda", torch.cuda.current_device())
+    experts, hidden, intermediate = 32, 1024, 1024
+    bits, topk, capacity = 3, 8, 32
+    tile_config = (64, 256, 64, 256)
+
+    w13 = torch.randint(
+        -32768,
+        32767,
+        (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+    w2 = torch.randint(
+        -32768,
+        32767,
+        (experts, intermediate // 16, hidden // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+
+    def scales(shape: tuple[int, ...]) -> torch.Tensor:
+        return (0.875 + 0.25 * torch.rand(shape, device=device)).to(torch.float16)
+
+    weights = _prepare_weights(
+        w13,
+        w2,
+        gate_suh=scales((experts, hidden)).contiguous(),
+        up_suh=scales((experts, hidden)).contiguous(),
+        intermediate_rotations=scales((experts, 3 * intermediate)).contiguous(),
+        down_svh=scales((experts, hidden)).contiguous(),
+        codebook="mcg",
+        mcg=0xCBAC1FED,
+        tile_config=tile_config,
+    )
+    plan = _plan(
+        weights,
+        max_tokens=capacity,
+        num_topk=topk,
+        route_num_experts=experts,
+        block_size_m=8,
+        device=device,
+    )
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    ids = torch.stack(
+        [torch.randperm(experts, device=device)[:topk] for _ in range(m)]
+    ).to(torch.int32)
+    router_weights = torch.rand((m, topk), dtype=torch.float32, device=device)
+    router_weights /= router_weights.sum(dim=1, keepdim=True)
+
+    binding = fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=x,
+        experts=weights,
+        topk_weights=router_weights,
+        topk_ids=ids,
+    )
+    eager = binding.run().clone()
+    torch.cuda.synchronize(device)
+    assert not torch.isnan(eager).any()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = binding.run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert not torch.isnan(captured).any(), (
+        f"NaN after graph replay at m={m} (capacity {capacity})"
+    )
+    assert torch.equal(captured, eager), (
+        f"graph replay at m={m} below capacity {capacity} disagrees with eager; "
+        "capture baked constants or a route-pack grid for the wrong m"
+    )
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, eager), (
+        f"second replay at m={m} drifted; replay depends on scratch state left "
+        "over from the capture pass"
+    )

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -225,6 +225,38 @@ def test_low_level_buffer_plan_honors_explicit_block_m() -> None:
         )
 
 
+def test_planned_route_block_overrides_live_batch_heuristic() -> None:
+    from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+        _resolve_route_block_size_m,
+    )
+
+    # m=1024/topk=8/E=256 selects 48 heuristically. A caller-owned arena
+    # planned for 64 must retain 64 so route packing cannot outgrow its
+    # block-expert table.
+    assert _resolve_route_block_size_m(
+        m=1024,
+        topk=8,
+        route_num_experts=256,
+        planned_block_size_m=None,
+        fused_launch=None,
+    ) == 48
+    assert _resolve_route_block_size_m(
+        m=1024,
+        topk=8,
+        route_num_experts=256,
+        planned_block_size_m=64,
+        fused_launch=None,
+    ) == 64
+    with pytest.raises(RuntimeError, match="planned_block_size_m=64"):
+        _resolve_route_block_size_m(
+            m=1024,
+            topk=8,
+            route_num_experts=256,
+            planned_block_size_m=64,
+            fused_launch=SimpleNamespace(moe_block_size=48),
+        )
+
+
 def _cpu_weight_tensors() -> tuple[torch.Tensor, ...]:
     w13 = torch.zeros((2, 1, 8, 8, 48), dtype=torch.int16)
     w2 = torch.zeros((1, 8, 8, 48), dtype=torch.int16)
@@ -766,6 +798,7 @@ def test_planned_full_rotation_small_m_partial_blocks(m: int) -> None:
             topk_weights=router_weights[rows].contiguous(),
             topk_ids=ids[rows].contiguous(),
         )
+        assert binding.route_block_size_m == plan.caps.w4a16_block_size_m
         out = fused_moe.run(binding=binding)
         torch.cuda.synchronize(device)
         return out.clone()
@@ -863,6 +896,7 @@ def test_planned_full_rotation_capture_below_capacity(m: int) -> None:
         topk_weights=router_weights,
         topk_ids=ids,
     )
+    assert eager_binding.route_block_size_m == plan.caps.w4a16_block_size_m
     eager = eager_binding.run().clone()
     torch.cuda.synchronize(device)
     assert not torch.isnan(eager).any()

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -9,6 +9,7 @@ import torch
 pytest.importorskip("cutlass")
 
 from sparkinfer.moe import fused_moe
+from sparkinfer.moe.fused_moe import META as FUSED_MOE_META
 from sparkinfer.moe._shared.kernels.w4a16.host import plan_w4a16_buffers
 from sparkinfer.moe._shared.kernels.w4a16.prepare import (
     PreparedW4A16MoeWeights,
@@ -69,6 +70,10 @@ def _caps(**overrides) -> fused_moe.Caps:
         quant_mode="w4a16",
         **values,
     )
+
+
+def test_fused_moe_metadata_advertises_trellis_input_dtypes() -> None:
+    assert {"bf16", "fp16"}.issubset(FUSED_MOE_META.dtypes)
 
 
 def test_caps_preserve_exact_block_m_and_input_dtypes() -> None:

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -76,6 +76,36 @@ def test_fused_moe_metadata_advertises_trellis_input_dtypes() -> None:
     assert {"bf16", "fp16"}.issubset(FUSED_MOE_META.dtypes)
 
 
+def test_rotation_placeholder_must_be_materialized_before_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    device = torch.device("cuda:127")
+    w4a16_kernel._ROT_SCALES_DUMMY.pop(device, None)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    with pytest.raises(RuntimeError, match="prewarm the planned launch"):
+        w4a16_kernel._rot_scales_dummy(device)
+
+
+def test_dense_scratch_cannot_allocate_during_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    with pytest.raises(RuntimeError, match="provide caller-owned storage"):
+        w4a16_kernel._trellis_dense_buffer(
+            "rotated_f16",
+            None,
+            shape=(2, 128),
+            dtype=torch.float16,
+            device=torch.device("cpu"),
+        )
+
+
 def test_caps_preserve_exact_block_m_and_input_dtypes() -> None:
     bf16 = _caps(w4a16_block_size_m=8, input_dtype=torch.bfloat16)
     fp16 = _caps(w4a16_block_size_m=64, input_dtype=torch.float16)
@@ -104,7 +134,7 @@ def _prepare_weights(
     input_dtype: torch.dtype = torch.bfloat16,
     activation: str = "silu",
     codebook: str = "mcg",
-    mcg: torch.Tensor | int | None = None,
+    mcg: torch.Tensor | int | None = 0xCBAC1FED,
     tile_config: tuple[int, int, int, int] = (64, 256, 64, 256),
 ) -> fused_moe.ExpertWeights:
     bits = int(w13.shape[-1]) // 16
@@ -216,7 +246,7 @@ def test_prepare_weights_rejects_non_mcg_before_cuda_work() -> None:
             codebook="mul1",
             tile_config=(64, 128, 64, 128),
         )
-    with pytest.raises(ValueError, match="unexpected .*MCG marker"):
+    with pytest.raises(ValueError, match=r"unexpected .*MCG marker"):
         _prepare_weights(
             w13,
             w2,
@@ -225,6 +255,17 @@ def test_prepare_weights_rejects_non_mcg_before_cuda_work() -> None:
             intermediate_rotations=intermediate,
             down_svh=down_svh,
             mcg=0x83DCD12D,
+            tile_config=(64, 128, 64, 128),
+        )
+    with pytest.raises(ValueError, match="requires the checkpoint's trellis_mcg"):
+        _prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate,
+            down_svh=down_svh,
+            mcg=None,
             tile_config=(64, 128, 64, 128),
         )
 
@@ -548,7 +589,7 @@ def test_planned_full_rotation_matches_reference_and_captures(
         device=device,
     )
     assert plan.caps.w4a16_block_size_m == 8
-    assert plan._core_workspace_plan.full_rotation
+    assert plan.full_rotation
 
     spec = plan.scratch_specs()[0]
     scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
@@ -702,7 +743,7 @@ def test_planned_full_rotation_small_m_partial_blocks(m: int) -> None:
         device=device,
     )
     assert plan.caps.w4a16_block_size_m == 8
-    assert plan._core_workspace_plan.full_rotation
+    assert plan.full_rotation
 
     spec = plan.scratch_specs()[0]
     scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
@@ -814,7 +855,7 @@ def test_planned_full_rotation_capture_below_capacity(m: int) -> None:
     router_weights = torch.rand((m, topk), dtype=torch.float32, device=device)
     router_weights /= router_weights.sum(dim=1, keepdim=True)
 
-    binding = fused_moe.bind(
+    eager_binding = fused_moe.bind(
         plan,
         scratch=scratch,
         a=x,
@@ -822,12 +863,20 @@ def test_planned_full_rotation_capture_below_capacity(m: int) -> None:
         topk_weights=router_weights,
         topk_ids=ids,
     )
-    eager = binding.run().clone()
+    eager = eager_binding.run().clone()
     torch.cuda.synchronize(device)
     assert not torch.isnan(eager).any()
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
+        binding = fused_moe.bind(
+            plan,
+            scratch=scratch,
+            a=x,
+            experts=weights,
+            topk_weights=router_weights,
+            topk_ids=ids,
+        )
         captured = binding.run()
     graph.replay()
     torch.cuda.synchronize(device)

--- a/tests/moe/test_tp_moe_scratch_bindings.py
+++ b/tests/moe/test_tp_moe_scratch_bindings.py
@@ -6,7 +6,18 @@ import pytest
 import torch
 
 import sparkinfer.moe.fused_moe._impl as tp_moe_impl
-from sparkinfer.moe.fused_moe._impl import SPARKINFERFP4ExpertWeights, TPMoEFP4Binding, TPMoERouteBinding, TPMoEScratchCaps, TPMoESparseFP4Binding, build_tp_moe_route_binding, build_tp_moe_sparse_fp4_binding, plan_sparkinfer_fp4_moe_weights, plan_tp_moe_scratch, prepare_sparkinfer_fp4_moe_weights
+from sparkinfer.moe.fused_moe._impl import (
+    SPARKINFERFP4ExpertWeights,
+    TPMoEFP4Binding,
+    TPMoERouteBinding,
+    TPMoEScratchCaps,
+    TPMoESparseFP4Binding,
+    build_tp_moe_route_binding,
+    build_tp_moe_sparse_fp4_binding,
+    plan_sparkinfer_fp4_moe_weights,
+    plan_tp_moe_scratch,
+    prepare_sparkinfer_fp4_moe_weights,
+)
 from sparkinfer.moe._shared.execution import PreparedWeightLayout
 from sparkinfer.moe._shared.kernels.w4a8.weights import repack_w4a8_weights
 
@@ -347,9 +358,7 @@ def _experts(
     if representation is not None and weight_plan.discards_source_parameters:
         value = representation.value
         canonical_w1 = getattr(value, "w13_rp", getattr(value, "w13", None))
-        canonical_s1 = getattr(
-            value, "w13_sfb", getattr(value, "w13_scale", None)
-        )
+        canonical_s1 = getattr(value, "w13_sfb", getattr(value, "w13_scale", None))
         canonical_w2 = getattr(value, "w2_rp", getattr(value, "w2", None))
         canonical_s2 = getattr(value, "w2_sfb", getattr(value, "w2_scale", None))
     return SPARKINFERFP4ExpertWeights(
@@ -557,7 +566,12 @@ def test_w4a16_materialize_can_prewarm_activation_amax_variant(
     ) -> None:
         captured["collect_activation_amax"] = bool(collect_activation_amax)
         workspace.planned_fused_moe_launches = {
-            ("packed", "e4m3_k16", int(token_count), bool(collect_activation_amax)): fused
+            (
+                "packed",
+                "e4m3_k16",
+                int(token_count),
+                bool(collect_activation_amax),
+            ): fused
             for token_count in token_counts
         }
         workspace.planned_topk_sum_launches = {
@@ -610,9 +624,7 @@ def test_w4a16_scratch_binding_carries_activation_amax_to_kernel(
         "w4a16",
         w4a16_layout=PreparedWeightLayout.MMA_PACKED,
     )
-    plan = plan_tp_moe_scratch(
-        _caps(weight_plan=weight_plan, route_num_experts=0)
-    )
+    plan = plan_tp_moe_scratch(_caps(weight_plan=weight_plan, route_num_experts=0))
     scratch = _scratch_for_plan(plan)
     tensors = _runtime_tensors()
     activation_amax = torch.zeros((3, 8, 2), dtype=torch.float32)
@@ -678,9 +690,26 @@ def test_tp_moe_scratch_plan_binding_maps_caller_owned_scratch() -> None:
 
     assert isinstance(binding, TPMoEFP4Binding)
     assert binding.row_counts is not None
-    assert binding.row_counts.untyped_storage().data_ptr() == scratch[0].untyped_storage().data_ptr()
+    assert (
+        binding.row_counts.untyped_storage().data_ptr()
+        == scratch[0].untyped_storage().data_ptr()
+    )
     assert binding.a is tensors["a"]
     assert binding.topk_ids is tensors["topk_ids"]
+
+
+def test_non_trellis_plan_rejects_expert_maps() -> None:
+    plan = plan_tp_moe_scratch(_caps())
+    scratch = _scratch_for_plan(plan)
+    tensors = _runtime_tensors()
+    route_expert_map = torch.arange(8, dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="require a full-rotation Trellis plan"):
+        plan.bind(
+            scratch=scratch,
+            **_binding_args(tensors, _experts(tensors, plan.caps.weight_plan)),
+            route_expert_map=route_expert_map,
+        )
 
 
 def test_tp_moe_scratch_plan_binds_caller_owned_scratch() -> None:
@@ -792,9 +821,7 @@ def test_tp_moe_scratch_plan_bind_does_not_materialize_workspace_pool(
         "w4a16",
         w4a16_layout=PreparedWeightLayout.MMA_PACKED,
     )
-    plan = plan_tp_moe_scratch(
-        _caps(weight_plan=weight_plan, route_num_experts=0)
-    )
+    plan = plan_tp_moe_scratch(_caps(weight_plan=weight_plan, route_num_experts=0))
     scratch = _scratch_for_plan(plan)
     tensors = _runtime_tensors()
 
@@ -911,7 +938,9 @@ def test_tp_moe_route_binding_run_uses_function_binding_argument(monkeypatch) ->
     assert calls["binding"] is binding
 
 
-def test_tp_moe_sparse_fp4_binding_run_uses_function_binding_argument(monkeypatch) -> None:
+def test_tp_moe_sparse_fp4_binding_run_uses_function_binding_argument(
+    monkeypatch,
+) -> None:
     scratch = tp_moe_impl.TPMoEWorkspacePool()
     tensors = _runtime_tensors()
     binding = build_tp_moe_sparse_fp4_binding(

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -39,6 +39,28 @@ def _expected_route_pack(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_route_pack_capacity_error_reports_live_contract() -> None:
+    topk_ids = torch.zeros((17, 8), dtype=torch.int32, device="cuda")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"topk_shape=\(17, 8\).*live_routes=136.*block_size=8.*"
+            r"num_experts=32.*packed_route_indices=1/.*block_expert_ids=1/"
+        ),
+    ):
+        pack_topk_routes_by_expert(
+            topk_ids,
+            8,
+            32,
+            packed_route_indices=torch.empty(1, dtype=torch.int32, device="cuda"),
+            block_expert_ids=torch.empty(1, dtype=torch.int32, device="cuda"),
+            packed_route_count=torch.empty(1, dtype=torch.int32, device="cuda"),
+            expert_offsets=torch.empty(33, dtype=torch.int32, device="cuda"),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
 @pytest.mark.parametrize("shape", [(1, 6), (23, 3), (128, 6), (160, 6), (512, 6)])
 @pytest.mark.parametrize("block_size", [8, 16, 32, 48, 64])


### PR DESCRIPTION
## Summary

Integrate EXL3 Trellis/MCG as a W4A16 weight format under the existing planned `sparkinfer.moe.fused_moe` API.

This supersedes #49's separate public `sparkinfer.moe.trellis_moe` surface while retaining its Trellis intrinsics, native weight preparation, full-rotation kernel path, graph-safe route packing, and dense kernel support.

## Why this shape

`trellis3_t256`, `nf3_2p1`, packed FP4, and ModelOpt NVFP4 all execute through the same fused-TP W4A16 strategy. The public API should therefore vary the weight recipe, not create one MoE operator per storage format.

The integration now uses one lifecycle:

- `plan_weights(source_format="exl3_trellis_mcg", quant_modes="w4a16", ...)`
- `prepare_weights(...)`
- `Caps(..., quant_mode="w4a16")`
- `plan(...)`
- caller-owned `scratch_specs()` / `bind(...)`
- `run(...)`

Trellis and NF3 share `PreparedW4A16MoeWeights`, `TPMoEScratchPlan`, the caller-owned scratch arena, cache clearing, and activation dispatch. No second arena or parallel bind/run implementation remains.

## Functional changes

- Add Trellis 3/4/5/6-bpw FP16/BF16 decode intrinsics.
- Add native Trellis256 MoE and dense weight preparation.
- Add `trellis3_t256` full-rotation W4A16 execution with FP32 route accumulation.
- Support both SiLU and SiTU through the standard fused-MoE activation contract.
- Keep persistent prepared weights free of duplicate scratch storage.
- Add public dense API at `sparkinfer.gemm.trellis_linear`; keep `_shared.kernels.w4a16` private.
- Gate support through the existing SM120/SM121 and CUTLASS DSL capability checks.
- Document why the kernel workspace is zeroed at bind time.
- Preserve the scheduler-planned route geometry through scratch binding and execution. The live batch heuristic may choose a different `block_m`; it must not silently invalidate the planned route and expert-block capacities.

## Review decomposition

Independent changes from #49 were split out:

- #88: compiler device/architecture compile-cache identity
- #89: high-i64 page-offset indexer regression test

This PR contains only the Trellis compute and unified MoE/dense API work.

## Validation

On the pinned CUDA 13.2 / SM120 v20-r11 runtime:

- 122 passed: Trellis fused-MoE/dense correctness, SiLU/SiTU, BF16/FP16, small-M partial blocks, below-capacity CUDA graph replay, shared execution/scratch lifecycle, route packing/capacity diagnostics, and public registry/API contracts.
- 19 passed in the paired vLLM #190 port tests.
- Unified runtime import smoke test confirms vLLM resolves `sparkinfer.moe.fused_moe`; no `trellis_moe` compatibility surface is required.
- A real layer-3 rank-0 checkpoint test used native Trellis tensors at production `H=6144`, `I=512`, executed the unified plan with zero-copy weights, and passed eager plus CUDA graph replay. Independent unified runs were bitwise identical. Against the r11 legacy `trellis_moe` runtime on the same deterministic input, relative L2 error was `2.01e-4`, cosine similarity `0.999999881`, and maximum absolute difference `5.65e-5` (the comparison spans intervening shared-W4A16 changes on `master`, not only the API wrapper).
- The full 295 GiB `brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw` checkpoint passed TP4/DCP4/MTP3 load, memory profiling, piecewise/full CUDA graph capture, MTP capture, and a real HTTP generation (`EXL3_OK`). At `GPU_MEMORY_UTILIZATION=0.90`, the run reported 735,232 KV-cache tokens and a 414.7 MiB planned EXL3 prefill arena per rank.
- This E2E run exposed and now covers the geometry contract: planning selected `block_m=64`, while the live `m=1024`, top-k 8, 256-expert heuristic preferred 48. The binding now carries the planned value into route packing and GEMM; disagreement with a supplied launch fails before execution. A direct GPU check also verified that 48 and 64 compile to distinct kernels, ruling out a compile-cache collision.
- Ruff and `git diff --check` pass for every changed file.

## Consumer migration

The paired vLLM #190 update changes its EXL3 backend from `trellis_moe` to the unified weight-plan and fused-MoE API. `trellis_moe` was unreleased, so no deprecated compatibility shim is added.
