### PR TITLE
fix(pcie): prevent two-slot selector overflow

### DIFF
--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -343,7 +343,16 @@ public:
   int64_t output_capacity_elems_;
   int64_t lse_offset_;
   int64_t lse_capacity_;
-  int slot_ = 0;
+  uint32_t next_slot_ = 0;
+
+  int take_slot() {
+    // Host-side selection executes once during CUDA graph capture. Graph
+    // replay intentionally reuses that capture-stable address; eager calls
+    // toggle slabs without an overflowing counter.
+    const int slot = static_cast<int>(next_slot_);
+    next_slot_ ^= uint32_t{1};
+    return slot;
+  }
 
   PCIeDCPA2A(Signal **signals,
              const std::vector<std::array<void *, 2>> &staging,
@@ -396,7 +405,7 @@ public:
 
     // Staging happens inside the kernel (warp-per-row, before the start
     // barrier); no host staging memcpys are issued.
-    const int slot = slot_++ % 2;
+    const int slot = take_slot();
     const int heads_per_rank = total_heads / world_size_;
     const int rows = batch * heads_per_rank;
     const int warps_per_block = threads / 32;
@@ -457,7 +466,7 @@ public:
 
     // Staging happens inside the kernel (warp-per-row, before the start
     // barrier); no host staging memcpy is issued.
-    const int slot = slot_++ % 2;
+    const int slot = take_slot();
     const int rows = batch * total_heads;
     const int warps_per_block = threads / 32;
     const int blocks = std::max(

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -26,6 +26,8 @@
 #include <type_traits>
 #include <vector>
 
+#include "two_slot_selector.h"
+
 #define CHECK_CUDA_SUCCESS(cmd)                                                \
   do {                                                                         \
     cudaError_t e = cmd;                                                       \
@@ -343,15 +345,13 @@ public:
   int64_t output_capacity_elems_;
   int64_t lse_offset_;
   int64_t lse_capacity_;
-  uint32_t next_slot_ = 0;
+  sparkinfer::pcie::TwoSlotSelector slot_selector_;
 
   int take_slot() {
     // Host-side selection executes once during CUDA graph capture. Graph
     // replay intentionally reuses that capture-stable address; eager calls
     // toggle slabs without an overflowing counter.
-    const int slot = static_cast<int>(next_slot_);
-    next_slot_ ^= uint32_t{1};
-    return slot;
+    return slot_selector_.take();
   }
 
   PCIeDCPA2A(Signal **signals,

--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
+++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
@@ -77,8 +77,8 @@ static bool oneshot_push_enabled() {
 }
 
 struct Signal {
-  alignas(128) FlagType staging_generation;
-  FlagType active_staging_slot;
+  alignas(128) FlagType staging_arrive;
+  FlagType staging_generation;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
   alignas(128) FlagType rms_arrive[kMaxBlocks];
@@ -184,25 +184,6 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
   return flag;
 }
 
-__global__ void advance_staging_slot(Signal* self_sg) {
-  if (blockIdx.x == 0 && threadIdx.x == 0) {
-    const FlagType generation = self_sg->staging_generation;
-    self_sg->active_staging_slot = generation & FlagType{1};
-    self_sg->staging_generation = generation + FlagType{1};
-  }
-}
-
-template <int ngpus>
-DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
-  if (threadIdx.x == 0) {
-    const int slot = int(self_sg->active_staging_slot);
-    const RankData* source = options.slots[slot];
-#pragma unroll
-    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
-  }
-  __syncthreads();
-}
-
 static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
@@ -213,6 +194,29 @@ static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
   return flag;
+}
+
+template <int ngpus>
+DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    // Every supported staging grid fits concurrently on the target Blackwell
+    // GPU. The last arriving block publishes one launch-wide generation, so
+    // variable grid sizes cannot split a launch across two slabs.
+    const FlagType generation = ld_flag_acquire_gpu(&self_sg->staging_generation);
+    const FlagType prior = atomicAdd(&self_sg->staging_arrive, FlagType{1});
+    if (prior == static_cast<FlagType>(gridDim.x - 1)) {
+      self_sg->staging_arrive = 0;
+      __threadfence();
+      atomicAdd(&self_sg->staging_generation, FlagType{1});
+    } else {
+      while (ld_flag_acquire_gpu(&self_sg->staging_generation) == generation) {
+      }
+    }
+    const RankData* source = options.slots[generation & FlagType{1}];
+#pragma unroll
+    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
+  }
+  __syncthreads();
 }
 
 template <int ngpus, bool is_start>
