### PR TITLE
fix(moe): reject unresolved capture launches

### DIFF
--- a/sparkinfer/_lib/compiler.py
+++ b/sparkinfer/_lib/compiler.py
@@ -2648,6 +2648,15 @@ def compile(
     compiled = _memory_cache_get(memory_cache_key)
     if compiled is not None:
         return compiled
+    from sparkinfer._lib.runtime_control import (
+        raise_if_kernel_resolution_frozen,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=func,
+        cache_key=compile_spec if compile_spec is not None else memory_cache_key,
+    )
 
     post_engine_start_log = _cute_compile_post_engine_start_log_enabled()
     payload = _compile_disk_cache_payload(
@@ -2720,15 +2729,6 @@ def compile(
 
             with _MEMORY_CACHE_LOCK:
                 _COMPILE_MISSES += 1
-            from sparkinfer._lib.runtime_control import (
-                raise_if_kernel_resolution_frozen,
-            )
-
-            raise_if_kernel_resolution_frozen(
-                "cute.compile",
-                target=func,
-                cache_key=compile_spec if compile_spec is not None else payload,
-            )
             call_kwargs = {
                 k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"
             }
@@ -2770,15 +2770,6 @@ def compile(
 
     with _MEMORY_CACHE_LOCK:
         _COMPILE_MISSES += 1
-    from sparkinfer._lib.runtime_control import (
-        raise_if_kernel_resolution_frozen,
-    )
-
-    raise_if_kernel_resolution_frozen(
-        "cute.compile",
-        target=func,
-        cache_key=compile_spec if compile_spec is not None else payload,
-    )
     call_kwargs = {k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"}
     compiled = _call_cute_compile(
         compile_callable,

--- a/sparkinfer/moe/_shared/kernels/dynamic.py
+++ b/sparkinfer/moe/_shared/kernels/dynamic.py
@@ -822,7 +822,11 @@ class MoEDynamicKernelBackend:
             source_tile_m=materialized_source_tile_m,
             deterministic_output=bool(deterministic_output),
             num_topk=self.num_topk,
-            activation=self.activation,
+            # This helper is gated-only and is never launched unless the split
+            # materialized path is active.  Use a valid inert specialization for
+            # non-split activations (notably ReLU2) instead of rejecting them
+            # during otherwise valid monolithic-kernel construction.
+            activation=self.activation if self.w4a8_split_materialized else "silu",
         )
         self.materialized_phase2_kernel = W4A8MaterializedPhase2Kernel(
             source_tile_m=materialized_source_tile_m,

--- a/sparkinfer/moe/_shared/kernels/dynamic.py
+++ b/sparkinfer/moe/_shared/kernels/dynamic.py
@@ -4200,15 +4200,7 @@ class MoEDynamicKernelBackend:
             # region; A bufs in sA past the FC2-intermediate bytes; FC1
             # residual bufs in sC (dead until the epilogue rendezvous); FC2
             # residual bufs alias the (FC1-only) A-buf region.
-            if cutlass.const_expr(self.w4a8_repacked):
-                w4a8_sa0 = (
-                    ctrl_base_addr
-                    + Int32(Storage._offsets["sA"])
-                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
-                )
-                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
-                w4a8_res2 = w4a8_sa0
-            elif cutlass.const_expr(self.w4a8_small):
+            if cutlass.const_expr(self.w4a8_repacked or self.w4a8_small):
                 w4a8_sa0 = (
                     ctrl_base_addr
                     + Int32(Storage._offsets["sA"])

--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
@@ -240,6 +240,27 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
     return 1 << (max(int(tokens), 1) - 1).bit_length()
 
 
+def route_pack_capacity(
+    numel: int,
+    block_size: int,
+    num_experts: int,
+    *,
+    topk: int = 1,
+    bucket_tokens: bool = True,
+) -> tuple[int, int, int]:
+    """Return the canonical routed-row, packed-slot, and block capacities."""
+    numel_capacity = (
+        route_pack_numel_capacity(numel, topk=topk)
+        if bucket_tokens
+        else max(int(numel), 1)
+    )
+    packed_routes = max_packed_route_slots(
+        numel_capacity, int(block_size), int(num_experts)
+    )
+    route_blocks = (packed_routes + int(block_size) - 1) // int(block_size)
+    return max(numel_capacity, 1), max(packed_routes, 1), max(route_blocks, 1)
+
+
 def max_w4a16_route_capacity(routed_rows: int, num_experts: int) -> tuple[int, int]:
     route_slots = 0
     route_blocks = 0
@@ -424,6 +445,7 @@ __all__ = [
     "plan_w4a16_buffers",
     "reorder_w13_to_gate_up",
     "route_pack_numel_capacity",
+    "route_pack_capacity",
     "route_pack_token_capacity",
     "select_route_block_size_m",
     "unswizzle_block_scale",

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -89,7 +89,6 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
     packed_gemm_scratch_elements,
     plan_w4a16_buffers,
-    route_pack_capacity,
     select_route_block_size_m,
     validate_activation,
 )
@@ -10181,21 +10180,15 @@ def run_w4a16_moe(
         )
 
     route_slots_for_scratch = int(m) * int(topk) * int(block_size_m)
-    if use_direct_topk_routes:
-        required_m_blocks = int(m) * int(topk)
-    else:
-        _, _, required_m_blocks = route_pack_capacity(
-            int(m) * int(topk),
-            int(block_size_m),
-            route_num_experts,
-            topk=topk,
-        )
+    required_m_blocks = int(m) * int(topk) if use_direct_topk_routes else 0
     if fused_launch is not None and not use_direct_topk_routes:
-        _, route_slots_capacity, route_blocks_capacity = route_pack_capacity(
+        route_slots_capacity = max_packed_route_slots(
             int(fused_launch.size_m) * int(topk),
             int(block_size_m),
             route_num_experts,
-            topk=topk,
+        )
+        route_blocks_capacity = (route_slots_capacity + int(block_size_m) - 1) // int(
+            block_size_m
         )
         if packed_route_indices is not None:
             if int(packed_route_indices.numel()) < route_slots_capacity:
@@ -10231,12 +10224,7 @@ def run_w4a16_moe(
             )
         )
         route_slots_for_scratch = int(packed_route_indices.numel())
-        if int(block_expert_ids.numel()) != int(required_m_blocks):
-            raise RuntimeError(
-                "W4A16 route packing did not produce the canonical launch capacity: "
-                f"runtime={int(block_expert_ids.numel())}, "
-                f"planned={int(required_m_blocks)}"
-            )
+        required_m_blocks = int(block_expert_ids.numel())
 
     props = torch.cuda.get_device_properties(a_input.device)
     sms = int(props.multi_processor_count)

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -7054,6 +7054,7 @@ def compile_w4a16_fused_moe(
     full_rotation: bool = False,
     rotation_input_dtype: str | None = None,
     broadcast_suh: bool = False,
+    _require_cached: bool = False,
 ) -> W4A16FusedMoeCompileResult:
     scale_format = _normalize_scale_format(scale_format)
     intermediate_rotation = bool(intermediate_rotation)
@@ -7432,6 +7433,13 @@ def compile_w4a16_fused_moe(
             size_m=size_m,
             max_m_blocks=max_m_blocks,
             blocks_per_sm=kernel.blocks_per_sm,
+        )
+    if _require_cached:
+        raise RuntimeError(
+            "W4A16 fused MoE launch is not resolved for CUDA graph capture "
+            f"(m={size_m}, moe_block_size={moe_block_size}, "
+            f"max_m_blocks={max_m_blocks}); run an eager warmup at this token "
+            "count before capturing"
         )
 
     if (not collect_activation_amax) and _small_m_direct_supported(
@@ -10274,6 +10282,7 @@ def run_w4a16_moe(
             intermediate_rotation=intermediate_rotation_scales is not None,
             full_rotation=full_rotation,
             rotation_input_dtype=rotation_input_dtype,
+            _require_cached=torch.cuda.is_current_stream_capturing(),
         )
     else:
         if int(fused_launch.size_m) < m:

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -89,6 +89,7 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
     packed_gemm_scratch_elements,
     plan_w4a16_buffers,
+    route_pack_capacity,
     select_route_block_size_m,
     validate_activation,
 )
@@ -9745,6 +9746,23 @@ def _resolve_route_block_size_m(
     return compiled
 
 
+def _w4a16_stream_is_capturing(
+    stream: cuda.CUstream,
+    *,
+    current_stream: cuda.CUstream,
+) -> bool:
+    """Observe capture on either Torch's current stream or an explicit stream."""
+    current_capturing = torch.cuda.is_current_stream_capturing()
+    if current_capturing or int(stream) == int(current_stream):
+        return current_capturing
+    result, status = cuda.cuStreamIsCapturing(stream)
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(
+            f"cuStreamIsCapturing failed for the selected W4A16 stream: {result}"
+        )
+    return int(status) != 0
+
+
 def run_w4a16_moe(
     a_input: torch.Tensor,
     prepared,
@@ -10013,7 +10031,8 @@ def run_w4a16_moe(
     if block_size_m not in _ALLOWED_ROUTED_SIZES:
         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
 
-    stream = current_cuda_stream() if stream is None else stream
+    current_stream = current_cuda_stream()
+    stream = current_stream if stream is None else stream
     if (not collect_activation_amax) and _small_m_direct_supported(
         m=m,
         hidden_size=hidden_size,
@@ -10162,15 +10181,21 @@ def run_w4a16_moe(
         )
 
     route_slots_for_scratch = int(m) * int(topk) * int(block_size_m)
-    required_m_blocks = int(m) * int(topk) if use_direct_topk_routes else 0
+    if use_direct_topk_routes:
+        required_m_blocks = int(m) * int(topk)
+    else:
+        _, _, required_m_blocks = route_pack_capacity(
+            int(m) * int(topk),
+            int(block_size_m),
+            route_num_experts,
+            topk=topk,
+        )
     if fused_launch is not None and not use_direct_topk_routes:
-        route_slots_capacity = max_packed_route_slots(
+        _, route_slots_capacity, route_blocks_capacity = route_pack_capacity(
             int(fused_launch.size_m) * int(topk),
             int(block_size_m),
             route_num_experts,
-        )
-        route_blocks_capacity = (route_slots_capacity + int(block_size_m) - 1) // int(
-            block_size_m
+            topk=topk,
         )
         if packed_route_indices is not None:
             if int(packed_route_indices.numel()) < route_slots_capacity:
@@ -10206,7 +10231,12 @@ def run_w4a16_moe(
             )
         )
         route_slots_for_scratch = int(packed_route_indices.numel())
-        required_m_blocks = int(block_expert_ids.numel())
+        if int(block_expert_ids.numel()) != int(required_m_blocks):
+            raise RuntimeError(
+                "W4A16 route packing did not produce the canonical launch capacity: "
+                f"runtime={int(block_expert_ids.numel())}, "
+                f"planned={int(required_m_blocks)}"
+            )
 
     props = torch.cuda.get_device_properties(a_input.device)
     sms = int(props.multi_processor_count)
@@ -10282,7 +10312,10 @@ def run_w4a16_moe(
             intermediate_rotation=intermediate_rotation_scales is not None,
             full_rotation=full_rotation,
             rotation_input_dtype=rotation_input_dtype,
-            _require_cached=torch.cuda.is_current_stream_capturing(),
+            _require_cached=_w4a16_stream_is_capturing(
+                stream,
+                current_stream=current_stream,
+            ),
         )
     else:
         if int(fused_launch.size_m) < m:

--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
@@ -6,10 +6,7 @@ import triton
 import triton.language as tl
 import torch
 
-from sparkinfer.moe._shared.kernels.w4a16.host import (
-    max_packed_route_slots,
-    route_pack_numel_capacity,
-)
+from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
 
 
 _COUNT_BLOCK_T = 256
@@ -306,25 +303,30 @@ def pack_topk_routes_by_expert(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     numel = int(topk_ids.numel())
     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
-    numel_capacity = route_pack_numel_capacity(numel, topk=topk)
-    capacity_packed_routes = max_packed_route_slots(
-        numel_capacity, int(block_size), int(num_experts)
-    )
-    capacity_route_blocks = (capacity_packed_routes + int(block_size) - 1) // int(
-        block_size
+    numel_capacity, capacity_packed_routes, capacity_route_blocks = (
+        route_pack_capacity(
+            numel,
+            int(block_size),
+            int(num_experts),
+            topk=topk,
+        )
     )
     if packed_route_indices is not None and block_expert_ids is not None:
         if (
             int(packed_route_indices.numel()) < capacity_packed_routes
             or int(block_expert_ids.numel()) < capacity_route_blocks
         ):
-            numel_capacity = numel
-            capacity_packed_routes = max_packed_route_slots(
-                numel, int(block_size), int(num_experts)
+            (
+                numel_capacity,
+                capacity_packed_routes,
+                capacity_route_blocks,
+            ) = route_pack_capacity(
+                numel,
+                int(block_size),
+                int(num_experts),
+                topk=topk,
+                bucket_tokens=False,
             )
-            capacity_route_blocks = (
-                capacity_packed_routes + int(block_size) - 1
-            ) // int(block_size)
     max_packed_routes = capacity_packed_routes
     max_route_blocks = capacity_route_blocks
     max_packed_routes = max(max_packed_routes, 1)

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -6497,7 +6497,7 @@ def _prewarm_w4a16_planned_launches(
     collect_activation_amax = bool(collect_activation_amax)
 
     from sparkinfer.moe._shared.kernels.w4a16.host import (
-        max_packed_route_slots,
+        route_pack_capacity,
         select_route_block_size_m,
     )
     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
@@ -6543,12 +6543,12 @@ def _prewarm_w4a16_planned_launches(
                 token_count, workspace.num_topk, workspace.route_E
             )
             routed_rows = int(token_count) * int(workspace.num_topk)
-            route_slots = max_packed_route_slots(
+            _, _, max_m_blocks = route_pack_capacity(
                 routed_rows,
                 block_size_m,
                 workspace.route_E,
+                topk=workspace.num_topk,
             )
-            max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
             fused_key = (
                 weight_layout,

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -6185,9 +6185,7 @@ def _plan_full_rotation_w4a16_launches(
     if torch.cuda.is_current_stream_capturing():
         raise RuntimeError("Trellis launch planning cannot run during capture")
 
-    from sparkinfer.moe._shared.kernels.w4a16.host import (
-        max_packed_route_slots,
-    )
+    from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
         _DEFAULT_MAX_SHARED_MEM,
         compile_w4a16_fused_moe,
@@ -6216,14 +6214,13 @@ def _plan_full_rotation_w4a16_launches(
             f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
         )
     w13_layout = "trellis3_t256_proj"
-    capacity_route_slots = max_packed_route_slots(
+    _, capacity_route_slots, capacity_m_blocks = route_pack_capacity(
         capacity_tokens * core_plan.num_topk,
         block_size_m,
         core_plan.route_E,
+        topk=core_plan.num_topk,
+        bucket_tokens=False,
     )
-    capacity_m_blocks = (
-        capacity_route_slots + block_size_m - 1
-    ) // block_size_m
     rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
 
     with torch.cuda.device(core_plan.device):
@@ -6548,6 +6545,7 @@ def _prewarm_w4a16_planned_launches(
                 block_size_m,
                 workspace.route_E,
                 topk=workspace.num_topk,
+                bucket_tokens=not full_rotation,
             )
             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
             fused_key = (

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -274,7 +274,7 @@ def test_uuid_unavailable_disables_disk_cache(monkeypatch):
     assert not compiler._cute_compile_disk_cache_enabled_for_payload(payload)
 
 
-def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
+def test_explicit_memory_cache_hit_skips_freeze_and_disk_payload(monkeypatch):
     cute = pytest.importorskip("cutlass.cute")
     compile_callable = object()
     compiled = object()
@@ -299,14 +299,55 @@ def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
             AssertionError("memory hit rebuilt the disk payload")
         ),
     )
+    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
 
-    assert (
-        compiler.compile(
-            test_explicit_memory_cache_hit_skips_disk_payload,
-            compile_spec=compile_spec,
+    runtime_control.freeze_kernel_resolution("cached compile remains launchable")
+    try:
+        assert (
+            compiler.compile(
+                test_explicit_memory_cache_hit_skips_freeze_and_disk_payload,
+                compile_spec=compile_spec,
+            )
+            is compiled
         )
-        is compiled
+    finally:
+        runtime_control.unfreeze_kernel_resolution()
+
+
+def test_frozen_memory_miss_rejects_before_disk_cache_load(monkeypatch):
+    cute = pytest.importorskip("cutlass.cute")
+    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
+    compile_spec = compiler.KernelCompileSpec.from_facts(
+        "test.freeze.disk_hit",
+        1,
+        ("rows", 8),
     )
+    monkeypatch.setattr(cute, "compile", object())
+    monkeypatch.setattr(compiler, "_memory_cache_get", lambda _key: None)
+    monkeypatch.setattr(
+        compiler,
+        "_compile_disk_cache_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("frozen miss built a persistent-cache payload")
+        ),
+    )
+    monkeypatch.setattr(
+        compiler,
+        "_load_cute_compile_from_disk",
+        lambda _key: (_ for _ in ()).throw(
+            AssertionError("frozen miss loaded a persistent module")
+        ),
+    )
+
+    runtime_control.freeze_kernel_resolution("disk hits must not bypass freeze")
+    try:
+        with pytest.raises(runtime_control.KernelResolutionFrozenError):
+            compiler.compile(
+                test_frozen_memory_miss_rejects_before_disk_cache_load,
+                compile_spec=compile_spec,
+            )
+    finally:
+        runtime_control.unfreeze_kernel_resolution()
 
 
 def test_v6_semantic_payload_matches_independent_validators(monkeypatch):

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -19,10 +19,15 @@ from sparkinfer.moe._shared.kernels.reference import (
     moe_reference_w4a16_f32,
     moe_reference_w4a16_fp4_e8m0_k32,
 )
-from sparkinfer.moe._shared.kernels.w4a16.host import max_packed_route_slots, select_route_block_size_m
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    route_pack_capacity,
+    select_route_block_size_m,
+)
 from sparkinfer.moe._shared.kernels.w4a16.kernel import (
     _DEFAULT_MAX_SHARED_MEM,
     MoEMicroKernelW4A16SmallMDirect,
+    _w4a16_stream_is_capturing,
     _small_m_direct_supported,
     compile_w4a16_fused_moe,
     compile_w4a16_topk_sum,
@@ -66,6 +71,159 @@ def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
             max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
             _require_cached=True,
         )
+
+
+def test_w4a16_capture_guard_checks_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    selected_stream = 22
+    queried: list[object] = []
+    monkeypatch.setattr(
+        w4a16_kernel.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel.cuda,
+        "cuStreamIsCapturing",
+        lambda stream: (
+            queried.append(stream) or w4a16_kernel.cuda.CUresult.CUDA_SUCCESS,
+            1,
+        ),
+    )
+
+    assert _w4a16_stream_is_capturing(selected_stream, current_stream=11)
+    assert queried == [selected_stream]
+
+
+def test_w4a16_capture_guard_preserves_current_stream_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    monkeypatch.setattr(
+        w4a16_kernel.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel.cuda,
+        "cuStreamIsCapturing",
+        lambda _stream: (_ for _ in ()).throw(
+            AssertionError("current-stream capture queried the selected stream")
+        ),
+    )
+
+    assert _w4a16_stream_is_capturing(22, current_stream=11)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "bucket_tokens"),
+    (
+        (1, 1),
+        (8, 8),
+        (9, 16),
+        (3072, 4096),
+        (4096, 4096),
+        (4097, 8192),
+    ),
+)
+def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
+    tokens: int,
+    bucket_tokens: int,
+) -> None:
+    topk = 8
+    block_size = 64
+    num_experts = 160
+    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
+        tokens * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+    )
+    expected_routes = bucket_tokens * topk
+    expected_packed = max_packed_route_slots(
+        expected_routes,
+        block_size,
+        num_experts,
+    )
+
+    assert routed_capacity == expected_routes
+    assert packed_routes == expected_packed
+    assert max_m_blocks == (expected_packed + block_size - 1) // block_size
+    if tokens == 3072:
+        assert max_m_blocks == 670
+
+
+def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from contextlib import nullcontext
+    from types import SimpleNamespace
+
+    from sparkinfer.moe.fused_moe import _impl as tp_moe_impl
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    workspace = SimpleNamespace(
+        device=torch.device("cuda"),
+        dtype=torch.bfloat16,
+        full_rotation=False,
+        route_block_size_m=64,
+        num_topk=8,
+        route_E=160,
+        weight_E=160,
+        k=6144,
+        n=2048,
+        activation="silu",
+        trellis_bits=3,
+        trellis_tile_config=None,
+    )
+    fused_calls: list[dict[str, object]] = []
+    resolved_fused = object()
+    monkeypatch.setattr(tp_moe_impl.torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(
+        tp_moe_impl.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        tp_moe_impl.torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(
+            multi_processor_count=188,
+            shared_memory_per_block_optin=_DEFAULT_MAX_SHARED_MEM,
+        ),
+    )
+    monkeypatch.setattr(w4a16_kernel, "_rot_scales_dummy", lambda _device: None)
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "compile_w4a16_fused_moe",
+        lambda **kwargs: fused_calls.append(kwargs) or resolved_fused,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "compile_w4a16_topk_sum",
+        lambda **_kwargs: object(),
+    )
+
+    tp_moe_impl._prewarm_w4a16_planned_launches(
+        workspace,
+        token_counts=(3072,),
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=1.0,
+        swiglu_beta=1.0,
+        collect_activation_amax=True,
+    )
+
+    assert len(fused_calls) == 1
+    assert fused_calls[0]["size_m"] == 3072
+    assert fused_calls[0]["max_m_blocks"] == 670
+    assert workspace.planned_fused_moe_launches[
+        ("packed", "e4m3_k16", 3072, True)
+    ] is resolved_fused
 
 
 def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -130,7 +130,7 @@ def test_w4a16_capture_guard_preserves_current_stream_capture(
         (4097, 8192),
     ),
 )
-def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
+def test_generic_w4a16_planner_runtime_key_agrees_at_bucket_boundaries(
     tokens: int,
     bucket_tokens: int,
 ) -> None:
@@ -157,7 +157,28 @@ def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
         assert max_m_blocks == 670
 
 
-def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
+def test_trellis_w4a16_planner_runtime_key_preserves_exact_capacity() -> None:
+    topk = 8
+    block_size = 64
+    num_experts = 160
+    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
+        3072 * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+        bucket_tokens=False,
+    )
+
+    assert routed_capacity == 3072 * topk
+    assert packed_routes == max_packed_route_slots(
+        3072 * topk,
+        block_size,
+        num_experts,
+    )
+    assert max_m_blocks == 542
+
+
+def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from contextlib import nullcontext
@@ -169,7 +190,7 @@ def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
     workspace = SimpleNamespace(
         device=torch.device("cuda"),
         dtype=torch.bfloat16,
-        full_rotation=False,
+        full_rotation=True,
         route_block_size_m=64,
         num_topk=8,
         route_E=160,
@@ -215,14 +236,17 @@ def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
         swiglu_limit=None,
         swiglu_alpha=1.0,
         swiglu_beta=1.0,
-        collect_activation_amax=True,
+        scale_format="e4m3_k32",
+        weight_layout="trellis3_t256",
+        w13_layout="trellis3_t256_proj",
+        collect_activation_amax=False,
     )
 
-    assert len(fused_calls) == 1
-    assert fused_calls[0]["size_m"] == 3072
-    assert fused_calls[0]["max_m_blocks"] == 670
+    assert len(fused_calls) == 2
+    assert {call["size_m"] for call in fused_calls} == {3072}
+    assert {call["max_m_blocks"] for call in fused_calls} == {542}
     assert workspace.planned_fused_moe_launches[
-        ("packed", "e4m3_k16", 3072, True)
+        ("trellis3_t256", "e4m3_k32", 3072, False)
     ] is resolved_fused
 
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -39,6 +39,35 @@ from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
 from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
 
 
+def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    monkeypatch.setattr(w4a16_kernel, "_FUSED_CACHE", {})
+    monkeypatch.setattr(w4a16_kernel.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="W4A16 fused MoE launch is not resolved for CUDA graph capture",
+    ):
+        compile_w4a16_fused_moe(
+            size_m=16,
+            hidden_size=128,
+            intermediate_size=128,
+            num_experts=8,
+            top_k=2,
+            activation="silu",
+            apply_router_weight_on_input=False,
+            zero_fc2_output=False,
+            moe_block_size=8,
+            max_m_blocks=16,
+            sms=188,
+            max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
+            _require_cached=True,
+        )
+
+
 def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:
     return (torch.rand(shape, device="cuda") * 0.25 + 0.03125).to(torch.float8_e4m3fn)
 


### PR DESCRIPTION
## Summary

Reject unresolved W4A16 launch resolution before compilation, persistent-cache lookup, filesystem/module loading, or CUDA module loading when the selected launch stream is being captured.

This is the current-`master` successor to #102. It contains only the capture-resolution commits after the obsolete stacked base.

## Change

- Preserve already-resolved in-memory launch hits during capture.
- Freeze resolution before persistent-cache payload construction or disk lookup.
- Add cache-only W4A16 fused-launch resolution for runtime capture misses.
- Detect capture on an explicitly selected non-current CUDA stream with `cuStreamIsCapturing`, while keeping the current-stream fast path.
- Use one route-capacity/key derivation across planner prewarm, route packing, slicing, and runtime resolution.
- Keep explicit eager planning and prewarm legal outside runtime launch resolution.

The failure is early and actionable: the operator must run eager warmup for the missing token count before capture. Non-capture behavior, launch ABI, kernel selection, and numerics are unchanged.

## Verification

```text
29 passed, 87 skipped
```

Focused suites cover memory hits, disk-hit rejection, selected-stream capture, generic capacity buckets, exact Trellis capacity, and capture-time planned prewarm. Changed-file Ruff checks and `git diff --check` pass.

No merge is performed by this PR creation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mixture-of-experts workload planning for more efficient token routing and packing.
  * Added support for a broader range of activation functions in optimized execution paths.
  * Improved compatibility with CUDA Graph capture and selected execution streams.

* **Bug Fixes**
  * Prevented unexpected compilation during graph capture.
  * Improved behavior when kernel resolution is frozen while cached kernels remain available.
  * Enhanced cache planning consistency for variable workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->