### PR TITLE
fix(mla): honor compressed cache physical page stride

### DIFF
--- a/sparkinfer/attention/_shared/mla/compressed_api.py
+++ b/sparkinfer/attention/_shared/mla/compressed_api.py
@@ -16,6 +16,7 @@ from .compressed_config import (
     compressed_mla_split_chunks_for_contract,
 )
 from .compressed_reference import (
+    COMPRESSED_MLA_BYTES_PER_TOKEN,
     COMPRESSED_MLA_DSV4_PAGE_SIZE,
     COMPRESSED_MLA_HEAD_DIM,
     compressed_mla_page_nbytes,
@@ -523,11 +524,14 @@ def _validate_compressed_cache_layout(
     page_size = int(page_size)
     if page_size <= 0:
         raise ValueError(f"{name} page_size must be positive, got {page_size}")
-    expected_page_nbytes = compressed_mla_page_nbytes(page_size)
-    if int(cache.shape[1]) != expected_page_nbytes:
+    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
+    padded_page_nbytes = compressed_mla_page_nbytes(page_size)
+    page_nbytes = int(cache.shape[1])
+    if page_nbytes not in (payload_nbytes, padded_page_nbytes):
         raise ValueError(
-            f"{name} page byte width must be {expected_page_nbytes} for page_size "
-            f"{page_size}, got {int(cache.shape[1])}"
+            f"{name} page byte width must be the contiguous payload "
+            f"{payload_nbytes} or padded width {padded_page_nbytes} for "
+            f"page_size {page_size}, got {page_nbytes}"
         )
 
 

--- a/sparkinfer/attention/_shared/mla/compressed_reference.py
+++ b/sparkinfer/attention/_shared/mla/compressed_reference.py
@@ -5,10 +5,11 @@ vector, a 64-dimension BF16 RoPE vector, and seven UE8M0 scale bytes for the
 noPE groups.  Within each page the token payloads are packed first, followed by
 the per-token scale region:
 
-    [page_size * 576 payload bytes][page_size * 8 scale bytes][padding]
+    [page_size * 576 payload bytes][page_size * 8 scale bytes][optional padding]
 
-The padding rounds page byte size up to a 576-byte multiple, matching the
-SGLang memory-pool contract.
+SGLang rounds the page byte size up to a 576-byte multiple. vLLM may instead
+use a contiguous allocation whose page stride ends immediately after the scale
+region. Both layouts contain the same compressed-MLA payload.
 """
 
 from __future__ import annotations

--- a/sparkinfer/attention/_shared/mla/kernel.py
+++ b/sparkinfer/attention/_shared/mla/kernel.py
@@ -2319,7 +2319,7 @@ def _cache_block_stride_bytes(
     record_bytes: int | None = None,
 ) -> int:
     from sparkinfer.attention._shared.mla.compressed_reference import (
-        compressed_mla_page_nbytes,
+        COMPRESSED_MLA_BYTES_PER_TOKEN,
     )
 
     if int(model_type) == int(ModelType.GLM_NSA):
@@ -2328,12 +2328,9 @@ def _cache_block_stride_bytes(
         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
         expected = int(page_size) * rec
     else:
-        expected = int(compressed_mla_page_nbytes(int(page_size)))
-    # Contiguous inputs are flattened before launch, so their original rank is
-    # not a physical-layout contract and the standard page stride applies.
-    # Packed vLLM page views are non-contiguous and carry the physical
-    # per-block stride in dimension 0.
-    if not cache.is_contiguous() and cache.ndim >= 2:
+        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
+    # Use the tensor's physical page stride for exact-payload and padded views.
+    if cache.ndim >= 2:
         stride = int(cache.stride(0)) * int(cache.element_size())
         if stride < expected:
             raise ValueError(

--- a/sparkinfer/attention/_shared/mla/prefill.py
+++ b/sparkinfer/attention/_shared/mla/prefill.py
@@ -48,7 +48,7 @@ def _cache_block_stride_bytes(
     record_bytes: int | None = None,
 ) -> int:
     from sparkinfer.attention._shared.mla.compressed_reference import (
-        compressed_mla_page_nbytes,
+        COMPRESSED_MLA_BYTES_PER_TOKEN,
     )
 
     if model_type == ModelType.GLM_NSA:
@@ -57,12 +57,10 @@ def _cache_block_stride_bytes(
         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
         expected = int(page_size) * rec
     else:
-        expected = int(compressed_mla_page_nbytes(int(page_size)))
-    # Contiguous inputs are flattened before launch, so their original rank is
-    # not a physical-layout contract and the standard page stride applies.
-    # Only packed, non-contiguous vLLM views preserve a real per-block stride in
-    # dimension 0.
-    if not cache.is_contiguous() and cache.ndim >= 2:
+        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
+    # The runtime page stride is part of the cache contract. It can be either
+    # the exact payload width or a larger packed/padded stride.
+    if cache.ndim >= 2:
         stride = int(cache.stride(0)) * int(cache.element_size())
         if stride < expected:
             raise ValueError(

--- a/sparkinfer/attention/_shared/mla/prefill_mg.py
+++ b/sparkinfer/attention/_shared/mla/prefill_mg.py
@@ -198,7 +198,7 @@ def _cache_block_stride_bytes(
     record_bytes: int | None = None,
 ) -> int:
     from sparkinfer.attention._shared.mla.compressed_reference import (
-        compressed_mla_page_nbytes,
+        COMPRESSED_MLA_BYTES_PER_TOKEN,
     )
 
     if is_glm:
@@ -207,12 +207,9 @@ def _cache_block_stride_bytes(
         rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
         expected = int(page_size) * rec
     else:
-        expected = int(compressed_mla_page_nbytes(int(page_size)))
-    # Contiguous inputs are flattened before launch, so their original rank is
-    # not a physical-layout contract and the standard page stride applies.
-    # Packed vLLM page views are non-contiguous and carry the physical
-    # per-block stride in dimension 0.
-    if not cache.is_contiguous() and cache.ndim >= 2:
+        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
+    # Use the tensor's physical page stride for exact-payload and padded views.
+    if cache.ndim >= 2:
         stride = int(cache.stride(0)) * int(cache.element_size())
         if stride < expected:
             raise ValueError(

--- a/tests/attention/test_compressed_mla.py
+++ b/tests/attention/test_compressed_mla.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 
 import pytest
 import torch
 
+from sparkinfer.attention._shared.mla.compressed_api import (
+    _validate_compressed_cache_layout,
+)
+from sparkinfer.attention._shared.mla.kernel import (
+    _cache_block_stride_bytes as _decode_cache_block_stride_bytes,
+)
+from sparkinfer.attention._shared.mla.prefill import (
+    _cache_block_stride_bytes as _prefill_cache_block_stride_bytes,
+)
+from sparkinfer.attention._shared.mla.prefill_mg import (
+    _cache_block_stride_bytes as _prefill_mg_cache_block_stride_bytes,
+)
 from sparkinfer.attention._shared.mla.compressed_reference import (
+    COMPRESSED_MLA_BYTES_PER_TOKEN,
     COMPRESSED_MLA_C128_PAGE_SIZE,
     COMPRESSED_MLA_DSV4_PAGE_SIZE,
+    compressed_mla_page_nbytes,
     compressed_sparse_mla_reference,
     pack_compressed_mla_kv_cache_reference,
 )
@@ -26,6 +41,68 @@ _SHARED_CORE_HEAD_DIM = 576
 _SHARED_CORE_V_HEAD_DIM = 512
 _LOCAL_Q_HEADS = 32
 _SM_SCALE = 1.0 / math.sqrt(_COMPRESSED_HEAD_DIM)
+
+
+@pytest.mark.parametrize("page_size", [16, 64, 256])
+def test_compressed_mla_layout_accepts_contiguous_and_padded_pages(
+    page_size: int,
+) -> None:
+    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
+    padded_nbytes = compressed_mla_page_nbytes(page_size)
+
+    _validate_compressed_cache_layout(
+        torch.empty((2, payload_nbytes), dtype=torch.uint8),
+        page_size=page_size,
+        name="cache",
+    )
+    _validate_compressed_cache_layout(
+        torch.empty((2, padded_nbytes), dtype=torch.uint8),
+        page_size=page_size,
+        name="cache",
+    )
+
+
+def test_compressed_mla_layout_rejects_short_page() -> None:
+    payload_nbytes = COMPRESSED_MLA_C128_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
+    with pytest.raises(ValueError, match="contiguous payload"):
+        _validate_compressed_cache_layout(
+            torch.empty((2, payload_nbytes - 1), dtype=torch.uint8),
+            page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
+            name="cache",
+        )
+
+
+@pytest.mark.parametrize(
+    "stride_fn,kwargs",
+    [
+        (_decode_cache_block_stride_bytes, {"model_type": 0}),
+        (_prefill_cache_block_stride_bytes, {"model_type": 0}),
+        (_prefill_mg_cache_block_stride_bytes, {"is_glm": False}),
+    ],
+)
+@pytest.mark.parametrize("padded", [False, True])
+def test_compressed_mla_dispatch_uses_physical_page_stride(
+    stride_fn: Callable[..., int],
+    kwargs: dict[str, object],
+    padded: bool,
+) -> None:
+    payload_nbytes = COMPRESSED_MLA_DSV4_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
+    physical_nbytes = (
+        compressed_mla_page_nbytes(COMPRESSED_MLA_DSV4_PAGE_SIZE)
+        if padded
+        else payload_nbytes
+    )
+    storage = torch.empty(2 * physical_nbytes, dtype=torch.uint8)
+    cache = torch.as_strided(
+        storage,
+        size=(2, payload_nbytes),
+        stride=(physical_nbytes, 1),
+    )
+
+    assert (
+        stride_fn(cache, page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE, **kwargs)
+        == physical_nbytes
+    )
 
 
 def _make_split_merge_tensors(


### PR DESCRIPTION
## Summary

Accept both valid compressed-MLA cache layouts and dispatch their actual physical page stride:

- exact vLLM payload pages (`page_size * 584` bytes)
- SGLang-compatible padded pages

The logical payload is identical. Padding is a physical allocation detail and must not be hard-coded as the kernel stride.

## Root cause

The DeepSeek-V4 0731 vLLM cache can expose a contiguous 64-token page as 37,376 bytes. SparkInfer validated and dispatched only the 37,440-byte padded layout. This rejected a valid cache before DSpark could start.

## Implementation

- accept exact-payload and padded page widths
- derive decode, single-GPU prefill, and multi-GPU prefill strides from `cache.stride(0)`
- retain a lower-bound check for malformed/overlapping pages
- no copy, replacement allocation, or extra VRAM

Paired vLLM change: the companion PR exports the logical payload while preserving the physical page stride.

## Validation

- `tests/attention/test_compressed_mla.py`: 12 passed
- TP2 B12X A8 MTP0: startup, prefill, and decode pass
- TP2 B12X A8 DSpark fixed K7: CUDA graph capture and sustained decode pass
- TP2 B12X A8 DSpark dynamic depth: varlen verification and physical suffix skipping pass
- exact-payload and padded synthetic layouts are both covered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compressed MLA cache validation to accept both contiguous and padded page layouts.
  * Standardized cache stride calculations across kernels for consistent behavior.

* **Documentation**
  * Updated module documentation to clarify page padding support and layout options.

* **Tests**
  * Added comprehensive tests for compressed MLA layouts, validating contiguous and padded cache handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->