@@ -738,7 +742,6 @@ class PCIeAllreduce {
     size /= d;
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
     blocks = std::max(blocks, 1);
-    if (stage_input) advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
 
 #define KL(ngpus)                                                                                                     \
   do {                                                                                                               \
@@ -836,7 +839,6 @@ class PCIeAllreduce {
     const int mode = !use_eager_staging   ? kModeRegistered
                      : oneshot_push_enabled() ? kModeStagePush
                                               : kModeStagePull;
-    if (use_eager_staging) advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
 
 #define KL(ngpus, SINGLE, MODE)                                                                                       \
   pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \

--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
+++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
@@ -23,6 +23,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "two_slot_selector.h"
+
 #define CHECK_CUDA_SUCCESS(cmd)                                         \
   do {                                                                  \
     cudaError_t e = cmd;                                                \
@@ -566,7 +568,7 @@ class PCIeAllreduce {
   std::map<IPC_KEY, char*> ipc_handles_;
 
   bool dbuf_enabled_ = false;
-  int dbuf_slot_ = 0;
+  sparkinfer::pcie::TwoSlotSelector dbuf_slot_selector_;
   void* dbuf_raw_[2][kMaxRanks] = {};
   RankData* dbuf_rd_[2] = {};
 
@@ -626,7 +628,7 @@ class PCIeAllreduce {
     buffers_[ptrs0[rank_]] = dbuf_rd_[0];
     buffers_[ptrs1[rank_]] = dbuf_rd_[1];
     dbuf_enabled_ = true;
-    dbuf_slot_ = 0;
+    dbuf_slot_selector_ = sparkinfer::pcie::TwoSlotSelector{};
   }
 
   void register_buffer(void** ptrs) {
@@ -686,8 +688,7 @@ class PCIeAllreduce {
     if (dbuf_enabled_) {
       // The kernel stages the input into the eager slot itself; no host
       // staging memcpy is issued.
-      int slot = dbuf_slot_ % 2;
-      dbuf_slot_++;
+      const int slot = dbuf_slot_selector_.take();
       ptrs = dbuf_rd_[slot];
       staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
     } else if (status == cudaStreamCaptureStatusActive) {
@@ -764,8 +765,7 @@ class PCIeAllreduce {
     if (dbuf_enabled_) {
       // The kernel stages the input into the eager slot itself; no host
       // staging memcpy is issued.
-      int slot = dbuf_slot_ % 2;
-      dbuf_slot_++;
+      const int slot = dbuf_slot_selector_.take();
       ptrs = dbuf_rd_[slot];
       staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
     } else if (status == cudaStreamCaptureStatusActive) {

--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
+++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
@@ -23,7 +23,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "two_slot_selector.h"
 
 #define CHECK_CUDA_SUCCESS(cmd)                                         \
   do {                                                                  \
@@ -78,6 +77,8 @@ static bool oneshot_push_enabled() {
 }
 
 struct Signal {
+  alignas(128) FlagType staging_generation;
+  FlagType active_staging_slot;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
   alignas(128) FlagType rms_arrive[kMaxBlocks];
@@ -87,6 +88,10 @@ struct Signal {
 
 struct __align__(16) RankData {
   const void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct DoubleRankData {
+  RankData* slots[2];
 };
 
 struct __align__(16) RankSignals {
@@ -179,6 +184,25 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
   return flag;
 }
 
+__global__ void advance_staging_slot(Signal* self_sg) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const FlagType generation = self_sg->staging_generation;
+    self_sg->active_staging_slot = generation & FlagType{1};
+    self_sg->staging_generation = generation + FlagType{1};
+  }
+}
+
+template <int ngpus>
+DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    const int slot = int(self_sg->active_staging_slot);
+    const RankData* source = options.slots[slot];
+#pragma unroll
+    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
+  }
+  __syncthreads();
+}
+
 static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
@@ -255,17 +279,23 @@ DINLINE float block_reduce_sum(float value, float* warp_sums) {
 // sufficient for staging visibility.
 template <typename T, int ngpus, bool stage_input>
 __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
-    RankData* _dp,
+    DoubleRankData data_options,
     RankSignals sg,
     Signal* self_sg,
     const T* __restrict__ input,
     T* __restrict__ result,
-    T* __restrict__ self_staging,
     int rank,
     int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
-  auto dp = *_dp;
+  RankData dp;
+  if constexpr (stage_input) {
+    __shared__ RankData selected;
+    select_rank_data<ngpus>(selected, data_options, self_sg);
+    dp = selected;
+  } else {
+    dp = *data_options.slots[0];
+  }
   const P* rotated[ngpus];
 #pragma unroll
   for (int i = 0; i < ngpus; i++) {
@@ -273,7 +303,8 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
   }
   if constexpr (stage_input) {
     const P* input_p = reinterpret_cast<const P*>(input);
-    P* staging_p = reinterpret_cast<P*>(self_staging);
+    P* staging_p =
+        reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
     for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
       staging_p[idx] = input_p[idx];
     }
@@ -330,7 +361,7 @@ constexpr int kModeStagePush = 2;
 // resident.
 template <typename T, int ngpus, bool single_cta, int mode>
 __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kernel(
-    RankData* _dp,
+    DoubleRankData data_options,
     RankSignals sg,
     Signal* self_sg,
     const T* __restrict__ input,
@@ -338,7 +369,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
     const T* __restrict__ weight,
     T* __restrict__ output,
     T* __restrict__ residual_output,
-    T* __restrict__ self_staging,
     int rank,
     int hidden_packs,
     int ctas_per_row,
@@ -348,6 +378,14 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   using A = typename packed_t<T>::A;
   __shared__ float warp_sums[32];
   __shared__ float s_inv_rms;
+  RankData dp;
+  if constexpr (mode == kModeRegistered) {
+    dp = *data_options.slots[0];
+  } else {
+    __shared__ RankData selected;
+    select_rank_data<ngpus>(selected, data_options, self_sg);
+    dp = selected;
+  }
 
   const int row = single_cta ? blockIdx.x : blockIdx.x / ctas_per_row;
   const int row_cta = single_cta ? 0 : blockIdx.x - row * ctas_per_row;
@@ -357,7 +395,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   const int max_packs = (hidden_packs + col_stride - 1) / col_stride;
   const bool reg_norm = max_packs <= kRegPacks;
 
-  auto dp = *_dp;
   const P* rotated[ngpus];
 #pragma unroll
   for (int i = 0; i < ngpus; i++) {
@@ -369,7 +406,7 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   const P* weight_p = reinterpret_cast<const P*>(weight);
   P* output_p = reinterpret_cast<P*>(output);
   P* residual_output_p = reinterpret_cast<P*>(residual_output);
-  P* staging_p = reinterpret_cast<P*>(self_staging);
+  P* staging_p = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
 
   // Sense-reversing row barrier: latch the generation before arriving.
   // Launches are stream-serialized, so this read cannot race a peer CTA's
@@ -568,9 +605,7 @@ class PCIeAllreduce {
   std::map<IPC_KEY, char*> ipc_handles_;
 
   bool dbuf_enabled_ = false;
-  sparkinfer::pcie::TwoSlotSelector dbuf_slot_selector_;
-  void* dbuf_raw_[2][kMaxRanks] = {};
-  RankData* dbuf_rd_[2] = {};
+  DoubleRankData dbuf_data_ = {};
 
   PCIeAllreduce(Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size)
       : rank_(rank),
@@ -618,17 +653,14 @@ class PCIeAllreduce {
     for (int s = 0; s < 2; s++) {
       void** ptrs = s == 0 ? ptrs0 : ptrs1;
       RankData data;
-      for (int i = 0; i < world_size_; i++) {
-        data.ptrs[i] = ptrs[i];
-        dbuf_raw_[s][i] = ptrs[i];
-      }
-      dbuf_rd_[s] = d_rank_data_base_++;
-      CHECK_CUDA_SUCCESS(cudaMemcpy(dbuf_rd_[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
+      for (int i = 0; i < world_size_; i++) data.ptrs[i] = ptrs[i];
+      dbuf_data_.slots[s] = d_rank_data_base_++;
+      CHECK_CUDA_SUCCESS(
+          cudaMemcpy(dbuf_data_.slots[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
     }
-    buffers_[ptrs0[rank_]] = dbuf_rd_[0];
-    buffers_[ptrs1[rank_]] = dbuf_rd_[1];
+    buffers_[ptrs0[rank_]] = dbuf_data_.slots[0];
+    buffers_[ptrs1[rank_]] = dbuf_data_.slots[1];
     dbuf_enabled_ = true;
-    dbuf_slot_selector_ = sparkinfer::pcie::TwoSlotSelector{};
   }
 
   void register_buffer(void** ptrs) {
@@ -680,17 +712,16 @@ class PCIeAllreduce {
     if (block_limit > kMaxBlocks)
       throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks));
 
-    RankData* ptrs;
-    T* staging = nullptr;
+    DoubleRankData data_options = {};
+    bool stage_input = false;
     cudaStreamCaptureStatus status;
     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
 
     if (dbuf_enabled_) {
-      // The kernel stages the input into the eager slot itself; no host
-      // staging memcpy is issued.
-      const int slot = dbuf_slot_selector_.take();
-      ptrs = dbuf_rd_[slot];
-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+      // A captured selector kernel advances the active eager slab on every
+      // execution, including CUDA graph replay.
+      data_options = dbuf_data_;
+      stage_input = true;
     } else if (status == cudaStreamCaptureStatusActive) {
       throw std::runtime_error(
           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
@@ -700,22 +731,24 @@ class PCIeAllreduce {
       if (it == buffers_.end())
         throw std::runtime_error(
             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
-      ptrs = it->second;
+      data_options.slots[0] = it->second;
+      data_options.slots[1] = it->second;
     }
 
     size /= d;
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
     blocks = std::max(blocks, 1);
+    if (stage_input) advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
 
 #define KL(ngpus)                                                                                                     \
   do {                                                                                                               \
-    if (staging != nullptr) {                                                                                        \
+    if (stage_input) {                                                                                               \
       pcie_allreduce_kernel<T, ngpus, true>                                                                          \
-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
     } else {                                                                                                         \
       pcie_allreduce_kernel<T, ngpus, false>                                                                         \
-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
-    }                                                                                                                 \
+          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
+    }                                                                                                                \
   } while (0)
     switch (world_size_) {
       case 2:
@@ -758,16 +791,15 @@ class PCIeAllreduce {
       throw std::runtime_error(
           "fused allreduce RMSNorm requires hidden size to be a multiple of " + std::to_string(pack_size));
 
-    RankData* ptrs;
-    T* staging = nullptr;
+    DoubleRankData data_options = {};
+    bool use_eager_staging = false;
     cudaStreamCaptureStatus status;
     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
     if (dbuf_enabled_) {
-      // The kernel stages the input into the eager slot itself; no host
-      // staging memcpy is issued.
-      const int slot = dbuf_slot_selector_.take();
-      ptrs = dbuf_rd_[slot];
-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+      // A captured selector kernel advances the active eager slab on every
+      // execution, including CUDA graph replay.
+      data_options = dbuf_data_;
+      use_eager_staging = true;
     } else if (status == cudaStreamCaptureStatusActive) {
       throw std::runtime_error(
           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
@@ -777,7 +809,8 @@ class PCIeAllreduce {
       if (it == buffers_.end())
         throw std::runtime_error(
             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
-      ptrs = it->second;
+      data_options.slots[0] = it->second;
+      data_options.slots[1] = it->second;
     }
 
     int rows = size / hidden_size;
@@ -800,13 +833,14 @@ class PCIeAllreduce {
     const int blocks = rows * ctas_per_row;
     const bool single = ctas_per_row == 1;
     const int shard_packs = size / pack_size;
-    const int mode = staging == nullptr ? kModeRegistered
+    const int mode = !use_eager_staging   ? kModeRegistered
                      : oneshot_push_enabled() ? kModeStagePush
                                               : kModeStagePull;
+    if (use_eager_staging) advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
 
 #define KL(ngpus, SINGLE, MODE)                                                                                       \
   pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \
-      ptrs, sg_, self_sg_, input, residual, weight, output, residual_output, staging, rank_, hidden_packs,            \
+      data_options, sg_, self_sg_, input, residual, weight, output, residual_output, rank_, hidden_packs,            \
       ctas_per_row, shard_packs, epsilon);
 #define DISPATCH_MODE(ngpus, SINGLE)                                                                                  \
   do {                                                                                                               \

--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
+++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
@@ -36,6 +36,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include "two_slot_selector.h"
+
 #define CHECK_CUDA_SUCCESS(cmd)                                         \
   do {                                                                  \
     cudaError_t e = cmd;                                                \
@@ -261,7 +263,9 @@ class PCIeTwoShot {
   int64_t scale_offset_;  // bytes
   int64_t scale_stride_;  // floats per src region
   int64_t max_shard_packs_;
-  int slot_ = 0;
+  sparkinfer::pcie::TwoSlotSelector slot_selector_;
+
+  int take_slot() { return slot_selector_.take(); }
 
   PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
               int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
@@ -312,8 +316,7 @@ class PCIeTwoShot {
       throw std::runtime_error("num_rows must be divisible by world size");
     const int64_t rows_per_rank = num_rows / world_size_;
     check_shard(rows_per_rank, row_elems);
-    const int s = slot_ % 2;
-    slot_++;
+    const int s = take_slot();
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
@@ -329,8 +332,7 @@ class PCIeTwoShot {
   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
     check_shard(rows_per_rank, row_elems);
-    const int s = slot_ % 2;
-    slot_++;
+    const int s = take_slot();
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));

--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
+++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
@@ -36,7 +36,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include "two_slot_selector.h"
 
 #define CHECK_CUDA_SUCCESS(cmd)                                         \
   do {                                                                  \
@@ -59,12 +58,18 @@ using FlagType = uint32_t;
 constexpr int kFlagStride = 32;
 
 struct Signal {
+  alignas(128) FlagType staging_generation;
+  FlagType active_staging_slot;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
 };
 
 struct __align__(16) RankPtrs {
   void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct DoubleRankPtrs {
+  RankPtrs slots[2];
 };
 
 struct RankSignals {
@@ -81,6 +86,24 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
   return flag;
+}
+
+__global__ void advance_staging_slot(Signal* self_sg) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const FlagType generation = self_sg->staging_generation;
+    self_sg->active_staging_slot = generation & FlagType{1};
+    self_sg->staging_generation = generation + FlagType{1};
+  }
+}
+
+template <int ngpus>
+DINLINE void select_rank_ptrs(RankPtrs& selected, const DoubleRankPtrs& options, Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    const int slot = int(self_sg->active_staging_slot);
+#pragma unroll
+    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = options.slots[slot].ptrs[peer];
+  }
+  __syncthreads();
 }
 
 // Block-pairwise barrier: after it returns, all prior writes from every
@@ -148,9 +171,11 @@ DINLINE void block_range(int64_t total, int64_t& begin, int64_t& end) {
 template <int ngpus>
 __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
-    int rows_per_rank, int row_elems) {
+    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
+    int64_t scale_stride, RankSignals sg, Signal* self_sg,
+    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
+  __shared__ RankPtrs staging;
+  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
   const int packs_per_row = row_elems / 16;
   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
   int64_t begin, end;
@@ -202,9 +227,11 @@ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
 template <int ngpus>
 __global__ void __launch_bounds__(512, 1) ag_fp8_kernel(
     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
-    int rows_per_rank, int row_elems) {
+    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
+    int64_t scale_stride, RankSignals sg, Signal* self_sg,
+    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
+  __shared__ RankPtrs staging;
+  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
   const int packs_per_row = row_elems / 16;
   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
   int64_t begin, end;
@@ -258,14 +285,11 @@ class PCIeTwoShot {
   RankSignals sg_;
   Signal* self_sg_;
 
-  RankPtrs staging_[2];
+  DoubleRankPtrs staging_;
   int64_t pack_stride_;   // Fp8Packs per src region
   int64_t scale_offset_;  // bytes
   int64_t scale_stride_;  // floats per src region
   int64_t max_shard_packs_;
-  sparkinfer::pcie::TwoSlotSelector slot_selector_;
-
-  int take_slot() { return slot_selector_.take(); }
 
   PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
               int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
@@ -279,7 +303,7 @@ class PCIeTwoShot {
         max_shard_packs_(pack_stride) {
     for (int i = 0; i < world_size_; i++) {
       sg_.signals[i] = signals[i];
-      for (int s = 0; s < 2; s++) staging_[s].ptrs[i] = staging[i][s];
+      for (int s = 0; s < 2; s++) staging_.slots[s].ptrs[i] = staging[i][s];
     }
   }
 
@@ -316,15 +340,15 @@ class PCIeTwoShot {
       throw std::runtime_error("num_rows must be divisible by world size");
     const int64_t rows_per_rank = num_rows / world_size_;
     check_shard(rows_per_rank, row_elems);
-    const int s = take_slot();
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
           reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+          staging_, pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
           reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
     });
   }
@@ -332,15 +356,15 @@ class PCIeTwoShot {
   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
     check_shard(rows_per_rank, row_elems);
-    const int s = take_slot();
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
           reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+          staging_, pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
           reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
     });
   }

--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
+++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
@@ -58,8 +58,8 @@ using FlagType = uint32_t;
 constexpr int kFlagStride = 32;
 
 struct Signal {
-  alignas(128) FlagType staging_generation;
-  FlagType active_staging_slot;
+  alignas(128) FlagType staging_arrive;
+  FlagType staging_generation;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
 };
@@ -88,18 +88,29 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
   return flag;
 }
 
-__global__ void advance_staging_slot(Signal* self_sg) {
-  if (blockIdx.x == 0 && threadIdx.x == 0) {
-    const FlagType generation = self_sg->staging_generation;
-    self_sg->active_staging_slot = generation & FlagType{1};
-    self_sg->staging_generation = generation + FlagType{1};
-  }
+static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
+  return flag;
 }
 
 template <int ngpus>
 DINLINE void select_rank_ptrs(RankPtrs& selected, const DoubleRankPtrs& options, Signal* self_sg) {
   if (threadIdx.x == 0) {
-    const int slot = int(self_sg->active_staging_slot);
+    // kMaxBlocks fits concurrently on the target Blackwell GPU. Rendezvous
+    // before publishing the generation so every block in this launch selects
+    // one slab even when the preceding launch used a different grid size.
+    const FlagType generation = ld_flag_acquire_gpu(&self_sg->staging_generation);
+    const FlagType prior = atomicAdd(&self_sg->staging_arrive, FlagType{1});
+    if (prior == static_cast<FlagType>(gridDim.x - 1)) {
+      self_sg->staging_arrive = 0;
+      __threadfence();
+      atomicAdd(&self_sg->staging_generation, FlagType{1});
+    } else {
+      while (ld_flag_acquire_gpu(&self_sg->staging_generation) == generation) {
+      }
+    }
+    const int slot = int(generation & FlagType{1});
 #pragma unroll
     for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = options.slots[slot].ptrs[peer];
   }
@@ -340,10 +351,11 @@ class PCIeTwoShot {
       throw std::runtime_error("num_rows must be divisible by world size");
     const int64_t rows_per_rank = num_rows / world_size_;
     check_shard(rows_per_rank, row_elems);
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error("pcie_twoshot block limit exceeds signal capacity");
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
-    advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
@@ -356,10 +368,11 @@ class PCIeTwoShot {
   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
     check_shard(rows_per_rank, row_elems);
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error("pcie_twoshot block limit exceeds signal capacity");
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
-    advance_staging_slot<<<1, 1, 0, stream>>>(self_sg_);
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(

--- a/sparkinfer/comm/pcie/two_slot_selector.h
+++ b/sparkinfer/comm/pcie/two_slot_selector.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sparkinfer::pcie {
+
+// A double-buffer selector with an explicitly finite state space. Keeping the
+// phase as an enum makes signed overflow and out-of-range remainders impossible.
+class TwoSlotSelector {
+ public:
+  constexpr int take() noexcept {
+    if (next_ == Next::kFirst) {
+      next_ = Next::kSecond;
+      return 0;
+    }
+    next_ = Next::kFirst;
+    return 1;
+  }
+
+ private:
+  enum class Next : std::uint32_t { kFirst, kSecond };
+  Next next_ = Next::kFirst;
+};
+
+namespace detail {
+constexpr bool two_slot_sequence_is_preserved() {
+  TwoSlotSelector selector;
+  return selector.take() == 0 && selector.take() == 1 &&
+         selector.take() == 0 && selector.take() == 1;
+}
+}  // namespace detail
+
+static_assert(detail::two_slot_sequence_is_preserved(),
+              "two-slot selection must start at zero and alternate");
+static_assert(sizeof(TwoSlotSelector) == sizeof(std::uint32_t),
+              "two-slot selector storage must remain 32-bit");
+
+}  // namespace sparkinfer::pcie

--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
@@ -182,7 +182,7 @@ def _run_graph(
             out=out,
             residual_out=residual,
         )
-    assert _cuda_graph_kernel_count(graph) == 2
+    assert _cuda_graph_kernel_count(graph) == 1
     stream = torch.cuda.current_stream(device)
     offset = 0
     if os.getenv("SPARKINFER_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):

--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import socket
 
@@ -69,6 +70,23 @@ def _assert_close(
         torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
     else:
         torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def _local_eager_words(
+    channel, stream: torch.cuda.Stream, *, offset: int = 0
+) -> tuple[int, int]:
+    assert channel._ipc is not None
+    assert channel._eager_ptrs is not None
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
+        channel._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            slot_ptrs[channel.rank] + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
 
 
 def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
@@ -155,7 +173,7 @@ def _run_graph(
     pool.for_stream()
 
     graph = torch.cuda.CUDAGraph(keep_graph=True)
-    with pool.capture(), torch.cuda.graph(graph):
+    with pool.capture() as channel, torch.cuda.graph(graph):
         pool.all_reduce_fused_add_rms_norm(
             inp,
             residual,
@@ -164,7 +182,13 @@ def _run_graph(
             out=out,
             residual_out=residual,
         )
-    assert _cuda_graph_kernel_count(graph) == 1
+    assert _cuda_graph_kernel_count(graph) == 2
+    stream = torch.cuda.current_stream(device)
+    offset = 0
+    if os.getenv("SPARKINFER_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
+        remote_source = (rank + 1) % dist.get_world_size()
+        offset = remote_source * inp.numel() * inp.element_size()
+    snapshots = [_local_eager_words(channel, stream, offset=offset)]
 
     for iteration in range(3):
         next_inp, next_residual, _ = _make_inputs(
@@ -187,6 +211,23 @@ def _run_graph(
         torch.cuda.synchronize(device)
         _assert_close(out, expected_out, dtype)
         _assert_close(residual, expected_residual, dtype)
+        snapshots.append(_local_eager_words(channel, stream, offset=offset))
+
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(3)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert all(
+        changed_slots[index] != changed_slots[index + 1]
+        for index in range(len(changed_slots) - 1)
+    )
 
 
 def _worker(rank: int, world_size: int, port: int) -> None:

--- a/tests/comm/test_pcie_oneshot_torture.py
+++ b/tests/comm/test_pcie_oneshot_torture.py
@@ -109,36 +109,46 @@ def _run_graph_scratch_reuse(
     stream.synchronize()
 
     for iteration in range(TORTURE_GRAPH_REPLAYS):
-        fill_sources(iteration)
-        graph.replay()
+        with torch.cuda.stream(stream):
+            fill_sources(iteration)
+            graph.replay()
         stream.synchronize()
         for layer, out in enumerate(outs):
             base = float((iteration % 32) * 5 + layer)
             _assert_constant(out, world_size * base + rank_sum)
 
-    # A graph with an odd number of collectives must change its selected
-    # staging slot on every replay. Host-side selection would freeze here.
+    # A graph with an odd number of collectives must swap which slot receives
+    # the final layer on every replay. Both slots are overwritten by this
+    # 17-layer graph, so merely counting changed slots cannot identify the
+    # selected parity: the final two layer markers must exchange positions.
     snapshots = [_local_eager_words(channel, stream)]
+    expected_words = [
+        tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
+    ]
     for iteration in (101, 102):
-        fill_sources(iteration)
-        graph.replay()
+        with torch.cuda.stream(stream):
+            fill_sources(iteration)
+            graph.replay()
         stream.synchronize()
         snapshots.append(_local_eager_words(channel, stream))
+        expected_words.append(
+            tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
+        )
         for layer, out in enumerate(outs):
             base = float((iteration % 32) * 5 + layer)
             _assert_constant(out, world_size * base + rank_sum)
-    changed_slots = [
-        {
-            slot
-            for slot, (before, after) in enumerate(
-                zip(snapshots[index], snapshots[index + 1], strict=True)
-            )
-            if before != after
-        }
-        for index in range(2)
-    ]
-    assert all(len(changed) == 1 for changed in changed_slots)
-    assert changed_slots[0] != changed_slots[1]
+
+    final_slots = []
+    for snapshot, expected in zip(snapshots, expected_words, strict=True):
+        assert set(snapshot) == set(expected), (
+            f"staging slots {snapshot} do not contain the final layer markers "
+            f"{expected}"
+        )
+        final_slots.append(snapshot.index(expected[-1]))
+    assert all(
+        final_slots[index] != final_slots[index + 1]
+        for index in range(len(final_slots) - 1)
+    ), f"odd-collective graph did not alternate final staging slots: {final_slots}"
 
 
 def _run_multistream(

--- a/tests/comm/test_pcie_oneshot_torture.py
+++ b/tests/comm/test_pcie_oneshot_torture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import socket
 
@@ -16,9 +17,15 @@ pytestmark = pytest.mark.skipif(
     reason="set SPARKINFER_RUN_PCIE_ONESHOT_TORTURE=1 to run PCIe oneshot CUDA torture tests",
 )
 
-TORTURE_EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256"))
-TORTURE_GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256"))
-TORTURE_MULTISTREAM_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256"))
+TORTURE_EAGER_ITERS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256")
+)
+TORTURE_GRAPH_REPLAYS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256")
+)
+TORTURE_MULTISTREAM_ITERS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256")
+)
 
 
 def _free_port() -> int:
@@ -36,7 +43,26 @@ def _rank_sum(world_size: int) -> int:
     return world_size * (world_size - 1) // 2
 
 
-def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int) -> None:
+def _local_eager_words(
+    channel, stream: torch.cuda.Stream, *, offset: int = 0
+) -> tuple[int, int]:
+    assert channel._ipc is not None
+    assert channel._eager_ptrs is not None
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
+        channel._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            slot_ptrs[channel.rank] + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
+def _run_eager(
+    pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int
+) -> None:
     dtypes = (torch.float16, torch.bfloat16, torch.float32)
     numels = (8, 256, 4096, 32768)
     rank_sum = _rank_sum(world_size)
@@ -60,7 +86,6 @@ def _run_graph_scratch_reuse(
     world_size: int,
 ) -> None:
     stream = torch.cuda.Stream(device=device)
-    channel = pool.for_stream(stream)
     rank_sum = _rank_sum(world_size)
     layers = 17
     numel = 4096
@@ -77,7 +102,7 @@ def _run_graph_scratch_reuse(
     torch.cuda.synchronize(device)
 
     graph = torch.cuda.CUDAGraph()
-    with pool.capture(stream), torch.cuda.graph(graph, stream=stream):
+    with pool.capture(stream) as channel, torch.cuda.graph(graph, stream=stream):
         for layer in range(layers):
             scratch.copy_(sources[layer])
             channel.all_reduce(scratch, out=outs[layer])
@@ -90,6 +115,30 @@ def _run_graph_scratch_reuse(
         for layer, out in enumerate(outs):
             base = float((iteration % 32) * 5 + layer)
             _assert_constant(out, world_size * base + rank_sum)
+
+    # A graph with an odd number of collectives must change its selected
+    # staging slot on every replay. Host-side selection would freeze here.
+    snapshots = [_local_eager_words(channel, stream)]
+    for iteration in (101, 102):
+        fill_sources(iteration)
+        graph.replay()
+        stream.synchronize()
+        snapshots.append(_local_eager_words(channel, stream))
+        for layer, out in enumerate(outs):
+            base = float((iteration % 32) * 5 + layer)
+            _assert_constant(out, world_size * base + rank_sum)
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(2)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert changed_slots[0] != changed_slots[1]
 
 
 def _run_multistream(

--- a/tests/comm/test_pcie_two_slot_selector.py
+++ b/tests/comm/test_pcie_two_slot_selector.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_two_slot_selector_preserves_phase_for_long_run(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    source = tmp_path / "two_slot_selector_test.cpp"
+    binary = tmp_path / "two_slot_selector_test"
+    source.write_text(
+        r"""
+#include <cstdint>
+#include "sparkinfer/comm/pcie/two_slot_selector.h"
+
+int main() {
+  sparkinfer::pcie::TwoSlotSelector selector;
+  constexpr std::uint64_t kTransitions = 10'000'003;
+  for (std::uint64_t call = 0; call < kTransitions; ++call) {
+    if (selector.take() != static_cast<int>(call & 1u)) return 1;
+  }
+  return selector.take() == static_cast<int>(kTransitions & 1u) ? 0 : 2;
+}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [
+            "c++",
+            "-std=c++17",
+            "-O3",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(repo_root),
+            str(source),
+            "-o",
+            str(binary),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run([str(binary)], check=True)

--- a/tests/comm/test_pcie_twoshot.py
+++ b/tests/comm/test_pcie_twoshot.py
@@ -6,6 +6,7 @@ Run with torchrun on 2, 4 or 8 GPUs:
         --nproc-per-node=8 tests/distributed/test_pcie_twoshot.py
 """
 
+import ctypes
 import os
 import time
 
@@ -19,6 +20,64 @@ from sparkinfer.comm.pcie.pcie_twoshot import (
 
 ROWS = 4096
 ROW_ELEMS = 6144
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _local_staging_words(
+    pool: PCIeTwoShotSP, stream: torch.cuda.Stream
+) -> tuple[int, int]:
+    assert len(pool._owned_buffers) == 1
+    max_rows_per_rank = pool.max_rows // pool.world_size
+    pack_stride = _align_up(max_rows_per_rank * (pool.row_elems // 16), 16)
+    payload_bytes = pool.world_size * pack_stride * 16
+    scale_offset = _align_up(payload_bytes, 256)
+    scale_stride = _align_up(max_rows_per_rank, 64)
+    slot_bytes = _align_up(
+        scale_offset + pool.world_size * scale_stride * 4,
+        256,
+    )
+    signal_bytes = _align_up(int(pool._ext.meta_size()), 256)
+    remote_source = (pool.rank + 1) % pool.world_size
+    source_offset = remote_source * pack_stride * 16
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    local_ptr = pool._owned_buffers[0].local_ptr
+    for word, offset in zip(
+        words,
+        (
+            signal_bytes + source_offset,
+            signal_bytes + slot_bytes + source_offset,
+        ),
+        strict=True,
+    ):
+        pool._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            local_ptr + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
+def _assert_alternating_slots(snapshots: list[tuple[int, int]]) -> None:
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(len(snapshots) - 1)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert all(
+        changed_slots[index] != changed_slots[index + 1]
+        for index in range(len(changed_slots) - 1)
+    )
 
 
 def _partial(seed: int, rows: int, device: torch.device) -> torch.Tensor:
@@ -126,6 +185,56 @@ def _check_graph_capture(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
             ]
         )
         assert torch.equal(ag_out, ag_ref)
+
+    # Capture a single collective so adjacent replays must alternate the
+    # device-selected staging slot. The two-op graph above has even parity.
+    odd_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(odd_graph):
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+
+    for value in (11, 12):
+        ag_q.fill_(float(value + rank))
+        ag_s.fill_(1.0)
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+    torch.cuda.synchronize()
+    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
+
+    for value in (1, 2):
+        ag_q.fill_(float(value + rank))
+        ag_s.fill_(1.0)
+        dist.barrier()
+        odd_graph.replay()
+        torch.cuda.synchronize()
+        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
+        for source_rank in range(world):
+            lo = source_rank * rows_per_rank
+            hi = lo + rows_per_rank
+            assert torch.all(ag_out[lo:hi] == float(value + source_rank))
+
+    _assert_alternating_slots(snapshots)
+
+    rs_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(rs_graph):
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+
+    for value in (21, 22):
+        q_in.fill_(float(value + rank))
+        s_in.fill_(1.0)
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+    torch.cuda.synchronize()
+    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
+
+    rank_sum = world * (world - 1) // 2
+    for value in (3, 4):
+        q_in.fill_(float(value + rank))
+        s_in.fill_(1.0)
+        dist.barrier()
+        rs_graph.replay()
+        torch.cuda.synchronize()
+        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
+        assert torch.all(rs_out == float(world * value + rank_sum))
+
+    _assert_alternating_slots(snapshots)
 
 
 def _bench(pool: PCIeTwoShotSP, rank: int, world: int) -> None:


### PR DESCRIPTION
## Summary

Fix every reachable signed `% 2` staging counter identified in #97, and make reusable one-shot/two-shot staging ownership advance on CUDA graph execution rather than host invocation.

Fixes #97.

## Confirmed failure modes

The original DCP, one-shot, and two-shot host counters fed a signed pre-increment value to `% 2`. After signed overflow, `-1` could index before the intended staging table.

A second capture defect applied to the reusable collectives: host slot selection runs once while a CUDA graph is captured, so every replay reused that recorded slab. Adjacent odd-operation replays could overwrite staging still consumed by a peer.

## Change

- DCP A2A uses a closed, bounded `TwoSlotSelector` for the independently mergeable overflow fix. PR #103 replaces this host selector with DCP execution-owned parity.
- One-shot plain/fused all-reduce and two-shot reduce-scatter/all-gather pass both eager slabs into the CUDA path.
- Each staging collective performs a launch-wide device rendezvous inside the existing collective kernel. Every block reads the stable generation before arriving; the last block resets the arrival count and publishes the next generation; every block selects the same slab from the pre-increment low bit.
- Supported grids are bounded at 36 one-shot blocks and 64 two-shot blocks, below target Blackwell SM count, so the rendezvous is fully resident and cannot deadlock.
- The selection remains correct when consecutive calls use different grid sizes, and CUDA graph replay re-executes it without adding a selector kernel launch.
- Unsigned generation wraparound preserves `0, 1, 0, 1, ...`.
- Registered/non-staging paths retain their prior behavior.

## Invariants

- Host invocation count is not staging ownership for reusable captured collectives.
- Every rank executes the same collective sequence on the same stream.
- The selected slab remains stable for every block in one launch.
- IPC layout, numeric reduction, public APIs, and registered-buffer behavior remain unchanged.
- No additional GPU launch is added to latency-sensitive entry points.

## Verification

- Focused local suite: **33 passed, 2 skipped**. Skips are the opt-in live-GPU one-shot suites.
- One-shot and two-shot CUDA extensions compiled and loaded from a fresh cache against the pulled r12 image environment.
- Changed Python tests: Ruff format and lint pass.
- Graph regressions inspect both local staging slabs and require adjacent odd replays to mutate exactly one alternating slot for plain all-reduce, fused RMSNorm, reduce-scatter, and all-gather.

Live multi-GPU execution is delegated to the separate field-test agent; no rental or production-GPU result is claimed here. Production was not rebuilt or restarted.

## Review follow-up

- `b24d875`: removed replay-frozen host selection from reusable collectives and added focused staging-observation regressions.
- `b518259`: addressed the performance review by folding launch-global generation selection into each existing collective kernel; fused graph kernel count remains one.

## Stack

PR #103 is stacked on this branch. Merge #101 first; #103 then removes the DCP-only host selector after migrating DCP to device execution parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PCIe collective communication during CUDA graph capture and replay.
  * Ensured staging buffers alternate correctly across all-reduce, reduce-scatter, and all-gather operations.
  * Improved reliability for eager and fused communication paths, including repeated and odd-numbered graph replays.

* **Tests**
  * Expanded coverage to verify buffer alternation, graph replay correctness, and long-running double-buffer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->