### PR TITLE
moe: bound W4A16 scratch and repair tail correctness

### DIFF
--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -562,7 +562,11 @@ class MoEMicroKernelBackend:
         col: Int32,
         n_cols: Int32,
     ) -> Float32:
-        addr = base_addr + ebase + Int64(kb16) * Int64(n_cols) + Int64(col)
+        # ModelOpt's E4M3 scale permutation is tiled in 64 output rows. Direct
+        # micro preparation retains the final padded tile so every permuted
+        # logical scale remains addressable.
+        packed_n_cols = (n_cols + Int32(63)) & ~Int32(63)
+        addr = base_addr + ebase + Int64(kb16) * Int64(packed_n_cols) + Int64(col)
         word = ld_global_nc_u32(addr & ~Int64(3))
         byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
         return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
@@ -2417,7 +2421,9 @@ class MoEMicroKernelBackend:
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
             ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
-            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.k_dim // 16) * cfg.two_n)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64(
+                (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
+            )
             thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
             xh_buf_base = Int32(0)
             if cutlass.const_expr(cfg.k_segments == 2):

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -857,10 +857,38 @@ class MoEMicroKernelBackend:
             row_mode_32_1 = k_row1 & Int32(31)
 
             kk_off = Int32(kk) * Int32(128)
-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+            if cutlass.const_expr(cfg.n < 256):
+                # The 128-u32 swizzle block pads narrow intermediates to 256
+                # logical values. FC1 writes only n/8 lanes in each 32-lane
+                # plane. Mask the remaining lanes before the dot: their
+                # weights are zero, but stale NaN scratch would make 0*NaN
+                # contaminate the warp reduction.
+                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                xh0 = (
+                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh1 = (
+                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh2 = (
+                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh3 = (
+                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+            else:
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
 
             u_packed0 = (
                 ld_global_nc_u32(
@@ -1508,10 +1536,36 @@ class MoEMicroKernelBackend:
             ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
 
             kk_off = token_inter_base + Int32(kk) * Int32(128)
-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+            if cutlass.const_expr(cfg.n < 256):
+                # Match the m==1 path above: the packed 128-u32 swizzle has
+                # unwritten padding whenever the logical intermediate is
+                # narrower than 256 values.
+                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                xh0 = (
+                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh1 = (
+                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh2 = (
+                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh3 = (
+                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+            else:
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
 
             u_packed0 = (
                 ld_global_nc_u32(

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -1120,12 +1120,20 @@ class MoEMicroKernelBackend:
                 if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
                     packed_u32 = Int32(nc * 32) + lane
                     w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
-                # If the last 256-wide chunk overhangs a non-256-aligned n
-                # (e.g. n=384), lanes past num_cb index the uninitialized
-                # intermediate tail. The weight there is already masked to 0,
-                # but 0 * NaN = NaN, so mask the activation read too. Gated by
-                # constexpr so 256-aligned shapes emit no extra runtime work.
-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                # If the last 256-value chunk overhangs logical n, lanes past
+                # the exact native row read an unwritten intermediate tail.
+                # The padded scale grid can look full at widths such as n=496,
+                # so its control-block count is not a valid activation bound.
+                # The weight is zero there, but 0 * NaN still poisons the sum.
+                # Preserve the legacy predicate for non-W4A16 modes and emit
+                # no extra work for 256-aligned native ModelOpt shapes.
+                if cutlass.const_expr(
+                    (self.w4a16_mode and cfg.n % 256 != 0)
+                    or (
+                        (not self.w4a16_mode)
+                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
+                    )
+                ):
                     xh0 = (
                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
                         if w_valid > Int32(0)
@@ -1936,9 +1944,15 @@ class MoEMicroKernelBackend:
                                 w2s_base_addr + next_ebase_sf + next_bsf_off3
                             )
                 kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
-                # See _m1_fc2_rowpair_wide: mask the intermediate tail read for
-                # non-256-aligned n (0 weight * NaN tail = NaN). constexpr-gated.
-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                # See _m1_fc2_rowpair_wide: logical n, not the padded scale
+                # grid, determines whether the native intermediate tail is live.
+                if cutlass.const_expr(
+                    (self.w4a16_mode and cfg.n % 256 != 0)
+                    or (
+                        (not self.w4a16_mode)
+                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
+                    )
+                ):
                     xh0 = (
                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
                         if w_valid > Int32(0)

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -719,8 +719,16 @@ class MoEMicroKernelBackend:
             num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
         if self.w4a16_mode and m > 1:
             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
-            # the 512-thread launch register limit.
-            num_fc1_chunks = max(num_fc1_chunks, n // (_BLOCK_SIZE * 2))
+            # the 512-thread launch register limit. The chunk count must still
+            # divide n into whole 16-value blocks: floor(n/32) silently made
+            # i_chunk non-integral at shapes such as n=144 (four 36-value
+            # chunks), so FC1 wrote only 128 of 144 logical values.
+            num_fc1_chunks = max(
+                num_fc1_chunks,
+                (n + (_BLOCK_SIZE * 2) - 1) // (_BLOCK_SIZE * 2),
+            )
+            while n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0:
+                num_fc1_chunks += 1
         if self.a8_mx_mode:
             # Per-32 self-ranging blocks: chunks must hold whole 32-blocks
             # (the default policy picks i_chunk=16 at m<=2).
@@ -821,6 +829,14 @@ class MoEMicroKernelBackend:
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+            # Native ModelOpt rows contain exactly n/8 packed u32 values.
+            # w2_sf_cols is padded to four scale columns, so its control-block
+            # count overstates the physical W2/packed-scale extent when n is a
+            # multiple of 16 but not 64 (for example, n=144). Keep the existing
+            # predicate byte-for-byte for the aligned production shapes, and
+            # gate odd-shape loads against the logical packed row instead.
+            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
         lane_mode_c = (lane >> Int32(1)) & Int32(3)
         bsf_byte_shift = lane_mode_c * Int32(8)
         out_acc0 = Float32(0.0)
@@ -1087,6 +1103,9 @@ class MoEMicroKernelBackend:
                 kk_off = Int32(kk) * n_u32_per_expert + chunk_base
                 cb_idx = Int32(nc) * Int32(4) + lane_cb
                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                    packed_u32 = Int32(nc * 32) + lane
+                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
                 # If the last 256-wide chunk overhangs a non-256-aligned n
                 # (e.g. n=384), lanes past num_cb index the uninitialized
                 # intermediate tail. The weight there is already masked to 0,
@@ -1499,6 +1518,8 @@ class MoEMicroKernelBackend:
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
         lane_mode_c = (lane >> Int32(1)) & Int32(3)
         bsf_byte_shift = lane_mode_c * Int32(8)
         out_acc0 = Float32(0.0)
@@ -1780,9 +1801,20 @@ class MoEMicroKernelBackend:
                 chunk_base = Int32(nc) * Int32(128)
                 cb_idx = Int32(nc) * Int32(4) + lane_cb
                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                    packed_u32 = Int32(nc * 32) + lane
+                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
                 if cutlass.const_expr(nc + 1 < cfg.fc2_n_chunks):
                     next_cb_idx = Int32(nc + 1) * Int32(4) + lane_cb
-                    if next_cb_idx < num_cb:
+                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
+                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                        next_packed_u32 = Int32((nc + 1) * 32) + lane
+                        next_w_valid = (
+                            Int32(1)
+                            if next_packed_u32 < Int32(cfg.n // 8)
+                            else Int32(0)
+                        )
+                    if next_w_valid > Int32(0):
                         next_chunk_base = Int32(nc + 1) * Int32(128)
                         prefetch_global_l2(
                             w2_base_addr
@@ -1820,7 +1852,12 @@ class MoEMicroKernelBackend:
                         cfg.w2_sf_rows * cfg.w2_sf_cols
                     )
                     next_cb_idx = lane_cb
-                    if next_cb_idx < num_cb:
+                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
+                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                        next_w_valid = (
+                            Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                        )
+                    if next_w_valid > Int32(0):
                         prefetch_global_l2(
                             w2_base_addr
                             + next_ebase_w

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -716,7 +716,21 @@ class MoEMicroKernelBackend:
                 rows_per_warp_div = 4
             elif cfg.k_segments_aligned and cfg.k_segments == 12 and self.is_gated:
                 rows_per_warp_div = 1
-            num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
+            num_fc1_chunks = min(
+                num_fc1_chunks,
+                max(1, n // (rows_per_warp_div * _BLOCK_SIZE)),
+            )
+            # The retile cap is a floor division, so it can choose a chunk
+            # count that no longer partitions a merely 16-aligned native
+            # ModelOpt intermediate (for example, n=144 caps 9 chunks at 4,
+            # yielding a truncated 36-value chunk). Walk down to the largest
+            # valid divisor so every FC1 chunk covers whole 16-value blocks.
+            # Aligned production shapes retain their existing geometry.
+            while num_fc1_chunks > 1 and (
+                n % num_fc1_chunks != 0
+                or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
+            ):
+                num_fc1_chunks -= 1
         if self.w4a16_mode and m > 1:
             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
             # the 512-thread launch register limit. The chunk count must still

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -106,9 +106,7 @@ def _fp6_micro_enabled() -> bool:
     Keeps the validated dynamic FP6 fused path as the only FP6 backend until
     the micro kernel is wired into dispatch and numerically proven.
     """
-    return os.environ.get(
-        "SPARKINFER_ENABLE_FP6_MICRO", "0"
-    ).strip().lower() not in (
+    return os.environ.get("SPARKINFER_ENABLE_FP6_MICRO", "0").strip().lower() not in (
         "",
         "0",
         "false",
@@ -727,8 +725,7 @@ class MoEMicroKernelBackend:
             # valid divisor so every FC1 chunk covers whole 16-value blocks.
             # Aligned production shapes retain their existing geometry.
             while num_fc1_chunks > 1 and (
-                n % num_fc1_chunks != 0
-                or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
+                n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
             ):
                 num_fc1_chunks -= 1
         if self.w4a16_mode and m > 1:
@@ -2486,9 +2483,7 @@ class MoEMicroKernelBackend:
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
             e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
-            ebase_sf_packed = Int64(eid) * Int64(
-                (cfg.k_dim // 32) * e8m0_w1_n_cols
-            )
+            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * e8m0_w1_n_cols)
             ebase_sf_packed_e4m3 = Int64(eid) * Int64(
                 (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
             )

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -2471,7 +2471,10 @@ class MoEMicroKernelBackend:
             # ---- FC1 weight load + dot product ----
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
-            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
+            e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
+            ebase_sf_packed = Int64(eid) * Int64(
+                (cfg.k_dim // 32) * e8m0_w1_n_cols
+            )
             ebase_sf_packed_e4m3 = Int64(eid) * Int64(
                 (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
             )
@@ -2644,7 +2647,7 @@ class MoEMicroKernelBackend:
 
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                            nc1 = Int32(cfg.two_n)
+                            nc1 = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -2768,7 +2771,7 @@ class MoEMicroKernelBackend:
 
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbbg = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                        nc1g = Int32(cfg.two_n)
+                        nc1g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3085,7 +3088,7 @@ class MoEMicroKernelBackend:
                         sf_u5 = Float32(0.0)
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb_u = lane_seg_base >> Int32(1)
-                            nc_u = Int32(cfg.two_n)
+                            nc_u = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -3225,7 +3228,7 @@ class MoEMicroKernelBackend:
                     sf_g5 = Float32(0.0)
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbb_g = lane_seg_base >> Int32(1)
-                        nc_g = Int32(cfg.two_n)
+                        nc_g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3463,7 +3466,7 @@ class MoEMicroKernelBackend:
 
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb_u = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                            nc_u = Int32(cfg.two_n)
+                            nc_u = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -3645,7 +3648,7 @@ class MoEMicroKernelBackend:
 
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbb_g = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                        nc_g = Int32(cfg.two_n)
+                        nc_g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3940,7 +3943,7 @@ class MoEMicroKernelBackend:
                                 ebase_sf_packed,
                                 lane,
                                 row_u,
-                                Int32(cfg.two_n),
+                                Int32(e8m0_w1_n_cols),
                                 Int32(cfg.k_dim // 32),
                             )
                             sf_u1 = sf_u0
@@ -3976,7 +3979,7 @@ class MoEMicroKernelBackend:
                             ebase_sf_packed,
                             lane,
                             row_g,
-                            Int32(cfg.two_n),
+                            Int32(e8m0_w1_n_cols),
                             Int32(cfg.k_dim // 32),
                         )
                         sf_g1 = sf_g0
@@ -4470,7 +4473,7 @@ class MoEMicroKernelBackend:
                                         ebase_sf_packed,
                                         scale_col >> Int32(1),
                                         row_g,
-                                        Int32(cfg.two_n),
+                                        Int32(e8m0_w1_n_cols),
                                         Int32(cfg.k_dim // 32),
                                     )
                                     if valid_seg > Int32(0)
@@ -4527,7 +4530,7 @@ class MoEMicroKernelBackend:
                                             ebase_sf_packed,
                                             scale_col >> Int32(1),
                                             row_u,
-                                            Int32(cfg.two_n),
+                                            Int32(e8m0_w1_n_cols),
                                             Int32(cfg.k_dim // 32),
                                         )
                                         if valid_seg > Int32(0)

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -752,9 +752,7 @@ class MoEMicroKernelBackend:
             # Likewise FC2 can expose every output-row task directly once
             # FC1 has completed in a prior launch.
             grid_x = max(1, fc2_tasks)
-        elif m == 1:
-            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
-        elif m == 2:
+        elif m in (1, 2):
             grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
         elif num_fc1_chunks < 16:
             grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
@@ -815,7 +813,6 @@ class MoEMicroKernelBackend:
         k_row1 = k_row0 + Int32(1)
 
         lane_byte_off = Int64(lane) * Int64(4)
-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
         sf_cols = Int32(cfg.w2_sf_cols)
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
@@ -1274,7 +1271,6 @@ class MoEMicroKernelBackend:
         k_row3 = k_row0 + Int32(3)
 
         lane_byte_off = Int64(lane) * Int64(4)
-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
         token_inter_base = t * Int32(cfg.inter_u32)
         sf_cols = Int32(cfg.w2_sf_cols)
         num_cb = sf_cols >> Int32(2)

--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
@@ -219,6 +219,20 @@ def select_route_block_size_m(m: int, topk: int, num_experts: int) -> int:
     return _W4A16_ALLOWED_ROUTED_SIZES[-1]
 
 
+def route_block_sizes_for_capacity(
+    max_tokens: int,
+    topk: int,
+    num_experts: int,
+) -> tuple[int, ...]:
+    """Conservative block-size set reachable within a token capacity."""
+    max_tokens = max(int(max_tokens), 1)
+    first = select_route_block_size_m(1, topk, num_experts)
+    last = select_route_block_size_m(max_tokens, topk, num_experts)
+    first_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(first)
+    last_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(last)
+    return _W4A16_ALLOWED_ROUTED_SIZES[first_idx : last_idx + 1]
+
+
 def max_packed_route_slots(numel: int, block_size: int, num_experts: int) -> int:
     max_packed_routes = int(numel) + int(num_experts) * (int(block_size) - 1)
     if int(numel) < int(num_experts):

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -1183,9 +1183,12 @@ def prepare_w4a16_e8m0_native_weights(
     w13_rows = shape.w13_rows
     is_gated = shape.is_gated
     allow_w2_k_tail = intermediate_size % 32 != 0
-    padded_w13_scale_n = (
-        _e8m0_logical_tail_scale_n(w13_rows) if allow_w2_k_tail else w13_rows
-    )
+    # Packed E8M0 scale rows are permuted in 64-row blocks independently of
+    # whether W2 has a compact K tail.  Ungated 32-aligned intermediates such
+    # as I=224 therefore still need W13's 224 scale rows padded to 256; tying
+    # this padding to ``allow_w2_k_tail`` advertised the direct shape and then
+    # rejected it during preparation.
+    padded_w13_scale_n = _e8m0_logical_tail_scale_n(w13_rows)
 
     w13_scale = _validate_e8m0_k32_scales(
         w13_e8m0_scale,

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -669,6 +669,7 @@ def _permute_nvfp4_scales(
     size_n: int,
     a_dtype: torch.dtype,
     row_rotation: int | None = None,
+    output_size_n: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     combined_scale_factor = _nvfp4_compute_scale_factor(scales, a_dtype)
     packed_scales: torch.Tensor | None = None
@@ -684,6 +685,7 @@ def _permute_nvfp4_scales(
             size_k=size_k,
             size_n=size_n,
             group_size=16,
+            output_size_n=output_size_n,
         )
         expert_packed = _process_nvfp4_packed_scales(
             expert_scales,
@@ -697,8 +699,9 @@ def _permute_nvfp4_scales(
             )
         packed_scales[expert].copy_(expert_packed)
     if packed_scales is None:
+        packed_size_n = int(size_n) if output_size_n is None else int(output_size_n)
         packed_scales = torch.empty(
-            (0, size_k // _PACKED_TILE_SIZE, size_n // 2),
+            (0, size_k // _PACKED_TILE_SIZE, packed_size_n // 2),
             dtype=torch.float8_e4m3fn,
             device=scales.device,
         )
@@ -1098,6 +1101,24 @@ def prepare_w4a16_modelopt_native_weights(
         size_n=hidden_size,
         a_dtype=params_dtype,
     )
+    micro_w13_scale = packed_w13_scale
+    micro_w13_global_scale = packed_w13_global_scale
+    if w13_rows % _PACKED_TILE_N_SIZE != 0:
+        # The direct micro reader uses the native 64-row scale permutation.
+        # Keep the final tile intact: truncating it after permutation discards
+        # logical rows whose permuted columns land above ``w13_rows``.
+        micro_scale_n = (
+            (w13_rows + _PACKED_TILE_N_SIZE - 1) // _PACKED_TILE_N_SIZE
+        ) * _PACKED_TILE_N_SIZE
+        micro_w13_scale, micro_w13_global_scale = _permute_nvfp4_scales(
+            w13_scale,
+            native_w13_global_scale,
+            size_k=hidden_size,
+            size_n=w13_rows,
+            a_dtype=params_dtype,
+            row_rotation=w13_row_rotation,
+            output_size_n=micro_scale_n,
+        )
 
     return W4A16ModelOptWeights(
         w13=w13_fp4,
@@ -1113,9 +1134,9 @@ def prepare_w4a16_modelopt_native_weights(
         is_gated=is_gated,
         params_dtype=params_dtype,
         source_format=source_format,
-        micro_w13_scale=packed_w13_scale,
+        micro_w13_scale=micro_w13_scale,
         micro_w13_global_scale=_process_nvfp4_micro_global_scale_from_packed(
-            packed_w13_global_scale,
+            micro_w13_global_scale,
             a_dtype=params_dtype,
         ),
         micro_w2_scale=packed_w2_scale,

--- a/sparkinfer/moe/ep_moe/_impl.py
+++ b/sparkinfer/moe/ep_moe/_impl.py
@@ -32,9 +32,9 @@ from sparkinfer.moe._shared.kernels.activations import (
     moe_activation_w1_rows,
 )
 from sparkinfer.moe._shared.kernels.w4a16.host import (
-    _W4A16_ALLOWED_ROUTED_SIZES,
     max_packed_route_slots,
     packed_gemm_scratch_elements,
+    route_block_sizes_for_capacity,
     route_pack_token_capacity,
 )
 
@@ -379,7 +379,12 @@ def plan_ep_moe_scratch(caps: EPMoEScratchCaps) -> EPMoEScratchPlan:
     route_blocks = 1
     fc1_tmp = 1
     fc2_tmp = 1
-    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+    block_sizes = route_block_sizes_for_capacity(
+        caps.max_tokens,
+        caps.num_topk,
+        caps.global_num_experts,
+    )
+    for block_size in block_sizes:
         slots = max_packed_route_slots(
             route_capacity_rows,
             int(block_size),

--- a/sparkinfer/moe/fused_moe/__init__.py
+++ b/sparkinfer/moe/fused_moe/__init__.py
@@ -14,6 +14,8 @@ Runtime lifecycle:
     ``plan(Caps)`` -> ``bind`` / ``bind_sparse`` / ``bind_route``
     (allocation-free views) -> ``run`` / ``run_sparse`` / ``route``
     (CUDA-graph capture safe)
+``required_nbytes(Caps)`` prices that scratch without compiling launches or
+retaining storage.
 ``route_topk`` is a standalone one-shot top-k router; ``run_sparse`` fuses
 gate -> top-k -> experts from router logits.
 
@@ -52,6 +54,7 @@ META = OpMeta(
         "Routing",
         "WeightsPlan",
         "plan",
+        "required_nbytes",
         "plan_execution",
         "plan_weights",
         "prepare_weights",
@@ -101,6 +104,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
         clear_caches,
         is_supported,
         plan,
+        required_nbytes,
         plan_execution,
         plan_weights,
         prepare_weights,

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -2533,11 +2533,14 @@ def _plan_core_workspace(
     )
     if implementation == "w4a16":
         from sparkinfer.moe._shared.kernels.w4a16.host import (
-            _W4A16_ALLOWED_ROUTED_SIZES,
             max_packed_route_slots,
             packed_gemm_scratch_elements,
+            route_block_sizes_for_capacity,
+            select_route_block_size_m,
         )
         from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+            _MAX_DIRECT_TOPK_ROUTE_M,
+            _TC_DECODE_MAX_M,
             _small_m_direct_supported,
         )
 
@@ -2552,8 +2555,9 @@ def _plan_core_workspace(
             if w4a16_weight_layout is not None
             else _w4a16_weight_layout_for_source(source_format)
         )
-        route_E = int(route_num_experts or weight_E)
+        requested_route_E = int(route_num_experts or weight_E)
         full_rotation = weight_layout == "trellis3_t256"
+        route_E = requested_route_E if full_rotation else int(weight_E)
         if full_rotation:
             if source_format != "exl3_trellis_mcg":
                 raise ValueError(
@@ -2574,16 +2578,41 @@ def _plan_core_workspace(
         fc1_c_tmp_elements = 1
         fc2_c_tmp_elements = 1
         sms = max(1, int(get_num_sm(device)))
+        topk = max(int(num_topk), 1)
+        token_capacity = (routed_capacity + topk - 1) // topk
+        direct_route_slots_by_block: dict[int, int] = {}
+        if weight_layout == "packed":
+            direct_m_cap = _MAX_DIRECT_TOPK_ROUTE_M
+            if dtype == torch.bfloat16 and is_gated_moe_activation(activation):
+                direct_m_cap = _TC_DECODE_MAX_M
+            for direct_m in range(1, min(token_capacity, direct_m_cap) + 1):
+                direct_block_size = (
+                    int(w4a16_block_size_m)
+                    if w4a16_block_size_m is not None
+                    else select_route_block_size_m(direct_m, topk, route_E)
+                )
+                direct_route_slots_by_block[direct_block_size] = max(
+                    direct_route_slots_by_block.get(direct_block_size, 0),
+                    direct_m * topk * direct_block_size,
+                )
         block_sizes = (
             (int(w4a16_block_size_m),)
             if w4a16_block_size_m is not None
-            else _W4A16_ALLOWED_ROUTED_SIZES
+            else route_block_sizes_for_capacity(
+                max_tokens=token_capacity,
+                topk=topk,
+                num_experts=route_E,
+            )
         )
         for block_size in block_sizes:
             route_slots = max_packed_route_slots(
                 routed_capacity,
                 int(block_size),
                 route_E,
+            )
+            scratch_route_slots = max(
+                route_slots,
+                direct_route_slots_by_block.get(int(block_size), 0),
             )
             route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
             route_slots_capacity = max(route_slots_capacity, route_slots)
@@ -2592,7 +2621,7 @@ def _plan_core_workspace(
                 fc1_c_tmp_elements,
                 packed_gemm_scratch_elements(
                     size_n=fc1_cols,
-                    route_slots=route_slots,
+                    route_slots=scratch_route_slots,
                     moe_block_size=int(block_size),
                     sms=sms,
                 ),
@@ -2601,7 +2630,7 @@ def _plan_core_workspace(
                 fc2_c_tmp_elements,
                 packed_gemm_scratch_elements(
                     size_n=int(k),
-                    route_slots=route_slots,
+                    route_slots=scratch_route_slots,
                     moe_block_size=int(block_size),
                     sms=sms,
                 ),
@@ -6365,14 +6394,16 @@ def _plan_full_rotation_w4a16_launches(
     return fused_launches, topk_sum_launches
 
 
-def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
-    deterministic_output = caps.deterministic_output
+def _plan_tp_moe_arena_layout_from_caps(
+    caps: TPMoEScratchCaps,
+    *,
+    deterministic_output: bool | None = None,
+) -> TPMoEArenaLayout:
+    if not isinstance(caps, TPMoEScratchCaps):
+        raise TypeError("caps must be a TPMoEScratchCaps")
     if deterministic_output is None:
-        deterministic_output = _dynamic_deterministic_output_enabled(
-            quant_mode=caps.quant_mode,
-            device=torch.device(caps.device),
-        )
-    layout = plan_tp_moe_arena_layout(
+        deterministic_output = caps.deterministic_output
+    return plan_tp_moe_arena_layout(
         max_tokens=caps.max_tokens,
         num_topk=caps.num_topk,
         device=caps.device,
@@ -6388,6 +6419,19 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         collect_activation_amax=caps.collect_activation_amax,
         deterministic_output=deterministic_output,
         w4a16_block_size_m=caps.w4a16_block_size_m,
+    )
+
+
+def tp_moe_required_nbytes(caps: TPMoEScratchCaps) -> int:
+    """Return the planned arena bytes without compiling launches or retaining storage."""
+    return _plan_tp_moe_arena_layout_from_caps(caps).total_nbytes
+
+
+def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+    deterministic_output = caps.deterministic_output
+    layout = _plan_tp_moe_arena_layout_from_caps(
+        caps,
+        deterministic_output=deterministic_output,
     )
     capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
     launch_plan = plan_tp_moe_execution(

--- a/sparkinfer/moe/fused_moe/api.py
+++ b/sparkinfer/moe/fused_moe/api.py
@@ -52,6 +52,9 @@ from ._impl import (
     plan_tp_moe_scratch as plan,
 )
 from ._impl import (
+    tp_moe_required_nbytes as required_nbytes,
+)
+from ._impl import (
     prepare_sparkinfer_fp4_moe_weights as prepare_weights,
 )
 from ._impl import (
@@ -91,6 +94,7 @@ __all__ = [
     "Routing",
     "WeightsPlan",
     "plan",
+    "required_nbytes",
     "plan_execution",
     "plan_weights",
     "prepare_weights",

--- a/tests/moe/test_ep_moe_api.py
+++ b/tests/moe/test_ep_moe_api.py
@@ -7,7 +7,10 @@ import sparkinfer.moe.ep_moe._impl as ep_moe
 from sparkinfer._lib.intrinsics import swizzle_block_scale
 from sparkinfer.moe.ep_moe._impl import EPMoEScratchCaps, plan_ep_moe_scratch, prepare_ep_expert_map, sparkinfer_ep_moe_fp4
 from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
-from sparkinfer.moe._shared.kernels.w4a16.host import max_w4a16_route_capacity
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    route_block_sizes_for_capacity,
+)
 from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
 
 
@@ -116,7 +119,20 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
     )
 
     layout = {spec.name: spec for spec in plan._layout}
-    expected_slots, expected_blocks = max_w4a16_route_capacity(4 * 2, 10)
+    block_sizes = route_block_sizes_for_capacity(3, 2, 10)
+    expected_slots = max(
+        max_packed_route_slots(4 * 2, block_size, 10)
+        for block_size in block_sizes
+    )
+    expected_blocks = max(
+        (
+            max_packed_route_slots(4 * 2, block_size, 10)
+            + block_size
+            - 1
+        )
+        // block_size
+        for block_size in block_sizes
+    )
     assert layout["packed_route_indices"].elements == expected_slots
     assert layout["block_expert_ids"].elements == expected_blocks
     assert layout["intermediate_cache2"].elements == 3 * 2 * 128

--- a/tests/moe/test_fused_moe_planning.py
+++ b/tests/moe/test_fused_moe_planning.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sparkinfer.moe import fused_moe
+import sparkinfer.moe.fused_moe._impl as fused_moe_impl
+
+
+def _weight_plan() -> fused_moe.WeightsPlan:
+    return fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="modelopt_nvfp4",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=6144,
+        intermediate_size=512,
+        w13_layout="w13",
+    )
+
+
+def _caps(*, block_size_m: int | None) -> fused_moe.Caps:
+    return fused_moe.Caps(
+        max_tokens=64,
+        num_topk=8,
+        route_num_experts=160,
+        device="cpu",
+        weight_plan=_weight_plan(),
+        quant_mode="w4a16",
+        w4a16_block_size_m=block_size_m,
+    )
+
+
+def _trellis_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="exl3_trellis_mcg",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=6144,
+        intermediate_size=512,
+        w13_layout="w13",
+        trellis_bits=3,
+        trellis_tile_config=(64, 256, 64, 256),
+    )
+    return fused_moe.Caps(
+        max_tokens=3072,
+        num_topk=8,
+        route_num_experts=160,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+        w4a16_block_size_m=64,
+    )
+
+
+def _small_packed_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="compressed_tensors",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=16,
+        hidden_size=128,
+        intermediate_size=128,
+        w13_layout="w13",
+    )
+    return fused_moe.Caps(
+        max_tokens=4,
+        num_topk=8,
+        route_num_experts=16,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+
+def _subset_router_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="compressed_tensors",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=128,
+        intermediate_size=128,
+        w13_layout="w13",
+    )
+    return fused_moe.Caps(
+        max_tokens=8,
+        num_topk=8,
+        route_num_experts=16,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+
+def test_required_nbytes_avoids_launch_prewarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    def fail_launch_prewarm(**_kwargs) -> None:
+        raise AssertionError("launch prewarm called")
+
+    monkeypatch.setattr(
+        fused_moe_impl,
+        "_plan_full_rotation_w4a16_launches",
+        fail_launch_prewarm,
+    )
+    caps = _trellis_caps()
+
+    required = fused_moe.required_nbytes(caps)
+
+    assert required > 1024 * 1024 * 1024
+    assert "required_nbytes" in fused_moe.META.entry_points
+    with pytest.raises(TypeError, match="TPMoEScratchCaps"):
+        fused_moe.required_nbytes(object())
+
+
+def test_required_nbytes_matches_scratch_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+    caps = _caps(block_size_m=8)
+
+    plan = fused_moe.plan(caps)
+
+    assert fused_moe.required_nbytes(caps) == plan.scratch_specs()[0].shape[0]
+
+
+def test_small_packed_plan_covers_direct_topk_scratch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    plan = fused_moe.plan(_small_packed_caps())
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+
+    assert specs["fc1_c_tmp"].shape == (131072,)
+    assert specs["fc2_c_tmp"].shape == (65536,)
+
+
+def test_non_trellis_core_sizes_routes_for_weight_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    plan = fused_moe.plan(_subset_router_caps())
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+
+    assert plan._core_workspace_plan.route_E == 160
+    assert specs["packed_route_indices"].shape == (512,)
+    assert specs["block_expert_ids"].shape == (64,)
+    assert specs["expert_offsets"].shape == (161,)
+
+
+def test_unpinned_small_capacity_matches_reachable_block_8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    automatic = fused_moe.required_nbytes(_caps(block_size_m=None))
+    exact = fused_moe.required_nbytes(_caps(block_size_m=8))
+    oversized = fused_moe.required_nbytes(_caps(block_size_m=64))
+
+    assert automatic == exact
+    assert oversized - automatic > 64 * 1024 * 1024

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -933,7 +933,7 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 224])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1030,6 +1030,11 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
         experts=w4a16_experts,
         topk_weights=topk_weights,
         topk_ids=topk_ids,
+        output=torch.empty(
+            (m, hidden_size),
+            dtype=x.dtype,
+            device=x.device,
+        ),
         quant_mode="w4a16",
     )
     expected = moe_reference_w4a16_f32(
@@ -1048,7 +1053,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
         activation=activation,
     )
 
-    first = binding.run()
+    first = binding.run().clone()
     torch.cuda.synchronize()
     first_metrics = compare_to_reference(first, expected)
     assert bool(torch.isfinite(first).all().item())
@@ -1058,13 +1063,29 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
     # and FC2 ignores every inactive lane on the same-binding replay.
     binding.intermediate_cache2.fill_(float("nan"))
-    replay = binding.run()
+    replay = binding.run().clone()
     torch.cuda.synchronize()
     replay_metrics = compare_to_reference(replay, expected)
     assert bool(torch.isfinite(replay).all().item())
     assert replay_metrics.cos > 0.999, replay_metrics
-    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
+
+    # Capture the same direct path once, then repeatedly replay it after
+    # poisoning the arena tail. Graph replay does not re-enter the Python spy,
+    # so three launches prove two eager calls plus one captured custom-op node.
+    graph = torch.cuda.CUDAGraph()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        graph_output = binding.run()
+    for _ in range(16):
+        binding.intermediate_cache2.fill_(float("nan"))
+        graph.replay()
+    torch.cuda.synchronize()
+    graph_metrics = compare_to_reference(graph_output, expected)
+    assert bool(torch.isfinite(graph_output).all().item())
+    assert graph_metrics.cos > 0.999, graph_metrics
+    torch.testing.assert_close(graph_output, first, atol=0.0, rtol=0.0)
+    assert direct_launches == [(m, intermediate_size)] * 3
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -885,15 +885,36 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 224])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
+    intermediate_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    experts, hidden_size, intermediate_size = 8, 128, 128
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    experts, hidden_size = 8, 128
     topk = 2
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
-    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0) + m)
+    torch.manual_seed(
+        20260730
+        + (1000 if activation == "silu" else 0)
+        + m
+        + intermediate_size
+    )
+    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
+    direct_launches: list[tuple[int, int]] = []
+
+    def spy_direct_launch(*args, **kwargs) -> None:
+        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
+        real_direct_launch(*args, **kwargs)
+
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_w4a16_small_m_direct_launch_flat",
+        spy_direct_launch,
+    )
     rows = intermediate_size * (2 if activation == "silu" else 1)
     w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
     w2_dense = (
@@ -988,6 +1009,8 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     replay_metrics = compare_to_reference(replay, expected)
     assert bool(torch.isfinite(replay).all().item())
     assert replay_metrics.cos > 0.999, replay_metrics
+    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
+    torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -420,6 +420,7 @@ def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("intermediate_size", [128, 224])
 @pytest.mark.parametrize("w13_layout", ["w13", "w31"])
 # 0.5 is small enough to actually engage the SwiGLU clamp at these scales.
 @pytest.mark.parametrize("swiglu_limit", [None, 0.5])
@@ -430,6 +431,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
     m: int,
     swiglu_limit: float | None,
     w13_layout: str,
+    intermediate_size: int,
 ) -> None:
     """Small-M micro decode path with native MXFP4 (E8M0 K/32) scales."""
     if swiglu_limit is not None and activation != "silu":
@@ -449,7 +451,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
             scale_format="e8m0_k32", **common
         )
         assert e4m3.__cache_key__ != e8m0.__cache_key__
-    experts, hidden_size, intermediate_size = 4, 128, 128
+    experts, hidden_size = 4, 128
     rows = intermediate_size * (2 if activation == "silu" else 1)
     topk = 2
     torch.manual_seed(20260601 + (1000 if activation == "silu" else 0) + m)

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -884,12 +884,16 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
+    m: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     experts, hidden_size, intermediate_size = 8, 128, 128
-    m, topk = 3, 2
-    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0))
+    topk = 2
+    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0) + m)
     rows = intermediate_size * (2 if activation == "silu" else 1)
     w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
     w2_dense = (
@@ -930,6 +934,22 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     )
     prepared_w4a16 = w4a16_experts.representation_for("w4a16")
     assert prepared_w4a16.weight_layout == "modelopt"
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout=prepared_w4a16.weight_layout,
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
     binding = make_tp_moe_fp4_binding(
         a=x,
         experts=w4a16_experts,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -35,7 +35,11 @@ from sparkinfer.moe._shared.kernels.w4a16.prepare import (
     prepare_w4a16_modelopt_nvfp4_weights as prepare_w4a16_weights,
     prepare_w4a16_packed_weights,
 )
-from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
+from tests._reference.helpers import (
+    make_tp_moe_fp4_binding,
+    prepare_tp_moe_fp4_experts,
+    run_tp_moe_fp4,
+)
 from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
 
 
@@ -876,6 +880,94 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
             topk,
             ids_dtype,
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
+    activation: str,
+) -> None:
+    experts, hidden_size, intermediate_size = 8, 128, 128
+    m, topk = 3, 2
+    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0))
+    rows = intermediate_size * (2 if activation == "silu" else 1)
+    w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
+    w2_dense = (
+        torch.randn(experts, hidden_size, intermediate_size, device="cuda") * 0.12
+    )
+    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+        w13_dense,
+        w13_global_scale,
+    )
+    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
+        w2_dense,
+        w2_global_scale,
+    )
+    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
+    topk_ids = torch.randint(
+        0,
+        experts,
+        (m, topk),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
+    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w4a16_experts = prepare_tp_moe_fp4_experts(
+        a=x,
+        a1_gscale=a_gscale,
+        w1_fp4=w13,
+        w1_blockscale=w13_blockscale,
+        w1_alphas=w13_global_scale,
+        a2_gscale=a_gscale,
+        w2_fp4=w2,
+        w2_blockscale=w2_blockscale,
+        w2_alphas=w2_global_scale,
+        activation=activation,
+        quant_mode="w4a16",
+    )
+    prepared_w4a16 = w4a16_experts.representation_for("w4a16")
+    assert prepared_w4a16.weight_layout == "modelopt"
+    binding = make_tp_moe_fp4_binding(
+        a=x,
+        experts=w4a16_experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_mode="w4a16",
+    )
+    expected = moe_reference_w4a16_f32(
+        x,
+        w13,
+        w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation=activation,
+    )
+
+    first = binding.run()
+    torch.cuda.synchronize()
+    first_metrics = compare_to_reference(first, expected)
+    assert bool(torch.isfinite(first).all().item())
+    assert first_metrics.cos > 0.999, first_metrics
+
+    # The arena legitimately preserves the padded half of each 128-u32
+    # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
+    # and FC2 ignores every inactive lane on the same-binding replay.
+    binding.intermediate_cache2.fill_(float("nan"))
+    replay = binding.run()
+    torch.cuda.synchronize()
+    replay_metrics = compare_to_reference(replay, expected)
+    assert bool(torch.isfinite(replay).all().item())
+    assert replay_metrics.cos > 0.999, replay_metrics
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -955,6 +955,12 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     )
     prepared_w4a16 = w4a16_experts.representation_for("w4a16")
     assert prepared_w4a16.weight_layout == "modelopt"
+    micro_w13_scale = prepared_w4a16.micro_w13_scale
+    assert micro_w13_scale is not None
+    expected_micro_w13_rows = ((rows + 63) // 64) * 64
+    assert int(micro_w13_scale.numel()) == (
+        experts * (hidden_size // 16) * expected_micro_w13_rows
+    )
     assert _small_m_direct_supported(
         m=m,
         hidden_size=hidden_size,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -264,6 +264,54 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
+@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
+def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
+    m: int,
+    activation: str,
+    intermediate_size: int,
+) -> None:
+    """Native ModelOpt decode supports every 16-aligned intermediate shape."""
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=128,
+        intermediate_size=intermediate_size,
+        num_experts=1,
+        topk=1,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout="modelopt",
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
+    kernel = MoEMicroKernelW4A16SmallMDirect(
+        activation=activation,
+        fast_math=True,
+        share_input_across_experts=True,
+        share_expert_scales=True,
+        single_token=m == 1,
+    )
+    kernel.configure(
+        m=m,
+        k=128,
+        n=intermediate_size,
+        num_topk=1,
+        weight_E=1,
+        max_active_ctas=1,
+    )
+    assert kernel._cfg is not None
+    assert kernel._cfg.n % kernel._cfg.fc1_chunks == 0
+    assert kernel._cfg.i_chunk % 16 == 0
+    assert kernel._cfg.inter_blocks * 16 == kernel._cfg.i_chunk
+    if m > 1:
+        assert kernel._cfg.i_chunk <= 32
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
@@ -1017,6 +1065,136 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     assert replay_metrics.cos > 0.999, replay_metrics
     assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
+def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
+    m: int,
+    activation: str,
+    intermediate_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the exact native row tail under CUDA memcheck.
+
+    I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
+    values per W2 row while the ModelOpt scale grid pads its control geometry
+    to 24. I=352 exercises the wide two-chunk kernel, whose final chunk has
+    only 12 logical lanes. Selecting the only expert makes an unmasked tail
+    load on the final W2 row cross the tensor allocation instead of merely
+    reading the next expert. Run this test under compute-sanitizer with
+    ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
+    direct-FC2 implementations.
+    """
+    experts, hidden_size, topk = 1, 128, 1
+    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    torch.manual_seed(
+        20260731
+        + m
+        + intermediate_size
+        + (1000 if activation == "silu" else 0)
+    )
+
+    rows = intermediate_size * (2 if activation == "silu" else 1)
+    w13_dense = (
+        torch.randn(
+            experts,
+            rows,
+            hidden_size,
+            device="cuda",
+        )
+        * 0.12
+    )
+    w2_dense = (
+        torch.randn(
+            experts,
+            hidden_size,
+            intermediate_size,
+            device="cuda",
+        )
+        * 0.12
+    )
+    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+        w13_dense,
+        w13_global_scale,
+    )
+    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
+        w2_dense,
+        w2_global_scale,
+    )
+    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
+    topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int32)
+    topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
+    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+
+    experts_w4a16 = prepare_tp_moe_fp4_experts(
+        a=x,
+        a1_gscale=a_gscale,
+        w1_fp4=w13,
+        w1_blockscale=w13_blockscale,
+        w1_alphas=w13_global_scale,
+        a2_gscale=a_gscale,
+        w2_fp4=w2,
+        w2_blockscale=w2_blockscale,
+        w2_alphas=w2_global_scale,
+        activation=activation,
+        quant_mode="w4a16",
+    )
+    prepared = experts_w4a16.representation_for("w4a16")
+    assert prepared.weight_layout == "modelopt"
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout=prepared.weight_layout,
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
+
+    binding = make_tp_moe_fp4_binding(
+        a=x,
+        experts=experts_w4a16,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_mode="w4a16",
+    )
+    expected = moe_reference_w4a16_f32(
+        x,
+        w13,
+        w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation=activation,
+    )
+
+    first = binding.run().clone()
+    binding.intermediate_cache2.fill_(float("nan"))
+    replay = binding.run().clone()
+    torch.cuda.synchronize()
+    for actual in (first, replay):
+        metrics = compare_to_reference(actual, expected)
+        assert bool(torch.isfinite(actual).all().item())
+        assert metrics.cos > 0.999, metrics
+    torch.testing.assert_close(first, replay, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -264,7 +264,7 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [16, 144, 352])
+@pytest.mark.parametrize("intermediate_size", [16, 144, 352, 496])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -945,7 +945,7 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352, 496])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1101,7 +1101,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("intermediate_size", [144, 352, 496])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
@@ -1114,12 +1114,13 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
 
     I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
     values per W2 row while the ModelOpt scale grid pads its control geometry
-    to 24. I=352 exercises the wide two-chunk kernel, whose final chunk has
-    only 12 logical lanes. Selecting the only expert makes an unmasked tail
-    load on the final W2 row cross the tensor allocation instead of merely
-    reading the next expert. Run this test under compute-sanitizer with
-    ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
-    direct-FC2 implementations.
+    to 24. I=352 exercises a partial scale/control tail in the wide kernel.
+    I=496 is the boundary case where that padded control grid looks completely
+    full even though the final two activation lanes are unwritten. Selecting
+    the only expert makes an unmasked W2 tail load cross the tensor allocation
+    instead of merely reading the next expert. Run this test under
+    compute-sanitizer with ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit
+    m==1/m>=2 and ungated/gated direct-FC2 implementations.
     """
     import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -19,7 +19,10 @@ from sparkinfer.moe._shared.kernels.reference import (
     moe_reference_w4a16_f32,
     moe_reference_w4a16_fp4_e8m0_k32,
 )
-from sparkinfer.moe._shared.kernels.w4a16.host import max_packed_route_slots, select_route_block_size_m
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    select_route_block_size_m,
+)
 from sparkinfer.moe._shared.kernels.w4a16.kernel import (
     _DEFAULT_MAX_SHARED_MEM,
     MoEMicroKernelW4A16SmallMDirect,
@@ -61,7 +64,7 @@ def _pattern_e8m0(shape: tuple[int, ...], *, offset: int = 0) -> torch.Tensor:
     numel = 1
     for dim in shape:
         numel *= int(dim)
-    storage = ((torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119)
+    storage = (torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119
     return storage.to(torch.uint8).reshape(shape).view(e8m0_dtype)
 
 
@@ -88,9 +91,7 @@ def _quantize_dense_moe_weight_storage(
             torch.float8_e4m3fn
         )
         scale = scale.to(torch.float32)
-        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(
-            min=1e-30
-        )
+        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(min=1e-30)
         clipped = torch.clamp(
             sliced * output_scale,
             -FLOAT4_E2M1_MAX,
@@ -110,7 +111,9 @@ def _make_weights(
     hidden_size: int,
     intermediate_size: int,
     activation: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
     is_gated = activation in {"silu", "situ"}
     w13_rows = intermediate_size * (2 if is_gated else 1)
     w13 = torch.randint(
@@ -133,8 +136,12 @@ def _make_weights(
     w2_blockscale = swizzle_block_scale(
         _positive_fp8((experts, hidden_size, intermediate_size // 16))
     )
-    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
-    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
+    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
+        torch.float32
+    )
+    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
+        torch.float32
+    )
     return w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale
 
 
@@ -447,12 +454,8 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
             share_expert_scales=True,
             single_token=True,
         )
-        e4m3 = MoEMicroKernelW4A16SmallMDirect(
-            scale_format="e4m3_k16", **common
-        )
-        e8m0 = MoEMicroKernelW4A16SmallMDirect(
-            scale_format="e8m0_k32", **common
-        )
+        e4m3 = MoEMicroKernelW4A16SmallMDirect(scale_format="e4m3_k16", **common)
+        e8m0 = MoEMicroKernelW4A16SmallMDirect(scale_format="e8m0_k32", **common)
         assert e4m3.__cache_key__ != e8m0.__cache_key__
     experts, hidden_size = 4, 128
     rows = intermediate_size * (2 if activation == "silu" else 1)
@@ -522,9 +525,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
         2 * m * fc2_n_chunks * 128 * topk, dtype=torch.bfloat16, device="cuda"
     )
     x = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
-    topk_ids = torch.randint(
-        0, experts, (m, topk), dtype=torch.int32, device="cuda"
-    )
+    topk_ids = torch.randint(0, experts, (m, topk), dtype=torch.int32, device="cuda")
     topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
 
     def launch() -> torch.Tensor:
@@ -818,20 +819,15 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
     for batch_size, seq_len, topk, ids_dtype, input_scale in cases:
         m = batch_size * seq_len
         torch.manual_seed(
-            20260525
-            + m * 31
-            + topk
-            + (1000 if activation == "silu" else 0)
+            20260525 + m * 31 + topk + (1000 if activation == "silu" else 0)
         )
         rows = intermediate_size * (2 if activation == "silu" else 1)
-        w13_dense = (
-            torch.randn(experts, rows, hidden_size, device="cuda")
-            * (0.18 if activation == "silu" else 0.08)
+        w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * (
+            0.18 if activation == "silu" else 0.08
         )
-        w2_dense = (
-            torch.randn(experts, hidden_size, intermediate_size, device="cuda")
-            * (0.18 if activation == "silu" else 0.08)
-        )
+        w2_dense = torch.randn(
+            experts, hidden_size, intermediate_size, device="cuda"
+        ) * (0.18 if activation == "silu" else 0.08)
         w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
         w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
         w13, w13_blockscale = _quantize_dense_moe_weight_storage(
@@ -964,10 +960,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     topk = 2
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
     torch.manual_seed(
-        20260730
-        + (1000 if activation == "silu" else 0)
-        + m
-        + intermediate_size
+        20260730 + (1000 if activation == "silu" else 0) + m + intermediate_size
     )
     real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
     direct_launches: list[tuple[int, int]] = []
@@ -1148,10 +1141,7 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
         spy_direct_launch,
     )
     torch.manual_seed(
-        20260731
-        + m
-        + intermediate_size
-        + (1000 if activation == "silu" else 0)
+        20260731 + m + intermediate_size + (1000 if activation == "silu" else 0)
     )
 
     rows = intermediate_size * (2 if activation == "silu" else 1)
@@ -1850,7 +1840,11 @@ def test_w4a16_modelopt_nvfp4_explicit_w13_layout_matches_oracle(
             [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
         ).contiguous()
 
-    prepare = prepare_w4a16_modelopt_native_weights if prepare_native else prepare_w4a16_weights
+    prepare = (
+        prepare_w4a16_modelopt_native_weights
+        if prepare_native
+        else prepare_w4a16_weights
+    )
     kwargs = {"source_format": "modelopt_nvfp4"} if prepare_native else {}
     prepared = prepare(
         source_w13,
@@ -1915,9 +1909,7 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
         activation=activation,
     )
     w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
-    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(
-        torch.float32
-    )
+    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
     w2_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
     a1_gscale = (1.0 / w13_input_scale).contiguous()
     a2_gscale = (1.0 / w2_input_scale).contiguous()
@@ -1961,8 +1953,9 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress(
-) -> None:
+def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress() -> (
+    None
+):
     torch.manual_seed(20260526)
     experts, hidden_size, intermediate_size = 8, 128, 128
     activation = "silu"
@@ -1973,9 +1966,7 @@ def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stres
         activation=activation,
     )
     reference_weights = tuple(t.clone() for t in weights)
-    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = (
-        weights
-    )
+    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
     a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
     weight_plan = plan_sparkinfer_fp4_moe_weights(
         quant_modes="w4a16",
@@ -2087,7 +2078,9 @@ def test_w4a16_moe_matches_oracle_with_expert_map(
     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
 
-    valid_global_ids = torch.arange(0, global_experts, 2, dtype=torch.int32, device="cuda")
+    valid_global_ids = torch.arange(
+        0, global_experts, 2, dtype=torch.int32, device="cuda"
+    )
     x = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
     topk_ids = valid_global_ids[
         torch.randint(0, local_experts, (m, topk), device="cuda")
@@ -2129,9 +2122,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
         activation=activation,
     )
     w13, w13_blockscale, _, w2, w2_blockscale, w2_global_scale = weights
-    w13_global_scale = torch.full(
-        (experts,), 8.0, dtype=torch.float32, device="cuda"
-    )
+    w13_global_scale = torch.full((experts,), 8.0, dtype=torch.float32, device="cuda")
     weights = (
         w13,
         w13_blockscale,
@@ -2219,9 +2210,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
     experts, hidden_size, intermediate_size = 8, 128, 128
     topk, live_m, capacity_m = 2, 24, 32
     activation = "relu2"
-    assert select_route_block_size_m(live_m, topk, experts) != select_route_block_size_m(
-        capacity_m, topk, experts
-    )
+    assert select_route_block_size_m(
+        live_m, topk, experts
+    ) != select_route_block_size_m(capacity_m, topk, experts)
     weights = _make_weights(
         experts=experts,
         hidden_size=hidden_size,
@@ -2229,7 +2220,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
         activation=activation,
     )
     x = (torch.randn(live_m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
-    topk_ids = torch.randint(0, experts, (live_m, topk), device="cuda", dtype=torch.int32)
+    topk_ids = torch.randint(
+        0, experts, (live_m, topk), device="cuda", dtype=torch.int32
+    )
     topk_weights = torch.softmax(torch.randn(live_m, topk, device="cuda"), dim=-1)
     prepared = prepare_w4a16_weights(
         *weights,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -264,7 +264,10 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [16, 144, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [16, 144, 352, 464, 480, 496, 512],
+)
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -945,7 +948,10 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [32, 128, 144, 224, 352, 464, 480, 496, 512],
+)
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1101,7 +1107,10 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("intermediate_size", [144, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [144, 352, 464, 480, 496, 512],
+)
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -499,6 +499,16 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
         params_dtype=torch.bfloat16,
         w13_layout=w13_layout,
     )
+    expected_w13_scale_rows = ((rows + 63) // 64) * 64
+    assert tuple(prepared.w13_scale.shape) == (
+        experts,
+        hidden_size // 32,
+        expected_w13_scale_rows,
+    )
+    assert prepared.micro_w13_scale is not None
+    assert int(prepared.micro_w13_scale.numel()) == (
+        experts * (hidden_size // 32) * expected_w13_scale_rows
+    )
     buffers = make_w4a16_buffers(
         prepared, m=m, topk=topk, dtype=torch.bfloat16, device=torch.device("cuda")
     )

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -264,7 +264,7 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("intermediate_size", [16, 144, 352])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -1088,8 +1088,22 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
     ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
     direct-FC2 implementations.
     """
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
     experts, hidden_size, topk = 1, 128, 1
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
+    direct_launches: list[tuple[int, int]] = []
+
+    def spy_direct_launch(*args, **kwargs) -> None:
+        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
+        real_direct_launch(*args, **kwargs)
+
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_w4a16_small_m_direct_launch_flat",
+        spy_direct_launch,
+    )
     torch.manual_seed(
         20260731
         + m
@@ -1194,6 +1208,7 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
         metrics = compare_to_reference(actual, expected)
         assert bool(torch.isfinite(actual).all().item())
         assert metrics.cos > 0.999, metrics
+    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(first, replay, rtol=0, atol=0)
 
 

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -6,6 +6,44 @@ import pytest
 import torch
 
 from sparkinfer.moe._shared.kernels.w4a16.kernel import pack_topk_routes_by_expert
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    route_block_sizes_for_capacity,
+    select_route_block_size_m,
+)
+
+
+@pytest.mark.parametrize(
+    ("max_tokens", "topk", "num_experts"),
+    [
+        (1, 8, 160),
+        (64, 8, 160),
+        (144, 8, 160),
+        (1024, 8, 256),
+        (32, 64, 8),
+    ],
+)
+def test_capacity_block_sizes_cover_every_live_selection(
+    max_tokens: int,
+    topk: int,
+    num_experts: int,
+) -> None:
+    planned = route_block_sizes_for_capacity(max_tokens, topk, num_experts)
+    selected = {
+        select_route_block_size_m(m, topk, num_experts)
+        for m in range(1, max_tokens + 1)
+    }
+
+    assert selected.issubset(planned)
+    assert planned[0] == select_route_block_size_m(1, topk, num_experts)
+    assert planned[-1] == select_route_block_size_m(
+        max_tokens,
+        topk,
+        num_experts,
+    )
+
+
+def test_small_capacity_needs_only_block_8() -> None:
+    assert route_block_sizes_for_capacity(64, 8, 160) == (8,)
 
 
 def _expected_route_pack(


### PR DESCRIPTION
## Summary

Bound unpinned W4A16 scratch planning to route block sizes reachable within the declared token capacity, mirror the correction in replicated-input EP, and expose a cheap public arena-sizing query.

This is stacked on #92 because the fixed-capacity Trellis planning API under review there is the source base. It addresses the safe planner work from #93; it does **not** clamp Trellis capacity or implement caller-side prefill chunking.

Related: #93

## Problem

`fused_moe` and `ep_moe` sized unpinned W4A16 route buffers and both fp32 `c_tmp` planes across every allowed block size `(8, 16, 32, 48, 64)`, even when runtime selection cannot reach most of them within `max_tokens`.

At `max_tokens=64`, `topk=8`, `E=160`, SM count 188, hidden 6144, intermediate/rank 512, the current full sweep prices the non-full W4A16 arena at 94.94 MiB. Runtime can select only block 8, whose exact arena is 30.03 MiB: **64.91 MiB/rank of unreachable reserve**.

The review also exposed two sizing hazards that a naive narrowing would make visible:

1. packed direct-topk/TC-decode uses `m * topk * block_m` scratch geometry instead of packed-route geometry;
2. non-Trellis binding cannot carry an expert map, so core route packing always uses `weight_E`, even when the router workspace uses a smaller `route_num_experts`.

Both are covered explicitly rather than relying on the old oversized sweep.

## Change

- Add `route_block_sizes_for_capacity(max_tokens, topk, num_experts)` using the same monotone selector as runtime.
- Size unpinned fused and EP route buffers only across that conservative reachable interval.
- Size fused `c_tmp` independently for both packed-route and every reachable direct-topk/TC-decode `(m, block)` geometry.
- Use `weight_E` for every non-Trellis W4A16 core route allocation; retain requested `route_E` for mapped full-rotation Trellis.
- Preserve explicit block pins exactly.
- Export `fused_moe.required_nbytes(Caps)`, which returns the complete caller-owned arena requirement without launch compilation or retained storage.

## Safety invariants

- Kernel selection, launch geometry, route packing, and numerical math are unchanged.
- Every runtime-selected block for `1 <= m <= max_tokens` is included.
- Block-8 doubled fp32 scratch accounting remains intact.
- EP still reserves power-of-two route-pack capacity before applying the reachable block set.
- Direct-topk affects only `c_tmp`; packed route-index and block-expert buffers are not inflated by direct geometry.
- Non-Trellis core `expert_offsets` and route buffers match the expert count the runtime actually packs.
- Full-rotation Trellis mapped-route behavior remains unchanged.


## Additional correctness value found during GPU qualification

The **64.91 MiB/rank** planner reduction is one value axis. GPU qualification also found four **pre-existing W4A16 correctness/memory-safety defects** that are worth landing independently of how reviewers value that memory saving. They were not introduced by the planner patch: initial commit `fa7a6ad` changed host-side planning/allocation, while the affected `micro.py` and `prepare.py` implementation was unchanged from base `06032ce`.

The smaller, correctly bounded arena made the first latent lifetime violation reproducible; poisoned replay, boundary, and Compute Sanitizer tests then exposed the remaining inherited defects:

| inherited defect | observed consequence |
|---|---|
| stale direct-FC2 scratch lanes | deterministic non-finite output on same-binding M=1/M=3 ReLU2 and SiLU replay |
| truncated 64-row ModelOpt scale tails | wrong numerical output for supported non-64 ReLU2 intermediates such as I=32/224 |
| coarse non-64 W/scale bounds and E8M0 scale stride | out-of-bounds reads; the uncorrected source produced 278 invalid global reads in the exact-source sanitizer control |
| wide activation-tail validity derived from padded rather than logical rows | stale/NaN consumption for supported I=464/480/496 residue classes |

The current GLM `I=1856` production shape is aligned and does not exercise those tail cases; matched A/B is therefore byte-identical and throughput-neutral there. The generic fixes still remove real wrong-output/OOB behavior for supported W4A16 shapes. In short: **the planner change recovers memory, while the later commits make the inherited kernel implementation safe and correct.**

## Observed sizing

CPU-isolated query against the r12 image dependencies and this source:

```text
auto=31491908 (30.03 MiB)
block8=31491908 (30.03 MiB)
block64=99553972 (94.94 MiB)
recovered_vs_worst=68062064 (64.91 MiB)
trellis_3072_required=1106622184 (1055.36 MiB)
```

The shipped vLLM EXL3 integration pins both decode and prefill block sizes, so the 64.91 MiB correction does not change that deployment directly. The new sizing query is the prerequisite for pricing the separate caller-side prefill-capacity tradeoff.

## Verification

All final validation ran in a separate CPU-only container (`--runtime crun`, `NVIDIA_VISIBLE_DEVICES=void`, empty `CUDA_VISIBLE_DEVICES`) using the exact pulled r12 image dependencies:

```text
32 passed, 80 skipped
```

Covered suites:

- `test_fused_moe_planning.py`
- `test_fused_moe_trellis.py`
- `test_fused_moe.py`
- `test_ep_moe_api.py`
- `test_w4a16_route_pack.py`

Changed-file Ruff lint and `git diff --check` pass.

Independent review initially found the direct-topk and non-Trellis expert-count hazards above. Regression tests were added for both exact cases; after both corrections the final verdict was **APPROVE**, with no remaining actionable defect. Residual risk is live-GPU execution, which is intentionally not claimed for this host-side planner-only change while the production deployment remains active.