### PR TITLE
[EXL3] consolidate mixed prefill and dense K6 runtime

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include sparkinfer/gemm/trellis_linear/csrc *.cu *.cuh *.h LICENSE*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ include = ["sparkinfer*"]
 
 [tool.setuptools.package-data]
 "sparkinfer.comm.pcie" = ["*.cu"]
-"sparkinfer.gemm.trellis_linear" = ["csrc/*.cu", "csrc/vendor/*.cuh", "csrc/vendor/*.h", "csrc/vendor/LICENSE*", "csrc/vendor/quant/*.cuh"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "SIM"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ include = ["sparkinfer*"]
 
 [tool.setuptools.package-data]
 "sparkinfer.comm.pcie" = ["*.cu"]
+"sparkinfer.gemm.trellis_linear" = ["csrc/*.cu", "csrc/vendor/*.cuh", "csrc/vendor/*.h", "csrc/vendor/LICENSE*", "csrc/vendor/quant/*.cuh"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "SIM"]

--- a/sparkinfer/_lib/compiler.py
+++ b/sparkinfer/_lib/compiler.py
@@ -2648,6 +2648,15 @@ def compile(
     compiled = _memory_cache_get(memory_cache_key)
     if compiled is not None:
         return compiled
+    from sparkinfer._lib.runtime_control import (
+        raise_if_kernel_resolution_frozen,
+    )
+
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=func,
+        cache_key=compile_spec if compile_spec is not None else memory_cache_key,
+    )
 
     post_engine_start_log = _cute_compile_post_engine_start_log_enabled()
     payload = _compile_disk_cache_payload(
@@ -2720,15 +2729,6 @@ def compile(
 
             with _MEMORY_CACHE_LOCK:
                 _COMPILE_MISSES += 1
-            from sparkinfer._lib.runtime_control import (
-                raise_if_kernel_resolution_frozen,
-            )
-
-            raise_if_kernel_resolution_frozen(
-                "cute.compile",
-                target=func,
-                cache_key=compile_spec if compile_spec is not None else payload,
-            )
             call_kwargs = {
                 k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"
             }
@@ -2770,15 +2770,6 @@ def compile(
 
     with _MEMORY_CACHE_LOCK:
         _COMPILE_MISSES += 1
-    from sparkinfer._lib.runtime_control import (
-        raise_if_kernel_resolution_frozen,
-    )
-
-    raise_if_kernel_resolution_frozen(
-        "cute.compile",
-        target=func,
-        cache_key=compile_spec if compile_spec is not None else payload,
-    )
     call_kwargs = {k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"}
     compiled = _call_cute_compile(
         compile_callable,

--- a/sparkinfer/_lib/intrinsics.py
+++ b/sparkinfer/_lib/intrinsics.py
@@ -6231,6 +6231,46 @@ def _trellis_mcg_asm_constants(asm: str) -> str:
 
 
 @dsl_user_op
+def trellis_align_stream_u32x2(z0, z1, z2, shift, word_delta, *, loc=None, ip=None):
+    """Align two words from a two- or three-word circular Trellis span.
+
+    This is the 32-bit SHF equivalent of shifting a temporary 64/96-bit integer.
+    Keeping the operation on the native integer pipe avoids compiler-generated
+    wide-integer carry chains in the K6 dequantization hot loop.
+    """
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [
+            Uint32(z0).ir_value(loc=loc, ip=ip),
+            Uint32(z1).ir_value(loc=loc, ip=ip),
+            Uint32(z2).ir_value(loc=loc, ip=ip),
+            Uint32(shift).ir_value(loc=loc, ip=ip),
+            Uint32(word_delta).ir_value(loc=loc, ip=ip),
+        ],
+        """
+        {
+            .reg .pred two_words;
+            .reg .b32 mid, upper;
+            setp.eq.u32 two_words, $6, 1;
+            selp.b32 mid, $2, $3, two_words;
+            selp.b32 upper, 0, $2, two_words;
+            shf.r.wrap.b32 $0, $4, mid, $5;
+            shf.r.wrap.b32 $1, mid, upper, $5;
+        }
+        """,
+        "=r,=r,r,r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
 def packed_dequant_trellis_to_half2x4(
     win_a, win_b, bits: int = 3, *, loc=None, ip=None
 ):

--- a/sparkinfer/_lib/intrinsics.py
+++ b/sparkinfer/_lib/intrinsics.py
@@ -423,9 +423,7 @@ def elem_pointer(x: cute.Tensor, coord, *, loc=None, ip=None) -> cute.Pointer:
 
 
 @dsl_user_op
-def ld_global_v2_u32(
-    base_ptr: Int64, *, loc=None, ip=None
-) -> Tuple[Uint32, Uint32]:
+def ld_global_v2_u32(base_ptr: Int64, *, loc=None, ip=None) -> Tuple[Uint32, Uint32]:
     """Load 64 bits (2 x uint32) from coherent global memory."""
     result = llvm.inline_asm(
         llvm.StructType.get_literal([T.i32(), T.i32()]),
@@ -6254,6 +6252,7 @@ def trellis_align_stream_u32x2(z0, z1, z2, shift, word_delta, *, loc=None, ip=No
             setp.eq.u32 two_words, $6, 1;
             selp.b32 mid, $2, $3, two_words;
             selp.b32 upper, 0, $2, two_words;
+            // PTX shf.r forms (b:a), so z0/mid and mid/upper are low/high.
             shf.r.wrap.b32 $0, $4, mid, $5;
             shf.r.wrap.b32 $1, mid, upper, $5;
         }

--- a/sparkinfer/gemm/trellis_linear/_small_m.py
+++ b/sparkinfer/gemm/trellis_linear/_small_m.py
@@ -34,6 +34,11 @@ def _default_num_sms(size_k: int, size_n: int, available_sms: int) -> int:
     return available_sms if target is None else min(available_sms, target)
 
 
+@lru_cache(maxsize=None)
+def _available_sms(device_index: int) -> int:
+    return int(torch.cuda.get_device_properties(device_index).multi_processor_count)
+
+
 def _extension_name() -> str:
     digest = hashlib.sha256()
     for path in (_SOURCE, *_VENDORED_FILES):
@@ -77,12 +82,20 @@ def run_k6_mcg(
     num_sms: int = 0,
 ) -> None:
     """Launch the capture-safe K6/MCG kernel on Torch's current stream."""
+    capability = torch.cuda.get_device_capability(x.device)
+    if capability != (12, 0):
+        raise NotImplementedError(
+            "Trellis K6 small-M kernel is built for sm_120 only; "
+            f"device reports sm_{capability[0]}{capability[1]}"
+        )
     if num_sms <= 0:
-        props = torch.cuda.get_device_properties(x.device)
+        device_index = x.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
         num_sms = _default_num_sms(
             int(x.shape[1]),
             int(output.shape[1]),
-            int(props.multi_processor_count),
+            _available_sms(int(device_index)),
         )
     _extension().launch_k6_mcg(
         x,

--- a/sparkinfer/gemm/trellis_linear/_small_m.py
+++ b/sparkinfer/gemm/trellis_linear/_small_m.py
@@ -1,0 +1,99 @@
+"""JIT binding for the SparkInfer-owned K6/MCG small-M CUDA kernel."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from functools import lru_cache
+from pathlib import Path
+
+import torch
+from torch.utils.cpp_extension import load
+
+
+_SOURCE_DIR = Path(__file__).resolve().parent / "csrc"
+_SOURCE = _SOURCE_DIR / "trellis_k6_small.cu"
+_VENDORED_FILES = tuple(sorted((_SOURCE_DIR / "vendor").rglob("*.[ch]*")))
+
+
+_GLM_K6_DECODE_SMS = {
+    # Q/indexer projection on the target stream.
+    (2048, 4096): 128,
+    # TP4 shared-expert FC1/FC2 run beside the target stream. These are the
+    # rank-local dimensions after column/row parallel slicing, not the full
+    # 4096/2048-wide shared MLP dimensions. The budgets match the E2E-optimal
+    # ExLlama autotuner result; using all 188 SMs serializes the graph branches.
+    (6144, 1024): 64,
+    (512, 6144): 96,
+}
+
+
+def _default_num_sms(size_k: int, size_n: int, available_sms: int) -> int:
+    """Select the measured GLM K6 decode overlap budget when applicable."""
+    target = _GLM_K6_DECODE_SMS.get((size_k, size_n))
+    return available_sms if target is None else min(available_sms, target)
+
+
+def _extension_name() -> str:
+    digest = hashlib.sha256()
+    for path in (_SOURCE, *_VENDORED_FILES):
+        if path.is_file():
+            digest.update(path.relative_to(_SOURCE_DIR).as_posix().encode())
+            digest.update(path.read_bytes())
+    return f"sparkinfer_trellis_k6_{digest.hexdigest()[:12]}"
+
+
+@lru_cache(maxsize=1)
+def _extension():
+    build_directory = os.environ.get("SPARKINFER_TRELLIS_BUILD_DIR")
+    if build_directory:
+        Path(build_directory).mkdir(parents=True, exist_ok=True)
+    return load(
+        name=_extension_name(),
+        sources=[str(_SOURCE)],
+        extra_include_paths=[str(_SOURCE_DIR)],
+        extra_cuda_cflags=[
+            "-O3",
+            "--use_fast_math",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "-gencode=arch=compute_120,code=sm_120",
+        ],
+        extra_cflags=["-O3"],
+        build_directory=build_directory,
+        verbose=os.environ.get("SPARKINFER_JIT_VERBOSE", "0") == "1",
+    )
+
+
+def run_k6_mcg(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    output: torch.Tensor,
+    suh: torch.Tensor,
+    rotated_input: torch.Tensor,
+    svh: torch.Tensor,
+    locks: torch.Tensor,
+    *,
+    num_sms: int = 0,
+) -> None:
+    """Launch the capture-safe K6/MCG kernel on Torch's current stream."""
+    if num_sms <= 0:
+        props = torch.cuda.get_device_properties(x.device)
+        num_sms = _default_num_sms(
+            int(x.shape[1]),
+            int(output.shape[1]),
+            int(props.multi_processor_count),
+        )
+    _extension().launch_k6_mcg(
+        x,
+        trellis,
+        output,
+        suh,
+        rotated_input,
+        svh,
+        locks,
+        int(num_sms),
+    )
+
+
+__all__ = ["run_k6_mcg"]

--- a/sparkinfer/gemm/trellis_linear/api.py
+++ b/sparkinfer/gemm/trellis_linear/api.py
@@ -57,6 +57,8 @@ def run(
     gemm_output_f16: Optional[torch.Tensor] = None,
     output_f16: Optional[torch.Tensor] = None,
     hadamard_128=None,
+    _moe_block_size: int = 64,
+    _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Execute Trellis GEMM, optionally reusing all capture-time storage."""
     return run_trellis256_dense(
@@ -71,6 +73,8 @@ def run(
         gemm_output_f16=gemm_output_f16,
         output_f16=output_f16,
         hadamard_128=hadamard_128,
+        _moe_block_size=_moe_block_size,
+        _force_tile_config=_force_tile_config,
     )
 
 

--- a/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
+++ b/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+//
+// Narrow K6/MCG dense launcher adapted from ExLlamaV3. The vendored kernel
+// headers retain their MIT license in vendor/LICENSE.exllamav3. SparkInfer
+// owns the tensor validation, workspace, dispatch, and CUDA-stream contract.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <algorithm>
+#include <cuda_fp16.h>
+#include <cooperative_groups.h>
+#include <torch/extension.h>
+
+#include "vendor/util.h"
+#include "vendor/util.cuh"
+
+namespace cg = cooperative_groups;
+
+#include "vendor/quant/exl3_gemm_kernel.cuh"
+
+namespace {
+
+constexpr int kBits = 6;
+constexpr int kCodebookMcg = 1;
+constexpr int kTileM = 16;
+constexpr int kTileK = 32;
+constexpr int kTileN = 128;
+constexpr int kSharedStages = 4;
+constexpr int kFragmentStages = 3;
+constexpr int kThreads = 512;
+constexpr int kDynamicSmem = 90 * 1024;
+
+void check_cuda(cudaError_t status, const char* operation) {
+  TORCH_CHECK(status == cudaSuccess, operation, ": ", cudaGetErrorString(status));
+}
+
+void launch_k6_mcg(
+    const torch::Tensor& input,
+    const torch::Tensor& trellis,
+    torch::Tensor& output,
+    const torch::Tensor& suh,
+    torch::Tensor& rotated_input,
+    const torch::Tensor& svh,
+    torch::Tensor& locks,
+    int64_t requested_sms) {
+  const c10::cuda::CUDAGuard device_guard(input.device());
+  TORCH_CHECK(input.is_cuda() && trellis.is_cuda() && output.is_cuda(),
+              "Trellis K6 tensors must be CUDA tensors");
+  TORCH_CHECK(input.scalar_type() == at::kHalf && output.scalar_type() == at::kHalf,
+              "Trellis K6 small-M path requires FP16 input and output");
+  TORCH_CHECK(trellis.scalar_type() == at::kShort,
+              "Trellis K6 payload must be viewed as int16");
+  TORCH_CHECK(suh.scalar_type() == at::kHalf && svh.scalar_type() == at::kHalf,
+              "Trellis K6 rotation scales must be FP16");
+  TORCH_CHECK(rotated_input.scalar_type() == at::kHalf,
+              "Trellis K6 rotated input must be FP16");
+  TORCH_CHECK(locks.scalar_type() == at::kInt,
+              "Trellis K6 lock workspace must be int32");
+  TORCH_CHECK(input.is_contiguous() && trellis.is_contiguous() &&
+                  output.is_contiguous() && suh.is_contiguous() &&
+                  rotated_input.is_contiguous() && svh.is_contiguous() &&
+                  locks.is_contiguous(),
+              "Trellis K6 small-M tensors must be contiguous");
+  TORCH_CHECK(input.dim() == 2 && output.dim() == 2 && trellis.dim() == 3,
+              "Trellis K6 expects A[M,K], B[K/16,N/16,96], C[M,N]");
+
+  int size_m = static_cast<int>(input.size(0));
+  int size_k = static_cast<int>(input.size(1));
+  int size_n = static_cast<int>(output.size(1));
+  TORCH_CHECK(size_m >= 1 && size_m <= 128,
+              "Trellis K6 small-M path supports 1..128 rows, got ", size_m);
+  TORCH_CHECK(output.size(0) == size_m && rotated_input.sizes() == input.sizes(),
+              "Trellis K6 output/scratch shapes do not match input");
+  TORCH_CHECK(trellis.size(0) * 16 == size_k &&
+                  trellis.size(1) * 16 == size_n && trellis.size(2) == 96,
+              "Trellis K6 native payload shape does not match M/K/N");
+  TORCH_CHECK(suh.numel() == size_k && svh.numel() == size_n,
+              "Trellis K6 rotation scale width mismatch");
+  TORCH_CHECK(size_k % kTileK == 0 && size_n % kTileN == 0,
+              "Trellis K6 K/N must be divisible by 32/128");
+  TORCH_CHECK(locks.numel() >= size_n / 16,
+              "Trellis K6 lock workspace is too small");
+
+  int device = input.get_device();
+  int available_sms = 0;
+  check_cuda(cudaDeviceGetAttribute(&available_sms, cudaDevAttrMultiProcessorCount,
+                                    device),
+             "cudaDeviceGetAttribute");
+  const int tiles = (size_k / kTileK) * (size_n / kTileN);
+  int num_sms = requested_sms > 0 ? static_cast<int>(requested_sms) : available_sms;
+  num_sms = std::max(1, std::min(num_sms, std::min(available_sms, tiles)));
+
+  auto kernel = exl3_gemm_kernel<kBits, false, kCodebookMcg, kTileM, kTileK,
+                                 kTileN, kSharedStages, kFragmentStages>;
+  check_cuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                  kDynamicSmem),
+             "cudaFuncSetAttribute");
+
+  const half* a_ptr = reinterpret_cast<const half*>(input.data_ptr<at::Half>());
+  const uint16_t* b_ptr =
+      reinterpret_cast<const uint16_t*>(trellis.data_ptr<int16_t>());
+  half* c_ptr = reinterpret_cast<half*>(output.data_ptr<at::Half>());
+  int* lock_ptr = locks.data_ptr<int>();
+  const half* suh_ptr = reinterpret_cast<const half*>(suh.data_ptr<at::Half>());
+  half* rotated_ptr =
+      reinterpret_cast<half*>(rotated_input.data_ptr<at::Half>());
+  const half* svh_ptr = reinterpret_cast<const half*>(svh.data_ptr<at::Half>());
+  void* args[] = {&a_ptr,       &b_ptr,      &c_ptr,  &size_m, &size_k,
+                  &size_n,     &lock_ptr,   &suh_ptr, &rotated_ptr, &svh_ptr};
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device).stream();
+  check_cuda(cudaLaunchCooperativeKernel(reinterpret_cast<void*>(kernel), num_sms,
+                                         kThreads, args, kDynamicSmem, stream),
+             "cudaLaunchCooperativeKernel");
+  check_cuda(cudaPeekAtLastError(), "Trellis K6 kernel launch");
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def("launch_k6_mcg", &launch_k6_mcg,
+             "SparkInfer K6/MCG small-M dense GEMM");
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
+++ b/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cuda_fp16.h>
 #include <cooperative_groups.h>
+#include <mutex>
 #include <torch/extension.h>
 
 #include "vendor/util.h"
@@ -27,8 +28,21 @@ constexpr int kTileK = 32;
 constexpr int kTileN = 128;
 constexpr int kSharedStages = 4;
 constexpr int kFragmentStages = 3;
-constexpr int kThreads = 512;
-constexpr int kDynamicSmem = 90 * 1024;
+constexpr int kThreads = EXL3_GEMM_BASE_THREADS * (kTileK / 16);
+constexpr int kFragmentsNPerWarp =
+    2 * (kTileN / 16) / (EXL3_GEMM_BASE_THREADS / 32);
+constexpr int kASharedElements = kTileM * kTileK;
+constexpr int kBSharedElements =
+    (kTileK / 16) * (kTileN / 16) * 16 * kBits;
+constexpr int kCSharedElements =
+    4 * EXL3_GEMM_BASE_THREADS * kFragmentsNPerWarp > kTileN * kTileM
+        ? 4 * EXL3_GEMM_BASE_THREADS * kFragmentsNPerWarp
+        : kTileN * kTileM;
+constexpr int kDynamicSmem =
+    kSharedStages * (2 * kASharedElements + 2 * kBSharedElements) +
+    4 * kCSharedElements;
+static_assert(kDynamicSmem <= EXL3_SMEM_MAX_BYTES,
+              "Trellis K6 kernel exceeds the vendored shared-memory limit");
 
 void check_cuda(cudaError_t status, const char* operation) {
   TORCH_CHECK(status == cudaSuccess, operation, ": ", cudaGetErrorString(status));
@@ -43,9 +57,17 @@ void launch_k6_mcg(
     const torch::Tensor& svh,
     torch::Tensor& locks,
     int64_t requested_sms) {
-  const c10::cuda::CUDAGuard device_guard(input.device());
-  TORCH_CHECK(input.is_cuda() && trellis.is_cuda() && output.is_cuda(),
+  TORCH_CHECK(input.is_cuda() && trellis.is_cuda() && output.is_cuda() &&
+                  suh.is_cuda() && rotated_input.is_cuda() && svh.is_cuda() &&
+                  locks.is_cuda(),
               "Trellis K6 tensors must be CUDA tensors");
+  const int device = input.get_device();
+  TORCH_CHECK(trellis.get_device() == device && output.get_device() == device &&
+                  suh.get_device() == device &&
+                  rotated_input.get_device() == device &&
+                  svh.get_device() == device && locks.get_device() == device,
+              "Trellis K6 tensors must share one CUDA device");
+  const c10::cuda::CUDAGuard device_guard(input.device());
   TORCH_CHECK(input.scalar_type() == at::kHalf && output.scalar_type() == at::kHalf,
               "Trellis K6 small-M path requires FP16 input and output");
   TORCH_CHECK(trellis.scalar_type() == at::kShort,
@@ -76,12 +98,13 @@ void launch_k6_mcg(
               "Trellis K6 native payload shape does not match M/K/N");
   TORCH_CHECK(suh.numel() == size_k && svh.numel() == size_n,
               "Trellis K6 rotation scale width mismatch");
-  TORCH_CHECK(size_k % kTileK == 0 && size_n % kTileN == 0,
-              "Trellis K6 K/N must be divisible by 32/128");
+  // The fused H128 preamble reads 128 contiguous scale elements per warp.
+  TORCH_CHECK(size_k % 128 == 0 && size_n % kTileN == 0,
+              "Trellis K6 K/N must be divisible by 128/128, got K=", size_k,
+              " N=", size_n);
   TORCH_CHECK(locks.numel() >= size_n / 16,
               "Trellis K6 lock workspace is too small");
 
-  int device = input.get_device();
   int available_sms = 0;
   check_cuda(cudaDeviceGetAttribute(&available_sms, cudaDevAttrMultiProcessorCount,
                                     device),
@@ -92,9 +115,13 @@ void launch_k6_mcg(
 
   auto kernel = exl3_gemm_kernel<kBits, false, kCodebookMcg, kTileM, kTileK,
                                  kTileN, kSharedStages, kFragmentStages>;
-  check_cuda(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                  kDynamicSmem),
-             "cudaFuncSetAttribute");
+  static std::once_flag smem_attribute_once;
+  std::call_once(smem_attribute_once, [&] {
+    check_cuda(cudaFuncSetAttribute(kernel,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                    kDynamicSmem),
+               "cudaFuncSetAttribute");
+  });
 
   const half* a_ptr = reinterpret_cast<const half*>(input.data_ptr<at::Half>());
   const uint16_t* b_ptr =
@@ -109,6 +136,8 @@ void launch_k6_mcg(
                   &size_n,     &lock_ptr,   &suh_ptr, &rotated_ptr, &svh_ptr};
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream(device).stream();
+  // Keep this launch one-dimensional: vendored H128 scale indexing assumes
+  // gridDim.y == 1 because the caller already supplies its per-K scale offset.
   check_cuda(cudaLaunchCooperativeKernel(reinterpret_cast<void*>(kernel), num_sms,
                                          kThreads, args, kDynamicSmem, stream),
              "cudaLaunchCooperativeKernel");

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Turboderp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
@@ -1,0 +1,29 @@
+#pragma once
+
+// Approximate tanh
+
+__forceinline__ __device__ float copysignf_pos(float a, float b)
+{
+    float r;
+    r = __int_as_float(__float_as_int(a) | (__float_as_int(b) & 0x80000000));
+    return r;
+}
+
+#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 750 || CUDART_VERSION < 11000))
+
+__inline__ __device__ float tanh_opt(float x)
+{
+    const float exp_val = -1.f * fabs(2 * x);
+    return copysignf_pos((1.0f - __expf(exp_val)) / (__expf(exp_val) + 1.0f), x);
+}
+
+#else
+
+__inline__ __device__ float tanh_opt(float x)
+{
+    float r;
+    asm("tanh.approx.f32 %0,%1; \n\t" : "=f"(r) : "f"(x));
+    return r;
+}
+
+#endif

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
@@ -27,3 +27,5 @@ __inline__ __device__ float tanh_opt(float x)
 }
 
 #endif
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
@@ -1,0 +1,348 @@
+#pragma once
+#include <cuda/atomic>
+
+// Tensor core fragments
+
+template <typename T, int n>
+struct Vec
+{
+    T elems[n];
+    __device__ T& operator[](int i) { return elems[i]; }
+};
+
+using FragA = Vec<half2, 4>;
+using FragB = Vec<half2, 2>;
+using FragC = Vec<float, 4>;
+using FragC_h = Vec<half2, 2>;
+
+// m8n8k4 tensor core matmul (emulated on Ampere and later), don't use
+//
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m8n8k4-with-f16-floating-point-type
+
+__device__ inline void ptx_mma_m8n8k4
+(
+    const Vec<half2, 2>& frag_a,
+    const Vec<half2, 2>& frag_b,
+    Vec<float, 8>& frag_c
+)
+{
+    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
+    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+    float* c = reinterpret_cast<float*>(&frag_c);
+    const float* d = reinterpret_cast<const float*>(&frag_c);
+
+    asm
+    (
+        "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, {%12,%13,%14,%15,%16,%17,%18,%19};\n"
+
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3]),"=f"(c[4]), "=f"(c[5]), "=f"(c[6]), "=f"(c[7])
+
+        :  "r"(a[0]), "r"(a[1]),
+           "r"(b[0]), "r"(b[1]),
+           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3]), "f"(d[4]), "f"(d[5]), "f"(d[6]), "f"(d[7])
+    );
+}
+
+// m16n8k16 tensor core matmul
+//
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+
+// FP16 @ FP16 + FP32 -> FP32
+__device__ inline void ptx_mma_m16n8k16
+(
+    const FragA& frag_a,
+    const FragB& frag_b,
+    FragC& frag_c
+)
+{
+    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
+    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+    float* c = reinterpret_cast<float*>(&frag_c);
+    const float* d = reinterpret_cast<const float*>(&frag_c);
+
+    asm
+    (
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        :  "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+           "r"(b[0]), "r"(b[1]),
+           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3])
+    );
+}
+
+// FP16 @ FP16 + FP16 -> FP16
+__device__ inline void ptx_mma_m16n8k16
+(
+    const FragA& frag_a,
+    const FragB& frag_b,
+    FragC_h& frag_c
+)
+{
+    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
+    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+    uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
+    const uint32_t* d = reinterpret_cast<const uint32_t*>(&frag_c);
+
+    asm
+    (
+        "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+        "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
+
+        : "=r"(c[0]), "=r"(c[1])
+        :  "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+           "r"(b[0]), "r"(b[1]),
+           "r"(d[0]), "r"(d[1])
+    );
+}
+
+// Global barrier
+
+__device__ inline void barrier_acquire
+(
+    int* lock,
+    int stage
+)
+{
+    if (threadIdx.x == 0)
+    {
+        volatile int state = -1;
+        do
+        {
+            asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+        }
+        while (state != stage);
+    }
+    __syncthreads();
+}
+
+__device__ inline void barrier_release
+(
+    int* lock,
+    int val,
+    bool reset
+)
+{
+    __syncthreads();
+    if (threadIdx.x == 0)
+    {
+        if (reset)
+        {
+            *lock = 0;
+            return;
+        }
+        asm volatile ("fence.acq_rel.gpu;\n");
+        asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val));
+    }
+}
+
+// Load global to shared memory, predicated. Seems to produce incorrect code when compiling for Blackwell, but
+// `if (...) cp_async(...)` compiles to a predicated instruction anyway
+
+__device__ inline void cp_async_pred(void* smem_ptr, const void* glob_ptr, bool pred = true)
+{
+    const int bytes = 16;
+    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+    asm volatile(
+        "{\n"
+        "   .reg .pred p;\n"
+        "   setp.ne.b32 p, %0, 0;\n"
+        "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+        "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(bytes)
+    );
+}
+
+// Load global to shared memory
+
+__device__ inline void cp_async(void* smem_ptr, const void* glob_ptr)
+{
+    const int bytes = 16;
+    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+    asm volatile(
+        "{\n"
+        "   cp.async.cg.shared.global [%0], [%1], %2;\n"
+        "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
+    );
+}
+
+// Load global to shared memory with cache hint to evict data from L2 ASAP
+
+__device__ inline void cp_async_stream(void* smem_ptr, const void* glob_ptr)
+{
+    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+    const int bytes = 16;
+    asm volatile
+    (
+        "{\n"
+        "   .reg .b64 p;\n"
+        "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;\n"
+        "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
+        "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
+    );
+}
+
+// Async copy fence, commit all pending async copies
+
+__device__ inline void cp_async_fence()
+{
+    asm volatile("cp.async.commit_group;\n" ::);
+}
+
+// Wait until at most n async groups are still pending.
+
+template <int n>
+__device__ inline void cp_async_wait()
+{
+    asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+}
+
+// Load 16x16 matrix fragment from shared memory, directly in tensor core layout
+
+__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr)
+{
+    uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+    asm volatile
+    (
+        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+        : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
+    );
+}
+
+__device__ inline uint32_t mul_lo_u32(uint32_t x, uint32_t y)
+{
+    uint32_t w;
+    asm volatile
+    (
+        "mul.lo.u32 %0, %1, %2;"
+        : "=r"(w)
+        :  "r"(x), "r"(y)
+    );
+    return w;
+}
+
+__device__ inline uint32_t mul_hi_u32(uint32_t x, uint32_t y)
+{
+    uint32_t w;
+    asm volatile
+    (
+        "mul.hi.u32 %0, %1, %2;"
+        : "=r"(w)
+        :  "r"(x), "r"(y)
+    );
+    return w;
+}
+
+// Memory ops
+
+__device__ __forceinline__ void stg_wt_u32(uint32_t* p, uint32_t v)
+{
+    asm volatile("st.global.wt.u32 [%0], %1;" :: "l"(p), "r"(v));
+}
+
+__device__ __forceinline__ void stg_wt_u128(uint4* p, const uint4 v)
+{
+    asm volatile ("st.global.wt.v4.u32 [%0], {%1,%2,%3,%4};"
+                  :: "l"(p),
+                     "r"(v.x), "r"(v.y), "r"(v.z), "r"(v.w));
+}
+
+__device__ __forceinline__ uint32_t ldg_cv_u32(const uint32_t* p)
+{
+    uint32_t v;
+    asm volatile("ld.global.cv.u32 %0, [%1];" : "=r"(v) : "l"(p));
+    return v;
+}
+
+__device__ __forceinline__ uint4 ldg_cv_u128(const uint4* p)
+{
+    uint4 v;
+    asm volatile ("ld.global.cv.v4.u32 {%0,%1,%2,%3}, [%4];"
+                  : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
+                  : "l"(p));
+    return v;
+}
+
+__device__ __forceinline__ uint32_t ldg_acquire_sys_u32(const uint32_t* p)
+{
+    uint32_t v;
+    asm volatile("ld.global.acquire.sys.u32 %0, [%1];"
+                 : "=r"(v) : "l"(p));
+    return v;
+}
+
+__device__ __forceinline__ uint64_t ldg_acquire_sys_u64(const uint64_t* p)
+{
+    uint64_t v;
+    asm volatile("ld.global.acquire.sys.u64 %0, [%1];" : "=l"(v) : "l"(p) : "memory");
+    return v;
+}
+
+__device__ __forceinline__ void stg_release_sys_u32(uint32_t* p, uint32_t v)
+{
+    asm volatile("st.global.release.sys.u32 [%0], %1;" :: "l"(p), "r"(v) : "memory");
+}
+
+__device__ __forceinline__ void stg_release_sys_u64(uint64_t* p, uint64_t v)
+{
+    asm volatile("st.global.release.sys.u64 [%0], %1;" :: "l"(p), "l"(v) : "memory");
+}
+
+// Global time in nanoseconds
+
+__device__ __forceinline__ uint64_t globaltimer_ns()
+{
+    uint64_t t;
+    asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(t));
+    return t;
+}
+
+// Bitfield stuff
+
+static __forceinline__ __device__ uint32_t bfe64(uint32_t lo, uint32_t hi, int offset, int length)
+{
+    uint64_t value = (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
+    uint64_t result64;
+    asm ("bfe.u64 %0, %1, %2, %3;"
+         : "=l"(result64)
+         : "l"(value), "r"(offset), "r"(length));
+    return static_cast<uint32_t>(result64);
+}
+
+#define FSHF_IMM(dst, lo, hi, imm) asm("shf.r.wrap.b32 %0, %1, %2, " #imm ";" : "=r"(dst) : "r"(lo), "r"(hi))
+#define BFE16_IMM(dst, src, imm) asm("bfe.u32 %0, %1, " #imm ", 16;" : "=r"(dst) : "r"(src))
+
+// Inter-block barrier
+
+__device__ inline void group_barrier
+(
+    int group_id,
+    int group_size,
+    int* barrier_counters_sense  // length 2*max(group_id). odd positions are flipped after sync (sense)
+)
+{
+    __syncthreads();
+
+    if (threadIdx.x == 0)
+    {
+        cuda::atomic_ref<int, cuda::thread_scope_device> counter(barrier_counters_sense[group_id * 2]);
+        cuda::atomic_ref<int, cuda::thread_scope_device> sense(barrier_counters_sense[group_id * 2 + 1]);
+
+        int old_sense = sense.load(cuda::memory_order_relaxed);
+        int old = counter.fetch_add(1, cuda::memory_order_acq_rel);
+
+        if (old == group_size - 1)
+        {
+            counter.store(0, cuda::memory_order_relaxed);
+            sense.store(1 - old_sense, cuda::memory_order_release);
+        }
+        else
+        {
+            while (sense.load(cuda::memory_order_acquire) == old_sense) __nanosleep(32);
+        }
+    }
+
+    __syncthreads();
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
@@ -346,3 +346,5 @@ __device__ inline void group_barrier
 
     __syncthreads();
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
@@ -1,0 +1,157 @@
+#pragma once
+
+// Force integer MAD on sm<=86. For some reason this performs better than letting the compiler emit IMUL
+// TODO: Keep an eye on new behavior in future versions of nvcc. While this is faster on RTX 3090, it really shouldn't be.
+template <uint32_t w>
+__device__ __forceinline__
+uint32_t mul_const_u32(uint32_t x)
+{
+    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 860)
+        uint32_t r;
+        asm volatile (
+            "{ .reg .u32 z,t;"
+            "  mov.u32 t, %laneid;"   // runtime SR
+            "  sub.u32 z, t, t;"      // z = 0 but data-dependent
+            "  mad.lo.u32 %0, %1, %2, z;"
+            "}"
+            : "=r"(r)
+            : "r"(x), "n"(w));
+        return r;
+    #else
+        return x * w;
+    #endif
+}
+
+template <int cb>
+__device__ inline half decode_3inst(uint32_t x)
+{
+    if constexpr (cb == 0)
+    {
+        x *= 89226354u;
+        x += 64248484u;
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x));
+        half2_uint32 xu(x);
+        return __hadd(__low2half(xu.as_half2), __high2half(xu.as_half2));
+    }
+    if constexpr (cb == 1)
+    {
+//        x *= 0xCBAC1FEDu;
+        x = mul_const_u32<0xCBAC1FEDu>(x);
+
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x));
+        half2_uint32 xu(x);
+        return __hadd(__low2half(xu.as_half2), __high2half(xu.as_half2));
+    }
+    if constexpr (cb == 2)
+    {
+        x *= 0x83DCD12Du;
+        uint32_t sum;
+        const uint32_t acc = 0x6400u;  // 0x6400 -> 1024.0 ..  0x67FF -> 2047.0
+        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum) : "r"(x), "r"(0), "r"(acc) : );
+        const __half k_inv_h = __ushort_as_half(0x1eee);  //  0.00677 = 1/147.7
+        const __half k_bias_h = __ushort_as_half(0xc931);  // -10.39 = (-1024.0 - 510.0) * k_inv_h
+        half_uint16 h((uint16_t) sum);
+        return __hfma(h.as_half, k_inv_h, k_bias_h);
+    }
+}
+
+template <int cb>
+__device__ inline half2 decode_3inst_2(uint32_t x0, uint32_t x1)
+{
+    if constexpr (cb == 0)
+    {
+        x0 *= 89226354u;
+        x1 *= 89226354u;
+        x0 += 64248484u;
+        x1 += 64248484u;
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
+        half2_uint32 xu0(x0);
+        half2_uint32 xu1(x1);
+        half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
+        half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
+        return __hadd2(d0, d1);
+    }
+    if constexpr (cb == 1)
+    {
+//        x0 *= 0xCBAC1FEDu;
+//        x1 *= 0xCBAC1FEDu;
+        x0 = mul_const_u32<0xCBAC1FEDu>(x0);
+        x1 = mul_const_u32<0xCBAC1FEDu>(x1);
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
+        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
+        half2_uint32 xu0(x0);
+        half2_uint32 xu1(x1);
+        half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
+        half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
+        return __hadd2(d0, d1);
+    }
+    if constexpr (cb == 2)
+    {
+        x0 *= 0x83DCD12Du;
+        x1 *= 0x83DCD12Du;
+        uint32_t sum0;
+        uint32_t sum1;
+        const uint32_t acc = 0x6400u;  // 0x6400 -> 1024.0 ..  0x67FF -> 2047.0
+        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum0) : "r"(x0), "r"(0), "r"(acc) : );
+        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum1) : "r"(x1), "r"(0), "r"(acc) : );
+        half2 k_inv_h2 = __half2half2(__ushort_as_half(0x1eee));  //  0.00677 = 1/147.7
+        half2 k_bias_h2 = __half2half2(__ushort_as_half(0xc931));  // -10.39 = (-1024.0 - 510.0) * k_inv_h
+        half_uint16 h0((uint16_t) sum0);
+        half_uint16 h1((uint16_t) sum1);
+        return __hfma2(__halves2half2(h0.as_half, h1.as_half), k_inv_h2, k_bias_h2);
+    }
+}
+
+__device__ inline half2 decode_mcg_product_2(uint32_t x0, uint32_t x1)
+{
+    asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
+    asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
+    half2_uint32 xu0(x0);
+    half2_uint32 xu1(x1);
+    half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
+    half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
+    return __hadd2(d0, d1);
+}
+
+template <int cb>
+__device__ inline float decode_3inst_f(uint64_t x)
+{
+    return __half2float(decode_3inst<cb>(x));
+}
+
+template <int cb>
+__device__ inline float decode_3inst_f_diff(uint64_t x, float d)
+{
+    return __half2float(decode_3inst<cb>(x)) - d;
+}
+
+// "2MAD" procedural codebook, much more overhead than 3INST, slightly better distribution at 2bpw
+// Not used currently
+
+//__device__ inline half decode_2mad(uint64_t x)
+//{
+//    x = x * 264435761u + 1013904223u;
+//    x = ((x * 1664525u) >> 32) + x;
+//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
+//    half y = __hmul(__int2half_rn(c), __float2half_rn(0.008415));
+//    return y;
+//}
+//
+//__device__ inline float decode_2mad_f(uint64_t x)
+//{
+//    x = x * 264435761u + 1013904223u;
+//    x = ((x * 1664525u) >> 32) + x;
+//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
+//    float y = __int2float_rn(c) * 0.008415f;
+//    return y;
+//}
+//
+//__device__ inline float decode_2mad_f_diff(uint64_t x, float d)
+//{
+//    x = x * 264435761u + 1013904223u;
+//    x = ((x * 1664525u) >> 32) + x;
+//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
+//    float y = fma(__int2float_rn(c), 0.008415f, -d);
+//    return y;
+//}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
@@ -155,3 +155,5 @@ __device__ inline float decode_3inst_f_diff(uint64_t x, float d)
 //    float y = fma(__int2float_rn(c), 0.008415f, -d);
 //    return y;
 //}
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
@@ -53,3 +53,5 @@ int g_get_cc(int device);
 int g_get_num_sms(int device);
 
 void prepare_ctx(int device);
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <tuple>
+#include <mutex>
+
+// Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
+#define MAX_TILES_C (1024 * 1024)
+#define MAX_BARRIERS 1024
+#define BARRIER_LOCKS_OFFSET MAX_TILES_C
+
+// MoE expert scheduler state, after the barrier counters: [0] next ticket,
+// [1] retired groups, [2 + group] ticket published to group. The state is
+// self-resetting and is zero-initialized with the rest of the lock buffer.
+#define MOE_MAX_GROUPS 64
+#define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
+#define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
+
+// Workspace size
+#define WORKSPACE_SIZE (16*1024*1024)
+
+// Treat hopper and blackwell as same arch for now
+#define MAX_DEVICES 16
+#define CC_OLD        1
+#define CC_AMPERE     2
+#define CC_ADA        3
+#define CC_HOPPER     4
+#define CC_BLACKWELL  4
+
+// Singleton to manage context for each device. Stores device attributes and a large-enough lock buffer per device
+class DevCtx
+{
+private:
+    int num_sms[MAX_DEVICES] = {};
+    int cc[MAX_DEVICES] = {};
+    void* locks[MAX_DEVICES] = {};
+    void* ws[MAX_DEVICES] = {};
+    std::mutex mtx;
+
+public:
+    static DevCtx& instance();
+    int get_num_sms(int device);
+    int get_cc(int device);
+    void* get_ws(int device);
+    int* get_locks(int device);
+
+private:
+    DevCtx() = default;
+    DevCtx(const DevCtx&) = delete;
+    DevCtx& operator=(const DevCtx&) = delete;
+};
+
+int g_get_cc(int device);
+int g_get_num_sms(int device);
+
+void prepare_ctx(int device);

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
@@ -1,0 +1,293 @@
+#pragma once
+
+#include "codebook.cuh"
+
+__device__ __forceinline__ uint32_t fshift(const uint32_t b, const uint32_t a, int shift)
+{
+     uint64_t merged = ((uint64_t)a << 32) | (uint64_t) b;
+     return (uint32_t)(merged >> shift);
+
+    // Conditional funnel shift is somehow no longer faster
+    // if (shift < 32) return __funnelshift_r(b, a, shift);
+    // return a >> (shift - 32);
+}
+
+template <int bits, int cb>
+__device__ __forceinline__ half dq(const uint32_t* ptr, int t_offset)
+{
+    int b0 = t_offset * bits + bits - 16 + 256 * bits;  // bit index, start of word0
+    int b1 = b0 + 16;                                   // bit index, end of word0
+    int i0 = b0 / 32;                                   // uint32 containing first bit of word0
+    int i1 = (b1 - 1) / 32;                             // uint32 containing last bit of word0, may be == i0
+    int s0 = (i1 + 1) * 32 - b1;                        // shift value to align word1 to 32-bit boundary
+
+    // Load 32 or 64 bits containing word0
+    uint32_t a = ptr[i0 % (bits * 256 / 32)];
+    uint32_t b = ptr[i1 % (bits * 256 / 32)];
+
+    // Shift into place
+    uint32_t w0 = __funnelshift_r(b, a, s0) & 0xffff;
+    return decode_3inst<cb>(w0);
+}
+
+template <int bits, int cb>
+__device__ __forceinline__ half2 dq2(const uint32_t* ptr, int t_offset)
+{
+    int b0 = t_offset * bits + bits - 16 + 256 * bits;  // bit index, start of word0
+    int b1 = b0 + 16;                                   // bit index, end of word0
+    int i0 = b0 / 32;                                   // uint32 containing first bit of word0
+    int i1 = (b1 - 1) / 32;                             // uint32 containing last bit of word0, may be == i0
+    int s0 = (i1 + 1) * 32 - b1;                        // shift value to align word1 to 32-bit boundary
+
+    // Load 32 or 64 bits containing word0
+    uint32_t a = ptr[i0 % (bits * 256 / 32)];
+    uint32_t b = ptr[i1 % (bits * 256 / 32)];
+
+    // Shift into place
+    uint32_t w1 = __funnelshift_r(b, a, s0)        & 0xffff;
+    uint32_t w0 = __funnelshift_r(b, a, s0 + bits) & 0xffff;
+    return decode_3inst_2<cb>(w0, w1);
+}
+
+template <int bits, int cb>
+__device__ __forceinline__ void dq4(const uint32_t* ptr, int t_offset, FragB& frag)
+{
+    int b0 = (t_offset + 257) * bits - 16;      // start of first word
+    int b1 = b0 + 3 * bits;                     // start of last word
+    int b2 = b1 + 16;                           // end of last word
+    int i0 = b0 / 32;                           // uint32 containing first bit of first word
+    int i2 = (b2 - 1) / 32;                     // uint32 containing last bit of last word, may be == i0
+    int s2 = (i2 + 1) * 32 - b2;                // shift value to align last word to 32-bit boundary
+
+    uint32_t a = ptr[i0 % (bits * 256 / 32)];
+    uint32_t b = ptr[i2 % (bits * 256 / 32)];
+    uint32_t w3 = fshift(b, a, s2)            & 0xffff;
+    uint32_t w2 = fshift(b, a, s2 + bits)     & 0xffff;
+    uint32_t w1 = fshift(b, a, s2 + bits * 2) & 0xffff;
+    uint32_t w0 = fshift(b, a, s2 + bits * 3) & 0xffff;
+    half2 d0d1 = decode_3inst_2<cb>(w0, w1);
+    half2 d2d3 = decode_3inst_2<cb>(w2, w3);
+    frag[0] = d0d1;
+    frag[1] = d2d3;
+}
+
+template <int bits, int cb>
+__device__ __forceinline__ void dq2x2(const uint32_t* ptr, int t_offset, FragB& frag)
+{
+    #pragma unroll
+    for (int i = 0; i < 2; ++i)
+    {
+        int b0 = (t_offset + 2 * i + 257) * bits - 16;  // start of first word
+        int b1 = b0 + 1 * bits;                         // start of last word
+        int b2 = b1 + 16;                               // end of last word
+        int i0 = b0 / 32;                               // uint32 containing first bit of first word
+        int i2 = (b2 - 1) / 32;                         // uint32 containing last bit of last word, may be == i0
+        int s2 = (i2 + 1) * 32 - b2;                    // shift value to align last word to 32-bit boundary
+
+        uint32_t a = ptr[i0 % (bits * 256 / 32)];
+        uint32_t b = ptr[i2 % (bits * 256 / 32)];
+        uint32_t w1 = fshift(b, a, s2)        & 0xffff;
+        uint32_t w0 = fshift(b, a, s2 + bits) & 0xffff;
+        half2 d0d1 = decode_3inst_2<cb>(w0, w1);
+        frag[i] = d0d1;
+    }
+}
+
+template <int bits, int cb, int align>
+__device__ __forceinline__ void dq8(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
+{
+    int b1 = (t_offset + 257) * bits;               // end of first word
+    int b0 = b1 - 16;                               // start of first word
+    int b2 = b1 + bits * 7;
+    int i0 = b0 / 32;                               // uint32 containing first bit of word0
+    int i2 = (b2 - 1) / 32;                         // uint32 containing last bit of word0, may be == i0
+    int s2 = (i2 + 1) * 32 - b2;                    // shift value to align last word to 32-bit boundary
+
+    uint32_t a = ptr[i0 % (bits * 256 / 32)];
+    uint32_t b = ptr[i2 % (bits * 256 / 32)];
+    uint32_t w0, w1, w2, w3, w4, w5, w6, w7;
+    if constexpr (align == 1)
+    {
+        w7 = fshift(b, a, s2);
+        w6 = fshift(b, a, s2 + bits);
+        w5 = fshift(b, a, s2 + bits * 2);
+        w4 = fshift(b, a, s2 + bits * 3);
+        w3 = fshift(b, a, s2 + bits * 4);
+        w2 = fshift(b, a, s2 + bits * 5);
+        w1 = fshift(b, a, s2 + bits * 6);
+        w0 = fshift(b, a, s2 + bits * 7);
+    }
+    if constexpr (align == 2)
+    {
+        w7 = fshift(b, a, s2);
+        w6 = w7 >> bits;
+        w5 = fshift(b, a, s2 + bits * 2);
+        w4 = w5 >> bits;
+        w3 = fshift(b, a, s2 + bits * 4);
+        w2 = w3 >> bits;
+        w1 = fshift(b, a, s2 + bits * 6);
+        w0 = w1 >> bits;
+    }
+    if constexpr (align == 4)
+    {
+        w7 = fshift(b, a, s2);
+        w6 = w7 >> bits;
+        w5 = w6 >> bits;
+        w4 = w5 >> bits;
+        w3 = fshift(b, a, s2 + bits * 4);
+        w2 = w3 >> bits;
+        w1 = w2 >> bits;
+        w0 = w1 >> bits;
+    }
+    if constexpr (align == 8)
+    {
+        w7 = fshift(b, a, s2);
+        w6 = w7 >> bits;
+        w5 = w6 >> bits;
+        w4 = w5 >> bits;
+        w3 = w4 >> bits;
+        w2 = w3 >> bits;
+        w1 = w2 >> bits;
+        w0 = w1 >> bits;
+    }
+    half2 d0d1 = decode_3inst_2<cb>(w0 & 0xffff, w1 & 0xffff);
+    half2 d2d3 = decode_3inst_2<cb>(w2 & 0xffff, w3 & 0xffff);
+    half2 d4d5 = decode_3inst_2<cb>(w4 & 0xffff, w5 & 0xffff);
+    half2 d6d7 = decode_3inst_2<cb>(w6 & 0xffff, w7 & 0xffff);
+    frag0[0] = d0d1;
+    frag0[1] = d2d3;
+    frag1[0] = d4d5;
+    frag1[1] = d6d7;
+}
+
+template <int cb>
+__device__ __forceinline__ void dq8_aligned_4bits(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
+{
+    uint32_t i0, i1, a, b, s, w0, w1, w2, w3, w4, w5, w6, w7;
+    i1 = t_offset >> 3;
+    i0 = (i1 + 31) & 31;
+    a = ptr[i0];
+    b = ptr[i1];
+    FSHF_IMM(s, b, a, 20);
+    w7 = b & 0xffff;
+    BFE16_IMM(w6, b, 4);
+    BFE16_IMM(w5, b, 8);
+    BFE16_IMM(w4, b, 12);
+    BFE16_IMM(w3, b, 16);
+    w2 = s & 0xffff;
+    BFE16_IMM(w1, s, 4);
+    BFE16_IMM(w0, s, 8);
+    frag0[0] = decode_3inst_2<cb>(w0, w1);
+    frag0[1] = decode_3inst_2<cb>(w2, w3);
+    frag1[0] = decode_3inst_2<cb>(w4, w5);
+    frag1[1] = decode_3inst_2<cb>(w6, w7);
+}
+
+template <int cb>
+__device__ __forceinline__ void dq8_aligned_2bits(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
+{
+    uint32_t i0, i1, a, b, w0, w1, w2, w3, w4, w5, w6, w7;
+    i1 = t_offset >> 4;
+    i0 = (i1 + 15) & 15;
+    a = ptr[i0];
+    b = ptr[i1];
+    b = fshift(b, a, ((~t_offset) & 8) << 1);
+    w7 = b & 0xffff;
+    BFE16_IMM(w6, b, 2);
+    BFE16_IMM(w5, b, 4);
+    BFE16_IMM(w4, b, 6);
+    BFE16_IMM(w3, b, 8);
+    BFE16_IMM(w2, b, 10);
+    BFE16_IMM(w1, b, 12);
+    BFE16_IMM(w0, b, 14);
+    frag0[0] = decode_3inst_2<cb>(w0, w1);
+    frag0[1] = decode_3inst_2<cb>(w2, w3);
+    frag1[0] = decode_3inst_2<cb>(w4, w5);
+    frag1[1] = decode_3inst_2<cb>(w6, w7);
+}
+
+template <int cb>
+__device__ __forceinline__ void dq8_aligned_1bit(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
+{
+    uint32_t i0, i1, a, b, w0, w1, w2, w3, w4, w5, w6, w7;
+    i1 = t_offset >> 5;
+    i0 = (i1 + 7) & 7;
+    a = ptr[i0];
+    b = ptr[i1];
+    b = fshift(b, a, ((~t_offset) & 24));
+    w7 = b & 0xffff;
+    BFE16_IMM(w6, b, 1);
+    BFE16_IMM(w5, b, 2);
+    BFE16_IMM(w4, b, 3);
+    BFE16_IMM(w3, b, 4);
+    BFE16_IMM(w2, b, 5);
+    BFE16_IMM(w1, b, 6);
+    BFE16_IMM(w0, b, 7);
+    frag0[0] = decode_3inst_2<cb>(w0, w1);
+    frag0[1] = decode_3inst_2<cb>(w2, w3);
+    frag1[0] = decode_3inst_2<cb>(w4, w5);
+    frag1[1] = decode_3inst_2<cb>(w6, w7);
+}
+
+
+template <int cb>
+__device__ __forceinline__ void dq8_aligned_4bits_bfe64(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
+{
+    int i1 = t_offset / 8;
+    int i0 = (i1 + 31) % 32;
+    uint32_t a = ptr[i0];
+    uint32_t b = ptr[i1];
+    uint32_t w7 = bfe64(b, a, 0, 16);
+    uint32_t w6 = bfe64(b, a, 4, 16);
+    uint32_t w5 = bfe64(b, a, 8, 16);
+    uint32_t w4 = bfe64(b, a, 12, 16);
+    uint32_t w3 = bfe64(b, a, 16, 16);
+    uint32_t w2 = bfe64(b, a, 20, 16);
+    uint32_t w1 = bfe64(b, a, 24, 16);
+    uint32_t w0 = bfe64(b, a, 28, 16);
+    frag0[0] = decode_3inst_2<cb>(w0, w1);
+    frag0[1] = decode_3inst_2<cb>(w2, w3);
+    frag1[0] = decode_3inst_2<cb>(w4, w5);
+    frag1[1] = decode_3inst_2<cb>(w6, w7);
+}
+
+template <int bits, int cb>
+__device__ __forceinline__ void dq_dispatch(const uint32_t* ptr, int idx, FragB& frag0, FragB& frag1)
+{
+    if constexpr (bits == 1)
+    {
+        dq8_aligned_1bit<cb>(ptr, idx, frag0, frag1);
+    }
+    else if constexpr (bits == 2)
+    {
+        dq8_aligned_2bits<cb>(ptr, idx, frag0, frag1);
+    }
+    else if constexpr (bits == 3)
+    {
+        dq8<bits, cb, 4>(ptr, idx, frag0, frag1);
+    }
+    else if constexpr (bits == 4)
+    {
+        dq8_aligned_4bits<cb>(ptr, idx, frag0, frag1);
+    }
+    else if constexpr (bits == 5)
+    {
+        dq4<bits, cb>(ptr, idx, frag0);
+        dq4<bits, cb>(ptr, idx + 4, frag1);
+    }
+    else if constexpr (bits == 6)
+    {
+        dq4<bits, cb>(ptr, idx, frag0);
+        dq4<bits, cb>(ptr, idx + 4, frag1);
+    }
+    else if constexpr (bits == 7)
+    {
+        dq2x2<bits, cb>(ptr, idx, frag0);
+        dq2x2<bits, cb>(ptr, idx + 4, frag1);
+    }
+    else if constexpr (bits == 8)
+    {
+        dq4<bits, cb>(ptr, idx, frag0);
+        dq4<bits, cb>(ptr, idx + 4, frag1);
+    }
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
@@ -254,6 +254,7 @@ __device__ __forceinline__ void dq8_aligned_4bits_bfe64(const uint32_t* ptr, int
 template <int bits, int cb>
 __device__ __forceinline__ void dq_dispatch(const uint32_t* ptr, int idx, FragB& frag0, FragB& frag1)
 {
+    static_assert(bits >= 1 && bits <= 8, "unsupported EXL3 bitrate");
     if constexpr (bits == 1)
     {
         dq8_aligned_1bit<cb>(ptr, idx, frag0, frag1);
@@ -291,3 +292,5 @@ __device__ __forceinline__ void dq_dispatch(const uint32_t* ptr, int idx, FragB&
         dq4<bits, cb>(ptr, idx + 4, frag1);
     }
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
@@ -1,0 +1,778 @@
+#pragma once
+
+#include "../ptx.cuh"
+
+// Constants
+#define EXL3_GEMM_BASE_THREADS 256
+#ifndef EXL3_SMEM_MAX_BYTES
+#define EXL3_SMEM_MAX_BYTES (90 * 1024)
+#endif
+#ifndef SMEM_MAX
+#define SMEM_MAX EXL3_SMEM_MAX_BYTES
+#endif
+
+#include "exl3_dq.cuh"
+
+// On GA10x and sm_120 consumer silicon, fp32-accumulating HMMA runs at
+// half rate. Accumulate each k-slice in fp16 and fold it into the persistent
+// fp32 accumulators before reduction. This changes numerical accumulation and
+// therefore remains an accuracy-gated optional variant.
+#if defined(__CUDA_ARCH__) && \
+    ((__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 1200))
+    #define EXL3_GEMM_H_ACC 1
+#else
+    #define EXL3_GEMM_H_ACC 0
+#endif
+
+template<EXL3_GEMM_T_ARGS, bool shmem_out_had>
+inline __device__
+void exl3_gemm_kernel_inner
+(
+    const half* __restrict__  A,
+    const uint16_t* __restrict__ B,
+    void* __restrict__ C,
+    const int size_m,
+    const int size_k,
+    const int size_n,
+    int* __restrict__ locks,
+    const half* post_scale
+)
+{
+    const int TILEBLOCKS_M = TILESIZE_M / 16;
+    const int TILEBLOCKS_K = TILESIZE_K / 16;
+    const int TILEBLOCKS_N = TILESIZE_N / 16;
+    // const int FRAGS_M = TILEBLOCKS_M;
+    const int FRAGS_N_PER_WARP = 2 * TILEBLOCKS_N / (EXL3_GEMM_BASE_THREADS / 32);
+
+    const int sh_a_stage_size = TILESIZE_M * TILESIZE_K;                         // in halfs
+    const int sh_b_stage_size = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;   // in uint16s
+    const int sh_c_size = MAX  // in floats
+    (
+        4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP,
+        shmem_out_had ? TILESIZE_N * TILESIZE_M : 0
+    );
+
+    // XOR-swizzle constants for bank-conflict-free A fragment loads
+    // col_swizzled = col ^ ((row >> SHIFT) & MASK)
+    const int A_COLS = TILESIZE_K / 8;                                            // int4 columns per row
+    const int A_SWIZZLE_MASK = A_COLS - 1;
+    const int A_SWIZZLE_SHIFT = (A_COLS <= 2) ? 2 : 1;
+
+    // Sanity checks
+    static_assert(EXL3_GEMM_BASE_THREADS == 256);
+    static_assert(TILESIZE_M % 16 == 0, "Invalid kernel params");
+    static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
+    static_assert(TILESIZE_N % 128 == 0, "Invalid kernel params");
+    static_assert
+    (
+        SMEM_MAX >= SH_STAGES * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size,
+        "Invalid kernel params (insufficient shared memory for shape)"
+    );
+
+    // Shared memory
+    extern __shared__ half shared[];
+    half* sh_a = shared;
+    uint16_t* sh_b = (uint16_t*) (sh_a + SH_STAGES * sh_a_stage_size);
+    float* sh_c = (float*) (sh_b + sh_b_stage_size * SH_STAGES);
+
+    // Thread index
+    int t = threadIdx.x % EXL3_GEMM_BASE_THREADS;
+    int sub_k = threadIdx.x / EXL3_GEMM_BASE_THREADS;
+    int warp_id = t / 32;
+    int lane_id = t % 32;
+
+    // Dimensions
+    //int tiles_m = CEIL_DIVIDE(size_m, TILESIZE_M);
+    int tiles_k = size_k / TILESIZE_K;
+    int tiles_n = size_n / TILESIZE_N;
+    //int blocks_m = 1;
+    //int blocks_k = tiles_k * TILEBLOCKS_K;
+    int blocks_n = tiles_n * TILEBLOCKS_N;
+
+    // Start and end index of current slice, must span at least one tile
+    int num_slices = gridDim.x;
+    int slice_beg = tiles_k * tiles_n * blockIdx.x / num_slices;
+    int slice_end = tiles_k * tiles_n * (blockIdx.x + 1) / num_slices;
+    int slice_len = slice_end - slice_beg;
+    if (slice_len < 1) return;
+
+    auto index_m = [&] (int slice_i) { return 0; }; //blockIdx.y; };
+    auto index_k = [&] (int slice_i) { return (slice_i % tiles_k); };
+    auto index_n = [&] (int slice_i) { return (slice_i / tiles_k); };
+
+    // Batch dimension
+    // int slice_m = index_m(slice_beg);
+    // int max_m = MIN(size_m - slice_m * TILESIZE_M, TILESIZE_M);
+    const int slice_m = 0;
+
+    // Pipe 0, global A, B tile and shared A, B tile
+    int slice0_k = index_k(slice_beg);
+    int slice0_n = index_n(slice_beg);
+    int slice0_iters = slice_len;
+
+    int gl_a_stride_m = TILESIZE_M * size_k;
+    const int gl_a_stride_k = TILESIZE_K;
+    const int sh0_a_stride_m = TILESIZE_M * TILESIZE_K;
+    const half* gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
+    half* sh0_a_ptr = sh_a + (slice0_iters % SH_STAGES) * sh_a_stage_size;
+
+    const int load_a_iters = CEIL_DIVIDE(sh0_a_stride_m / 8, EXL3_GEMM_BASE_THREADS);
+    bool pred_a_gl[load_a_iters];
+    int load_a_gl[load_a_iters];
+    int load_a_sh[load_a_iters];
+    for (int i = 0; i < load_a_iters; ++i)
+    {
+        int k = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_a_stride_k / 8);
+        int m = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_a_stride_k / 8);
+        load_a_gl[i] = m * size_k / 8 + k;
+        load_a_sh[i] = m * A_COLS + (k ^ ((m >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK));
+        pred_a_gl[i] = m < size_m;
+    }
+
+    int gl_b_stride_k = blocks_n * TILEBLOCKS_K * 256 / 16 * bits;
+    const int gl_b_stride_n = TILEBLOCKS_N * 256 / 16 * bits;
+    const int sh0_b_stride_k = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;
+    const uint16_t* gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
+    uint16_t* sh0_b_ptr = sh_b + (slice0_iters % SH_STAGES) * sh_b_stage_size;
+
+    const int load_b_iters = CEIL_DIVIDE(sh0_b_stride_k / 8, EXL3_GEMM_BASE_THREADS);
+    bool pred_b_gl[load_b_iters];
+    int load_b_gl[load_b_iters];
+    for (int i = 0; i < load_b_iters; ++i)
+    {
+        int n = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_b_stride_n / 8);
+        int k = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_b_stride_n / 8);
+        load_b_gl[i] = k * (blocks_n * 256 / 16 * bits / 8) + n;
+        pred_b_gl[i] = i * EXL3_GEMM_BASE_THREADS + t < sh0_b_stride_k / 8;
+    }
+
+    auto advance0 = [&] ()
+    {
+        slice0_k++;
+        slice0_iters--;
+
+        int stage = slice0_iters % SH_STAGES;
+        sh0_a_ptr = sh_a + stage * sh_a_stage_size;
+        sh0_b_ptr = sh_b + stage * sh_b_stage_size;
+
+        if (slice0_k >= tiles_k)
+        {
+            slice0_k = 0;
+            slice0_n++;
+            gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
+            gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
+        }
+        else
+        {
+            gl_a_ptr += gl_a_stride_k;
+            gl_b_ptr += gl_b_stride_k;
+        }
+    };
+
+    // Pipe 1, shared A, B tile and registers
+    int slice1_k = slice0_k;
+    int slice1_n = slice0_n;
+    int slice1_iters = slice0_iters;
+
+    half* sh1_a_ptr = sh_a + (slice1_iters % SH_STAGES) * sh_a_stage_size;
+    uint16_t* sh1_b_ptr = sh_b + (slice1_iters % SH_STAGES) * sh_b_stage_size;
+
+    auto advance1 = [&] ()
+    {
+        slice1_k++;
+        slice1_iters--;
+
+        int stage = slice1_iters % SH_STAGES;
+        sh1_a_ptr = sh_a + stage * sh_a_stage_size;
+        sh1_b_ptr = sh_b + stage * sh_b_stage_size;
+
+        if (slice1_k >= tiles_k)
+        {
+            slice1_k = 0;
+            slice1_n++;
+        }
+    };
+
+    // Pipe 2
+    int slice2_k = slice0_k;
+    int slice2_k0 = slice0_k;
+    int slice2_n = slice0_n;
+    int slice2_iters = slice0_iters;
+
+    int gl_c_stride_n = TILESIZE_N;
+    int gl_c_stride_m = TILESIZE_M * size_n;
+
+    half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
+    float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
+
+    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
+    register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
+    register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #if EXL3_GEMM_H_ACC
+        register FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    #endif
+
+    auto advance2 = [&] ()
+    {
+        slice2_k++;
+        slice2_iters--;
+
+        if (slice2_k >= tiles_k)
+        {
+            slice2_k = 0;
+            slice2_k0 = 0;
+            slice2_n++;
+            if constexpr (c_fp32)
+                gl_c_ptr_32 += gl_c_stride_n;
+            else
+                gl_c_ptr_16 += gl_c_stride_n;
+        }
+    };
+
+    // Schedule load of the next A, B tiles to shared memory and advance the pipeline
+    auto async_load_gl = [&] ()
+    {
+        if (sub_k)
+        {
+            cp_async_fence();
+            return;
+        }
+
+        if (slice0_iters)
+        {
+            // Copy tile from row-major A matrix (XOR-swizzled for bank-conflict-free ldmatrix)
+            {
+                const int4* gl = (const int4*) gl_a_ptr;
+                int4* sh = (int4*) sh0_a_ptr;
+                #pragma unroll
+                for (int i = 0; i < load_a_iters; ++i)
+                {
+                    if (pred_a_gl[i]) cp_async(sh + load_a_sh[i], gl + load_a_gl[i]);
+                }
+            }
+
+            // Copy tile of 256-element blocks from quantized B matrix
+            {
+                const int4* gl = (const int4*) gl_b_ptr;
+                int4* sh = (int4*) sh0_b_ptr;
+                #pragma unroll
+                for (int i = 0; i < load_b_iters; ++i)
+                {
+                    // cp_async_pred(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i], pred_b_gl[i]);
+                    if (pred_b_gl[i]) cp_async(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i]);
+                }
+            }
+            advance0();
+        }
+
+        // Sync and advance
+        cp_async_fence();
+    };
+
+    // Load fragments
+    // Ref. for fragment layout:
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+    auto load_frags = [&] (int buf)
+    {
+        if (!slice1_iters) return;
+
+        // A fragments (XOR-swizzled shared memory layout)
+        {
+            int r = (lane_id % 8) + 8 * ((lane_id / 8) % 2);
+            int base_c = lane_id / 16 + sub_k * 2;
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                int R = r + m * 16;
+                int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
+                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
+            }
+        }
+
+        // B fragments
+        #pragma unroll
+        for (int n2 = 0; n2 < FRAGS_N_PER_WARP; n2 += 2)
+        {
+            int sub_n2 = warp_id * FRAGS_N_PER_WARP / 2 + n2 / 2;
+            const uint32_t* shb = (const uint32_t*) (sh1_b_ptr + (sub_k * TILEBLOCKS_N + sub_n2) * 256 / 16 * bits);
+
+            dq_dispatch<bits, cb>(shb, lane_id << 3, frag_b[buf][n2], frag_b[buf][n2 + 1]);
+        }
+
+        __syncthreads();
+        advance1();
+    };
+
+    // Clear C fragments
+    auto clear_frag_c = [&] ()
+    {
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                frag_c[m][n] = {};
+        }
+        #if EXL3_GEMM_H_ACC
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                    frag_c_h[m][n] = {};
+            }
+        #endif
+    };
+
+    // Threadblock reduction
+    auto threadblock_reduce = [&] ()
+    {
+        auto store = [&] (int i, int m)
+        {
+            if (sub_k == i)
+            {
+                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    #pragma unroll
+                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[m][n][j];
+                }
+            }
+            __syncthreads();
+        };
+
+        auto add = [&] (int i, int m)
+        {
+            if (sub_k == i)
+            {
+                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    #pragma unroll
+                    for (int j = 0; j < 4; ++j) frag_c[m][n][j] += *sh_red++;
+                }
+            }
+        };
+
+        auto store_small = [&] (int i, int m)
+        {
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
+            {
+                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    *sh_red++ = frag_c[m][n][0];
+                    *sh_red++ = frag_c[m][n][1];
+                }
+            }
+            __syncthreads();
+        };
+
+        auto add_small = [&] (int i, int m)
+        {
+            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
+            {
+                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    frag_c[m][n][0] += *sh_red++;
+                    frag_c[m][n][1] += *sh_red++;
+                }
+            }
+        };
+
+        // Reuse the same reduction scratch for each 16-row M block. The
+        // barrier between blocks prevents the next store from racing the
+        // preceding add without increasing the dynamic-smem footprint.
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            if (size_m <= 8)
+            {
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store_small(1, m);
+                    add_small(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store_small(1, m);
+                    add_small(0, m);
+                    store_small(2, m);
+                    add_small(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store_small(3, m);
+                    add_small(2, m);
+                    store_small(1, m);
+                    add_small(0, m);
+                    store_small(2, m);
+                    add_small(0, m);
+                }
+            }
+            else
+            {
+                if constexpr (TILEBLOCKS_K == 2)
+                {
+                    store(1, m);
+                    add(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 3)
+                {
+                    store(1, m);
+                    add(0, m);
+                    store(2, m);
+                    add(0, m);
+                }
+                if constexpr (TILEBLOCKS_K == 4)
+                {
+                    store(3, m);
+                    add(2, m);
+                    store(1, m);
+                    add(0, m);
+                    store(2, m);
+                    add(0, m);
+                }
+            }
+
+            if constexpr (TILEBLOCKS_K > 1 && TILEBLOCKS_M > 1)
+                if (m + 1 < TILEBLOCKS_M) __syncthreads();
+        }
+    };
+
+    // Pre-hadamard: Write final output tile to shmem
+    auto write_sum_tile_sh = [&]()
+    {
+        const int n0 = warp_id * FRAGS_N_PER_WARP;
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            const int r0 = m * 16 + lane_id / 4;
+            const int r1 = r0 + 8;
+            if (r0 < size_m)
+            {
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = sh_c + r0 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[m][n][0];
+                    *c_ptr++ = frag_c[m][n][1];
+                }
+            }
+            if (r1 < size_m)
+            {
+                const int c = (lane_id % 4) * 2;
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float* c_ptr = sh_c + r1 * TILESIZE_N + (n0 + n) * 8 + c;
+                    *c_ptr++ = frag_c[m][n][2];
+                    *c_ptr++ = frag_c[m][n][3];
+                }
+            }
+        }
+    };
+
+    // Copy output tile to global with hadamard transform and out scale
+    auto output_had_sh_gl = [&]()
+    {
+        int sh_warp = warp_id;
+        constexpr int active_warps = EXL3_GEMM_BASE_THREADS / 32;
+        for (;; sh_warp += active_warps)
+        {
+            int col = sh_warp % (TILESIZE_N / 128);
+            int row = sh_warp / (TILESIZE_N / 128);
+            if (row >= size_m) break;
+
+            const float* had_in = sh_c + row * TILESIZE_N + col * 128;
+            const half* post_scale_c = post_scale + slice2_n * gl_c_stride_n + col * 128;
+
+            if constexpr (c_fp32)
+            {
+                float* had_out = gl_c_ptr_32 + row * size_n + col * 128;
+                had_ff_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
+            }
+            else
+            {
+                half* had_out = gl_c_ptr_16 + row * size_n + col * 128;
+                had_fh_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
+            }
+        }
+    };
+
+    auto read_sum_gl = [&]()
+    {
+        int n0 = warp_id * FRAGS_N_PER_WARP;
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                int r0 = m * 16 + lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
+                        frag_c[m][n][0] += *c_ptr++;
+                        frag_c[m][n][1] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[m][n][0] += interm.x;
+                        frag_c[m][n][1] += interm.y;
+                    }
+                }
+                if (r1 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
+                        frag_c[m][n][2] += *c_ptr++;
+                        frag_c[m][n][3] += *c_ptr++;
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
+                        float2 interm = __half22float2(*c_ptr);
+                        frag_c[m][n][2] += interm.x;
+                        frag_c[m][n][3] += interm.y;
+                    }
+                }
+            }
+        }
+    };
+
+    auto write_sum_gl = [&]()
+    {
+        int n0 = warp_id * FRAGS_N_PER_WARP;
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                int r0 = m * 16 + lane_id / 4;
+                int r1 = r0 + 8;
+                int c = (lane_id % 4) * 2;
+                if (r0 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][0];
+                        *c_ptr++ = frag_c[m][n][1];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[m][n][0], frag_c[m][n][1]);
+                        *c_ptr = sum;
+                    }
+                }
+                if (r1 < size_m)
+                {
+                    if constexpr (c_fp32)
+                    {
+                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
+                        *c_ptr++ = frag_c[m][n][2];
+                        *c_ptr++ = frag_c[m][n][3];
+                    }
+                    else
+                    {
+                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
+                        half2 sum = __floats2half2_rn(frag_c[m][n][2], frag_c[m][n][3]);
+                        *c_ptr = sum;
+                    }
+                }
+            }
+        }
+    };
+
+    // Output reduction
+    auto reduce = [&] ()
+    {
+        #if EXL3_GEMM_H_ACC
+            // Fold the fp16 MMA accumulators into fp32 once per k-slice.
+            #pragma unroll
+            for (int m = 0; m < TILEBLOCKS_M; ++m)
+            {
+                #pragma unroll
+                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+                {
+                    float2 f0 = __half22float2(frag_c_h[m][n][0]);
+                    float2 f1 = __half22float2(frag_c_h[m][n][1]);
+                    frag_c[m][n][0] += f0.x;
+                    frag_c[m][n][1] += f0.y;
+                    frag_c[m][n][2] += f1.x;
+                    frag_c[m][n][3] += f1.y;
+                }
+            }
+        #endif
+
+        // First reduce all partial sums along k for the current slice
+        threadblock_reduce();
+
+        // Process (partial) slices within column in reverse order so the threadblock doing the bottom slice is
+        // free to proceed to the next column right away
+        int lock_i = tiles_k - slice2_k - 1;
+        int lock_d = slice2_k - slice2_k0 + 1;
+        int* lock = &locks[slice_m * blocks_n + slice2_n];
+
+        barrier_acquire(lock, lock_i);
+
+        bool first = lock_i == 0;
+        bool last = lock_i + lock_d == tiles_k;
+
+        // Second and subsequent threadblocks in column read back the intermediate sum from global memory
+        if (!sub_k && !first)
+        {
+            read_sum_gl();
+        }
+
+        // All but last threadblock in column write the intermediate result to global memory
+        if (!sub_k && !last)
+        {
+            write_sum_gl();
+        }
+
+        // Last block writes in row-major format
+        if (!sub_k && last)
+        {
+            if constexpr (shmem_out_had)
+                write_sum_tile_sh();
+            else
+                write_sum_gl();
+        }
+
+        if constexpr (shmem_out_had)
+        {
+            if (last) __syncthreads();
+            if (!sub_k && last)
+                output_had_sh_gl();
+        }
+
+        barrier_release(lock, lock_d, last);
+
+        clear_frag_c();
+    };
+
+    // Wait until there are at most SH_STAGES - 2 async copies pending, i.e. at least one stage has finished loading
+    auto wait_stage = [&] ()
+    {
+        cp_async_wait<SH_STAGES - 2>();
+        __syncthreads();
+    };
+
+    // Perform tensor core matmul on current tile
+    auto matmul = [&] (int buf)
+    {
+        #pragma unroll
+        for (int m = 0; m < TILEBLOCKS_M; ++m)
+        {
+            #pragma unroll
+            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
+            {
+                #if EXL3_GEMM_H_ACC
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
+                #else
+                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
+                #endif
+            }
+        }
+    };
+
+    // Start global to shared pipeline
+    #pragma unroll
+    for (int i = 0; i < SH_STAGES - 1; ++i)
+        async_load_gl();
+    wait_stage();
+
+    // Start shared to register pipeline.
+    clear_frag_c();
+    if constexpr (FRAG_STAGES > 1)
+        load_frags(0);
+
+    // Main loop. Fragments are double buffered to allow more interleaving. This is especially important to hide the
+    // dequantization overhead, but we need two different iterations of the main loop to avoid confusing the compiler
+    // and making it (sometimes) place the fragment arrays in local memory
+
+    #define FSTAGE_OLD(_load, _mul) \
+        async_load_gl(); \
+        wait_stage(); \
+        load_frags(_load); \
+        matmul(_mul); \
+        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
+        advance2(); \
+        if (!slice2_iters) break; \
+
+    #define FSTAGE(_load, _mul) \
+        async_load_gl(); \
+        wait_stage(); \
+        matmul(_mul); \
+        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
+        advance2(); \
+        if (!slice2_iters) break; \
+        load_frags(_load); \
+
+    if constexpr (FRAG_STAGES == 1)
+    {
+        while (true)
+        {
+            FSTAGE_OLD(0, 0);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 2)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(0, 1);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 3)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(0, 2);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 4)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(3, 2);
+            FSTAGE(0, 3);
+        }
+    }
+
+    if constexpr (FRAG_STAGES == 5)
+    {
+        while (true)
+        {
+            FSTAGE(1, 0);
+            FSTAGE(2, 1);
+            FSTAGE(3, 2);
+            FSTAGE(4, 3);
+            FSTAGE(0, 4);
+        }
+    }
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
@@ -17,11 +17,13 @@
 // half rate. Accumulate each k-slice in fp16 and fold it into the persistent
 // fp32 accumulators before reduction. This changes numerical accumulation and
 // therefore remains an accuracy-gated optional variant.
-#if defined(__CUDA_ARCH__) && \
-    ((__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 1200))
-    #define EXL3_GEMM_H_ACC 1
-#else
-    #define EXL3_GEMM_H_ACC 0
+#ifndef EXL3_GEMM_H_ACC
+    #if defined(__CUDA_ARCH__) && \
+        ((__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 1200))
+        #define EXL3_GEMM_H_ACC 1
+    #else
+        #define EXL3_GEMM_H_ACC 0
+    #endif
 #endif
 
 template<EXL3_GEMM_T_ARGS, bool shmem_out_had>
@@ -205,11 +207,11 @@ void exl3_gemm_kernel_inner
     half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
     float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
 
-    register FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
-    register FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
-    register FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+    FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
+    FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
+    FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
     #if EXL3_GEMM_H_ACC
-        register FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
+        FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
     #endif
 
     auto advance2 = [&] ()
@@ -776,3 +778,5 @@ void exl3_gemm_kernel_inner
         }
     }
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
@@ -1,0 +1,279 @@
+#pragma once
+
+#include "exl3_kernel_map.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_gemm_inner.cuh"
+#include "exl3_devctx.cuh"
+
+template<EXL3_GEMM_T_ARGS>
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * TILESIZE_K / 16)
+void exl3_gemm_kernel(EXL3_GEMM_ARGS)
+{
+    auto grid = cg::this_grid();
+
+    // if (suh)
+    {
+        int total_warps = size_m * size_k / 128;
+        int warps_grid = gridDim.x * blockDim.x / 32;
+        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
+
+        for(; this_warp < total_warps; this_warp += warps_grid)
+            had_hf_r_128_inner<true, false>
+            (
+                A + this_warp * 128,
+                A_had + this_warp * 128,
+                suh + (this_warp * 128) % size_k,
+                0.088388347648f  // 1/sqrt(128)
+            );
+
+        grid.sync();
+        A = A_had;
+    }
+
+    int size_m_ = size_m;
+    const half* A_ = A;
+    void* C_ = C;
+
+    while (size_m_ > 0)
+    {
+        exl3_gemm_kernel_inner
+        <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, true>
+        (A_, B, C_, MIN(size_m_, 16), size_k, size_n, locks, svh);
+
+        A_ += 16 * size_k;
+        if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * size_n);
+        else                  C_ = (void*) (((half*) C_) + 16 * size_n);
+        size_m_ -= 16;
+
+        if (size_m_ > 0 || svh)
+            grid.sync();
+    }
+
+    // if (svh)
+    /*
+    {
+        int total_warps = size_m * size_n / 128;
+        int warps_grid = gridDim.x * blockDim.x / 32;
+        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
+
+        for(; this_warp < total_warps; this_warp += warps_grid)
+        {
+            if constexpr (c_fp32)
+                had_ff_r_128_inner<false, true>
+                (
+                    ((const float*) C) + this_warp * 128,
+                    ((float*) C) + this_warp * 128,
+                    svh + (this_warp * 128) % size_n,
+                    0.088388347648f  // 1/sqrt(128)
+                );
+            else
+                had_hf_r_128_inner<false, true>
+                (
+                    ((const half*) C) + this_warp * 128,
+                    ((half*) C) + this_warp * 128,
+                    svh + (this_warp * 128) % size_n,
+                    0.088388347648f  // 1/sqrt(128)
+                );
+        }
+    }
+     */
+}
+
+#define MAX_INDICES 128
+
+__device__ int64_t v_indices[128];
+__device__ half v_weights[128];
+__device__ int bszm_sync;
+
+template<EXL3_GEMM_T_ARGS>
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * TILESIZE_K / 16)
+void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
+{
+    int bszm = MAX(bszm_in, bszm_out);
+    auto grid = cg::this_grid();
+
+    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
+        int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
+    #endif
+
+    // Pack indices within min_index <= idx < max_index
+
+    if (min_index >= 0)
+    {
+        if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0)
+        {
+            int j = 0;
+            for (int i = 0; i < bszm; ++i)
+            {
+                int idx = B_indices[i];
+                if (idx >= min_index && idx < max_index)
+                {
+                    v_indices[j] = idx - min_index;
+                    if (B_weights) v_weights[j] = B_weights[i];
+                    j++;
+                }
+            }
+            bszm_sync = j;
+            for (; j < bszm; ++j)
+            {
+                v_indices[j] = -1;
+            }
+        }
+        __threadfence();
+        grid.sync();
+        B_indices = v_indices;
+        if (B_weights) B_weights = v_weights;
+        bszm = bszm_sync;
+    }
+
+    for (int i = 0; i < bszm; i += gridDim.z)
+    {
+        int j = i + blockIdx.z;
+        int mat_index = -1;
+        const uint16_t* B = nullptr;
+        if (j >= bszm) j = -1;
+        else
+        {
+            mat_index = B_indices ? (int) B_indices[j] : j;
+            if (mat_index >= 0)
+            {
+                B = B_list[mat_index];
+            }
+        }
+
+        // Had and input scales
+
+        if (B)
+        {
+            int total_warps = size_m * size_k / 128;
+            int warps_grid = gridDim.x * blockDim.x / 32;
+            int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
+
+            const half* suh = suh_list[mat_index];
+            const half* A_ = bszm_in == 1 ? A : A + j * size_m * size_k;
+            half* A_had_ = A_had + j * size_m * size_k;
+
+            for(; this_warp < total_warps; this_warp += warps_grid)
+                had_hf_r_128_inner<true, false>
+                (
+                    A_ + this_warp * 128,
+                    A_had_ + this_warp * 128,
+                    suh + (this_warp * 128) % size_k,
+                    0.088388347648f  // 1/sqrt(128)
+                );
+        }
+
+        #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
+            group_barrier(blockIdx.z, gridDim.x, barrier_counters_sense);
+        #else
+            grid.sync();
+        #endif
+
+        // Matmul
+
+        int size_m_ = size_m;
+        half* A_ = A_had + j * size_m * size_k;
+        void* C_;
+        if constexpr (c_fp32) C_ = (void*) (((float*) C) + j * size_m * size_n);
+        else                  C_ = (void*) (((half*) C) + j * size_m * size_n);
+
+        while (size_m_ > 0)
+        {
+            if (B)
+            {
+                int lock_offs = blockIdx.z * size_n / 128;
+
+                exl3_gemm_kernel_inner
+                <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, false>
+                (A_, B, C_, MIN(size_m_, 16), size_k, size_n, locks + lock_offs, nullptr);
+            }
+
+            A_ += 16 * size_k;
+            if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * size_n);
+            else                  C_ = (void*) (((half*) C_) + 16 * size_n);
+            size_m_ -= 16;
+
+            #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
+                group_barrier(blockIdx.z, gridDim.x, barrier_counters_sense);
+            #else
+                grid.sync();
+            #endif
+        }
+
+        // Had and output scales
+
+        if (B)
+        {
+            int total_warps = size_m * size_n / 128;
+            int warps_grid = gridDim.x * blockDim.x / 32;
+            int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
+
+            const half* svh = svh_list[mat_index];
+            float scale = 0.088388347648f;  // 1/sqrt(128)
+            if (B_weights) scale *= __half2float(B_weights[j]);
+
+            if constexpr (c_fp32) C_ = (void*) (((float*) C) + j * size_m * size_n);
+            else                  C_ = (void*) (((half*) C) + j * size_m * size_n);
+
+            for(; this_warp < total_warps; this_warp += warps_grid)
+            {
+                if constexpr (c_fp32)
+                    had_ff_r_128_inner<false, true>
+                    (
+                        ((const float*) C_) + this_warp * 128,
+                        ((float*) C_) + this_warp * 128,
+                        svh + (this_warp * 128) % size_n,
+                        scale
+                    );
+                else
+                    had_hf_r_128_inner<false, true>
+                    (
+                        ((const half*) C_) + this_warp * 128,
+                        ((half*) C_) + this_warp * 128,
+                        svh + (this_warp * 128) % size_n,
+                        scale
+                    );
+            }
+        }
+    }
+
+    if (B_weights)
+        grid.sync();
+
+    // Final reduction
+    if (B_weights && blockIdx.z == 0)
+    {
+        int total_warps = size_m * size_n / 32;
+        int warps_grid = gridDim.x * blockDim.x / 32;
+        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
+        int this_lane = threadIdx.x % 32;
+
+        for(; this_warp < total_warps; this_warp += warps_grid)
+        {
+            if constexpr (c_fp32)
+            {
+                float* C__ = ((float*) C) + this_warp * 32 + this_lane;
+                float* C___ = C__;
+                float sum = 0.0f;
+                for (int j = 0; j < bszm; ++j)
+                {
+                    sum += *C___;
+                    C___ += size_m * size_n;
+                }
+                *C__ = sum;
+            }
+            else
+            {
+                half* C__ = ((half*) C) + this_warp * 32 + this_lane;
+                half* C___ = C__;
+                half sum = {};
+                for (int j = 0; j < bszm; ++j)
+                {
+                    sum = __hadd(sum, *C___);
+                    C___ += size_m * size_n;
+                }
+                *C__ = sum;
+            }
+        }
+    }
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
@@ -277,3 +277,5 @@ void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
         }
     }
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
@@ -1,0 +1,142 @@
+#pragma once
+
+int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int bits, bool multi);
+int exl3_gemm_num_kernel_shapes();
+bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int bits);
+
+#define EXL3_GEMM_T_ARGS \
+    const int bits, \
+    const bool c_fp32, \
+    const int cb, \
+    const int TILESIZE_M, \
+    const int TILESIZE_K, \
+    const int TILESIZE_N, \
+    const int SH_STAGES, \
+    const int FRAG_STAGES
+
+#define EXL3_GEMM_ARGS \
+    const half* __restrict__  A, \
+    const uint16_t* __restrict__ B, \
+    void* __restrict__ C, \
+    const int size_m, \
+    const int size_k, \
+    const int size_n, \
+    int* __restrict__ locks, \
+    const half* __restrict__ suh, \
+    half* __restrict__ A_had, \
+    const half* __restrict__ svh
+
+#define EXL3_MGEMM_ARGS \
+    const half* __restrict__  A, \
+    const uint16_t** __restrict__ B_list, \
+    void* __restrict__ C, \
+    const int size_m, \
+    const int size_k, \
+    const int size_n, \
+    int* __restrict__ locks, \
+    const half** __restrict__ suh_list, \
+    half* __restrict__ A_had, \
+    const half** __restrict__ svh_list, \
+    int64_t* B_indices, \
+    half* B_weights, \
+    const int bszm_in, \
+    const int bszm_out, \
+    const int min_index, \
+    const int max_index
+
+typedef void (*fp_exl3_gemm_kernel) (EXL3_GEMM_ARGS);
+typedef void (*fp_exl3_mgemm_kernel) (EXL3_MGEMM_ARGS);
+
+#define EXL3_GEMM_SHAPE_1     16,     16,    128,     6,     5
+#define EXL3_GEMM_SHAPE_2     16,     32,    128,     4,     3
+#define EXL3_GEMM_SHAPE_3     16,     32,    256,     4,     3
+#define EXL3_GEMM_SHAPE_4     16,     16,    512,     4,     3
+
+#define EXL3_GEMM_TILESIZE_K  0, 16, 32, 32, 16
+#define EXL3_GEMM_TILESIZE_N  0, 128, 128, 256, 512
+#define EXL3_GEMM_BLOCKDIM  0, 256, 512, 512, 256
+
+#define EXL3_GEMM_NUM_SHAPES 4
+
+// Shape 1 not currently used anywhere
+#define EXL3_GEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
+    nullptr, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
+    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
+
+#define EXL3_MGEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
+    nullptr, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
+    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
+
+#define EXL3_GEMM_BASE_THREADS 256
+
+#define ALL_EXL3_KERNEL_EXTERNS(K) \
+    extern fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp32_b##K[]; \
+    extern fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp16_b##K[]; \
+    extern fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp32_b##K[]; \
+    extern fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp16_b##K[]; \
+
+#define ALL_EXL3_KERNEL_INSTANCES(K) \
+    fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp32_b##K[] = { \
+        EXL3_GEMM_KERNEL_INSTANCES(K, true, 0), \
+        EXL3_GEMM_KERNEL_INSTANCES(K, true, 1), \
+        EXL3_GEMM_KERNEL_INSTANCES(K, true, 2) \
+    }; \
+    \
+    fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp16_b##K[] = { \
+        EXL3_GEMM_KERNEL_INSTANCES(K, false, 0), \
+        EXL3_GEMM_KERNEL_INSTANCES(K, false, 1), \
+        EXL3_GEMM_KERNEL_INSTANCES(K, false, 2) \
+    }; \
+    \
+    fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp32_b##K[] = { \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 0), \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 1), \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 2) \
+    }; \
+    \
+    fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp16_b##K[] = { \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 0), \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 1), \
+        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 2) \
+    };
+
+fp_exl3_gemm_kernel select_exl3_gemm_kernel
+(
+    const int cc,
+    const int size_m,
+    const int size_k,
+    const int size_n,
+    const int bits,
+    const bool c_fp32,
+    const int force_shape_idx,
+    int* out_block_dim,
+    int* out_shape_idx,
+    int* out_num_sms,
+    const int cb
+);
+
+fp_exl3_mgemm_kernel select_exl3_mgemm_kernel
+(
+    const int cc,
+    const int size_m,
+    const int size_k,
+    const int size_n,
+    const int K,
+    const bool c_fp32,
+    const int force_shape_idx,
+    int* out_block_dim,
+    int* out_shape_idx,
+    int* out_num_sms,
+    const int cb,
+    const int bszm_in,
+    const int bszm_out
+);
+
+fp_exl3_gemm_kernel get_gemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);
+fp_exl3_mgemm_kernel get_mgemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
@@ -140,3 +140,5 @@ fp_exl3_mgemm_kernel select_exl3_mgemm_kernel
 
 fp_exl3_gemm_kernel get_gemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);
 fp_exl3_mgemm_kernel get_mgemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
@@ -457,3 +457,5 @@ void had_hf_r_128_d_inner
     atomicAdd(output_ptr + 64 + t, sh[64 + t]);
     atomicAdd(output_ptr + 96 + t, sh[96 + t]);
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
@@ -1,0 +1,459 @@
+#pragma once
+#include "../compat.cuh"
+
+#define ACT_SILU 0
+#define ACT_GELU 1
+
+// Hadamard transform 128-element vector across one warp, with optional pre and post scales
+
+__device__ inline half hreduce(half2 x)
+{
+    return __hadd(__low2half(x), __high2half(x));
+}
+
+__device__ inline void shuffle_had_f4x32(float& h0, float& h1, float& h2, float& h3, const int lane_id)
+{
+    #pragma unroll
+    for (int i = 1; i < 32; i <<= 1)
+    {
+        uint32_t i0 = __float_as_uint(h0);
+        uint32_t i1 = __float_as_uint(h1);
+        uint32_t i2 = __float_as_uint(h2);
+        uint32_t i3 = __float_as_uint(h3);
+        uint64_t h01 =  (uint64_t) i0 | (((uint64_t) i1) << 32);
+        uint64_t h23 =  (uint64_t) i2 | (((uint64_t) i3) << 32);
+        uint64_t ph01 = __shfl_xor_sync(0xffffffff, h01, i);
+        uint64_t ph23 = __shfl_xor_sync(0xffffffff, h23, i);
+        float ph0 = __uint_as_float((uint32_t) (ph01 & 0xffffffff));
+        float ph1 = __uint_as_float((uint32_t) (ph01 >> 32));
+        float ph2 = __uint_as_float((uint32_t) (ph23 & 0xffffffff));
+        float ph3 = __uint_as_float((uint32_t) (ph23 >> 32));
+        int32_t sfm = -static_cast<int32_t>(lane_id & i) >> 31;
+        i0 ^= sfm & 0x80000000;
+        i1 ^= sfm & 0x80000000;
+        i2 ^= sfm & 0x80000000;
+        i3 ^= sfm & 0x80000000;
+        h0 = __uint_as_float(i0) + ph0;
+        h1 = __uint_as_float(i1) + ph1;
+        h2 = __uint_as_float(i2) + ph2;
+        h3 = __uint_as_float(i3) + ph3;
+    }
+}
+
+__device__ inline void shuffle_had_f2x32(float& v, float& w, const int lane_id)
+{
+    #pragma unroll
+    for (int i = 1; i < 32; i <<= 1)
+    {
+        uint64_t vw = ((uint64_t) __float_as_uint(v)) | (((uint64_t) __float_as_uint(w)) << 32);
+        uint64_t pvw = __shfl_xor_sync(0xffffffff, vw, i);
+        float pv = __uint_as_float((uint32_t) (pvw & 0xffffffff));
+        float pw = __uint_as_float((uint32_t) (pvw >> 32));
+        uint32_t vi = __float_as_uint(v);
+        uint32_t wi = __float_as_uint(w);
+        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
+        vi ^= (sfm & 0x80000000);
+        wi ^= (sfm & 0x80000000);
+        v = __uint_as_float(vi) + pv;
+        w = __uint_as_float(wi) + pw;
+    }
+}
+
+__device__ inline float shuffle_had_fx32(float v, const int lane_id)
+{
+    for (int i = 1; i < 32; i <<= 1)
+    {
+        float pv = __shfl_xor_sync(0xffffffff, v, i);
+        uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
+        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
+        *vi ^= (sfm & 0x80000000);
+        v = v + pv;
+    }
+    return v;
+}
+
+__device__ inline half2 shuffle_had_h2x32(half2 v, int lane_id)
+{
+    for (int i = 1; i < 32; i <<= 1)
+    {
+        half2 pv = __shfl_xor_sync(0xffffffff, v, i);
+        uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
+        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
+        *vi ^= (sfm & 0x80008000);
+        v = __hadd2(v, pv);
+    }
+    return v;
+}
+
+// Half vector, half scales
+
+template <bool pre_scale, bool post_scale>
+inline __device__
+void had_hf_r_128_inner
+(
+    const half* __restrict__ input_ptr,
+    half* __restrict__ output_ptr,
+    const half* __restrict__ scale,
+    const float r_scale
+)
+{
+    int t = threadIdx.x & 31;
+
+    // Load
+    half4 v = ((half4*) input_ptr)[t];
+
+    // Pre scale
+    if constexpr (pre_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        v.x = __hmul2(v.x, scales.x);
+        v.y = __hmul2(v.y, scales.y);
+    }
+
+    // 4 element had
+    float v0 = __half2float(__low2half(v.x));
+    float v1 = __half2float(__high2half(v.x));
+    float v2 = __half2float(__low2half(v.y));
+    float v3 = __half2float(__high2half(v.y));
+    float s0 = v0 + v1;
+    float d0 = v0 - v1;
+    float s1 = v2 + v3;
+    float d1 = v2 - v3;
+    float h0 = s0 + s1;
+    float h1 = d0 + d1;
+    float h2 = s0 - s1;
+    float h3 = d0 - d1;
+
+    // 32 element had, warp shuffle
+    shuffle_had_f4x32(h0, h1, h2, h3, t);
+    v.x = __floats2half2_rn(h0 * r_scale, h1 * r_scale);
+    v.y = __floats2half2_rn(h2 * r_scale, h3 * r_scale);
+
+    // Post scale
+    if constexpr (post_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        v.x = __hmul2(v.x, scales.x);
+        v.y = __hmul2(v.y, scales.y);
+    }
+
+    // Store
+    ((half4*) output_ptr)[t] = v;
+}
+
+// Float vector, half scales
+
+template <bool pre_scale, bool post_scale>
+inline __device__
+void had_ff_r_128_inner
+(
+    const float* __restrict__ input_ptr,
+    float* __restrict__ output_ptr,
+    const half* __restrict__ scale,
+    const float r_scale
+)
+{
+    int t = threadIdx.x & 31;
+
+    // Load
+    float4 v = ((float4*) input_ptr)[t];
+
+    // Pre scale
+    if constexpr (pre_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        v.x *= __low2float(scales.x);
+        v.y *= __high2float(scales.x);
+        v.z *= __low2float(scales.y);
+        v.w *= __high2float(scales.y);
+    }
+
+    // 4 element had
+    float v0 = v.x;
+    float v1 = v.y;
+    float v2 = v.z;
+    float v3 = v.w;
+    float s0 = v0 + v1;
+    float d0 = v0 - v1;
+    float s1 = v2 + v3;
+    float d1 = v2 - v3;
+    v.x = s0 + s1;
+    v.y = d0 + d1;
+    v.z = s0 - s1;
+    v.w = d0 - d1;
+
+    // 32 element had, warp shuffle
+    shuffle_had_f2x32(v.x, v.y, t);
+    shuffle_had_f2x32(v.z, v.w, t);
+    v.x *= r_scale;
+    v.y *= r_scale;
+    v.z *= r_scale;
+    v.w *= r_scale;
+
+    // Post scale
+    if constexpr (post_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        v.x *= __low2float(scales.x);
+        v.y *= __high2float(scales.x);
+        v.z *= __low2float(scales.y);
+        v.w *= __high2float(scales.y);
+    }
+
+    // Store
+    ((float4*) output_ptr)[t] = v;
+}
+
+// Float vector, half scales, half output
+
+template <bool pre_scale, bool post_scale>
+inline __device__
+void had_fh_r_128_inner
+(
+    const float* __restrict__ input_ptr,
+    half* __restrict__ output_ptr,
+    const half* __restrict__ scale,
+    const float r_scale
+)
+{
+    int t = threadIdx.x & 31;
+
+    // Load
+    float4 v = ((float4*) input_ptr)[t];
+
+    // Pre scale
+    if constexpr (pre_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        v.x *= __low2float(scales.x);
+        v.y *= __high2float(scales.x);
+        v.z *= __low2float(scales.y);
+        v.w *= __high2float(scales.y);
+    }
+
+    // 4 element had
+    float v0 = v.x;
+    float v1 = v.y;
+    float v2 = v.z;
+    float v3 = v.w;
+    float s0 = v0 + v1;
+    float d0 = v0 - v1;
+    float s1 = v2 + v3;
+    float d1 = v2 - v3;
+    v.x = s0 + s1;
+    v.y = d0 + d1;
+    v.z = s0 - s1;
+    v.w = d0 - d1;
+
+    // 32 element had, warp shuffle
+    shuffle_had_f2x32(v.x, v.y, t);
+    shuffle_had_f2x32(v.z, v.w, t);
+    v.x *= r_scale;
+    v.y *= r_scale;
+    v.z *= r_scale;
+    v.w *= r_scale;
+
+    half4 o;
+    o.x = __floats2half2_rn(v.x, v.y);
+    o.y = __floats2half2_rn(v.z, v.w);
+
+    // Post scale
+    if constexpr (post_scale)
+    {
+        int i = blockIdx.y * 32 + t;
+        half4 scales = ((half4*) scale)[i];
+        o.x = __hmul2(o.x, scales.x);
+        o.y = __hmul2(o.y, scales.y);
+    }
+
+    // Store
+    ((half4*) output_ptr)[t] = o;
+}
+
+// Fused op: o <- in_had(silu(out_had(g)) * out_had(u))
+
+inline __device__
+void had_hf_r_128_guad_inner
+(
+    const half* __restrict__ input_ptr_g,
+    const half* __restrict__ input_ptr_u,
+    half* __restrict__ output_ptr,
+    const half* __restrict__ post_scale_g,
+    const half* __restrict__ post_scale_u,
+    const half* __restrict__ pre_scale_d,
+    const float r_scale,
+    const float act_limit,
+    const int act_function
+)
+{
+    int t = threadIdx.x & 31;
+
+    auto had = [&](half4& v)
+    {
+        // 4 element had
+        float v0 = __half2float(__low2half(v.x));
+        float v1 = __half2float(__high2half(v.x));
+        float v2 = __half2float(__low2half(v.y));
+        float v3 = __half2float(__high2half(v.y));
+        float s0 = v0 + v1;
+        float d0 = v0 - v1;
+        float s1 = v2 + v3;
+        float d1 = v2 - v3;
+        float h0 = s0 + s1;
+        float h1 = d0 + d1;
+        float h2 = s0 - s1;
+        float h3 = d0 - d1;
+
+        // 32 element had, warp shuffle
+        shuffle_had_f4x32(h0, h1, h2, h3, t);
+        v.x = __floats2half2_rn(h0 * r_scale, h1 * r_scale);
+        v.y = __floats2half2_rn(h2 * r_scale, h3 * r_scale);
+
+        return v;
+    };
+
+    auto _silu = [&](const half2& x)
+    {
+        half2 one = __float2half2_rn(1.0f);
+        half2 neg_x = __hneg2(x);
+        half2 e = h2exp(neg_x);
+        half2 sum = __hadd2(one, e);
+        half2 r = h2rcp(sum);
+        half2 result = __hmul2(x, r);
+        return result;
+    };
+
+    auto _gelu = [&](const half2& x)
+    {
+        float2 xf = __half22float2(x);
+        const float c = 0.797884560803f;  // sqrt(2/Pi)
+        xf.x = 0.5f * xf.x * (1.0f + tanh_opt(c * (xf.x + 0.044715f * xf.x * xf.x * xf.x)));
+        xf.y = 0.5f * xf.y * (1.0f + tanh_opt(c * (xf.y + 0.044715f * xf.y * xf.y * xf.y)));
+        return __float22half2_rn(xf);
+    };
+
+    // Load
+    half4 vg = ((half4*) input_ptr_g)[t];
+    half4 vu = ((half4*) input_ptr_u)[t];
+
+    // Hadamard
+    vg = had(vg);
+    vu = had(vu);
+
+    // Post scale  TODO: should maybe do this in float32
+    int i = blockIdx.y * 32 + t;
+    half4 scales_g = ((half4*) post_scale_g)[i];
+    half4 scales_u = ((half4*) post_scale_u)[i];
+    vg.x = __hmul2(vg.x, scales_g.x);
+    vg.y = __hmul2(vg.y, scales_g.y);
+    vu.x = __hmul2(vu.x, scales_u.x);
+    vu.y = __hmul2(vu.y, scales_u.y);
+
+    // Activation
+    switch (act_function)
+    {
+        case ACT_SILU:
+            vg.x = _silu(vg.x);
+            vg.y = _silu(vg.y);
+            break;
+
+        case ACT_GELU:
+            vg.x = _gelu(vg.x);
+            vg.y = _gelu(vg.y);
+            break;
+
+        default:
+            break;
+    }
+
+    // Optional activation limits
+    if (act_limit != 0.0f)
+    {
+        vu.x = __hmax2(vu.x, __float2half2_rn(-act_limit));
+        vu.y = __hmax2(vu.y, __float2half2_rn(-act_limit));
+        vu.x = __hmin2(vu.x, __float2half2_rn(act_limit));
+        vu.y = __hmin2(vu.y, __float2half2_rn(act_limit));
+        vg.x = __hmin2(vg.x, __float2half2_rn(act_limit));
+        vg.y = __hmin2(vg.y, __float2half2_rn(act_limit));
+    }
+
+    // Gate
+    vg.x = __hmul2(vg.x, vu.x);
+    vg.y = __hmul2(vg.y, vu.y);
+
+    // Pre scale (d)
+    half4 scales_d = ((half4*) pre_scale_d)[i];
+    vg.x = __hmul2(vg.x, scales_d.x);
+    vg.y = __hmul2(vg.y, scales_d.y);
+
+    // Hadamard
+    vg = had(vg);
+
+    // Store
+    ((half4*) output_ptr)[t] = vg;
+}
+
+// Fused op: o += float(out_had(i)), atomic
+
+inline __device__
+void had_hf_r_128_d_inner
+(
+    const half* __restrict__ input_ptr,
+    float* __restrict__ output_ptr,
+    const half* __restrict__ post_scale,
+    const float r_scale
+)
+{
+    int t = threadIdx.x & 31;
+
+    // Load
+    half4 v = ((half4*) input_ptr)[t];
+
+    // 4 element had
+    float v0 = __half2float(__low2half(v.x));
+    float v1 = __half2float(__high2half(v.x));
+    float v2 = __half2float(__low2half(v.y));
+    float v3 = __half2float(__high2half(v.y));
+    float s0 = v0 + v1;
+    float d0 = v0 - v1;
+    float s1 = v2 + v3;
+    float d1 = v2 - v3;
+    float h0 = s0 + s1;
+    float h1 = d0 + d1;
+    float h2 = s0 - s1;
+    float h3 = d0 - d1;
+
+    // 32 element had, warp shuffle
+    shuffle_had_f4x32(h0, h1, h2, h3, t);
+    h0 *= r_scale;
+    h1 *= r_scale;
+    h2 *= r_scale;
+    h3 *= r_scale;
+
+    // Post scale
+    int i = blockIdx.y * 32 + t;
+    half4 scales = ((half4*) post_scale)[i];
+    h0 *= __low2float(scales.x);
+    h1 *= __high2float(scales.x);
+    h2 *= __low2float(scales.y);
+    h3 *= __high2float(scales.y);
+
+    // Reshuffle in shmem for coalesced store with atomicAdd
+    extern __shared__ float temp_shared[];
+    int warp_id = threadIdx.x / 32;
+    float* sh = temp_shared + warp_id * 128;
+    sh[t * 4 + 0] = h0;
+    sh[t * 4 + 1] = h1;
+    sh[t * 4 + 2] = h2;
+    sh[t * 4 + 3] = h3;
+    __syncwarp();
+    atomicAdd(output_ptr +  0 + t, sh[ 0 + t]);
+    atomicAdd(output_ptr + 32 + t, sh[32 + t]);
+    atomicAdd(output_ptr + 64 + t, sh[64 + t]);
+    atomicAdd(output_ptr + 96 + t, sh[96 + t]);
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
@@ -1,0 +1,139 @@
+#pragma once
+
+typedef struct __align__(8) half4
+{
+    half2 x;
+    half2 y;
+    __device__ half4() = default;
+    __device__ half4(half2 x_, half2 y_) : x(x_), y(y_) {}
+    __device__ half4(half h0, half h1, half h2, half h3) :
+         x(__halves2half2(h0, h1)),
+         y(__halves2half2(h2, h3)) {}
+}
+half4;
+
+typedef struct __align__(8) bfloat164
+{
+    __nv_bfloat162 x;
+    __nv_bfloat162 y;
+    __device__ bfloat164() = default;
+    __device__ bfloat164(__nv_bfloat162 x_, __nv_bfloat162 y_): x(x_), y(y_) {}
+    __device__ bfloat164(__nv_bfloat16 b0, __nv_bfloat16 b1, __nv_bfloat16 b2, __nv_bfloat16 b3) :
+        x(__halves2bfloat162(b0, b1)),
+        y(__halves2bfloat162(b2, b3)) {}
+}
+bfloat164;
+
+typedef struct __align__(16) half8
+{
+    half2 x;
+    half2 y;
+    half2 z;
+    half2 w;
+     __device__ half8() = default;
+     __device__ half8(half2 x_, half2 y_, half2 z_, half2 w_) : x(x_), y(y_), z(z_), w(w_) {}
+     __device__ half8(half h0, half h1, half h2, half h3, half h4, half h5, half h6, half h7) :
+         x(__halves2half2(h0, h1)),
+         y(__halves2half2(h2, h3)),
+         z(__halves2half2(h4, h5)),
+         w(__halves2half2(h6, h7)) {}
+}
+half8;
+
+struct Dim3
+{
+    int m;
+    int k;
+    int n;
+    inline __device__ int numel_a() { return m * k; }
+    inline __device__ int numel_b() { return k * n; }
+    inline __device__ int numel_c() { return m * n; }
+};
+
+#define READ128(__x, __y) ((uint4*)&__x)[0] = ((uint4*)(__y))[0];
+#define WRITE128(__x, __y) ((uint4*)__x)[0] = ((uint4*)(&__y))[0];
+#define READ64(__x, __y) ((uint2*)&__x)[0] = ((uint2*)(__y))[0];
+#define WRITE64(__x, __y) ((uint2*)__x)[0] = ((uint2*)(&__y))[0];
+
+#define LOW_TO_FLOAT(__x) __half2float(__low2half(__x))
+#define HIGH_TO_FLOAT(__x) __half2float(__high2half(__x))
+
+#define LOW_TO_FLOAT(__x) __half2float(__low2half(__x))
+#define HIGH_TO_FLOAT(__x) __half2float(__high2half(__x))
+
+#define CLAMP(__x, __min, __max) fmaxf(__min, fminf(__x, __max))
+#define CLAMP_FP16(__x) CLAMP(__x, -65504.0f, 65504.0f)
+
+#define SWAP16(__x) __byte_perm(__x, 0, 0x1032)
+
+union half2_uint32
+{
+    uint32_t as_uint32;
+    half2 as_half2;
+    __device__ half2_uint32(uint32_t val) : as_uint32(val) {}
+    __device__ half2_uint32(half2 val) : as_half2(val) {}
+    __device__ half2_uint32() : as_uint32(0) {}
+};
+
+union half_uint16
+{
+    uint16_t as_uint16;
+    half as_half;
+    __device__ half_uint16(uint16_t val) : as_uint16(val) {}
+    __device__ half_uint16(half val) : as_half(val) {}
+    __device__ half_uint16() : as_uint16(0) {}
+};
+
+#define cuda_check(ans) { gpu_assert((ans), __FILE__, __LINE__); }
+inline void gpu_assert(cudaError_t code, const char *file, int line, bool abort=true)
+{
+   if (code != cudaSuccess)
+   {
+      fprintf(stderr,"GPU assert: %s %s %d\n", cudaGetErrorString(code), file, line);
+      if (abort) exit(code);
+   }
+}
+
+inline const char* cublasGetErrorString(cublasStatus_t status) {
+    switch (status) {
+        case CUBLAS_STATUS_SUCCESS:           return "CUBLAS_STATUS_SUCCESS";
+        case CUBLAS_STATUS_NOT_INITIALIZED:   return "CUBLAS_STATUS_NOT_INITIALIZED";
+        case CUBLAS_STATUS_ALLOC_FAILED:      return "CUBLAS_STATUS_ALLOC_FAILED";
+        case CUBLAS_STATUS_INVALID_VALUE:     return "CUBLAS_STATUS_INVALID_VALUE";
+        case CUBLAS_STATUS_ARCH_MISMATCH:     return "CUBLAS_STATUS_ARCH_MISMATCH";
+        case CUBLAS_STATUS_MAPPING_ERROR:     return "CUBLAS_STATUS_MAPPING_ERROR";
+        case CUBLAS_STATUS_EXECUTION_FAILED:  return "CUBLAS_STATUS_EXECUTION_FAILED";
+        case CUBLAS_STATUS_INTERNAL_ERROR:    return "CUBLAS_STATUS_INTERNAL_ERROR";
+        case CUBLAS_STATUS_NOT_SUPPORTED:     return "CUBLAS_STATUS_NOT_SUPPORTED";
+        case CUBLAS_STATUS_LICENSE_ERROR:     return "CUBLAS_STATUS_LICENSE_ERROR";
+        default:                              return "Unknown cuBLAS status";
+    }
+}
+
+#define cublas_check(ans) { cublas_assert((ans), __FILE__, __LINE__); }
+inline void cublas_assert(cublasStatus_t code, const char *file, int line, bool abort=true)
+{
+    if (code != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "cuBLAS assert: %s %s %d\n",
+                cublasGetErrorString(code), file, line);
+        if (abort) exit(static_cast<int>(code));
+    }
+}
+
+__device__ inline float fxor(float v, uint32_t mask)
+{
+    uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
+    *vi ^= mask;
+    return v;
+}
+
+__device__ inline half2 h2xor(half2 v, uint32_t mask)
+{
+    uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
+    *vi ^= mask;
+    return v;
+}
+
+#define NEG_INF_F16 __ushort_as_half(0xFC00)
+#define POS_INF_F16 __ushort_as_half(0x7C00)

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
@@ -84,43 +84,6 @@ union half_uint16
     __device__ half_uint16() : as_uint16(0) {}
 };
 
-#define cuda_check(ans) { gpu_assert((ans), __FILE__, __LINE__); }
-inline void gpu_assert(cudaError_t code, const char *file, int line, bool abort=true)
-{
-   if (code != cudaSuccess)
-   {
-      fprintf(stderr,"GPU assert: %s %s %d\n", cudaGetErrorString(code), file, line);
-      if (abort) exit(code);
-   }
-}
-
-inline const char* cublasGetErrorString(cublasStatus_t status) {
-    switch (status) {
-        case CUBLAS_STATUS_SUCCESS:           return "CUBLAS_STATUS_SUCCESS";
-        case CUBLAS_STATUS_NOT_INITIALIZED:   return "CUBLAS_STATUS_NOT_INITIALIZED";
-        case CUBLAS_STATUS_ALLOC_FAILED:      return "CUBLAS_STATUS_ALLOC_FAILED";
-        case CUBLAS_STATUS_INVALID_VALUE:     return "CUBLAS_STATUS_INVALID_VALUE";
-        case CUBLAS_STATUS_ARCH_MISMATCH:     return "CUBLAS_STATUS_ARCH_MISMATCH";
-        case CUBLAS_STATUS_MAPPING_ERROR:     return "CUBLAS_STATUS_MAPPING_ERROR";
-        case CUBLAS_STATUS_EXECUTION_FAILED:  return "CUBLAS_STATUS_EXECUTION_FAILED";
-        case CUBLAS_STATUS_INTERNAL_ERROR:    return "CUBLAS_STATUS_INTERNAL_ERROR";
-        case CUBLAS_STATUS_NOT_SUPPORTED:     return "CUBLAS_STATUS_NOT_SUPPORTED";
-        case CUBLAS_STATUS_LICENSE_ERROR:     return "CUBLAS_STATUS_LICENSE_ERROR";
-        default:                              return "Unknown cuBLAS status";
-    }
-}
-
-#define cublas_check(ans) { cublas_assert((ans), __FILE__, __LINE__); }
-inline void cublas_assert(cublasStatus_t code, const char *file, int line, bool abort=true)
-{
-    if (code != CUBLAS_STATUS_SUCCESS)
-    {
-        fprintf(stderr, "cuBLAS assert: %s %s %d\n",
-                cublasGetErrorString(code), file, line);
-        if (abort) exit(static_cast<int>(code));
-    }
-}
-
 __device__ inline float fxor(float v, uint32_t mask)
 {
     uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
@@ -137,3 +100,5 @@ __device__ inline half2 h2xor(half2 v, uint32_t mask)
 
 #define NEG_INF_F16 __ushort_as_half(0xFC00)
 #define POS_INF_F16 __ushort_as_half(0x7C00)
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <chrono>
+
+#define CEIL_DIVIDE(x, size) (((x) + (size) - 1) / (size))
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+
+// Some decluttering macros
+//
+// TORCH_CHECK_DTYPE(x, T):                     assert x is dtype T
+// TORCH_CHECK_DTYPE_OPT(x, T):                 assert x is dtype T, unless x is None
+// TORCH_CHECK_FLOAT_HALF(x):                   assert x is either kFloat or kHalf
+// TORCH_CHECK_SHAPES(x, i, y, j, scale):       assert x.size(i) == y.size(j) * scale
+// TORCH_CHECK_SHAPES_OPT(x, i, y, j, scale):   assert x.size(i) == y.size(j) * scale, unless x is None
+// TORCH_CHECK_SHAPES_FULL(x, y):               assert x and y are same shape
+// TORCH_CHECK_NUMEL(x, y):                     assert x and y have same number of elements
+// TORCH_CHECK_DIV(x, i, divisor):              assert x.size(i) is divisible by divisor
+// TORCH_CHECK_DIM(x, D):                       assert x has D dimensions
+// TORCH_CHECK_DIM_OPT(x, D):                   assert x has D dimensions, unless x is None
+// TORCH_CHECK_SIZE(x, i, s):                   assert x.size(i) == s
+// OPTPTR(x):                                   x.data_ptr() or nullptr if x is None
+
+#define TORCH_CHECK_DTYPE(__x, __dtype) TORCH_CHECK((__x).dtype() == at::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_DTYPE_OPT(__x, __dtype) TORCH_CHECK((!__x.has_value()) || (__x).value().dtype() == at::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_FLOAT_HALF(__x) TORCH_CHECK((__x).dtype() == at::kHalf || (__x).dtype() == at::kFloat,  #__x " is incorrect datatype, must be kHalf or kFloat")
+#define TORCH_CHECK_SHAPES(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPES_OPT(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((!(__x).has_value()) || (__x).value().size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPES_FULL(__x, __y) TORCH_CHECK((__x).sizes() == (__y).sizes(), #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_NUMEL(__x, __y) TORCH_CHECK((__x).numel() == (__y).numel(), #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_DIV(__x, __dim_x, __div) TORCH_CHECK((__x).size(__dim_x) % __div == 0, #__x " dimension " #__dim_x " must be divisible by " #__div)
+#define TORCH_CHECK_DIM(__x, __dims) TORCH_CHECK((__x).dim() == __dims, #__x " must have " #__dims " dimensions")
+#define TORCH_CHECK_DIM_OPT(__x, __dims) TORCH_CHECK((!__x.has_value()) || (__x).value().dim() == __dims, #__x " must have " #__dims " dimensions")
+#define TORCH_CHECK_SIZE(__x, __dim_x, __s) TORCH_CHECK((__x).size(__dim_x) == (__s), #__x " dimension " #__dim_x " is incorrect size")
+#define OPTPTR(__x) (__x.has_value() ? __x.value().data_ptr() : nullptr)
+
+// Debug stuff
+
+#define DBGS(__x) printf("%s\n", __x)
+#define DBGI(__x) \
+    printf("%s: %i\n", #__x, __x)
+#define DBGI2(__x, __y) \
+    printf("%s, %s: %i, %i\n", #__x, #__y, __x, __y)
+#define DBGI3(__x, __y, __z) \
+    printf("%s, %s, %s: %i, %i, %i\n", #__x, #__y, #__z, __x, __y, __z)
+#define DBGI4(__x, __y, __z, __w) \
+    printf("%s, %s, %s, %s: %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, __x, __y, __z, __w)
+#define DBGI5(__x, __y, __z, __w, __v) \
+    printf("%s, %s, %s, %s, %s: %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, __x, __y, __z, __w, __v)
+#define DBGI6(__x, __y, __z, __w, __v, __u) \
+    printf("%s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, __x, __y, __z, __w, __v, __u)
+#define DBGI7(__x, __y, __z, __w, __v, __u, __t) \
+    printf("%s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, __x, __y, __z, __w, __v, __u, __t)
+#define DBGI8(__x, __y, __z, __w, __v, __u, __t, __s) \
+    printf("%s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, __x, __y, __z, __w, __v, __u, __t, __s)
+#define DBGI9(__x, __y, __z, __w, __v, __u, __t, __s, __r) \
+    printf("%s, %s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, #__r, __x, __y, __z, __w, __v, __u, __t, __s, __r)
+#define DBGI10(__x, __y, __z, __w, __v, __u, __t, __s, __r, __q) \
+    printf("%s, %s, %s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, #__r, #__q, __x, __y, __z, __w, __v, __u, __t, __s, __r, __q)
+#define DBGX(__x) printf("%s: %x\n", #__x, __x)
+#define DBGX2(__x, __y) printf("%s, %s: %x, %x\n", #__x, #__y, __x, __y)
+#define DBGX3(__x, __y, __z) printf("%s, %s, %s: %x, %x, %x\n", #__x, #__y, #__z, __x, __y, __z)
+#define DBGIX(__x, __y) printf("%s, %s: %i, %x\n", #__x, #__y, __x, __y)
+#define DBGIX2(__x, __y, __z) printf("%s, %s, %s: %i, %x, %x\n", #__x, #__y, #__z, __x, __y, __z)
+#define DBGIF(__x, __y) printf("%s, %s: %i, %f\n", #__x, #__y, __x, __y)
+#define DBGIF2(__x, __y, __z) printf("%s, %s, %s: %i, %f, %f\n", #__x, #__y, #__z, __x, __y, __z)
+#define DBGF(__x) printf("%s: %f\n", #__x, __x)
+#define DBGF2(__x, __y) printf("%s, %s: %f, %f\n", #__x, #__y, __x, __y)
+#define DBGF3(__x, __y, __z) printf("%s, %s, %s: %f, %f, %f\n", #__x, #__y, #__z, __x, __y, __z)
+#define DBGF4(__x, __y, __z, __w) printf("%s, %s, %s, %s: %f, %f, %f, %f\n", #__x, #__y, #__z, #__w, __x, __y, __z, __w)
+#define DBGH(__x) printf("%s: %f\n", #__x, __half2float(__x))
+#define DBGH2(__x, __y) printf("%s, %s: %f, %f\n", #__x, #__y, __half2float(__x), __half2float(__y))
+#define DBGH3(__x, __y, __z) printf("%s, %s, %s: %f, %f, %f\n", #__x, #__y, #__z, __half2float(__x), __half2float(__y), __half2float(__z))
+#define DBGIH(__x, __y) printf("%s, %s: %i, %f\n", #__x, #__y, __x, __half2float(__y))
+#define DBGIH2(__x, __y, __z) printf("%s, %s, %s: %i, %f, %f\n", #__x, #__y, #__z, __x, __half2float(__y), __half2float(__z))
+#define DBGI2H2(__x, __y, __z, __w) printf("%s, %s, %s, %s: %i, %i, %f, %f\n", #__x, #__y, #__z, #__w, __x, __y, __half2float(__z), __half2float(__w))
+#define DBGIH3(__x, __y, __z, __w) printf("%s, %s, %s, %s: %i, %f, %f, %f\n", #__x, #__y, #__z, #__w, __x, __half2float(__y), __half2float(__z), __half2float(__w))
+#define DBGIH4(__x, __y, __z, __w, __v) printf("%s, %s, %s, %s, %s: %i, %f, %f, %f, %f\n", #__x, #__y, #__z, #__w, #__v, __x, __half2float(__y), __half2float(__z), __half2float(__w), __half2float(__v))
+#define DBGA(__x) printf("%s: %016llx\n", #__x, __x)
+#define DBGIA(__x, __y) printf("%s, %s: %i, %016llx\n", #__x, #__y, __x, __y)
+#define DBGI2A(__x, __y, __z) printf("%s, %s, %s: %i, %i, %016llx\n", #__x, #__y, #__z, __x, __y, __z)
+
+#define TIME_START \
+    auto start = std::chrono::high_resolution_clock::now()
+
+#define TIME_STOP \
+    do { \
+        auto stop = std::chrono::high_resolution_clock::now(); \
+        auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(stop - start); \
+        DBGI(duration_us); \
+    } while (false)
+
+/*
+Compile-time for loop. Supports template instancing. Example usage:
+
+int kernel_arg = select_kernel_somehow();
+
+// Not nice
+if (kernel_arg == 2)
+    launch_kernel_instance<2><<< ... >>>( ... )
+if (kernel_arg == 3)
+    launch_kernel_instance<3><<< ... >>>( ... )
+if (kernel_arg == 4)
+    launch_kernel_instance<4><<< ... >>>( ... )
+if (kernel_arg == 6)
+    launch_kernel_instance<6><<< ... >>>( ... )
+if (kernel_arg == 8)
+    launch_kernel_instance<8><<< ... >>>( ... )
+
+// Nice?
+static_for_pack<2, 3, 4, 6, 8>([&](auto ic)
+{
+    constexpr int i = decltype(ic)::value;
+    if (kernel_arg == i)
+        launch_kernel_instance<i><<< ... >>>( ... )
+});
+
+// Ultimately much cleaner
+#define __(i, j) quant_cache_paged_kernel<i, j>
+constexpr auto quant_cache_paged_kernel_instances = std::array
+{
+    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
+    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
+    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
+    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
+    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
+    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
+    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
+};
+#undef __
+*/
+
+// This breaks with nesting on VC++ older than 17.13 (late 2024 preview)
+template <int... Values, class F>
+constexpr void static_for_pack(F&& f)
+{
+    (f(std::integral_constant<int, Values>{}), ...);
+}

--- a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
+++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
@@ -136,3 +136,5 @@ constexpr void static_for_pack(F&& f)
 {
     (f(std::integral_constant<int, Values>{}), ...);
 }
+// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
+// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3

--- a/sparkinfer/moe/_shared/kernels/dynamic.py
+++ b/sparkinfer/moe/_shared/kernels/dynamic.py
@@ -822,7 +822,11 @@ class MoEDynamicKernelBackend:
             source_tile_m=materialized_source_tile_m,
             deterministic_output=bool(deterministic_output),
             num_topk=self.num_topk,
-            activation=self.activation,
+            # This helper is gated-only and is never launched unless the split
+            # materialized path is active.  Use a valid inert specialization for
+            # non-split activations (notably ReLU2) instead of rejecting them
+            # during otherwise valid monolithic-kernel construction.
+            activation=self.activation if self.w4a8_split_materialized else "silu",
         )
         self.materialized_phase2_kernel = W4A8MaterializedPhase2Kernel(
             source_tile_m=materialized_source_tile_m,

--- a/sparkinfer/moe/_shared/kernels/dynamic.py
+++ b/sparkinfer/moe/_shared/kernels/dynamic.py
@@ -4200,15 +4200,7 @@ class MoEDynamicKernelBackend:
             # region; A bufs in sA past the FC2-intermediate bytes; FC1
             # residual bufs in sC (dead until the epilogue rendezvous); FC2
             # residual bufs alias the (FC1-only) A-buf region.
-            if cutlass.const_expr(self.w4a8_repacked):
-                w4a8_sa0 = (
-                    ctrl_base_addr
-                    + Int32(Storage._offsets["sA"])
-                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
-                )
-                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
-                w4a8_res2 = w4a8_sa0
-            elif cutlass.const_expr(self.w4a8_small):
+            if cutlass.const_expr(self.w4a8_repacked or self.w4a8_small):
                 w4a8_sa0 = (
                     ctrl_base_addr
                     + Int32(Storage._offsets["sA"])

--- a/sparkinfer/moe/_shared/kernels/dynamic.py
+++ b/sparkinfer/moe/_shared/kernels/dynamic.py
@@ -1069,12 +1069,8 @@ class MoEDynamicKernelBackend:
         # MMA dispatch selector: FP6/FP8 byte-containers are indistinguishable
         # from FP8 by dtype, so pass the explicit sub-format string ("e4m3"/
         # "e2m3"/"e3m2"); the native FP4 path keeps passing the operand dtype.
-        self._mma_fmt_a = (
-            self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
-        )
-        self._mma_fmt_b = (
-            self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
-        )
+        self._mma_fmt_a = self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
+        self._mma_fmt_b = self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
         self.num_m_tiles = self.tile_shape_mnk[0] // (16 * self.atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (8 * self.atom_shape[1])
@@ -1409,9 +1405,7 @@ class MoEDynamicKernelBackend:
             beta = cutlass.Float32(SITU_DEFAULT_BETA)
             linear_beta = cutlass.Float32(SITU_DEFAULT_LINEAR_BETA)
             situ_gate = (
-                beta
-                * cute.math.tanh(gate / beta, fastmath=self.fast_math)
-                * sigmoid
+                beta * cute.math.tanh(gate / beta, fastmath=self.fast_math) * sigmoid
             )
             situ_up = linear_beta * cute.math.tanh(
                 up / linear_beta,
@@ -2640,9 +2634,7 @@ class MoEDynamicKernelBackend:
             # for the expansion (cute.recast_tensor strips sB's swizzle), and
             # ``storage`` must not be referenced inside warp-dispatch branches,
             # so only these Int32 addresses may cross into them.
-            sB_packed = cute.make_tensor(
-                storage.sB.data_ptr(), b_packed_smem_staged
-            )
+            sB_packed = cute.make_tensor(storage.sB.data_ptr(), b_packed_smem_staged)
             sB_up_packed = cute.make_tensor(
                 storage.sB_up.data_ptr(), b_packed_smem_staged
             )
@@ -5908,23 +5900,17 @@ class MoEDynamicKernelBackend:
                                 zero_total = Int32(128) * sf_blocks_per_row
                                 zero_idx = Int32(tidx)
                                 while zero_idx < zero_total:
-                                    st_shared_u8(
-                                        sfa_base_addr + zero_idx, Uint8(0)
-                                    )
+                                    st_shared_u8(sfa_base_addr + zero_idx, Uint8(0))
                                     zero_idx += Int32(
-                                        self.num_mma_warps
-                                        * self.num_threads_per_warp
+                                        self.num_mma_warps * self.num_threads_per_warp
                                     )
                                 self.epilog_sync_barrier.arrive_and_wait()
                                 zero_total_sa = Int32(128) * packed_cols
                                 zsa_idx = Int32(tidx)
                                 while zsa_idx < zero_total_sa:
-                                    st_shared_u8(
-                                        sa_base_addr + zsa_idx, Uint8(0)
-                                    )
+                                    st_shared_u8(sa_base_addr + zsa_idx, Uint8(0))
                                     zsa_idx += Int32(
-                                        self.num_mma_warps
-                                        * self.num_threads_per_warp
+                                        self.num_mma_warps * self.num_threads_per_warp
                                     )
                                 self.epilog_sync_barrier.arrive_and_wait()
                             quant_gs_value = gs_value
@@ -6011,9 +5997,7 @@ class MoEDynamicKernelBackend:
                                             ]
                                         )
                                         values[elem_idx] = value
-                                        block_max = fmax_f32(
-                                            block_max, fabs_f32(value)
-                                        )
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
                                     containers, scale_byte = (
                                         moe_mxfp6_quantize_input_block_containers(
                                             values,
@@ -6032,9 +6016,7 @@ class MoEDynamicKernelBackend:
                                     _row_flat = row * Int32(self.tile_shape_mnk[2])
                                     for elem_idx in cutlass.range_constexpr(32):
                                         _flat = (
-                                            _row_flat
-                                            + block_start
-                                            + Int32(elem_idx)
+                                            _row_flat + block_start + Int32(elem_idx)
                                         )
                                         st_shared_u8(
                                             sa_base_addr + (_flat ^ _row_sw),
@@ -6054,9 +6036,7 @@ class MoEDynamicKernelBackend:
                                             ]
                                         )
                                         values[elem_idx] = value
-                                        block_max = fmax_f32(
-                                            block_max, fabs_f32(value)
-                                        )
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
 
                                     packed64 = Uint64(0)
                                     scale_byte = Uint8(0)

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -562,7 +562,11 @@ class MoEMicroKernelBackend:
         col: Int32,
         n_cols: Int32,
     ) -> Float32:
-        addr = base_addr + ebase + Int64(kb16) * Int64(n_cols) + Int64(col)
+        # ModelOpt's E4M3 scale permutation is tiled in 64 output rows. Direct
+        # micro preparation retains the final padded tile so every permuted
+        # logical scale remains addressable.
+        packed_n_cols = (n_cols + Int32(63)) & ~Int32(63)
+        addr = base_addr + ebase + Int64(kb16) * Int64(packed_n_cols) + Int64(col)
         word = ld_global_nc_u32(addr & ~Int64(3))
         byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
         return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
@@ -2417,7 +2421,9 @@ class MoEMicroKernelBackend:
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
             ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
-            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.k_dim // 16) * cfg.two_n)
+            ebase_sf_packed_e4m3 = Int64(eid) * Int64(
+                (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
+            )
             thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
             xh_buf_base = Int32(0)
             if cutlass.const_expr(cfg.k_segments == 2):

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -857,10 +857,38 @@ class MoEMicroKernelBackend:
             row_mode_32_1 = k_row1 & Int32(31)
 
             kk_off = Int32(kk) * Int32(128)
-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+            if cutlass.const_expr(cfg.n < 256):
+                # The 128-u32 swizzle block pads narrow intermediates to 256
+                # logical values. FC1 writes only n/8 lanes in each 32-lane
+                # plane. Mask the remaining lanes before the dot: their
+                # weights are zero, but stale NaN scratch would make 0*NaN
+                # contaminate the warp reduction.
+                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                xh0 = (
+                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh1 = (
+                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh2 = (
+                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh3 = (
+                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+            else:
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
 
             u_packed0 = (
                 ld_global_nc_u32(
@@ -1508,10 +1536,36 @@ class MoEMicroKernelBackend:
             ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
 
             kk_off = token_inter_base + Int32(kk) * Int32(128)
-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+            if cutlass.const_expr(cfg.n < 256):
+                # Match the m==1 path above: the packed 128-u32 swizzle has
+                # unwritten padding whenever the logical intermediate is
+                # narrower than 256 values.
+                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                xh0 = (
+                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh1 = (
+                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh2 = (
+                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+                xh3 = (
+                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+                    if inter_valid > Int32(0)
+                    else Uint32(0)
+                )
+            else:
+                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
 
             u_packed0 = (
                 ld_global_nc_u32(

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -1120,12 +1120,20 @@ class MoEMicroKernelBackend:
                 if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
                     packed_u32 = Int32(nc * 32) + lane
                     w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
-                # If the last 256-wide chunk overhangs a non-256-aligned n
-                # (e.g. n=384), lanes past num_cb index the uninitialized
-                # intermediate tail. The weight there is already masked to 0,
-                # but 0 * NaN = NaN, so mask the activation read too. Gated by
-                # constexpr so 256-aligned shapes emit no extra runtime work.
-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                # If the last 256-value chunk overhangs logical n, lanes past
+                # the exact native row read an unwritten intermediate tail.
+                # The padded scale grid can look full at widths such as n=496,
+                # so its control-block count is not a valid activation bound.
+                # The weight is zero there, but 0 * NaN still poisons the sum.
+                # Preserve the legacy predicate for non-W4A16 modes and emit
+                # no extra work for 256-aligned native ModelOpt shapes.
+                if cutlass.const_expr(
+                    (self.w4a16_mode and cfg.n % 256 != 0)
+                    or (
+                        (not self.w4a16_mode)
+                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
+                    )
+                ):
                     xh0 = (
                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
                         if w_valid > Int32(0)
@@ -1936,9 +1944,15 @@ class MoEMicroKernelBackend:
                                 w2s_base_addr + next_ebase_sf + next_bsf_off3
                             )
                 kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
-                # See _m1_fc2_rowpair_wide: mask the intermediate tail read for
-                # non-256-aligned n (0 weight * NaN tail = NaN). constexpr-gated.
-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
+                # See _m1_fc2_rowpair_wide: logical n, not the padded scale
+                # grid, determines whether the native intermediate tail is live.
+                if cutlass.const_expr(
+                    (self.w4a16_mode and cfg.n % 256 != 0)
+                    or (
+                        (not self.w4a16_mode)
+                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
+                    )
+                ):
                     xh0 = (
                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
                         if w_valid > Int32(0)

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -719,8 +719,16 @@ class MoEMicroKernelBackend:
             num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
         if self.w4a16_mode and m > 1:
             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
-            # the 512-thread launch register limit.
-            num_fc1_chunks = max(num_fc1_chunks, n // (_BLOCK_SIZE * 2))
+            # the 512-thread launch register limit. The chunk count must still
+            # divide n into whole 16-value blocks: floor(n/32) silently made
+            # i_chunk non-integral at shapes such as n=144 (four 36-value
+            # chunks), so FC1 wrote only 128 of 144 logical values.
+            num_fc1_chunks = max(
+                num_fc1_chunks,
+                (n + (_BLOCK_SIZE * 2) - 1) // (_BLOCK_SIZE * 2),
+            )
+            while n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0:
+                num_fc1_chunks += 1
         if self.a8_mx_mode:
             # Per-32 self-ranging blocks: chunks must hold whole 32-blocks
             # (the default policy picks i_chunk=16 at m<=2).
@@ -821,6 +829,14 @@ class MoEMicroKernelBackend:
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+            # Native ModelOpt rows contain exactly n/8 packed u32 values.
+            # w2_sf_cols is padded to four scale columns, so its control-block
+            # count overstates the physical W2/packed-scale extent when n is a
+            # multiple of 16 but not 64 (for example, n=144). Keep the existing
+            # predicate byte-for-byte for the aligned production shapes, and
+            # gate odd-shape loads against the logical packed row instead.
+            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
         lane_mode_c = (lane >> Int32(1)) & Int32(3)
         bsf_byte_shift = lane_mode_c * Int32(8)
         out_acc0 = Float32(0.0)
@@ -1087,6 +1103,9 @@ class MoEMicroKernelBackend:
                 kk_off = Int32(kk) * n_u32_per_expert + chunk_base
                 cb_idx = Int32(nc) * Int32(4) + lane_cb
                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                    packed_u32 = Int32(nc * 32) + lane
+                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
                 # If the last 256-wide chunk overhangs a non-256-aligned n
                 # (e.g. n=384), lanes past num_cb index the uninitialized
                 # intermediate tail. The weight there is already masked to 0,
@@ -1499,6 +1518,8 @@ class MoEMicroKernelBackend:
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
+        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
         lane_mode_c = (lane >> Int32(1)) & Int32(3)
         bsf_byte_shift = lane_mode_c * Int32(8)
         out_acc0 = Float32(0.0)
@@ -1780,9 +1801,20 @@ class MoEMicroKernelBackend:
                 chunk_base = Int32(nc) * Int32(128)
                 cb_idx = Int32(nc) * Int32(4) + lane_cb
                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                    packed_u32 = Int32(nc * 32) + lane
+                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
                 if cutlass.const_expr(nc + 1 < cfg.fc2_n_chunks):
                     next_cb_idx = Int32(nc + 1) * Int32(4) + lane_cb
-                    if next_cb_idx < num_cb:
+                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
+                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                        next_packed_u32 = Int32((nc + 1) * 32) + lane
+                        next_w_valid = (
+                            Int32(1)
+                            if next_packed_u32 < Int32(cfg.n // 8)
+                            else Int32(0)
+                        )
+                    if next_w_valid > Int32(0):
                         next_chunk_base = Int32(nc + 1) * Int32(128)
                         prefetch_global_l2(
                             w2_base_addr
@@ -1820,7 +1852,12 @@ class MoEMicroKernelBackend:
                         cfg.w2_sf_rows * cfg.w2_sf_cols
                     )
                     next_cb_idx = lane_cb
-                    if next_cb_idx < num_cb:
+                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
+                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
+                        next_w_valid = (
+                            Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+                        )
+                    if next_w_valid > Int32(0):
                         prefetch_global_l2(
                             w2_base_addr
                             + next_ebase_w

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -716,7 +716,21 @@ class MoEMicroKernelBackend:
                 rows_per_warp_div = 4
             elif cfg.k_segments_aligned and cfg.k_segments == 12 and self.is_gated:
                 rows_per_warp_div = 1
-            num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
+            num_fc1_chunks = min(
+                num_fc1_chunks,
+                max(1, n // (rows_per_warp_div * _BLOCK_SIZE)),
+            )
+            # The retile cap is a floor division, so it can choose a chunk
+            # count that no longer partitions a merely 16-aligned native
+            # ModelOpt intermediate (for example, n=144 caps 9 chunks at 4,
+            # yielding a truncated 36-value chunk). Walk down to the largest
+            # valid divisor so every FC1 chunk covers whole 16-value blocks.
+            # Aligned production shapes retain their existing geometry.
+            while num_fc1_chunks > 1 and (
+                n % num_fc1_chunks != 0
+                or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
+            ):
+                num_fc1_chunks -= 1
         if self.w4a16_mode and m > 1:
             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
             # the 512-thread launch register limit. The chunk count must still

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -106,9 +106,7 @@ def _fp6_micro_enabled() -> bool:
     Keeps the validated dynamic FP6 fused path as the only FP6 backend until
     the micro kernel is wired into dispatch and numerically proven.
     """
-    return os.environ.get(
-        "SPARKINFER_ENABLE_FP6_MICRO", "0"
-    ).strip().lower() not in (
+    return os.environ.get("SPARKINFER_ENABLE_FP6_MICRO", "0").strip().lower() not in (
         "",
         "0",
         "false",
@@ -727,8 +725,7 @@ class MoEMicroKernelBackend:
             # valid divisor so every FC1 chunk covers whole 16-value blocks.
             # Aligned production shapes retain their existing geometry.
             while num_fc1_chunks > 1 and (
-                n % num_fc1_chunks != 0
-                or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
+                n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
             ):
                 num_fc1_chunks -= 1
         if self.w4a16_mode and m > 1:
@@ -2486,9 +2483,7 @@ class MoEMicroKernelBackend:
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
             e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
-            ebase_sf_packed = Int64(eid) * Int64(
-                (cfg.k_dim // 32) * e8m0_w1_n_cols
-            )
+            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * e8m0_w1_n_cols)
             ebase_sf_packed_e4m3 = Int64(eid) * Int64(
                 (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
             )

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -2471,7 +2471,10 @@ class MoEMicroKernelBackend:
             # ---- FC1 weight load + dot product ----
             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
-            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
+            e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
+            ebase_sf_packed = Int64(eid) * Int64(
+                (cfg.k_dim // 32) * e8m0_w1_n_cols
+            )
             ebase_sf_packed_e4m3 = Int64(eid) * Int64(
                 (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
             )
@@ -2644,7 +2647,7 @@ class MoEMicroKernelBackend:
 
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                            nc1 = Int32(cfg.two_n)
+                            nc1 = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -2768,7 +2771,7 @@ class MoEMicroKernelBackend:
 
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbbg = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                        nc1g = Int32(cfg.two_n)
+                        nc1g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3085,7 +3088,7 @@ class MoEMicroKernelBackend:
                         sf_u5 = Float32(0.0)
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb_u = lane_seg_base >> Int32(1)
-                            nc_u = Int32(cfg.two_n)
+                            nc_u = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -3225,7 +3228,7 @@ class MoEMicroKernelBackend:
                     sf_g5 = Float32(0.0)
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbb_g = lane_seg_base >> Int32(1)
-                        nc_g = Int32(cfg.two_n)
+                        nc_g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3463,7 +3466,7 @@ class MoEMicroKernelBackend:
 
                         if cutlass.const_expr(self.scale_format_e8m0_k32):
                             kbb_u = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                            nc_u = Int32(cfg.two_n)
+                            nc_u = Int32(e8m0_w1_n_cols)
                             u_k0 = self._ld_e8m0_scale(
                                 w1s_base_addr,
                                 ebase_sf_packed,
@@ -3645,7 +3648,7 @@ class MoEMicroKernelBackend:
 
                     if cutlass.const_expr(self.scale_format_e8m0_k32):
                         kbb_g = (lane * Int32(cfg.k_segments)) >> Int32(1)
-                        nc_g = Int32(cfg.two_n)
+                        nc_g = Int32(e8m0_w1_n_cols)
                         g_k0 = self._ld_e8m0_scale(
                             w1s_base_addr,
                             ebase_sf_packed,
@@ -3940,7 +3943,7 @@ class MoEMicroKernelBackend:
                                 ebase_sf_packed,
                                 lane,
                                 row_u,
-                                Int32(cfg.two_n),
+                                Int32(e8m0_w1_n_cols),
                                 Int32(cfg.k_dim // 32),
                             )
                             sf_u1 = sf_u0
@@ -3976,7 +3979,7 @@ class MoEMicroKernelBackend:
                             ebase_sf_packed,
                             lane,
                             row_g,
-                            Int32(cfg.two_n),
+                            Int32(e8m0_w1_n_cols),
                             Int32(cfg.k_dim // 32),
                         )
                         sf_g1 = sf_g0
@@ -4470,7 +4473,7 @@ class MoEMicroKernelBackend:
                                         ebase_sf_packed,
                                         scale_col >> Int32(1),
                                         row_g,
-                                        Int32(cfg.two_n),
+                                        Int32(e8m0_w1_n_cols),
                                         Int32(cfg.k_dim // 32),
                                     )
                                     if valid_seg > Int32(0)
@@ -4527,7 +4530,7 @@ class MoEMicroKernelBackend:
                                             ebase_sf_packed,
                                             scale_col >> Int32(1),
                                             row_u,
-                                            Int32(cfg.two_n),
+                                            Int32(e8m0_w1_n_cols),
                                             Int32(cfg.k_dim // 32),
                                         )
                                         if valid_seg > Int32(0)

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -752,9 +752,7 @@ class MoEMicroKernelBackend:
             # Likewise FC2 can expose every output-row task directly once
             # FC1 has completed in a prior launch.
             grid_x = max(1, fc2_tasks)
-        elif m == 1:
-            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
-        elif m == 2:
+        elif m in (1, 2):
             grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
         elif num_fc1_chunks < 16:
             grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
@@ -815,7 +813,6 @@ class MoEMicroKernelBackend:
         k_row1 = k_row0 + Int32(1)
 
         lane_byte_off = Int64(lane) * Int64(4)
-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
         sf_cols = Int32(cfg.w2_sf_cols)
         num_cb = sf_cols >> Int32(2)
         lane_cb = lane >> Int32(3)
@@ -1274,7 +1271,6 @@ class MoEMicroKernelBackend:
         k_row3 = k_row0 + Int32(3)
 
         lane_byte_off = Int64(lane) * Int64(4)
-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
         token_inter_base = t * Int32(cfg.inter_u32)
         sf_cols = Int32(cfg.w2_sf_cols)
         num_cb = sf_cols >> Int32(2)

--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
@@ -219,6 +219,20 @@ def select_route_block_size_m(m: int, topk: int, num_experts: int) -> int:
     return _W4A16_ALLOWED_ROUTED_SIZES[-1]
 
 
+def route_block_sizes_for_capacity(
+    max_tokens: int,
+    topk: int,
+    num_experts: int,
+) -> tuple[int, ...]:
+    """Conservative block-size set reachable within a token capacity."""
+    max_tokens = max(int(max_tokens), 1)
+    first = select_route_block_size_m(1, topk, num_experts)
+    last = select_route_block_size_m(max_tokens, topk, num_experts)
+    first_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(first)
+    last_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(last)
+    return _W4A16_ALLOWED_ROUTED_SIZES[first_idx : last_idx + 1]
+
+
 def max_packed_route_slots(numel: int, block_size: int, num_experts: int) -> int:
     max_packed_routes = int(numel) + int(num_experts) * (int(block_size) - 1)
     if int(numel) < int(num_experts):

--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
@@ -254,6 +254,27 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
     return 1 << (max(int(tokens), 1) - 1).bit_length()
 
 
+def route_pack_capacity(
+    numel: int,
+    block_size: int,
+    num_experts: int,
+    *,
+    topk: int = 1,
+    bucket_tokens: bool = True,
+) -> tuple[int, int, int]:
+    """Return the canonical routed-row, packed-slot, and block capacities."""
+    numel_capacity = (
+        route_pack_numel_capacity(numel, topk=topk)
+        if bucket_tokens
+        else max(int(numel), 1)
+    )
+    packed_routes = max_packed_route_slots(
+        numel_capacity, int(block_size), int(num_experts)
+    )
+    route_blocks = (packed_routes + int(block_size) - 1) // int(block_size)
+    return max(numel_capacity, 1), max(packed_routes, 1), max(route_blocks, 1)
+
+
 def max_w4a16_route_capacity(routed_rows: int, num_experts: int) -> tuple[int, int]:
     route_slots = 0
     route_blocks = 0
@@ -446,6 +467,7 @@ __all__ = [
     "plan_w4a16_buffers",
     "reorder_w13_to_gate_up",
     "route_pack_numel_capacity",
+    "route_pack_capacity",
     "route_pack_token_capacity",
     "select_route_block_size_m",
     "unswizzle_block_scale",

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -89,6 +89,7 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
     packed_gemm_scratch_elements,
     plan_w4a16_buffers,
+    route_pack_capacity,
     select_route_block_size_m,
     validate_activation,
 )
@@ -10197,6 +10198,23 @@ def _resolve_route_block_size_m(
     return compiled
 
 
+def _w4a16_stream_is_capturing(
+    stream: cuda.CUstream,
+    *,
+    current_stream: cuda.CUstream,
+) -> bool:
+    """Observe capture on either Torch's current stream or an explicit stream."""
+    current_capturing = torch.cuda.is_current_stream_capturing()
+    if current_capturing or int(stream) == int(current_stream):
+        return current_capturing
+    result, status = cuda.cuStreamIsCapturing(stream)
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(
+            f"cuStreamIsCapturing failed for the selected W4A16 stream: {result}"
+        )
+    return int(status) != 0
+
+
 def run_w4a16_moe(
     a_input: torch.Tensor,
     prepared,
@@ -10465,7 +10483,8 @@ def run_w4a16_moe(
     if block_size_m not in _ALLOWED_ROUTED_SIZES:
         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
 
-    stream = current_cuda_stream() if stream is None else stream
+    current_stream = current_cuda_stream()
+    stream = current_stream if stream is None else stream
     if (not collect_activation_amax) and _small_m_direct_supported(
         m=m,
         hidden_size=hidden_size,
@@ -10627,15 +10646,21 @@ def run_w4a16_moe(
         )
 
     route_slots_for_scratch = int(m) * int(topk) * int(block_size_m)
-    required_m_blocks = int(m) * int(topk) if use_direct_topk_routes else 0
+    if use_direct_topk_routes:
+        required_m_blocks = int(m) * int(topk)
+    else:
+        _, _, required_m_blocks = route_pack_capacity(
+            int(m) * int(topk),
+            int(block_size_m),
+            route_num_experts,
+            topk=topk,
+        )
     if fused_launch is not None and not use_direct_topk_routes:
-        route_slots_capacity = max_packed_route_slots(
+        _, route_slots_capacity, route_blocks_capacity = route_pack_capacity(
             int(fused_launch.size_m) * int(topk),
             int(block_size_m),
             route_num_experts,
-        )
-        route_blocks_capacity = (route_slots_capacity + int(block_size_m) - 1) // int(
-            block_size_m
+            topk=topk,
         )
         if packed_route_indices is not None:
             if int(packed_route_indices.numel()) < route_slots_capacity:
@@ -10671,7 +10696,12 @@ def run_w4a16_moe(
             )
         )
         route_slots_for_scratch = int(packed_route_indices.numel())
-        required_m_blocks = int(block_expert_ids.numel())
+        if int(block_expert_ids.numel()) != int(required_m_blocks):
+            raise RuntimeError(
+                "W4A16 route packing did not produce the canonical launch capacity: "
+                f"runtime={int(block_expert_ids.numel())}, "
+                f"planned={int(required_m_blocks)}"
+            )
 
     props = torch.cuda.get_device_properties(a_input.device)
     sms = int(props.multi_processor_count)
@@ -10752,7 +10782,10 @@ def run_w4a16_moe(
             intermediate_rotation=intermediate_rotation_scales is not None,
             full_rotation=full_rotation,
             rotation_input_dtype=rotation_input_dtype,
-            _require_cached=torch.cuda.is_current_stream_capturing(),
+            _require_cached=_w4a16_stream_is_capturing(
+                stream,
+                current_stream=current_stream,
+            ),
         )
     else:
         if int(fused_launch.size_m) < m:

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -7480,6 +7480,7 @@ def compile_w4a16_fused_moe(
     full_rotation: bool = False,
     rotation_input_dtype: str | None = None,
     broadcast_suh: bool = False,
+    _require_cached: bool = False,
 ) -> W4A16FusedMoeCompileResult:
     scale_format = _normalize_scale_format(scale_format)
     intermediate_rotation = bool(intermediate_rotation)
@@ -7866,6 +7867,13 @@ def compile_w4a16_fused_moe(
             num_experts=num_experts,
             max_m_blocks=max_m_blocks,
             blocks_per_sm=kernel.blocks_per_sm,
+        )
+    if _require_cached:
+        raise RuntimeError(
+            "W4A16 fused MoE launch is not resolved for CUDA graph capture "
+            f"(m={size_m}, moe_block_size={moe_block_size}, "
+            f"max_m_blocks={max_m_blocks}); run an eager warmup at this token "
+            "count before capturing"
         )
 
     if (not collect_activation_amax) and _small_m_direct_supported(
@@ -10744,6 +10752,7 @@ def run_w4a16_moe(
             intermediate_rotation=intermediate_rotation_scales is not None,
             full_rotation=full_rotation,
             rotation_input_dtype=rotation_input_dtype,
+            _require_cached=torch.cuda.is_current_stream_capturing(),
         )
     else:
         if int(fused_launch.size_m) < m:

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -6921,9 +6921,7 @@ class W4A16TopKSumKernel:
                         v1 = fc2_flat[base + Int32(1)].to(cutlass.Float32)
                         v2 = fc2_flat[base + Int32(2)].to(cutlass.Float32)
                         v3 = fc2_flat[base + Int32(3)].to(cutlass.Float32)
-                        h0, h1, h2, h3 = self._had128_quad(
-                            v0, v1, v2, v3, lane
-                        )
+                        h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
                         if cutlass.const_expr(self.broadcast_svh):
                             sbase = col0
                         else:
@@ -8940,9 +8938,7 @@ def _w4a16_fused_moe_launch_flat(
             )
         suh_gate_arg = suh_gate_table.reshape(-1)
         suh_up_arg = suh_up_table.reshape(-1)
-        broadcast_suh = (
-            num_experts > 1 and suh_gate_arg.numel() == hidden_size
-        )
+        broadcast_suh = num_experts > 1 and suh_gate_arg.numel() == hidden_size
         if broadcast_suh != (suh_up_arg.numel() == hidden_size):
             raise ValueError(
                 "suh gate/up tables must both be per-expert or both broadcast"

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -201,6 +201,9 @@ _W4A16_REGS_SM121 = {
     (256, 2, 16, 4, False): 212,
     (128, 2, 4, 8, False): 215,
     (128, 2, 8, 4, False): 214,
+    # Measured from the spill-free mixed-Trellis block-32 prefill kernel.
+    # FC2 keeps the paired-M8 schedule qualified by mixed_trellis.py.
+    (256, 2, 8, 8, False): 175,
     (256, 3, 16, 4, False): 249,
     (128, 3, 4, 8, False): 249,
     (128, 3, 8, 4, False): 250,

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -205,6 +205,11 @@ _W4A16_REGS_SM121 = {
     (128, 3, 4, 8, False): 249,
     (128, 3, 8, 4, False): 250,
     (256, 4, 16, 4, False): 255,
+    # Measured by the mixed-Trellis block-64 qualification gate. This is the
+    # stock one-grid prefill tile geometry (N=128, K=128) with four 16-row
+    # route blocks per CTA. Keeping the measured entry permits block-64
+    # routing without changing the K3/K4 accumulation geometry.
+    (256, 4, 8, 8, False): 255,
     (128, 4, 4, 8, False): 255,
     (128, 4, 8, 4, False): 255,
 }
@@ -4602,6 +4607,7 @@ class W4A16FusedMoeKernel:
         fc2_tile_k: int,
         moe_block_size: int,
         max_m_blocks: int,
+        fc2_moe_block_size: int | None = None,
         element_dtype: str = "bf16",
         fast_math: bool = True,
         swiglu_limit: float | None = None,
@@ -4675,6 +4681,18 @@ class W4A16FusedMoeKernel:
         }
         self.top_k = int(top_k)
         self.moe_block_size = int(moe_block_size)
+        self.fc2_moe_block_size = int(
+            moe_block_size if fc2_moe_block_size is None else fc2_moe_block_size
+        )
+        if (
+            self.fc2_moe_block_size not in _ALLOWED_ROUTED_SIZES
+            or self.moe_block_size % self.fc2_moe_block_size != 0
+        ):
+            raise ValueError(
+                "FC2 route subtile must be an allowed divisor of the packed "
+                f"route block: packed={self.moe_block_size}, "
+                f"fc2={self.fc2_moe_block_size}"
+            )
         self.activation = activation
         self.activation_is_gated = is_gated
         self.activation_is_situ = activation == SITU
@@ -4781,8 +4799,10 @@ class W4A16FusedMoeKernel:
             ),
             tile_n=fc2_tile_n,
             tile_k=fc2_tile_k,
-            moe_block_size=moe_block_size,
-            max_m_blocks=max_m_blocks,
+            moe_block_size=self.fc2_moe_block_size,
+            max_m_blocks=(
+                max_m_blocks * self.moe_block_size // self.fc2_moe_block_size
+            ),
             element_dtype=element_dtype,
             weight_layout=weight_layout,
             scale_format=scale_format,

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -11,10 +11,14 @@ import cuda.bindings.driver as cuda
 import cuda.bindings.runtime as cuda_runtime
 import cutlass
 import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as cutlass_utils
+import cutlass.utils.hopper_helpers as sm90_utils
 import torch
 from cutlass.base_dsl.compiler import OptLevel
 from cutlass._mlir.dialects import llvm
-from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, Uint64, dsl_user_op
+from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, dsl_user_op
+from cutlass.cute.nvgpu import cpasync
 
 from sparkinfer._lib.compiler import (
     KernelCompileSpec,
@@ -78,6 +82,7 @@ from sparkinfer._lib.intrinsics import (
     st_shared_v4_f32,
     st_shared_v4_u32,
     threadfence,
+    trellis_align_stream_u32x2,
     warp_reduce,
 )
 from sparkinfer._lib.utils import current_cuda_stream, make_ptr
@@ -515,6 +520,7 @@ class W4A16GemmCompileResult:
     w13_layout: str = "w13"
     dense_route_fast_path: bool = False
     trellis_bits: int = 3
+    tma_warp_specialized: bool = False
 
 
 @dataclass(frozen=True)
@@ -1099,6 +1105,13 @@ class W4A16GemmKernel:
     @cute.jit
     def _int4_addr(self, smem_base: Int32, int4_off: Int32) -> Int32:
         return smem_base + int4_off * Int32(16)
+
+    @cute.jit
+    def _epilogue_sync(self, sync_barrier: cutlass.Constexpr = None):
+        if cutlass.const_expr(sync_barrier is None):
+            cute.arch.sync_threads()
+        else:
+            sync_barrier.arrive_and_wait()
 
     @cute.jit
     def _dequant_e2m1x4_to_elem2x2(self, packed: Uint32):
@@ -2875,11 +2888,20 @@ class W4A16GemmKernel:
         reduce_slice_idx: Int32,
         lock_slot: Int32,
         uses_m_block_8: cutlass.Constexpr[bool],
+        sync_barrier: cutlass.Constexpr = None,
     ):
         if cutlass.const_expr(uses_m_block_8):
             self._fold_cta_partials_m8(acc0, smem_base, tid)
         else:
-            self._fold_cta_partials_large_m(acc0, acc1, acc2, acc3, smem_base, tid)
+            self._fold_cta_partials_large_m(
+                acc0,
+                acc1,
+                acc2,
+                acc3,
+                smem_base,
+                tid,
+                sync_barrier,
+            )
 
         if reduce_slice_count > Int32(1):
             self._wait_for_reduction_turn(
@@ -2929,6 +2951,7 @@ class W4A16GemmKernel:
                     output_n_tile,
                     block_valid_rows,
                     global_scale_f32,
+                    sync_barrier,
                 )
 
     @cute.jit
@@ -3708,16 +3731,9 @@ class W4A16GemmKernel:
                 z0 = ld_shared_u32(b_region + (tbase + i0) * Int32(4))
                 z1 = ld_shared_u32(b_region + (tbase + i1) * Int32(4))
                 z2 = ld_shared_u32(b_region + (tbase + i2) * Int32(4))
-                stream64 = Uint64(0)
-                if delta == Int32(1):
-                    stream64 = ((Uint64(z0) << Uint64(32)) | Uint64(z2)) >> Uint64(s2)
-                else:
-                    lower64 = (Uint64(z1) << Uint64(32)) | Uint64(z2)
-                    stream64 = (lower64 >> Uint64(s2)) | (
-                        Uint64(z0) << (Uint64(64) - Uint64(s2))
-                    )
-                wa[jj] = Uint32(stream64)
-                wb[jj] = Uint32(stream64 >> Uint64(32))
+                wa[jj], wb[jj] = trellis_align_stream_u32x2(
+                    z0, z1, z2, s2, delta
+                )
         return wa[0], wa[1], wa[2], wa[3], wb[0], wb[1], wb[2], wb[3]
 
     @cute.jit
@@ -4632,6 +4648,7 @@ class W4A16GemmKernel:
         block_valid_rows: Int32,
         metadata_row_base: Int32,
         store_iters: cutlass.Constexpr[int],
+        sync_barrier: cutlass.Constexpr = None,
     ):
         for _ in cutlass.range_constexpr(store_iters):
             row = c_gl_wr // c_gl_stride
@@ -4688,7 +4705,7 @@ class W4A16GemmKernel:
                     )
             c_gl_wr += c_gl_wr_delta
             c_sh_rd += c_sh_rd_delta
-        cute.arch.sync_threads()
+        self._epilogue_sync(sync_barrier)
 
     @cute.jit
     def _drain_output_smem_tail(
@@ -4704,6 +4721,7 @@ class W4A16GemmKernel:
         block_valid_rows: Int32,
         metadata_row_base: Int32,
         store_iters: cutlass.Constexpr[int],
+        sync_barrier: cutlass.Constexpr = None,
     ):
         for _ in cutlass.range_constexpr(store_iters):
             row = c_gl_wr // c_gl_stride_covered
@@ -4752,7 +4770,7 @@ class W4A16GemmKernel:
                     )
             c_gl_wr += c_gl_wr_delta
             c_sh_rd += c_sh_rd_delta
-        cute.arch.sync_threads()
+        self._epilogue_sync(sync_barrier)
 
     @cute.jit
     def _store_tile_m8(
@@ -4872,6 +4890,7 @@ class W4A16GemmKernel:
         acc3,
         smem_base: Int32,
         tid: Int32,
+        sync_barrier: cutlass.Constexpr = None,
     ):
         red_off = self.cta_threads // self.b_sh_stride_threads // 2
         if cutlass.const_expr(red_off >= 1):
@@ -4889,6 +4908,7 @@ class W4A16GemmKernel:
                         red_sh_stride,
                         red_sh_delta,
                         red_sh_rd,
+                        sync_barrier,
                     )
                 elif cutlass.const_expr(mb == 1):
                     self._fold_cta_partials_large_m_block(
@@ -4899,6 +4919,7 @@ class W4A16GemmKernel:
                         red_sh_stride,
                         red_sh_delta,
                         red_sh_rd,
+                        sync_barrier,
                     )
                 elif cutlass.const_expr(mb == 2):
                     self._fold_cta_partials_large_m_block(
@@ -4909,6 +4930,7 @@ class W4A16GemmKernel:
                         red_sh_stride,
                         red_sh_delta,
                         red_sh_rd,
+                        sync_barrier,
                     )
                 else:
                     self._fold_cta_partials_large_m_block(
@@ -4919,6 +4941,7 @@ class W4A16GemmKernel:
                         red_sh_stride,
                         red_sh_delta,
                         red_sh_rd,
+                        sync_barrier,
                     )
 
     @cute.jit
@@ -4931,6 +4954,7 @@ class W4A16GemmKernel:
         red_sh_stride: Int32,
         red_sh_delta: Int32,
         red_sh_rd: Int32,
+        sync_barrier: cutlass.Constexpr = None,
     ):
         if cutlass.const_expr(red_off == 2):
             if Int32(2) <= red_idx and red_idx < Int32(4):
@@ -4953,7 +4977,7 @@ class W4A16GemmKernel:
                             (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
                         ],
                     )
-            cute.arch.sync_threads()
+            self._epilogue_sync(sync_barrier)
 
         if Int32(1) <= red_idx and red_idx < Int32(2):
             for flat_j in cutlass.range_constexpr(8):
@@ -5022,7 +5046,7 @@ class W4A16GemmKernel:
                         (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
                     ],
                 )
-        cute.arch.sync_threads()
+        self._epilogue_sync(sync_barrier)
 
         if red_idx == Int32(0):
             for flat_j in cutlass.range_constexpr(8):
@@ -5063,7 +5087,7 @@ class W4A16GemmKernel:
                     ]
                     + r3
                 )
-        cute.arch.sync_threads()
+        self._epilogue_sync(sync_barrier)
 
     @cute.jit
     def _write_bf16x2_shared(
@@ -5093,6 +5117,7 @@ class W4A16GemmKernel:
         output_n_tile: Int32,
         block_valid_rows: Int32,
         global_scale_f32: cutlass.Float32,
+        sync_barrier: cutlass.Constexpr = None,
     ):
         if cutlass.const_expr(self.has_n_tile_tail):
             (
@@ -5142,7 +5167,7 @@ class W4A16GemmKernel:
                         acc3, smem_base, c_sh_wr, c_sh_stride, write_scale
                     )
                 c_sh_wr += Int32(16 * (4 * (2 * self.cta_n_blocks + 1)))
-        cute.arch.sync_threads()
+        self._epilogue_sync(sync_barrier)
 
         store_iters = _covering_count(
             16 * self.cta_m_blocks,
@@ -5161,6 +5186,7 @@ class W4A16GemmKernel:
                 block_valid_rows,
                 Int32(0),
                 store_iters,
+                sync_barrier,
             )
         else:
             self._drain_output_smem(
@@ -5174,6 +5200,7 @@ class W4A16GemmKernel:
                 block_valid_rows,
                 Int32(0),
                 store_iters,
+                sync_barrier,
             )
 
     @cute.jit
@@ -5231,6 +5258,534 @@ class W4A16GemmKernel:
                 ],
                 write_scale,
             )
+
+
+class W4A16TrellisDenseTmaKernel(W4A16GemmKernel):
+    """Experimental K6 dense GEMM with a dedicated TMA producer warp.
+
+    This path intentionally retains the existing Trellis dequant, MMA lane
+    mapping, reduction, and store code. Only global-to-shared staging changes:
+    one dedicated producer warp moves the contiguous A tile and native K6
+    payload while four consumer warps compute. Keeping it as a separate gated
+    kernel makes the experiment incapable of changing routed MoE or non-K6
+    behavior.
+    """
+
+    # Two complete warpgroups preserve enough registers for the accumulator:
+    # four compute warps, then one DMA warp plus three idle producer warps.
+    _TMA_THREADS = 8 * 32
+    _TMA_COMPUTE_THREADS = 4 * 32
+    _TMA_STAGES = 2
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if not (
+            self.dense_route_fast_path
+            and self.weight_layout_trellis256
+            and self.trellis_bits == 6
+            and self.is_fp16
+            and self.moe_block_size == 64
+            and self.tile_k == 64
+            and self.tile_n == 128
+            and self.cta_threads == self._TMA_COMPUTE_THREADS
+            and self.schedule_whole_tiles
+            and not self.has_logical_tail
+            and not self.dual_a
+        ):
+            raise ValueError(
+                "Trellis dense TMA warp specialization requires exact FP16 K6 "
+                "E=1 M64/K64/N128 whole-tile geometry"
+            )
+        self.tma_compute_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self._TMA_COMPUTE_THREADS,
+        )
+        # Separate two-stage A/B TMA storage leaves room for one CTA per SM.
+        # The base kernel's occupancy estimate only accounts for its legacy
+        # aliased storage and can otherwise launch an oversized persistent grid.
+        self.blocks_per_sm = 1
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (*super().__cache_key__, "trellis_dense_tma_warp_v21_linear")
+
+    @cute.jit
+    def __call__(
+        self,
+        a_bf16_ptr: cute.Pointer,
+        a_alt_bf16_ptr: cute.Pointer,
+        b_i32: cute.Tensor,
+        c_bf16_ptr: cute.Pointer,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        a_smem_layout = cute.tile_to_shape(
+            cute.nvgpu.warpgroup.make_smem_layout_atom(
+                sm90_utils.get_smem_layout_atom(
+                    cutlass_utils.LayoutEnum.ROW_MAJOR,
+                    cutlass.Float16,
+                    self.tile_k,
+                ),
+                cutlass.Float16,
+            ),
+            (self.moe_block_size, self.tile_k, self._TMA_STAGES),
+            order=(1, 0, 2),
+        )
+        b_smem_layout = cute.make_layout(
+            (
+                self.cta_k_blocks,
+                self.cta_n_blocks,
+                8 * self.trellis_bits,
+                self._TMA_STAGES,
+            ),
+            stride=(
+                self.cta_n_blocks * (8 * self.trellis_bits),
+                8 * self.trellis_bits,
+                1,
+                self.cta_k_blocks
+                * self.cta_n_blocks
+                * (8 * self.trellis_bits),
+            ),
+        )
+        a = cute.make_tensor(
+            a_bf16_ptr,
+            layout=cute.make_layout(
+                (active_m, Int32(self.size_k)),
+                stride=(Int32(self.size_k), 1),
+            ),
+        )
+        c_bf16_flat = cute.make_tensor(
+            c_bf16_ptr,
+            layout=cute.make_layout(
+                (active_m * Int32(self.size_n),),
+                stride=(1,),
+            ),
+        )
+        a_atom_tma, a_tma = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            a,
+            cute.slice_(a_smem_layout, (None, None, 0)),
+            (self.moe_block_size, self.tile_k),
+            num_multicast=1,
+        )
+        b_atom_tma, b_tma = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            b_i32,
+            cute.slice_(b_smem_layout, (None, None, None, 0)),
+            (self.cta_k_blocks, self.cta_n_blocks, 8 * self.trellis_bits),
+            num_multicast=1,
+        )
+        self.kernel_tma(
+            a_atom_tma,
+            a_tma,
+            b_atom_tma,
+            b_tma,
+            c_bf16_flat,
+            scales_i32_flat,
+            global_scale,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            topk_weights_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            active_m,
+            a_smem_layout,
+            b_smem_layout,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=(self._TMA_THREADS, 1, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel_tma(
+        self,
+        a_atom_tma: cute.CopyAtom,
+        a: cute.Tensor,
+        b_atom_tma: cute.CopyAtom,
+        b: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.Layout,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        tid = Int32(tidx)
+        warp_idx = tid // Int32(32)
+        cta = Int32(bidx)
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            barriers: cute.struct.MemRange[
+                cutlass.Int64, self._TMA_STAGES * 2
+            ]
+            prefix: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.sh_a_off * 4],
+                1024,
+            ]
+            sa: cute.struct.MemRange[
+                cutlass.Float16,
+                cute.cosize(a_smem_layout),
+            ]
+            sb_data: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, cute.cosize(b_smem_layout)],
+                1024,
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.prefix.data_ptr())
+        sa = storage.sa.get_tensor(
+            a_smem_layout.outer,
+            swizzle=a_smem_layout.inner,
+        )
+        sb = storage.sb_data.get_tensor(b_smem_layout)
+        b_smem_base = shared_ptr_to_u32(storage.sb_data.data_ptr())
+        ga = cute.local_tile(
+            a,
+            (self.moe_block_size, self.tile_k),
+            (None, None),
+        )
+        gb = cute.local_tile(
+            b,
+            (self.cta_k_blocks, self.cta_n_blocks, 8 * self.trellis_bits),
+            (None, None, None),
+        )
+        cta_layout = cute.make_layout(1)
+        tsa, tga = cpasync.tma_partition(
+            a_atom_tma,
+            0,
+            cta_layout,
+            cute.group_modes(sa, 0, 2),
+            cute.group_modes(ga, 0, 2),
+        )
+        tsb, tgb = cpasync.tma_partition(
+            b_atom_tma,
+            0,
+            cta_layout,
+            cute.group_modes(sb, 0, 3),
+            cute.group_modes(gb, 0, 3),
+        )
+        tma_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self._TMA_STAGES,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 4),
+            tx_count=(
+                self.moe_block_size * self.tile_k * 2
+                + self.cta_k_blocks
+                * self.cta_n_blocks
+                * (8 * self.trellis_bits)
+                * 4
+            ),
+            barrier_storage=storage.barriers.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        if tid == Int32(0):
+            cpasync.prefetch_descriptor(a_atom_tma)
+            cpasync.prefetch_descriptor(b_atom_tma)
+        cute.arch.sync_threads()
+
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer,
+            self._TMA_STAGES,
+        )
+        consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer,
+            self._TMA_STAGES,
+        )
+        if warp_idx < Int32(4):
+            cute.arch.setmaxregister_increase(248)
+        else:
+            cute.arch.setmaxregister_decrease(24)
+        grid_x, _, _ = cute.arch.grid_dim()
+        route_blocks = active_m // Int32(self.moe_block_size)
+        total_tiles = route_blocks * Int32(self.n_tiles)
+        work_tile = cta
+        while work_tile < total_tiles:
+            route_block_idx = work_tile // Int32(self.n_tiles)
+            output_n_tile = work_tile - route_block_idx * Int32(self.n_tiles)
+            self._run_tile_tma(
+                a,
+                c_bf16_flat,
+                global_scale,
+                packed_route_indices,
+                topk_weights_flat,
+                c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                b_smem_base,
+                tid,
+                warp_idx,
+                route_block_idx,
+                output_n_tile,
+                Int32(0),
+                Int32(self.k_tiles),
+                Int32(1),
+                Int32(0),
+                Int32(0),
+                active_m,
+                a_atom_tma,
+                b_atom_tma,
+                tsa,
+                tga,
+                tsb,
+                tgb,
+                tma_pipeline,
+                producer_state,
+                consumer_state,
+            )
+            work_tile += Int32(grid_x)
+        if warp_idx == Int32(4):
+            tma_pipeline.producer_tail(producer_state)
+
+    @cute.jit
+    def _run_tile_tma(
+        self,
+        a: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        b_smem_base: Int32,
+        tid: Int32,
+        warp_idx: Int32,
+        route_block_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_m: Int32,
+        a_atom_tma: cute.CopyAtom,
+        b_atom_tma: cute.CopyAtom,
+        tsa: cute.Tensor,
+        tga: cute.Tensor,
+        tsb: cute.Tensor,
+        tgb: cute.Tensor,
+        tma_pipeline,
+        producer_state,
+        consumer_state,
+    ):
+        (
+            global_scale_f32,
+            block_valid_rows,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            b_sh_rd,
+            s_sh_rd,
+        ) = self._tile_common_prologue(
+            global_scale,
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            Int32(0),
+            output_n_tile,
+            active_m,
+        )
+
+        if warp_idx == Int32(4):
+            tile_idx = Int32(0)
+            while tile_idx < reduce_tile_count:
+                tma_pipeline.producer_acquire(producer_state)
+                source_k_tile = reduce_k_tile + tile_idx
+                cute.copy(
+                    a_atom_tma,
+                    tga[(None, route_block_idx, source_k_tile)],
+                    tsa[(None, producer_state.index)],
+                    tma_bar_ptr=tma_pipeline.producer_get_barrier(producer_state),
+                )
+                cute.copy(
+                    b_atom_tma,
+                    tgb[(None, source_k_tile, output_n_tile, Int32(0))],
+                    tsb[(None, producer_state.index)],
+                    tma_bar_ptr=tma_pipeline.producer_get_barrier(producer_state),
+                )
+                tma_pipeline.producer_commit(producer_state)
+                producer_state.advance()
+                tile_idx += Int32(1)
+        elif warp_idx < Int32(4):
+            self._consume_tile_tma(
+                c_bf16_flat,
+                c_tmp_f32_flat,
+                locks_i32_flat,
+                smem_base,
+                b_smem_base,
+                tid,
+                output_n_tile,
+                block_valid_rows,
+                global_scale_f32,
+                reduce_tile_count,
+                reduce_slice_count,
+                reduce_slice_idx,
+                lock_slot,
+                tma_pipeline,
+                consumer_state,
+                b_sh_rd,
+                s_sh_rd,
+            )
+
+        # Keep producer and consumers together through the complete tile
+        # lifecycle before this CTA can leave the pipeline.
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _consume_tile_tma(
+        self,
+        c_bf16_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        b_smem_base: Int32,
+        tid: Int32,
+        output_n_tile: Int32,
+        block_valid_rows: Int32,
+        global_scale_f32: cutlass.Float32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        tma_pipeline,
+        consumer_state,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+    ):
+        a_sh_rd = self._a_shared_read_offset(tid, 16)
+        acc0 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        acc1 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        acc2 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        acc3 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
+            acc0[frag].fill(0.0)
+            acc1[frag].fill(0.0)
+            acc2[frag].fill(0.0)
+            acc3[frag].fill(0.0)
+
+        b_regs = cute.make_rmem_tensor((2, 4), Uint32)
+        a_regs = cute.make_rmem_tensor((self.cta_m_blocks, 4), Uint32)
+        b_frag = cute.make_rmem_tensor((2, 2), Uint32)
+        tile_idx = Int32(0)
+        while tile_idx < reduce_tile_count:
+            tma_pipeline.consumer_wait(consumer_state)
+            pipe = consumer_state.index
+            for kk in cutlass.range_constexpr(self.b_sh_wr_iters):
+                q0, q1, q2, q3, s0, s1, s2, s3 = (
+                    self._load_b_registers_trellis256(
+                        # The shared loader adds the legacy B-region offset.
+                        # Cancel it here because sb_data is already the region
+                        # base of the separate TMA staging allocation.
+                        b_smem_base - Int32(self.sh_b_off * 16),
+                        tid,
+                        pipe,
+                        Int32(kk),
+                    )
+                )
+                b_regs[0, 0] = q0
+                b_regs[0, 1] = q1
+                b_regs[0, 2] = q2
+                b_regs[0, 3] = q3
+                b_regs[1, 0] = s0
+                b_regs[1, 1] = s1
+                b_regs[1, 2] = s2
+                b_regs[1, 3] = s3
+                self._load_a_register_bundle(
+                    a_regs,
+                    smem_base,
+                    a_sh_rd,
+                    pipe,
+                    Int32(kk),
+                    False,
+                )
+                for jj in cutlass.range_constexpr(4):
+                    self._scaled_dequant_b_fragment_trellis256(
+                        b_frag,
+                        b_regs[0, jj],
+                        b_regs[1, jj],
+                    )
+                    for mb in cutlass.range_constexpr(self.cta_m_blocks):
+                        if cutlass.const_expr(mb == 0):
+                            self._mma_accumulate_large_m(
+                                acc0, a_regs, mb, jj, b_frag
+                            )
+                        elif cutlass.const_expr(mb == 1):
+                            self._mma_accumulate_large_m(
+                                acc1, a_regs, mb, jj, b_frag
+                            )
+                        elif cutlass.const_expr(mb == 2):
+                            self._mma_accumulate_large_m(
+                                acc2, a_regs, mb, jj, b_frag
+                            )
+                        else:
+                            self._mma_accumulate_large_m(
+                                acc3, a_regs, mb, jj, b_frag
+                            )
+            tma_pipeline.consumer_release(consumer_state)
+            consumer_state.advance()
+            tile_idx += Int32(1)
+
+        self._finish_tile(
+            acc0,
+            acc1,
+            acc2,
+            acc3,
+            c_bf16_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            output_n_tile,
+            block_valid_rows,
+            global_scale_f32,
+            reduce_slice_count,
+            reduce_slice_idx,
+            lock_slot,
+            False,
+            self.tma_compute_barrier,
+        )
 
 
 class W4A16FusedMoeKernel:
@@ -7709,10 +8264,156 @@ class W4A16TopKSumKernel:
         return h0 * rs, h1 * rs, h2 * rs, h3 * rs
 
 
+class W4A16DenseHadamard128Kernel:
+    """FP16 blockwise H128 used by native dense Trellis linears.
+
+    EXL3 applies an incoherence scale before the input rotation and after the
+    output rotation.  Keeping both forms in one SparkInfer kernel removes the
+    runtime dependency on exllamav3_ext while preserving that ordering.
+    """
+
+    def __init__(self, *, width: int, scale_before: bool):
+        if width <= 0 or width % 128 != 0:
+            raise ValueError("dense H128 width must be a positive multiple of 128")
+        self.width = int(width)
+        self.scale_before = bool(scale_before)
+        self.cta_threads = 256
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (self.width, self.scale_before, self.cta_threads)
+
+    @cute.jit
+    def __call__(
+        self,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        scale_ptr: cute.Pointer,
+        active_m: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        input_flat = cute.make_tensor(
+            input_ptr,
+            layout=cute.make_layout((active_m * Int32(self.width),), stride=(1,)),
+        )
+        output_flat = cute.make_tensor(
+            output_ptr,
+            layout=cute.make_layout((active_m * Int32(self.width),), stride=(1,)),
+        )
+        scale_flat = cute.make_tensor(
+            scale_ptr,
+            layout=cute.make_layout((Int32(self.width),), stride=(1,)),
+        )
+        total_units = active_m * Int32(self.width // 128)
+        grid = (_covering_count(total_units, self.cta_threads // 32), 1, 1)
+        self.kernel(input_flat, output_flat, scale_flat, active_m).launch(
+            grid=grid,
+            block=[self.cta_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        input_flat: cute.Tensor,
+        output_flat: cute.Tensor,
+        scale_flat: cute.Tensor,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        tid = Int32(tidx)
+        lane = tid & Int32(31)
+        warp = tid >> Int32(5)
+        unit = Int32(bidx) * Int32(self.cta_threads // 32) + warp
+        nblocks = Int32(self.width // 128)
+        total_units = active_m * nblocks
+        if unit < total_units:
+            row = unit // nblocks
+            block = unit - row * nblocks
+            col0 = block * Int32(128) + lane * Int32(4)
+            base = row * Int32(self.width) + col0
+            v0 = input_flat[base + Int32(0)].to(cutlass.Float32)
+            v1 = input_flat[base + Int32(1)].to(cutlass.Float32)
+            v2 = input_flat[base + Int32(2)].to(cutlass.Float32)
+            v3 = input_flat[base + Int32(3)].to(cutlass.Float32)
+            if cutlass.const_expr(self.scale_before):
+                # exllamav3 uses __hmul2 before the transform; preserve the
+                # intermediate fp16 rounding instead of promoting the product.
+                v0 = cutlass.Float16(
+                    v0 * scale_flat[col0 + Int32(0)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                v1 = cutlass.Float16(
+                    v1 * scale_flat[col0 + Int32(1)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                v2 = cutlass.Float16(
+                    v2 * scale_flat[col0 + Int32(2)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+                v3 = cutlass.Float16(
+                    v3 * scale_flat[col0 + Int32(3)].to(cutlass.Float32)
+                ).to(cutlass.Float32)
+            h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
+            if cutlass.const_expr(not self.scale_before):
+                # The reference rounds H128 to fp16 before the post-scale.
+                h0 = cutlass.Float16(h0).to(cutlass.Float32) * scale_flat[
+                    col0 + Int32(0)
+                ].to(cutlass.Float32)
+                h1 = cutlass.Float16(h1).to(cutlass.Float32) * scale_flat[
+                    col0 + Int32(1)
+                ].to(cutlass.Float32)
+                h2 = cutlass.Float16(h2).to(cutlass.Float32) * scale_flat[
+                    col0 + Int32(2)
+                ].to(cutlass.Float32)
+                h3 = cutlass.Float16(h3).to(cutlass.Float32) * scale_flat[
+                    col0 + Int32(3)
+                ].to(cutlass.Float32)
+            output_flat[base + Int32(0)] = cutlass.Float16(h0)
+            output_flat[base + Int32(1)] = cutlass.Float16(h1)
+            output_flat[base + Int32(2)] = cutlass.Float16(h2)
+            output_flat[base + Int32(3)] = cutlass.Float16(h3)
+
+    @cute.jit
+    def _had128_quad(
+        self,
+        v0: cutlass.Float32,
+        v1: cutlass.Float32,
+        v2: cutlass.Float32,
+        v3: cutlass.Float32,
+        lane: Int32,
+    ):
+        s0 = v0 + v1
+        d0 = v0 - v1
+        s1 = v2 + v3
+        d1 = v2 - v3
+        h0 = s0 + s1
+        h1 = d0 + d1
+        h2 = s0 - s1
+        h3 = d0 - d1
+        for i in cutlass.range_constexpr(5):
+            step = 1 << i
+            p0 = cute.arch.shuffle_sync_bfly(h0, offset=step)
+            p1 = cute.arch.shuffle_sync_bfly(h1, offset=step)
+            p2 = cute.arch.shuffle_sync_bfly(h2, offset=step)
+            p3 = cute.arch.shuffle_sync_bfly(h3, offset=step)
+            if (lane & Int32(step)) != Int32(0):
+                h0 = p0 - h0
+                h1 = p1 - h1
+                h2 = p2 - h2
+                h3 = p3 - h3
+            else:
+                h0 = p0 + h0
+                h1 = p1 + h1
+                h2 = p2 + h2
+                h3 = p3 + h3
+        scale = cutlass.Float32(0.088388347648)
+        return h0 * scale, h1 * scale, h2 * scale, h3 * scale
+
+
 _CACHE: dict[tuple, W4A16GemmCompileResult] = {}
 _FUSED_CACHE: dict[tuple, W4A16FusedMoeCompileResult] = {}
 _ACTIVATION_CACHE: dict[tuple, W4A16ActivationCompileResult] = {}
 _SUM_CACHE: dict[tuple, W4A16TopKSumCompileResult] = {}
+_DENSE_HAD128_CACHE: dict[tuple, object] = {}
 _SMALL_M_DIRECT_CACHE: dict[tuple, _W4A16SmallMDirectLaunch] = {}
 
 
@@ -7986,7 +8687,26 @@ def compile_w4a16_gemm(
         device = int(torch.cuda.current_device())
     else:
         device = None
-    kernel = W4A16GemmKernel(
+    tma_warp_specialized = bool(
+        os.environ.get("SPARKINFER_TRELLIS_DENSE_TMA_WARP", "0") == "1"
+        and dense_route_fast_path
+        and weight_layout == "trellis3_t256"
+        and int(trellis_bits) == 6
+        and element_dtype == "fp16"
+        and int(moe_block_size) == 64
+        and int(tile_k) == 64
+        and int(tile_n) == 128
+        and int(size_m) % 64 == 0
+        and int(size_n) % 256 == 0
+        and int(size_k) % 64 == 0
+        and w13_layout == "packed"
+    )
+    kernel_cls = (
+        W4A16TrellisDenseTmaKernel
+        if tma_warp_specialized
+        else W4A16GemmKernel
+    )
+    kernel = kernel_cls(
         size_m=size_m,
         size_n=size_n,
         size_k=size_k,
@@ -8018,7 +8738,11 @@ def compile_w4a16_gemm(
             blocks_per_sm=kernel.blocks_per_sm,
         )
 
-    compile_size_m = _fake_m_for_specialization(size_m)
+    compile_size_m = (
+        int(size_m)
+        if tma_warp_specialized
+        else _fake_m_for_specialization(size_m)
+    )
     compile_route_blocks = 1
     compile_route_slots = compile_route_blocks * int(moe_block_size)
     a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
@@ -8028,11 +8752,19 @@ def compile_w4a16_gemm(
         )
     else:
         b_fake_elements = num_experts * (size_k // 16) * (size_n // 16 * 32)
-    b_fake = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32,
-        (b_fake_elements,),
-        assumed_align=16,
-    )
+    if tma_warp_specialized:
+        b_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (size_k // 16, size_n // 16, 8 * int(trellis_bits)),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+    else:
+        b_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (b_fake_elements,),
+            assumed_align=16,
+        )
     c_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     scales_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
@@ -8112,6 +8844,7 @@ def compile_w4a16_gemm(
             3,
             cache_key,
         ),
+        dsl_compile_options=(OptLevel(2) if tma_warp_specialized else None),
     )
     result = W4A16GemmCompileResult(
         compiled=compiled,
@@ -8125,6 +8858,7 @@ def compile_w4a16_gemm(
         w13_layout=w13_layout,
         dense_route_fast_path=bool(dense_route_fast_path),
         trellis_bits=int(trellis_bits),
+        tma_warp_specialized=tma_warp_specialized,
     )
     _CACHE[cache_key] = result
     return result
@@ -10549,6 +11283,107 @@ def _trellis256_dense_tile_config(size_k: int, size_n: int) -> tuple[int, int]:
     )
 
 
+def _trellis256_dense_launch_geometry(
+    *,
+    size_m: int,
+    size_k: int,
+    size_n: int,
+    sms: int,
+) -> tuple[int, tuple[int, int]]:
+    """Avoid short spill waves in the persistent dense-Trellis schedule.
+
+    A default M64/N256 launch can leave only a handful of CTAs in a second or
+    third SM wave. Narrow projections benefit from a smaller M tile, while wide
+    projections already expose enough N parallelism and only need N128 for a
+    two-wave spill. Past three waves the smaller tile's scheduler overhead costs
+    more than the remaining imbalance.
+    """
+    default = (64, (64, 256 if size_n % 256 == 0 else 128))
+    if size_n % 256 != 0 or sms <= 0:
+        return default
+    tasks = _covering_count(int(size_m), 64) * (int(size_n) // 256)
+    waves = _covering_count(tasks, int(sms))
+    if waves not in (2, 3):
+        return default
+    spill = tasks - (waves - 1) * int(sms)
+    if spill > max(16, int(sms) // 10):
+        return default
+    n_tiles_256 = int(size_n) // 256
+    if n_tiles_256 <= 32:
+        return (48, (64, 128 if waves == 2 else 256))
+    if waves == 2:
+        return (64, (64, 128))
+    if int(size_k) <= 4096:
+        return (48, (64, 256))
+    return default
+
+
+def _compile_trellis_dense_hadamard128(*, width: int, scale_before: bool):
+    cache_key = ("trellis_dense_hadamard128", int(width), bool(scale_before))
+    cached = _DENSE_HAD128_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    kernel = W4A16DenseHadamard128Kernel(
+        width=int(width),
+        scale_before=bool(scale_before),
+    )
+    fp16_fake = make_ptr(
+        cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = sparkinfer_compile(
+        kernel,
+        fp16_fake,
+        fp16_fake,
+        fp16_fake,
+        Int32(1),
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "gemm.trellis_dense.hadamard128",
+            1,
+            cache_key,
+        ),
+    )
+    _DENSE_HAD128_CACHE[cache_key] = compiled
+    return compiled
+
+
+def _run_trellis_dense_hadamard128(
+    x: torch.Tensor,
+    output: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    scale_before: bool,
+) -> None:
+    if x.dtype != torch.float16 or output.dtype != torch.float16:
+        raise TypeError("native dense H128 requires fp16 input and output")
+    if x.ndim != 2 or output.shape != x.shape or not x.is_contiguous():
+        raise ValueError("native dense H128 requires equal contiguous rank-2 tensors")
+    if not output.is_contiguous() or output.device != x.device:
+        raise ValueError("native dense H128 output must be contiguous on the input device")
+    if (
+        scale.dtype != torch.float16
+        or scale.device != x.device
+        or not scale.is_contiguous()
+        or scale.numel() != x.shape[1]
+    ):
+        raise ValueError("native dense H128 scale must be contiguous fp16 with width elements")
+    compiled = _compile_trellis_dense_hadamard128(
+        width=int(x.shape[1]),
+        scale_before=bool(scale_before),
+    )
+    fp16 = cutlass.Float16
+    compiled(
+        make_ptr(fp16, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(fp16, output.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(fp16, scale.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
+        int(x.shape[0]),
+        current_cuda_stream(),
+    )
+
+
 def _resolve_exl3_hadamard_128(hadamard_128):
     if hadamard_128 is None:
         try:
@@ -10610,6 +11445,8 @@ def _run_trellis256_dense_current_device(
     output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
+    _moe_block_size: int = 64,
+    _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Run one native EXL3 linear on the already-selected CUDA device.
 
@@ -10664,6 +11501,75 @@ def _run_trellis256_dense_current_device(
         dtype=x.dtype,
         device=x.device,
     )
+    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
+        raise ValueError("c_tmp must be at least 16-byte aligned")
+
+    external_hadamard_128 = (
+        None
+        if hadamard_128 is None
+        else _resolve_exl3_hadamard_128(hadamard_128)
+    )
+
+    # Decode and small batches use one cooperative K6 kernel that owns both
+    # H128 rotations. This avoids three launches and the generic routed-GEMM
+    # scheduler while retaining the checkpoint-native Trellis representation.
+    use_k6_small = (
+        m <= 128
+        and trellis_bits == 6
+        and compute_dtype == torch.float16
+        and external_hadamard_128 is None
+    )
+    if use_k6_small:
+        if x.dtype == torch.float16:
+            x_f16 = x
+        else:
+            input_f16 = _trellis_dense_buffer(
+                "input_f16",
+                input_f16,
+                shape=(m, size_k),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            input_f16.copy_(x)
+            x_f16 = input_f16
+        rotated_f16 = _trellis_dense_buffer(
+            "rotated_f16",
+            rotated_f16,
+            shape=(m, size_k),
+            dtype=torch.float16,
+            device=x.device,
+        )
+        if output.dtype == torch.float16:
+            small_output = output
+        else:
+            output_f16 = _trellis_dense_buffer(
+                "output_f16",
+                output_f16,
+                shape=(m, size_n),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            small_output = output_f16
+        from sparkinfer.gemm.trellis_linear._small_m import run_k6_mcg
+
+        trellis_i16 = prepared_dense.trellis.view(torch.int16).view(
+            size_k // 16,
+            size_n // 16,
+            96,
+        )
+        run_k6_mcg(
+            x_f16,
+            trellis_i16,
+            small_output,
+            prepared_dense.suh,
+            rotated_f16,
+            prepared_dense.svh,
+            prepared_dense.workspace,
+        )
+        if output.dtype != torch.float16:
+            output.copy_(small_output)
+        return output
+
     gemm_output = _trellis_dense_buffer(
         "gemm_output",
         gemm_output,
@@ -10671,10 +11577,6 @@ def _run_trellis256_dense_current_device(
         dtype=compute_dtype,
         device=x.device,
     )
-    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
-        raise ValueError("c_tmp must be at least 16-byte aligned")
-
-    hadamard_128 = _resolve_exl3_hadamard_128(hadamard_128)
     if x.dtype == torch.float16:
         x_f16 = x
     else:
@@ -10694,7 +11596,15 @@ def _run_trellis256_dense_current_device(
         dtype=torch.float16,
         device=x.device,
     )
-    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
+    if external_hadamard_128 is None:
+        _run_trellis_dense_hadamard128(
+            x_f16,
+            rotated_f16,
+            prepared_dense.suh,
+            scale_before=True,
+        )
+    else:
+        external_hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
     if compute_dtype == torch.float16:
         rotated_compute = rotated_f16
     else:
@@ -10712,10 +11622,40 @@ def _run_trellis256_dense_current_device(
     max_shared_mem = int(
         getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
     )
-    moe_block_size = 64
+    moe_block_size = int(_moe_block_size)
+    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
+        raise ValueError(
+            f"unsupported Trellis dense moe_block_size={moe_block_size}"
+        )
+    use_tma_warp_tile = bool(
+        _force_tile_config is None
+        and os.environ.get("SPARKINFER_TRELLIS_DENSE_TMA_WARP", "0") == "1"
+        and moe_block_size == 64
+        and trellis_bits == 6
+        and compute_dtype == torch.float16
+        and m == 2048
+        and size_k == 4096
+        and size_n == 6144
+    )
+    if use_tma_warp_tile:
+        # The warp-specialized K6 kernel uses a narrower N tile to fit separate
+        # two-stage A/B TMA pipelines without reducing the compute warp budget.
+        tile_k, tile_n = (64, 128)
+    elif _force_tile_config is None and moe_block_size == 64:
+        moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
+            size_m=m,
+            size_k=size_k,
+            size_n=size_n,
+            sms=sms,
+        )
+    else:
+        tile_k, tile_n = (
+            _trellis256_dense_tile_config(size_k, size_n)
+            if _force_tile_config is None
+            else (int(_force_tile_config[0]), int(_force_tile_config[1]))
+        )
     route_blocks = (m + moe_block_size - 1) // moe_block_size
     route_slots = route_blocks * moe_block_size
-    tile_k, tile_n = _trellis256_dense_tile_config(size_k, size_n)
     launch = _compile_w4a16_gemm_launch(
         size_m=m,
         size_n=size_n,
@@ -10746,6 +11686,13 @@ def _run_trellis256_dense_current_device(
         sms * int(launch.kernel.blocks_per_sm),
         max(route_blocks * n_tiles, 1),
     )
+    trellis_arg = prepared_dense.trellis
+    if launch.kernel.tma_warp_specialized:
+        trellis_arg = prepared_dense.trellis.view(torch.int32).view(
+            size_k // 16,
+            size_n // 16,
+            8 * trellis_bits,
+        )
     launch.kernel.compiled(
         make_ptr(
             cutlass_dtype,
@@ -10759,7 +11706,7 @@ def _run_trellis256_dense_current_device(
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
-        prepared_dense.trellis,
+        trellis_arg,
         make_ptr(
             cutlass_dtype,
             gemm_output.data_ptr(),
@@ -10792,7 +11739,15 @@ def _run_trellis256_dense_current_device(
         gemm_output_f16.copy_(gemm_output)
         gemm_f16 = gemm_output_f16
     if output.dtype == torch.float16:
-        hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
+        if external_hadamard_128 is None:
+            _run_trellis_dense_hadamard128(
+                gemm_f16,
+                output,
+                prepared_dense.svh,
+                scale_before=False,
+            )
+        else:
+            external_hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
     else:
         output_f16 = _trellis_dense_buffer(
             "output_f16",
@@ -10801,7 +11756,17 @@ def _run_trellis256_dense_current_device(
             dtype=torch.float16,
             device=x.device,
         )
-        hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
+        if external_hadamard_128 is None:
+            _run_trellis_dense_hadamard128(
+                gemm_f16,
+                output_f16,
+                prepared_dense.svh,
+                scale_before=False,
+            )
+        else:
+            external_hadamard_128(
+                gemm_f16, output_f16, None, prepared_dense.svh, 1.0
+            )
         output.copy_(output_f16)
     return output
 
@@ -10820,6 +11785,8 @@ def run_trellis256_dense(
     output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
+    _moe_block_size: int = 64,
+    _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Run one native 3/4/5/6-bpw EXL3 linear through the fused t256 GEMM.
 
@@ -10850,6 +11817,8 @@ def run_trellis256_dense(
             output_f16=output_f16,
             hadamard_128=hadamard_128,
             stream=None,
+            _moe_block_size=_moe_block_size,
+            _force_tile_config=_force_tile_config,
         )
 
 

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -11,14 +11,10 @@ import cuda.bindings.driver as cuda
 import cuda.bindings.runtime as cuda_runtime
 import cutlass
 import cutlass.cute as cute
-import cutlass.pipeline as pipeline
-import cutlass.utils as cutlass_utils
-import cutlass.utils.hopper_helpers as sm90_utils
 import torch
 from cutlass.base_dsl.compiler import OptLevel
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, dsl_user_op
-from cutlass.cute.nvgpu import cpasync
 
 from sparkinfer._lib.compiler import (
     KernelCompileSpec,
@@ -520,7 +516,6 @@ class W4A16GemmCompileResult:
     w13_layout: str = "w13"
     dense_route_fast_path: bool = False
     trellis_bits: int = 3
-    tma_warp_specialized: bool = False
 
 
 @dataclass(frozen=True)
@@ -1016,9 +1011,7 @@ class W4A16GemmKernel:
         self.s_sh_stage = self.s_tb_groups * self.s_sh_stride
         self.tb_n_warps = self.cta_n_blocks // 4
 
-        route_metadata_rows = self.moe_block_size * (
-            2 if self.paired_m8_routes else 1
-        )
+        route_metadata_rows = self.moe_block_size * (2 if self.paired_m8_routes else 1)
         sh_block_route_indices = route_metadata_rows // 4
         sh_rd_block_route_indices = route_metadata_rows // 4
         sh_block_topk_weights = route_metadata_rows // 2
@@ -1745,8 +1738,7 @@ class W4A16GemmKernel:
                 if idx >= active_size_m * Int32(self.top_k):
                     safe_idx = Int32(0)
                 topk = (
-                    topk_weights_flat[safe_idx].to(cutlass.Float32)
-                    * global_scale_f32
+                    topk_weights_flat[safe_idx].to(cutlass.Float32) * global_scale_f32
                 )
                 st_shared_u32(
                     smem_base + Int32(self.sh_topk_off * 16) + tid * Int32(4),
@@ -2802,12 +2794,10 @@ class W4A16GemmKernel:
                                 )
                             elif cutlass.const_expr(self.weight_layout_nf3):
                                 lo_w = b_scale_cur[0, jj // 2]
-                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(
-                                    0xFFFF
+                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(0xFFFF)
+                                hi8 = (b_scale_cur[0, 2] >> Uint32(8 * jj)) & Uint32(
+                                    0xFF
                                 )
-                                hi8 = (
-                                    b_scale_cur[0, 2] >> Uint32(8 * jj)
-                                ) & Uint32(0xFF)
                                 self._scaled_dequant_b_fragment_nf3(
                                     b_frag,
                                     lo16,
@@ -2815,9 +2805,7 @@ class W4A16GemmKernel:
                                     b_scale_cur[1, jj],
                                 )
                             else:
-                                q, s = self._select_b_scale_register(
-                                    jj, b_scale_cur
-                                )
+                                q, s = self._select_b_scale_register(jj, b_scale_cur)
                                 self._scaled_dequant_b_fragment(b_frag, q, s)
                             self._mma_accumulate_m8(
                                 acc0,
@@ -2832,15 +2820,9 @@ class W4A16GemmKernel:
                                 b_frag,
                             )
 
-                        self._copy_a_register_bundle_m8(
-                            a0_regs_cur, a0_regs_next
-                        )
-                        self._copy_a_register_bundle_m8(
-                            a1_regs_cur, a1_regs_next
-                        )
-                        self._copy_b_scale_register_bundle(
-                            b_scale_cur, b_scale_next
-                        )
+                        self._copy_a_register_bundle_m8(a0_regs_cur, a0_regs_next)
+                        self._copy_a_register_bundle_m8(a1_regs_cur, a1_regs_next)
+                        self._copy_b_scale_register_bundle(b_scale_cur, b_scale_next)
                     tile_idx += Int32(1)
             cute.arch.sync_threads()
             if tile_idx < k_tiles:
@@ -3731,9 +3713,7 @@ class W4A16GemmKernel:
                 z0 = ld_shared_u32(b_region + (tbase + i0) * Int32(4))
                 z1 = ld_shared_u32(b_region + (tbase + i1) * Int32(4))
                 z2 = ld_shared_u32(b_region + (tbase + i2) * Int32(4))
-                wa[jj], wb[jj] = trellis_align_stream_u32x2(
-                    z0, z1, z2, s2, delta
-                )
+                wa[jj], wb[jj] = trellis_align_stream_u32x2(z0, z1, z2, s2, delta)
         return wa[0], wa[1], wa[2], wa[3], wb[0], wb[1], wb[2], wb[3]
 
     @cute.jit
@@ -4052,9 +4032,8 @@ class W4A16GemmKernel:
                 metadata_row = Int32(-1)
                 if row < Int32(self.moe_block_size):
                     metadata_row = row
-                elif (
-                    row >= Int32(2 * self.moe_block_size)
-                    and row < Int32(3 * self.moe_block_size)
+                elif row >= Int32(2 * self.moe_block_size) and row < Int32(
+                    3 * self.moe_block_size
                 ):
                     metadata_row = row - Int32(self.moe_block_size)
             route_index = Int32(0)
@@ -4090,13 +4069,10 @@ class W4A16GemmKernel:
             if cutlass.const_expr(paired_m8):
                 if row < Int32(self.moe_block_size):
                     row_valid = row < block_valid_rows
-                elif (
-                    row >= Int32(2 * self.moe_block_size)
-                    and row < Int32(3 * self.moe_block_size)
+                elif row >= Int32(2 * self.moe_block_size) and row < Int32(
+                    3 * self.moe_block_size
                 ):
-                    row_valid = (
-                        row - Int32(2 * self.moe_block_size) < block_valid_rows1
-                    )
+                    row_valid = row - Int32(2 * self.moe_block_size) < block_valid_rows1
                 else:
                     row_valid = row < Int32(0)
             if cutlass.const_expr(self.has_k_tile_tail):
@@ -4655,9 +4631,7 @@ class W4A16GemmKernel:
             if row < block_valid_rows:
                 metadata_row = metadata_row_base + row
                 route_index = ld_shared_i32_relaxed(
-                    smem_base
-                    + Int32(self.sh_route_off * 16)
-                    + metadata_row * Int32(4)
+                    smem_base + Int32(self.sh_route_off * 16) + metadata_row * Int32(4)
                 )
                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(
                     c_gl_wr % c_gl_stride
@@ -4729,9 +4703,7 @@ class W4A16GemmKernel:
             if row < block_valid_rows and col_word < c_gl_stride:
                 metadata_row = metadata_row_base + row
                 route_index = ld_shared_i32_relaxed(
-                    smem_base
-                    + Int32(self.sh_route_off * 16)
-                    + metadata_row * Int32(4)
+                    smem_base + Int32(self.sh_route_off * 16) + metadata_row * Int32(4)
                 )
                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(col_word)
                 q0, q1, q2, q3 = ld_shared_v4_u32(
@@ -5260,534 +5232,6 @@ class W4A16GemmKernel:
             )
 
 
-class W4A16TrellisDenseTmaKernel(W4A16GemmKernel):
-    """Experimental K6 dense GEMM with a dedicated TMA producer warp.
-
-    This path intentionally retains the existing Trellis dequant, MMA lane
-    mapping, reduction, and store code. Only global-to-shared staging changes:
-    one dedicated producer warp moves the contiguous A tile and native K6
-    payload while four consumer warps compute. Keeping it as a separate gated
-    kernel makes the experiment incapable of changing routed MoE or non-K6
-    behavior.
-    """
-
-    # Two complete warpgroups preserve enough registers for the accumulator:
-    # four compute warps, then one DMA warp plus three idle producer warps.
-    _TMA_THREADS = 8 * 32
-    _TMA_COMPUTE_THREADS = 4 * 32
-    _TMA_STAGES = 2
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        if not (
-            self.dense_route_fast_path
-            and self.weight_layout_trellis256
-            and self.trellis_bits == 6
-            and self.is_fp16
-            and self.moe_block_size == 64
-            and self.tile_k == 64
-            and self.tile_n == 128
-            and self.cta_threads == self._TMA_COMPUTE_THREADS
-            and self.schedule_whole_tiles
-            and not self.has_logical_tail
-            and not self.dual_a
-        ):
-            raise ValueError(
-                "Trellis dense TMA warp specialization requires exact FP16 K6 "
-                "E=1 M64/K64/N128 whole-tile geometry"
-            )
-        self.tma_compute_barrier = pipeline.NamedBarrier(
-            barrier_id=1,
-            num_threads=self._TMA_COMPUTE_THREADS,
-        )
-        # Separate two-stage A/B TMA storage leaves room for one CTA per SM.
-        # The base kernel's occupancy estimate only accounts for its legacy
-        # aliased storage and can otherwise launch an oversized persistent grid.
-        self.blocks_per_sm = 1
-
-    @property
-    def __cache_key__(self) -> tuple[object, ...]:
-        return (*super().__cache_key__, "trellis_dense_tma_warp_v21_linear")
-
-    @cute.jit
-    def __call__(
-        self,
-        a_bf16_ptr: cute.Pointer,
-        a_alt_bf16_ptr: cute.Pointer,
-        b_i32: cute.Tensor,
-        c_bf16_ptr: cute.Pointer,
-        scales_i32_flat: cute.Tensor,
-        global_scale: cute.Tensor,
-        packed_route_indices: cute.Tensor,
-        block_expert_ids: cute.Tensor,
-        packed_route_count: cute.Tensor,
-        topk_weights_flat: cute.Tensor,
-        c_tmp_f32_flat: cute.Tensor,
-        locks_i32_flat: cute.Tensor,
-        active_m: cutlass.Int32,
-        grid_x: cutlass.Int32,
-        stream: cuda.CUstream,
-    ):
-        a_smem_layout = cute.tile_to_shape(
-            cute.nvgpu.warpgroup.make_smem_layout_atom(
-                sm90_utils.get_smem_layout_atom(
-                    cutlass_utils.LayoutEnum.ROW_MAJOR,
-                    cutlass.Float16,
-                    self.tile_k,
-                ),
-                cutlass.Float16,
-            ),
-            (self.moe_block_size, self.tile_k, self._TMA_STAGES),
-            order=(1, 0, 2),
-        )
-        b_smem_layout = cute.make_layout(
-            (
-                self.cta_k_blocks,
-                self.cta_n_blocks,
-                8 * self.trellis_bits,
-                self._TMA_STAGES,
-            ),
-            stride=(
-                self.cta_n_blocks * (8 * self.trellis_bits),
-                8 * self.trellis_bits,
-                1,
-                self.cta_k_blocks
-                * self.cta_n_blocks
-                * (8 * self.trellis_bits),
-            ),
-        )
-        a = cute.make_tensor(
-            a_bf16_ptr,
-            layout=cute.make_layout(
-                (active_m, Int32(self.size_k)),
-                stride=(Int32(self.size_k), 1),
-            ),
-        )
-        c_bf16_flat = cute.make_tensor(
-            c_bf16_ptr,
-            layout=cute.make_layout(
-                (active_m * Int32(self.size_n),),
-                stride=(1,),
-            ),
-        )
-        a_atom_tma, a_tma = cpasync.make_tiled_tma_atom(
-            cpasync.CopyBulkTensorTileG2SOp(),
-            a,
-            cute.slice_(a_smem_layout, (None, None, 0)),
-            (self.moe_block_size, self.tile_k),
-            num_multicast=1,
-        )
-        b_atom_tma, b_tma = cpasync.make_tiled_tma_atom(
-            cpasync.CopyBulkTensorTileG2SOp(),
-            b_i32,
-            cute.slice_(b_smem_layout, (None, None, None, 0)),
-            (self.cta_k_blocks, self.cta_n_blocks, 8 * self.trellis_bits),
-            num_multicast=1,
-        )
-        self.kernel_tma(
-            a_atom_tma,
-            a_tma,
-            b_atom_tma,
-            b_tma,
-            c_bf16_flat,
-            scales_i32_flat,
-            global_scale,
-            packed_route_indices,
-            block_expert_ids,
-            packed_route_count,
-            topk_weights_flat,
-            c_tmp_f32_flat,
-            locks_i32_flat,
-            active_m,
-            a_smem_layout,
-            b_smem_layout,
-        ).launch(
-            grid=(grid_x, 1, 1),
-            block=(self._TMA_THREADS, 1, 1),
-            min_blocks_per_mp=1,
-            stream=stream,
-        )
-
-    @cute.kernel
-    def kernel_tma(
-        self,
-        a_atom_tma: cute.CopyAtom,
-        a: cute.Tensor,
-        b_atom_tma: cute.CopyAtom,
-        b: cute.Tensor,
-        c_bf16_flat: cute.Tensor,
-        scales_i32_flat: cute.Tensor,
-        global_scale: cute.Tensor,
-        packed_route_indices: cute.Tensor,
-        block_expert_ids: cute.Tensor,
-        packed_route_count: cute.Tensor,
-        topk_weights_flat: cute.Tensor,
-        c_tmp_f32_flat: cute.Tensor,
-        locks_i32_flat: cute.Tensor,
-        active_m: cutlass.Int32,
-        a_smem_layout: cute.ComposedLayout,
-        b_smem_layout: cute.Layout,
-    ):
-        tidx, _, _ = cute.arch.thread_idx()
-        bidx, _, _ = cute.arch.block_idx()
-        tid = Int32(tidx)
-        warp_idx = tid // Int32(32)
-        cta = Int32(bidx)
-        smem = cutlass.utils.SmemAllocator()
-
-        @cute.struct
-        class Storage:
-            barriers: cute.struct.MemRange[
-                cutlass.Int64, self._TMA_STAGES * 2
-            ]
-            prefix: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Uint32, self.sh_a_off * 4],
-                1024,
-            ]
-            sa: cute.struct.MemRange[
-                cutlass.Float16,
-                cute.cosize(a_smem_layout),
-            ]
-            sb_data: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Int32, cute.cosize(b_smem_layout)],
-                1024,
-            ]
-
-        storage = smem.allocate(Storage)
-        smem_base = shared_ptr_to_u32(storage.prefix.data_ptr())
-        sa = storage.sa.get_tensor(
-            a_smem_layout.outer,
-            swizzle=a_smem_layout.inner,
-        )
-        sb = storage.sb_data.get_tensor(b_smem_layout)
-        b_smem_base = shared_ptr_to_u32(storage.sb_data.data_ptr())
-        ga = cute.local_tile(
-            a,
-            (self.moe_block_size, self.tile_k),
-            (None, None),
-        )
-        gb = cute.local_tile(
-            b,
-            (self.cta_k_blocks, self.cta_n_blocks, 8 * self.trellis_bits),
-            (None, None, None),
-        )
-        cta_layout = cute.make_layout(1)
-        tsa, tga = cpasync.tma_partition(
-            a_atom_tma,
-            0,
-            cta_layout,
-            cute.group_modes(sa, 0, 2),
-            cute.group_modes(ga, 0, 2),
-        )
-        tsb, tgb = cpasync.tma_partition(
-            b_atom_tma,
-            0,
-            cta_layout,
-            cute.group_modes(sb, 0, 3),
-            cute.group_modes(gb, 0, 3),
-        )
-        tma_pipeline = pipeline.PipelineTmaAsync.create(
-            num_stages=self._TMA_STAGES,
-            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
-            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 4),
-            tx_count=(
-                self.moe_block_size * self.tile_k * 2
-                + self.cta_k_blocks
-                * self.cta_n_blocks
-                * (8 * self.trellis_bits)
-                * 4
-            ),
-            barrier_storage=storage.barriers.data_ptr(),
-            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
-        )
-        if tid == Int32(0):
-            cpasync.prefetch_descriptor(a_atom_tma)
-            cpasync.prefetch_descriptor(b_atom_tma)
-        cute.arch.sync_threads()
-
-        producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer,
-            self._TMA_STAGES,
-        )
-        consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer,
-            self._TMA_STAGES,
-        )
-        if warp_idx < Int32(4):
-            cute.arch.setmaxregister_increase(248)
-        else:
-            cute.arch.setmaxregister_decrease(24)
-        grid_x, _, _ = cute.arch.grid_dim()
-        route_blocks = active_m // Int32(self.moe_block_size)
-        total_tiles = route_blocks * Int32(self.n_tiles)
-        work_tile = cta
-        while work_tile < total_tiles:
-            route_block_idx = work_tile // Int32(self.n_tiles)
-            output_n_tile = work_tile - route_block_idx * Int32(self.n_tiles)
-            self._run_tile_tma(
-                a,
-                c_bf16_flat,
-                global_scale,
-                packed_route_indices,
-                topk_weights_flat,
-                c_tmp_f32_flat,
-                locks_i32_flat,
-                smem_base,
-                b_smem_base,
-                tid,
-                warp_idx,
-                route_block_idx,
-                output_n_tile,
-                Int32(0),
-                Int32(self.k_tiles),
-                Int32(1),
-                Int32(0),
-                Int32(0),
-                active_m,
-                a_atom_tma,
-                b_atom_tma,
-                tsa,
-                tga,
-                tsb,
-                tgb,
-                tma_pipeline,
-                producer_state,
-                consumer_state,
-            )
-            work_tile += Int32(grid_x)
-        if warp_idx == Int32(4):
-            tma_pipeline.producer_tail(producer_state)
-
-    @cute.jit
-    def _run_tile_tma(
-        self,
-        a: cute.Tensor,
-        c_bf16_flat: cute.Tensor,
-        global_scale: cute.Tensor,
-        packed_route_indices: cute.Tensor,
-        topk_weights_flat: cute.Tensor,
-        c_tmp_f32_flat: cute.Tensor,
-        locks_i32_flat: cute.Tensor,
-        smem_base: Int32,
-        b_smem_base: Int32,
-        tid: Int32,
-        warp_idx: Int32,
-        route_block_idx: Int32,
-        output_n_tile: Int32,
-        reduce_k_tile: Int32,
-        reduce_tile_count: Int32,
-        reduce_slice_count: Int32,
-        reduce_slice_idx: Int32,
-        lock_slot: Int32,
-        active_m: Int32,
-        a_atom_tma: cute.CopyAtom,
-        b_atom_tma: cute.CopyAtom,
-        tsa: cute.Tensor,
-        tga: cute.Tensor,
-        tsb: cute.Tensor,
-        tgb: cute.Tensor,
-        tma_pipeline,
-        producer_state,
-        consumer_state,
-    ):
-        (
-            global_scale_f32,
-            block_valid_rows,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            b_sh_rd,
-            s_sh_rd,
-        ) = self._tile_common_prologue(
-            global_scale,
-            packed_route_indices,
-            topk_weights_flat,
-            smem_base,
-            tid,
-            route_block_idx,
-            Int32(0),
-            output_n_tile,
-            active_m,
-        )
-
-        if warp_idx == Int32(4):
-            tile_idx = Int32(0)
-            while tile_idx < reduce_tile_count:
-                tma_pipeline.producer_acquire(producer_state)
-                source_k_tile = reduce_k_tile + tile_idx
-                cute.copy(
-                    a_atom_tma,
-                    tga[(None, route_block_idx, source_k_tile)],
-                    tsa[(None, producer_state.index)],
-                    tma_bar_ptr=tma_pipeline.producer_get_barrier(producer_state),
-                )
-                cute.copy(
-                    b_atom_tma,
-                    tgb[(None, source_k_tile, output_n_tile, Int32(0))],
-                    tsb[(None, producer_state.index)],
-                    tma_bar_ptr=tma_pipeline.producer_get_barrier(producer_state),
-                )
-                tma_pipeline.producer_commit(producer_state)
-                producer_state.advance()
-                tile_idx += Int32(1)
-        elif warp_idx < Int32(4):
-            self._consume_tile_tma(
-                c_bf16_flat,
-                c_tmp_f32_flat,
-                locks_i32_flat,
-                smem_base,
-                b_smem_base,
-                tid,
-                output_n_tile,
-                block_valid_rows,
-                global_scale_f32,
-                reduce_tile_count,
-                reduce_slice_count,
-                reduce_slice_idx,
-                lock_slot,
-                tma_pipeline,
-                consumer_state,
-                b_sh_rd,
-                s_sh_rd,
-            )
-
-        # Keep producer and consumers together through the complete tile
-        # lifecycle before this CTA can leave the pipeline.
-        cute.arch.sync_threads()
-
-    @cute.jit
-    def _consume_tile_tma(
-        self,
-        c_bf16_flat: cute.Tensor,
-        c_tmp_f32_flat: cute.Tensor,
-        locks_i32_flat: cute.Tensor,
-        smem_base: Int32,
-        b_smem_base: Int32,
-        tid: Int32,
-        output_n_tile: Int32,
-        block_valid_rows: Int32,
-        global_scale_f32: cutlass.Float32,
-        reduce_tile_count: Int32,
-        reduce_slice_count: Int32,
-        reduce_slice_idx: Int32,
-        lock_slot: Int32,
-        tma_pipeline,
-        consumer_state,
-        b_sh_rd: Int32,
-        s_sh_rd: Int32,
-    ):
-        a_sh_rd = self._a_shared_read_offset(tid, 16)
-        acc0 = [
-            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
-            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
-        ]
-        acc1 = [
-            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
-            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
-        ]
-        acc2 = [
-            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
-            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
-        ]
-        acc3 = [
-            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
-            for _ in range(32 // _SCALAR_ACC_FRAGMENT_WIDTH)
-        ]
-        for frag in cutlass.range_constexpr(32 // _SCALAR_ACC_FRAGMENT_WIDTH):
-            acc0[frag].fill(0.0)
-            acc1[frag].fill(0.0)
-            acc2[frag].fill(0.0)
-            acc3[frag].fill(0.0)
-
-        b_regs = cute.make_rmem_tensor((2, 4), Uint32)
-        a_regs = cute.make_rmem_tensor((self.cta_m_blocks, 4), Uint32)
-        b_frag = cute.make_rmem_tensor((2, 2), Uint32)
-        tile_idx = Int32(0)
-        while tile_idx < reduce_tile_count:
-            tma_pipeline.consumer_wait(consumer_state)
-            pipe = consumer_state.index
-            for kk in cutlass.range_constexpr(self.b_sh_wr_iters):
-                q0, q1, q2, q3, s0, s1, s2, s3 = (
-                    self._load_b_registers_trellis256(
-                        # The shared loader adds the legacy B-region offset.
-                        # Cancel it here because sb_data is already the region
-                        # base of the separate TMA staging allocation.
-                        b_smem_base - Int32(self.sh_b_off * 16),
-                        tid,
-                        pipe,
-                        Int32(kk),
-                    )
-                )
-                b_regs[0, 0] = q0
-                b_regs[0, 1] = q1
-                b_regs[0, 2] = q2
-                b_regs[0, 3] = q3
-                b_regs[1, 0] = s0
-                b_regs[1, 1] = s1
-                b_regs[1, 2] = s2
-                b_regs[1, 3] = s3
-                self._load_a_register_bundle(
-                    a_regs,
-                    smem_base,
-                    a_sh_rd,
-                    pipe,
-                    Int32(kk),
-                    False,
-                )
-                for jj in cutlass.range_constexpr(4):
-                    self._scaled_dequant_b_fragment_trellis256(
-                        b_frag,
-                        b_regs[0, jj],
-                        b_regs[1, jj],
-                    )
-                    for mb in cutlass.range_constexpr(self.cta_m_blocks):
-                        if cutlass.const_expr(mb == 0):
-                            self._mma_accumulate_large_m(
-                                acc0, a_regs, mb, jj, b_frag
-                            )
-                        elif cutlass.const_expr(mb == 1):
-                            self._mma_accumulate_large_m(
-                                acc1, a_regs, mb, jj, b_frag
-                            )
-                        elif cutlass.const_expr(mb == 2):
-                            self._mma_accumulate_large_m(
-                                acc2, a_regs, mb, jj, b_frag
-                            )
-                        else:
-                            self._mma_accumulate_large_m(
-                                acc3, a_regs, mb, jj, b_frag
-                            )
-            tma_pipeline.consumer_release(consumer_state)
-            consumer_state.advance()
-            tile_idx += Int32(1)
-
-        self._finish_tile(
-            acc0,
-            acc1,
-            acc2,
-            acc3,
-            c_bf16_flat,
-            c_tmp_f32_flat,
-            locks_i32_flat,
-            smem_base,
-            tid,
-            output_n_tile,
-            block_valid_rows,
-            global_scale_f32,
-            reduce_slice_count,
-            reduce_slice_idx,
-            lock_slot,
-            False,
-            self.tma_compute_barrier,
-        )
-
-
 class W4A16FusedMoeKernel:
     def __init__(
         self,
@@ -5884,9 +5328,7 @@ class W4A16FusedMoeKernel:
         self.fc2_moe_block_size = int(
             moe_block_size if fc2_moe_block_size is None else fc2_moe_block_size
         )
-        self.fc2_schedule_route_block_factor = int(
-            fc2_schedule_route_block_factor
-        )
+        self.fc2_schedule_route_block_factor = int(fc2_schedule_route_block_factor)
         if (
             self.fc2_moe_block_size not in _ALLOWED_ROUTED_SIZES
             or self.moe_block_size % self.fc2_moe_block_size != 0
@@ -5896,13 +5338,10 @@ class W4A16FusedMoeKernel:
                 f"route block: packed={self.moe_block_size}, "
                 f"fc2={self.fc2_moe_block_size}"
             )
-        expected_fc2_schedule_factor = (
-            self.moe_block_size // self.fc2_moe_block_size
-        )
+        expected_fc2_schedule_factor = self.moe_block_size // self.fc2_moe_block_size
         if (
             self.fc2_schedule_route_block_factor < 1
-            or expected_fc2_schedule_factor % self.fc2_schedule_route_block_factor
-            != 0
+            or expected_fc2_schedule_factor % self.fc2_schedule_route_block_factor != 0
         ):
             raise ValueError(
                 "FC2 schedule factor must divide one packed route block: "
@@ -6233,9 +5672,7 @@ class W4A16FusedMoeKernel:
         expert_count = Int64(weight_num_experts)
         if cutlass.const_expr(self.weight_layout == "modelopt"):
             w13_elements = (
-                expert_count
-                * Int64(self.fc1_cols)
-                * Int64(self.hidden_size // 2)
+                expert_count * Int64(self.fc1_cols) * Int64(self.hidden_size // 2)
             )
             w2_elements = (
                 expert_count
@@ -6745,6 +6182,7 @@ class W4A16FusedMoeKernel:
             active_m * Int32(self.top_k),
             fc2_emit_tile,
         )
+
     @cute.jit
     def _grid_barrier(
         self,
@@ -6810,19 +6248,14 @@ class W4A16FusedMoeKernel:
             route_pos = unit // nblk
             blk = unit - route_pos * nblk
             route = packed_route_indices[route_pos].to(Int32)
-            expert = block_expert_ids[
-                route_pos // Int32(self.moe_block_size)
-            ].to(Int32)
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
             if cutlass.const_expr(self.direct_topk_routes):
                 route = route_pos
                 expert = packed_route_indices[route_pos].to(Int32)
                 if cutlass.const_expr(self.use_expert_map):
                     global_expert = expert
                     expert = Int32(-1)
-                    if (
-                        global_expert >= Int32(0)
-                        and global_expert < route_num_experts
-                    ):
+                    if global_expert >= Int32(0) and global_expert < route_num_experts:
                         expert = expert_map_flat[global_expert].to(Int32)
             if (
                 route >= Int32(0)
@@ -6921,19 +6354,14 @@ class W4A16FusedMoeKernel:
             route_pos = unit // nblk
             blk = unit - route_pos * nblk
             row = packed_route_indices[route_pos].to(Int32)
-            expert = block_expert_ids[
-                route_pos // Int32(self.moe_block_size)
-            ].to(Int32)
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
             if cutlass.const_expr(self.direct_topk_routes):
                 row = route_pos
                 expert = packed_route_indices[route_pos].to(Int32)
                 if cutlass.const_expr(self.use_expert_map):
                     global_expert = expert
                     expert = Int32(-1)
-                    if (
-                        global_expert >= Int32(0)
-                        and global_expert < route_num_experts
-                    ):
+                    if global_expert >= Int32(0) and global_expert < route_num_experts:
                         expert = expert_map_flat[global_expert].to(Int32)
             if (
                 row >= Int32(0)
@@ -8061,9 +7489,7 @@ class W4A16TopKSumKernel:
             svh_rows = Int64(1)
         svh_flat = cute.make_tensor(
             svh_ptr,
-            layout=cute.make_layout(
-                (svh_rows * Int64(self.hidden_size),), stride=(1,)
-            ),
+            layout=cute.make_layout((svh_rows * Int64(self.hidden_size),), stride=(1,)),
         )
         if cutlass.const_expr(self.full_rotation):
             total = active_m * Int32(self.hidden_size // 128)
@@ -8125,9 +7551,7 @@ class W4A16TopKSumKernel:
                 route_values = cute.make_tensor(
                     route_values_ptr, cute.make_layout(self.topk * 128)
                 )
-                route_weights_ptr = cute.arch.alloc_smem(
-                    cutlass.Float32, self.topk
-                )
+                route_weights_ptr = cute.arch.alloc_smem(cutlass.Float32, self.topk)
                 route_weights = cute.make_tensor(
                     route_weights_ptr, cute.make_layout(self.topk)
                 )
@@ -8221,9 +7645,9 @@ class W4A16TopKSumKernel:
                     if expert < Int32(0) or expert >= weight_num_experts:
                         valid_route = Int32(0)
                 if valid_route != Int32(0):
-                    route_value = fc2_flat[
-                        row * Int32(self.hidden_size) + col
-                    ].to(cutlass.Float32)
+                    route_value = fc2_flat[row * Int32(self.hidden_size) + col].to(
+                        cutlass.Float32
+                    )
                     acc += _materialize_w4a16_topk_route_f32(route_value)
             output_flat[idx] = self._cast_elem(acc)
 
@@ -8687,26 +8111,7 @@ def compile_w4a16_gemm(
         device = int(torch.cuda.current_device())
     else:
         device = None
-    tma_warp_specialized = bool(
-        os.environ.get("SPARKINFER_TRELLIS_DENSE_TMA_WARP", "0") == "1"
-        and dense_route_fast_path
-        and weight_layout == "trellis3_t256"
-        and int(trellis_bits) == 6
-        and element_dtype == "fp16"
-        and int(moe_block_size) == 64
-        and int(tile_k) == 64
-        and int(tile_n) == 128
-        and int(size_m) % 64 == 0
-        and int(size_n) % 256 == 0
-        and int(size_k) % 64 == 0
-        and w13_layout == "packed"
-    )
-    kernel_cls = (
-        W4A16TrellisDenseTmaKernel
-        if tma_warp_specialized
-        else W4A16GemmKernel
-    )
-    kernel = kernel_cls(
+    kernel = W4A16GemmKernel(
         size_m=size_m,
         size_n=size_n,
         size_k=size_k,
@@ -8738,11 +8143,7 @@ def compile_w4a16_gemm(
             blocks_per_sm=kernel.blocks_per_sm,
         )
 
-    compile_size_m = (
-        int(size_m)
-        if tma_warp_specialized
-        else _fake_m_for_specialization(size_m)
-    )
+    compile_size_m = _fake_m_for_specialization(size_m)
     compile_route_blocks = 1
     compile_route_slots = compile_route_blocks * int(moe_block_size)
     a_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
@@ -8752,19 +8153,11 @@ def compile_w4a16_gemm(
         )
     else:
         b_fake_elements = num_experts * (size_k // 16) * (size_n // 16 * 32)
-    if tma_warp_specialized:
-        b_fake = cute.runtime.make_fake_compact_tensor(
-            cutlass.Int32,
-            (size_k // 16, size_n // 16, 8 * int(trellis_bits)),
-            stride_order=(2, 1, 0),
-            assumed_align=16,
-        )
-    else:
-        b_fake = cute.runtime.make_fake_compact_tensor(
-            cutlass.Int32,
-            (b_fake_elements,),
-            assumed_align=16,
-        )
+    b_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (b_fake_elements,),
+        assumed_align=16,
+    )
     c_fake = make_ptr(cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16)
     scales_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
@@ -8844,7 +8237,6 @@ def compile_w4a16_gemm(
             3,
             cache_key,
         ),
-        dsl_compile_options=(OptLevel(2) if tma_warp_specialized else None),
     )
     result = W4A16GemmCompileResult(
         compiled=compiled,
@@ -8858,7 +8250,6 @@ def compile_w4a16_gemm(
         w13_layout=w13_layout,
         dense_route_fast_path=bool(dense_route_fast_path),
         trellis_bits=int(trellis_bits),
-        tma_warp_specialized=tma_warp_specialized,
     )
     _CACHE[cache_key] = result
     return result
@@ -10324,9 +9715,7 @@ def _w4a16_fused_moe_launch_flat(
             or expert_map.ndim != 1
             or not expert_map.is_contiguous()
         ):
-            raise ValueError(
-                "expert_map must be contiguous int32 on the input device"
-            )
+            raise ValueError("expert_map must be contiguous int32 on the input device")
     if collect_activation_amax and activation_amax is None:
         raise ValueError("activation_amax is required for calibrated W4A16 launch")
     activation_amax_arg = (
@@ -10405,9 +9794,7 @@ def _w4a16_fused_moe_launch_flat(
         cutlass.Uint8 if weight_layout == "modelopt" else cutlass.Int32
     )
     expert_map_addr = (
-        packed_route_indices.data_ptr()
-        if expert_map is None
-        else expert_map.data_ptr()
+        packed_route_indices.data_ptr() if expert_map is None else expert_map.data_ptr()
     )
     route_num_experts = 0 if expert_map is None else int(expert_map.numel())
     fused.compiled(
@@ -11327,9 +10714,7 @@ def _compile_trellis_dense_hadamard128(*, width: int, scale_before: bool):
         width=int(width),
         scale_before=bool(scale_before),
     )
-    fp16_fake = make_ptr(
-        cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16
-    )
+    fp16_fake = make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16)
     raise_if_kernel_resolution_frozen(
         "cute.compile", target=kernel, cache_key=cache_key
     )
@@ -11362,14 +10747,18 @@ def _run_trellis_dense_hadamard128(
     if x.ndim != 2 or output.shape != x.shape or not x.is_contiguous():
         raise ValueError("native dense H128 requires equal contiguous rank-2 tensors")
     if not output.is_contiguous() or output.device != x.device:
-        raise ValueError("native dense H128 output must be contiguous on the input device")
+        raise ValueError(
+            "native dense H128 output must be contiguous on the input device"
+        )
     if (
         scale.dtype != torch.float16
         or scale.device != x.device
         or not scale.is_contiguous()
         or scale.numel() != x.shape[1]
     ):
-        raise ValueError("native dense H128 scale must be contiguous fp16 with width elements")
+        raise ValueError(
+            "native dense H128 scale must be contiguous fp16 with width elements"
+        )
     compiled = _compile_trellis_dense_hadamard128(
         width=int(x.shape[1]),
         scale_before=bool(scale_before),
@@ -11505,9 +10894,7 @@ def _run_trellis256_dense_current_device(
         raise ValueError("c_tmp must be at least 16-byte aligned")
 
     external_hadamard_128 = (
-        None
-        if hadamard_128 is None
-        else _resolve_exl3_hadamard_128(hadamard_128)
+        None if hadamard_128 is None else _resolve_exl3_hadamard_128(hadamard_128)
     )
 
     # Decode and small batches use one cooperative K6 kernel that owns both
@@ -11623,25 +11010,7 @@ def _run_trellis256_dense_current_device(
         getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
     )
     moe_block_size = int(_moe_block_size)
-    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
-        raise ValueError(
-            f"unsupported Trellis dense moe_block_size={moe_block_size}"
-        )
-    use_tma_warp_tile = bool(
-        _force_tile_config is None
-        and os.environ.get("SPARKINFER_TRELLIS_DENSE_TMA_WARP", "0") == "1"
-        and moe_block_size == 64
-        and trellis_bits == 6
-        and compute_dtype == torch.float16
-        and m == 2048
-        and size_k == 4096
-        and size_n == 6144
-    )
-    if use_tma_warp_tile:
-        # The warp-specialized K6 kernel uses a narrower N tile to fit separate
-        # two-stage A/B TMA pipelines without reducing the compute warp budget.
-        tile_k, tile_n = (64, 128)
-    elif _force_tile_config is None and moe_block_size == 64:
+    if _force_tile_config is None and moe_block_size == 64:
         moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
             size_m=m,
             size_k=size_k,
@@ -11654,6 +11023,8 @@ def _run_trellis256_dense_current_device(
             if _force_tile_config is None
             else (int(_force_tile_config[0]), int(_force_tile_config[1]))
         )
+    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
+        raise ValueError(f"unsupported Trellis dense moe_block_size={moe_block_size}")
     route_blocks = (m + moe_block_size - 1) // moe_block_size
     route_slots = route_blocks * moe_block_size
     launch = _compile_w4a16_gemm_launch(
@@ -11686,13 +11057,6 @@ def _run_trellis256_dense_current_device(
         sms * int(launch.kernel.blocks_per_sm),
         max(route_blocks * n_tiles, 1),
     )
-    trellis_arg = prepared_dense.trellis
-    if launch.kernel.tma_warp_specialized:
-        trellis_arg = prepared_dense.trellis.view(torch.int32).view(
-            size_k // 16,
-            size_n // 16,
-            8 * trellis_bits,
-        )
     launch.kernel.compiled(
         make_ptr(
             cutlass_dtype,
@@ -11706,7 +11070,7 @@ def _run_trellis256_dense_current_device(
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
-        trellis_arg,
+        prepared_dense.trellis,
         make_ptr(
             cutlass_dtype,
             gemm_output.data_ptr(),
@@ -11764,9 +11128,7 @@ def _run_trellis256_dense_current_device(
                 scale_before=False,
             )
         else:
-            external_hadamard_128(
-                gemm_f16, output_f16, None, prepared_dense.svh, 1.0
-            )
+            external_hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
         output.copy_(output_f16)
     return output
 
@@ -12245,9 +11607,7 @@ def run_w4a16_moe(
 
     mapped_direct = expert_map is not None
     direct_m_cap = (
-        _W4A16_SMALL_M_DIRECT_MAX_M
-        if mapped_direct
-        else _MAX_DIRECT_TOPK_ROUTE_M
+        _W4A16_SMALL_M_DIRECT_MAX_M if mapped_direct else _MAX_DIRECT_TOPK_ROUTE_M
     )
     direct_layout_ok = weight_layout in ("packed", "nf3_2p1") or (
         mapped_direct and full_rotation and weight_layout == "trellis3_t256"
@@ -12267,8 +11627,7 @@ def run_w4a16_moe(
         )
         and (
             fused_launch is None
-            or bool(getattr(fused_launch, "use_expert_map", False))
-            == mapped_direct
+            or bool(getattr(fused_launch, "use_expert_map", False)) == mapped_direct
         )
     )
     if (

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -89,7 +89,6 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
     packed_gemm_scratch_elements,
     plan_w4a16_buffers,
-    route_pack_capacity,
     select_route_block_size_m,
     validate_activation,
 )
@@ -10646,21 +10645,15 @@ def run_w4a16_moe(
         )
 
     route_slots_for_scratch = int(m) * int(topk) * int(block_size_m)
-    if use_direct_topk_routes:
-        required_m_blocks = int(m) * int(topk)
-    else:
-        _, _, required_m_blocks = route_pack_capacity(
-            int(m) * int(topk),
-            int(block_size_m),
-            route_num_experts,
-            topk=topk,
-        )
+    required_m_blocks = int(m) * int(topk) if use_direct_topk_routes else 0
     if fused_launch is not None and not use_direct_topk_routes:
-        _, route_slots_capacity, route_blocks_capacity = route_pack_capacity(
+        route_slots_capacity = max_packed_route_slots(
             int(fused_launch.size_m) * int(topk),
             int(block_size_m),
             route_num_experts,
-            topk=topk,
+        )
+        route_blocks_capacity = (route_slots_capacity + int(block_size_m) - 1) // int(
+            block_size_m
         )
         if packed_route_indices is not None:
             if int(packed_route_indices.numel()) < route_slots_capacity:
@@ -10696,12 +10689,7 @@ def run_w4a16_moe(
             )
         )
         route_slots_for_scratch = int(packed_route_indices.numel())
-        if int(block_expert_ids.numel()) != int(required_m_blocks):
-            raise RuntimeError(
-                "W4A16 route packing did not produce the canonical launch capacity: "
-                f"runtime={int(block_expert_ids.numel())}, "
-                f"planned={int(required_m_blocks)}"
-            )
+        required_m_blocks = int(block_expert_ids.numel())
 
     props = torch.cuda.get_device_properties(a_input.device)
     sms = int(props.multi_processor_count)

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -708,6 +708,7 @@ class W4A16GemmKernel:
         fused_sum_topk: int = 1,
         schedule_whole_tiles: bool = False,
         dynamic_num_experts: bool = False,
+        schedule_route_block_factor: int = 1,
     ):
         if element_dtype not in {"bf16", "fp16"}:
             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
@@ -892,6 +893,18 @@ class W4A16GemmKernel:
         # the split-K tail machinery entirely. Requires the host to bound the
         # wave count; used by the exact-geometry hybrid decode schedule.
         self.schedule_whole_tiles = bool(schedule_whole_tiles)
+        self.schedule_route_block_factor = int(schedule_route_block_factor)
+        if self.schedule_route_block_factor < 1:
+            raise ValueError("schedule_route_block_factor must be >= 1")
+        if self.schedule_route_block_factor != 1 and (
+            not self.schedule_whole_tiles
+            or self.direct_topk_routes
+            or self.dense_route_fast_path
+        ):
+            raise ValueError(
+                "grouped route-block scheduling requires route-packed "
+                "whole-tile execution"
+            )
         if (
             self.schedule_whole_tiles
             and not self.direct_topk_routes
@@ -1050,6 +1063,7 @@ class W4A16GemmKernel:
             # entry even when their arithmetic geometry otherwise matches.
             self.blocks_per_sm,
             self.schedule_whole_tiles,
+            self.schedule_route_block_factor,
         )
 
     @cute.jit
@@ -1305,7 +1319,7 @@ class W4A16GemmKernel:
             ) // Int32(self.moe_block_size)
         elif cutlass.const_expr(not self.direct_topk_routes):
             route_blocks = packed_route_count[Int32(0)].to(Int32) // Int32(
-                self.moe_block_size
+                self.moe_block_size * self.schedule_route_block_factor
             )
         k_tiles = Int32(self.k_tiles)
         global_mn_tiles = route_blocks * n_tiles
@@ -4608,6 +4622,7 @@ class W4A16FusedMoeKernel:
         moe_block_size: int,
         max_m_blocks: int,
         fc2_moe_block_size: int | None = None,
+        fc2_schedule_route_block_factor: int = 1,
         element_dtype: str = "bf16",
         fast_math: bool = True,
         swiglu_limit: float | None = None,
@@ -4684,6 +4699,9 @@ class W4A16FusedMoeKernel:
         self.fc2_moe_block_size = int(
             moe_block_size if fc2_moe_block_size is None else fc2_moe_block_size
         )
+        self.fc2_schedule_route_block_factor = int(
+            fc2_schedule_route_block_factor
+        )
         if (
             self.fc2_moe_block_size not in _ALLOWED_ROUTED_SIZES
             or self.moe_block_size % self.fc2_moe_block_size != 0
@@ -4692,6 +4710,18 @@ class W4A16FusedMoeKernel:
                 "FC2 route subtile must be an allowed divisor of the packed "
                 f"route block: packed={self.moe_block_size}, "
                 f"fc2={self.fc2_moe_block_size}"
+            )
+        expected_fc2_schedule_factor = (
+            self.moe_block_size // self.fc2_moe_block_size
+        )
+        if self.fc2_schedule_route_block_factor not in (
+            1,
+            expected_fc2_schedule_factor,
+        ):
+            raise ValueError(
+                "FC2 schedule factor must be one or cover one packed route "
+                f"block: factor={self.fc2_schedule_route_block_factor}, "
+                f"expected={expected_fc2_schedule_factor}"
             )
         self.activation = activation
         self.activation_is_gated = is_gated
@@ -4814,6 +4844,7 @@ class W4A16FusedMoeKernel:
             fused_sum_topk=int(top_k),
             schedule_whole_tiles=self.schedule_whole_tiles,
             dynamic_num_experts=self.dynamic_num_experts,
+            schedule_route_block_factor=self.fc2_schedule_route_block_factor,
         )
         self.cta_threads = max(self.fc1.cta_threads, self.fc2.cta_threads)
         if self.fc1.cta_threads != self.fc2.cta_threads:

--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
@@ -709,6 +709,7 @@ class W4A16GemmKernel:
         schedule_whole_tiles: bool = False,
         dynamic_num_experts: bool = False,
         schedule_route_block_factor: int = 1,
+        paired_m8_routes: bool = False,
     ):
         if element_dtype not in {"bf16", "fp16"}:
             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
@@ -919,6 +920,16 @@ class W4A16GemmKernel:
             raise ValueError("fused_sum_topk must be >= 1")
         self.cta_m_blocks = int(_covering_count(moe_block_size, 16))
         self.uses_m_block_8 = moe_block_size == 8
+        self.paired_m8_routes = bool(paired_m8_routes)
+        if self.paired_m8_routes and (
+            not self.uses_m_block_8
+            or not self.schedule_whole_tiles
+            or self.schedule_route_block_factor != 2
+        ):
+            raise ValueError(
+                "paired_m8_routes requires M8 whole-tile scheduling with "
+                "schedule_route_block_factor=2"
+            )
         self.max_m_blocks = int(max_m_blocks)
         if torch.cuda.is_available():
             props = torch.cuda.get_device_properties(torch.cuda.current_device())
@@ -950,6 +961,11 @@ class W4A16GemmKernel:
         # W4A16 shared-memory geometry, in int4 units unless noted.
         self.a_sh_stride = 16 * self.cta_k_blocks // 8
         self.a_sh_stage = self.a_sh_stride * (16 * self.cta_m_blocks)
+        if self.paired_m8_routes:
+            # The M8 ldmatrix mapping consumes a padded 16-row slab: rows 8-15
+            # must remain zero.  A paired tile therefore needs two independent
+            # 16-row slabs even though only eight rows in each slab are live.
+            self.a_sh_stage *= 2
         self.a_gl_rd_delta_o = 16 * self.cta_k_blocks // 8
         self.a_sh_wr_delta = self.a_sh_stride * (
             self.cta_threads // self.a_gl_rd_delta_o
@@ -991,9 +1007,12 @@ class W4A16GemmKernel:
         self.s_sh_stage = self.s_tb_groups * self.s_sh_stride
         self.tb_n_warps = self.cta_n_blocks // 4
 
-        sh_block_route_indices = self.moe_block_size // 4
-        sh_rd_block_route_indices = self.moe_block_size // 4
-        sh_block_topk_weights = self.moe_block_size // 2
+        route_metadata_rows = self.moe_block_size * (
+            2 if self.paired_m8_routes else 1
+        )
+        sh_block_route_indices = route_metadata_rows // 4
+        sh_rd_block_route_indices = route_metadata_rows // 4
+        sh_block_topk_weights = route_metadata_rows // 2
         self.sh_valid_count_off = (
             sh_block_route_indices + sh_rd_block_route_indices + sh_block_topk_weights
         )
@@ -1064,6 +1083,7 @@ class W4A16GemmKernel:
             self.blocks_per_sm,
             self.schedule_whole_tiles,
             self.schedule_route_block_factor,
+            self.paired_m8_routes,
         )
 
     @cute.jit
@@ -1646,6 +1666,85 @@ class W4A16GemmKernel:
         return valid_count
 
     @cute.jit
+    def _read_moe_block_data_pair(
+        self,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        global_scale_f32: cutlass.Float32,
+        active_size_m: Int32,
+    ):
+        """Load two adjacent M8 route blocks into one 16-row metadata slab."""
+        route_indices_int4_addr = self._int4_addr(
+            smem_base, Int32(self.sh_route_off) + tid
+        )
+        route_indices_gmem = get_ptr_as_int64(
+            packed_route_indices,
+            route_block_idx * Int32(self.moe_block_size) + tid * Int32(4),
+        )
+        cp_async4_shared_global_pred(
+            route_indices_int4_addr,
+            route_indices_gmem,
+            (tid < Int32(2 * self.moe_block_size // 4)).to(Int32),
+        )
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+
+        if tid >= Int32(self.cta_threads - 32):
+            lane = tid - Int32(self.cta_threads - 32)
+            valid0 = Int32(0)
+            valid1 = Int32(0)
+            if lane < Int32(2 * self.moe_block_size):
+                idx = ld_shared_i32_relaxed(
+                    smem_base + Int32(self.sh_route_off * 16) + lane * Int32(4)
+                )
+                valid = (idx < active_size_m * Int32(self.top_k)).to(Int32)
+                if lane < Int32(self.moe_block_size):
+                    valid0 = valid
+                else:
+                    valid1 = valid
+            valid0 = cute.arch.warp_redux_sync(valid0, "add")
+            valid1 = cute.arch.warp_redux_sync(valid1, "add")
+            if lane == Int32(0):
+                valid_addr = smem_base + Int32(self.sh_valid_count_off * 16)
+                st_shared_i32(valid_addr, valid0)
+                st_shared_i32(valid_addr + Int32(4), valid1)
+
+        if tid < Int32(2 * self.moe_block_size):
+            idx = ld_shared_i32_relaxed(
+                smem_base + Int32(self.sh_route_off * 16) + tid * Int32(4)
+            )
+            rd_row = idx // Int32(self.top_k)
+            if cutlass.const_expr(self.route_major_a):
+                rd_row = idx
+            st_shared_i32(
+                smem_base + Int32(self.sh_rd_route_off * 16) + tid * Int32(4),
+                rd_row,
+            )
+            if cutlass.const_expr(self.mul_topk_weights):
+                safe_idx = idx
+                if idx >= active_size_m * Int32(self.top_k):
+                    safe_idx = Int32(0)
+                topk = (
+                    topk_weights_flat[safe_idx].to(cutlass.Float32)
+                    * global_scale_f32
+                )
+                st_shared_u32(
+                    smem_base + Int32(self.sh_topk_off * 16) + tid * Int32(4),
+                    self._broadcast_f32_to_elem2(topk),
+                )
+
+        cute.arch.sync_threads()
+        valid_addr = smem_base + Int32(self.sh_valid_count_off * 16)
+        block_valid_rows0 = ld_shared_i32_relaxed(valid_addr)
+        block_valid_rows1 = ld_shared_i32_relaxed(valid_addr + Int32(4))
+        cute.arch.sync_threads()
+        return block_valid_rows0, block_valid_rows1
+
+    @cute.jit
     def _run_tile(
         self,
         a_bf16_flat: cute.Tensor,
@@ -1774,6 +1873,42 @@ class W4A16GemmKernel:
             a_rows_per_iter,
             b_sh_rd,
             s_sh_rd,
+        )
+
+    @cute.jit
+    def _tile_common_prologue_pair(
+        self,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        active_size_m: Int32,
+    ):
+        global_scale_f32 = global_scale[expert_idx].to(cutlass.Float32)
+        if cutlass.const_expr(self.scale_format_e8m0_k32):
+            if cutlass.const_expr(self.is_fp16):
+                global_scale_f32 *= cutlass.Float32(_E8M0_K32_FP16_GLOBAL_COMPENSATION)
+            else:
+                global_scale_f32 *= cutlass.Float32(_E8M0_K32_BF16_GLOBAL_COMPENSATION)
+        block_valid_rows0, block_valid_rows1 = self._read_moe_block_data_pair(
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            global_scale_f32,
+            active_size_m,
+        )
+        offsets = self._tile_stream_offsets(tid, expert_idx, output_n_tile)
+        return (
+            global_scale_f32,
+            block_valid_rows0,
+            block_valid_rows1,
+            *offsets,
         )
 
     @cute.jit
@@ -1915,6 +2050,8 @@ class W4A16GemmKernel:
             k_tiles,
             reduce_k_tile,
             block_valid_rows,
+            Int32(0),
+            False,
             a_gl_stride,
             b_gl_stride,
             s_gl_stride,
@@ -1996,10 +2133,199 @@ class W4A16GemmKernel:
             tid,
             output_n_tile,
             block_valid_rows,
+            Int32(0),
             global_scale_f32,
             reduce_slice_count,
             reduce_slice_idx,
             lock_slot,
+            True,
+        )
+
+    @cute.jit
+    def _run_tile_m8_pair(
+        self,
+        a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        c_bf16_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights_flat: cute.Tensor,
+        c_tmp_f32_flat: cute.Tensor,
+        locks_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        expert_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_size_m: Int32,
+    ):
+        (
+            global_scale_f32,
+            block_valid_rows0,
+            block_valid_rows1,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            b_sh_rd,
+            s_sh_rd,
+        ) = self._tile_common_prologue_pair(
+            global_scale,
+            packed_route_indices,
+            topk_weights_flat,
+            smem_base,
+            tid,
+            route_block_idx,
+            expert_idx,
+            output_n_tile,
+            active_size_m,
+        )
+        a0_sh_rd = self._a_shared_read_offset(tid, 8)
+        a1_sh_rd = a0_sh_rd + Int32(self.a_sh_rd_delta_i)
+
+        acc0 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(16 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        acc1 = [
+            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
+            for _ in range(16 // _SCALAR_ACC_FRAGMENT_WIDTH)
+        ]
+        for frag in cutlass.range_constexpr(16 // _SCALAR_ACC_FRAGMENT_WIDTH):
+            acc0[frag].fill(0.0)
+            acc1[frag].fill(0.0)
+
+        k_tiles = reduce_tile_count
+        self._prefetch_initial_tiles(
+            a_bf16_flat,
+            a_alt_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows0,
+            block_valid_rows1,
+            True,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+        )
+
+        b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
+        b_scale_next = cute.make_rmem_tensor((2, 4), Uint32)
+        self._load_b_scale_register_bundle(
+            b_scale_cur,
+            smem_base,
+            tid,
+            b_sh_rd,
+            s_sh_rd,
+            Int32(0),
+            Int32(0),
+        )
+        a0_regs_cur = cute.make_rmem_tensor((2,), Uint32)
+        a0_regs_next = cute.make_rmem_tensor((2,), Uint32)
+        a1_regs_cur = cute.make_rmem_tensor((2,), Uint32)
+        a1_regs_next = cute.make_rmem_tensor((2,), Uint32)
+        self._load_a_registers_m8_bundle(
+            a0_regs_cur, smem_base, a0_sh_rd, Int32(0), Int32(0)
+        )
+        self._load_a_registers_m8_bundle(
+            a1_regs_cur, smem_base, a1_sh_rd, Int32(0), Int32(0)
+        )
+        self._run_mma_pipeline_m8_pair(
+            a_bf16_flat,
+            a_alt_bf16_flat,
+            b_i32_flat,
+            scales_i32_flat,
+            smem_base,
+            tid,
+            acc0,
+            acc1,
+            b_scale_cur,
+            b_scale_next,
+            a0_regs_cur,
+            a0_regs_next,
+            a1_regs_cur,
+            a1_regs_next,
+            b_sh_rd,
+            s_sh_rd,
+            a0_sh_rd,
+            a1_sh_rd,
+            k_tiles,
+            reduce_k_tile,
+            block_valid_rows0,
+            block_valid_rows1,
+            a_gl_stride,
+            b_gl_stride,
+            s_gl_stride,
+            scales_expert_off,
+            b_gl_rd_base,
+            a_gl_rd_row,
+            a_gl_rd_col0,
+            a_sh_wr,
+            a_rows_per_iter,
+            output_n_tile,
+            expert_idx,
+        )
+
+        self._finish_tile(
+            acc0,
+            acc0,
+            acc0,
+            acc0,
+            c_bf16_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            output_n_tile,
+            block_valid_rows0,
+            Int32(0),
+            global_scale_f32,
+            reduce_slice_count,
+            reduce_slice_idx,
+            lock_slot,
+            True,
+        )
+        self._finish_tile(
+            acc1,
+            acc1,
+            acc1,
+            acc1,
+            c_bf16_flat,
+            c_tmp_f32_flat,
+            locks_i32_flat,
+            smem_base,
+            tid,
+            output_n_tile,
+            block_valid_rows1,
+            Int32(self.moe_block_size),
+            global_scale_f32,
+            reduce_slice_count,
+            reduce_slice_idx,
+            lock_slot + Int32(1),
             True,
         )
 
@@ -2100,6 +2426,8 @@ class W4A16GemmKernel:
             k_tiles,
             reduce_k_tile,
             block_valid_rows,
+            Int32(0),
+            False,
             a_gl_stride,
             b_gl_stride,
             s_gl_stride,
@@ -2181,6 +2509,7 @@ class W4A16GemmKernel:
             tid,
             output_n_tile,
             block_valid_rows,
+            Int32(0),
             global_scale_f32,
             reduce_slice_count,
             reduce_slice_idx,
@@ -2258,6 +2587,8 @@ class W4A16GemmKernel:
                             k_tiles,
                             reduce_k_tile,
                             block_valid_rows,
+                            Int32(0),
+                            False,
                             a_gl_stride,
                             b_gl_stride,
                             s_gl_stride,
@@ -2360,6 +2691,168 @@ class W4A16GemmKernel:
                 )
 
     @cute.jit
+    def _run_mma_pipeline_m8_pair(
+        self,
+        a_bf16_flat: cute.Tensor,
+        a_alt_bf16_flat: cute.Tensor,
+        b_i32_flat: cute.Tensor,
+        scales_i32_flat: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        acc0,
+        acc1,
+        b_scale_cur: cute.Tensor,
+        b_scale_next: cute.Tensor,
+        a0_regs_cur: cute.Tensor,
+        a0_regs_next: cute.Tensor,
+        a1_regs_cur: cute.Tensor,
+        a1_regs_next: cute.Tensor,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        a0_sh_rd: Int32,
+        a1_sh_rd: Int32,
+        k_tiles: Int32,
+        reduce_k_tile: Int32,
+        block_valid_rows0: Int32,
+        block_valid_rows1: Int32,
+        a_gl_stride: Int32,
+        b_gl_stride: Int32,
+        s_gl_stride: Int32,
+        scales_expert_off: Int32,
+        b_gl_rd_base: Int32,
+        a_gl_rd_row: Int32,
+        a_gl_rd_col0: Int32,
+        a_sh_wr: Int32,
+        a_rows_per_iter: Int32,
+        output_n_tile: Int32,
+        expert_idx: Int32,
+    ):
+        b_frag = cute.make_rmem_tensor((2, 2), Uint32)
+        tile_idx = Int32(0)
+        while tile_idx < k_tiles:
+            for pipe in cutlass.range_constexpr(_STAGES):
+                if tile_idx < k_tiles:
+                    for kk in cutlass.range_constexpr(self.b_sh_wr_iters):
+                        self._load_next_fragment_bundle_m8_pair(
+                            b_scale_next,
+                            a0_regs_next,
+                            a1_regs_next,
+                            smem_base,
+                            tid,
+                            b_sh_rd,
+                            s_sh_rd,
+                            a0_sh_rd,
+                            a1_sh_rd,
+                            pipe,
+                            kk,
+                            tile_idx,
+                            k_tiles,
+                        )
+
+                        self._prefetch_pipeline_step(
+                            a_bf16_flat,
+                            a_alt_bf16_flat,
+                            b_i32_flat,
+                            scales_i32_flat,
+                            smem_base,
+                            tid,
+                            pipe,
+                            kk,
+                            tile_idx,
+                            k_tiles,
+                            reduce_k_tile,
+                            block_valid_rows0,
+                            block_valid_rows1,
+                            True,
+                            a_gl_stride,
+                            b_gl_stride,
+                            s_gl_stride,
+                            scales_expert_off,
+                            b_gl_rd_base,
+                            a_gl_rd_row,
+                            a_gl_rd_col0,
+                            a_sh_wr,
+                            a_rows_per_iter,
+                            output_n_tile,
+                            expert_idx,
+                        )
+
+                        for jj in cutlass.range_constexpr(4):
+                            if cutlass.const_expr(self.weight_layout_trellis256):
+                                self._scaled_dequant_b_fragment_trellis256(
+                                    b_frag,
+                                    b_scale_cur[0, jj],
+                                    b_scale_cur[1, jj],
+                                )
+                            elif cutlass.const_expr(self.weight_layout_nf3):
+                                lo_w = b_scale_cur[0, jj // 2]
+                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(
+                                    0xFFFF
+                                )
+                                hi8 = (
+                                    b_scale_cur[0, 2] >> Uint32(8 * jj)
+                                ) & Uint32(0xFF)
+                                self._scaled_dequant_b_fragment_nf3(
+                                    b_frag,
+                                    lo16,
+                                    hi8,
+                                    b_scale_cur[1, jj],
+                                )
+                            else:
+                                q, s = self._select_b_scale_register(
+                                    jj, b_scale_cur
+                                )
+                                self._scaled_dequant_b_fragment(b_frag, q, s)
+                            self._mma_accumulate_m8(
+                                acc0,
+                                jj,
+                                a0_regs_cur,
+                                b_frag,
+                            )
+                            self._mma_accumulate_m8(
+                                acc1,
+                                jj,
+                                a1_regs_cur,
+                                b_frag,
+                            )
+
+                        self._copy_a_register_bundle_m8(
+                            a0_regs_cur, a0_regs_next
+                        )
+                        self._copy_a_register_bundle_m8(
+                            a1_regs_cur, a1_regs_next
+                        )
+                        self._copy_b_scale_register_bundle(
+                            b_scale_cur, b_scale_next
+                        )
+                    tile_idx += Int32(1)
+            cute.arch.sync_threads()
+            if tile_idx < k_tiles:
+                self._load_b_scale_register_bundle(
+                    b_scale_cur,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    Int32(0),
+                    Int32(0),
+                )
+                self._load_a_registers_m8_bundle(
+                    a0_regs_cur,
+                    smem_base,
+                    a0_sh_rd,
+                    Int32(0),
+                    Int32(0),
+                )
+                self._load_a_registers_m8_bundle(
+                    a1_regs_cur,
+                    smem_base,
+                    a1_sh_rd,
+                    Int32(0),
+                    Int32(0),
+                )
+
+    @cute.jit
     def _finish_tile(
         self,
         acc0,
@@ -2373,6 +2866,7 @@ class W4A16GemmKernel:
         tid: Int32,
         output_n_tile: Int32,
         block_valid_rows: Int32,
+        metadata_row_base: Int32,
         global_scale_f32: cutlass.Float32,
         reduce_slice_count: Int32,
         reduce_slice_idx: Int32,
@@ -2417,6 +2911,7 @@ class W4A16GemmKernel:
                     tid,
                     output_n_tile,
                     block_valid_rows,
+                    metadata_row_base,
                     global_scale_f32,
                 )
             else:
@@ -2990,6 +3485,80 @@ class W4A16GemmKernel:
                 )
 
     @cute.jit
+    def _load_next_fragment_bundle_m8_pair(
+        self,
+        b_scale_next: cute.Tensor,
+        a0_regs_next: cute.Tensor,
+        a1_regs_next: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        b_sh_rd: Int32,
+        s_sh_rd: Int32,
+        a0_sh_rd: Int32,
+        a1_sh_rd: Int32,
+        pipe: cutlass.Constexpr[int],
+        kk: cutlass.Constexpr[int],
+        tile_idx: Int32,
+        k_tiles: Int32,
+    ):
+        self._clear_b_scale_register_bundle(b_scale_next)
+        self._clear_a_register_bundle_m8(a0_regs_next)
+        self._clear_a_register_bundle_m8(a1_regs_next)
+
+        if cutlass.const_expr(kk + 1 < self.b_sh_wr_iters):
+            if tile_idx < k_tiles:
+                self._load_b_scale_register_bundle(
+                    b_scale_next,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    Int32(pipe),
+                    Int32(kk + 1),
+                )
+                self._load_a_registers_m8_bundle(
+                    a0_regs_next,
+                    smem_base,
+                    a0_sh_rd,
+                    Int32(pipe),
+                    Int32(kk + 1),
+                )
+                self._load_a_registers_m8_bundle(
+                    a1_regs_next,
+                    smem_base,
+                    a1_sh_rd,
+                    Int32(pipe),
+                    Int32(kk + 1),
+                )
+        else:
+            next_tile = tile_idx + Int32(1)
+            if next_tile < k_tiles:
+                next_pipe = Int32((pipe + 1) % _STAGES)
+                self._load_b_scale_register_bundle(
+                    b_scale_next,
+                    smem_base,
+                    tid,
+                    b_sh_rd,
+                    s_sh_rd,
+                    next_pipe,
+                    Int32(0),
+                )
+                self._load_a_registers_m8_bundle(
+                    a0_regs_next,
+                    smem_base,
+                    a0_sh_rd,
+                    next_pipe,
+                    Int32(0),
+                )
+                self._load_a_registers_m8_bundle(
+                    a1_regs_next,
+                    smem_base,
+                    a1_sh_rd,
+                    next_pipe,
+                    Int32(0),
+                )
+
+    @cute.jit
     def _scaled_dequant_b_fragment(self, frag: cute.Tensor, q: Uint32, s: Uint32):
         bq1 = q
         bq0 = bq1 << Uint32(8)
@@ -3441,6 +4010,8 @@ class W4A16GemmKernel:
         pipe: Int32,
         tile_idx: Int32,
         block_valid_rows: Int32,
+        block_valid_rows1: Int32,
+        paired_m8: cutlass.Constexpr[bool],
         a_gl_stride: Int32,
         b_gl_stride: Int32,
         s_gl_stride: Int32,
@@ -3455,10 +4026,24 @@ class W4A16GemmKernel:
     ):
         for i in cutlass.range_constexpr(self.a_sh_wr_iters):
             row = a_rows_per_iter * Int32(i) + a_gl_rd_row
+            metadata_row = row
+            route_rows = Int32(self.moe_block_size)
+            if cutlass.const_expr(paired_m8):
+                route_rows = Int32(2 * self.moe_block_size)
+                metadata_row = Int32(-1)
+                if row < Int32(self.moe_block_size):
+                    metadata_row = row
+                elif (
+                    row >= Int32(2 * self.moe_block_size)
+                    and row < Int32(3 * self.moe_block_size)
+                ):
+                    metadata_row = row - Int32(self.moe_block_size)
             route_index = Int32(0)
-            if row < Int32(self.moe_block_size):
+            if metadata_row >= Int32(0) and metadata_row < route_rows:
                 route_index = ld_shared_i32_relaxed(
-                    smem_base + Int32(self.sh_rd_route_off * 16) + row * Int32(4)
+                    smem_base
+                    + Int32(self.sh_rd_route_off * 16)
+                    + metadata_row * Int32(4)
                 )
             a_int4 = (
                 Int64(route_index) * Int64(a_gl_stride)
@@ -3482,9 +4067,22 @@ class W4A16GemmKernel:
                 # stage, so this adds neither shared memory nor MMA work.
                 if output_n_tile >= Int32(self.n_tiles // 2):
                     a_src = get_ptr_as_int64(a_alt_bf16_flat, a_int4 * Int32(8))
+            row_valid = row < block_valid_rows
+            if cutlass.const_expr(paired_m8):
+                if row < Int32(self.moe_block_size):
+                    row_valid = row < block_valid_rows
+                elif (
+                    row >= Int32(2 * self.moe_block_size)
+                    and row < Int32(3 * self.moe_block_size)
+                ):
+                    row_valid = (
+                        row - Int32(2 * self.moe_block_size) < block_valid_rows1
+                    )
+                else:
+                    row_valid = row < Int32(0)
             if cutlass.const_expr(self.has_k_tile_tail):
                 a_k_int4 = tile_idx * Int32(self.a_gl_rd_delta_o) + a_gl_rd_col0
-                if row < block_valid_rows and a_k_int4 < a_gl_stride:
+                if row_valid and a_k_int4 < a_gl_stride:
                     cp_async4_shared_global(
                         a_dst,
                         a_src,
@@ -3495,7 +4093,7 @@ class W4A16GemmKernel:
                 cp_async4_shared_global_pred(
                     a_dst,
                     a_src,
-                    (row < block_valid_rows).to(Int32),
+                    row_valid.to(Int32),
                 )
 
         if cutlass.const_expr(self.weight_layout_trellis256):
@@ -3662,6 +4260,8 @@ class W4A16GemmKernel:
         k_tiles: Int32,
         reduce_k_tile: Int32,
         block_valid_rows: Int32,
+        block_valid_rows1: Int32,
+        paired_m8: cutlass.Constexpr[bool],
         a_gl_stride: Int32,
         b_gl_stride: Int32,
         s_gl_stride: Int32,
@@ -3687,6 +4287,8 @@ class W4A16GemmKernel:
                 k_tiles,
                 reduce_k_tile,
                 block_valid_rows,
+                block_valid_rows1,
+                paired_m8,
                 a_gl_stride,
                 b_gl_stride,
                 s_gl_stride,
@@ -3712,6 +4314,8 @@ class W4A16GemmKernel:
         k_tiles: Int32,
         reduce_k_tile: Int32,
         block_valid_rows: Int32,
+        block_valid_rows1: Int32,
+        paired_m8: cutlass.Constexpr[bool],
         a_gl_stride: Int32,
         b_gl_stride: Int32,
         s_gl_stride: Int32,
@@ -3736,6 +4340,8 @@ class W4A16GemmKernel:
                     Int32(pipe),
                     reduce_k_tile + Int32(pipe),
                     block_valid_rows,
+                    block_valid_rows1,
+                    paired_m8,
                     a_gl_stride,
                     b_gl_stride,
                     s_gl_stride,
@@ -3767,6 +4373,8 @@ class W4A16GemmKernel:
         k_tiles: Int32,
         reduce_k_tile: Int32,
         block_valid_rows: Int32,
+        block_valid_rows1: Int32,
+        paired_m8: cutlass.Constexpr[bool],
         a_gl_stride: Int32,
         b_gl_stride: Int32,
         s_gl_stride: Int32,
@@ -3791,6 +4399,8 @@ class W4A16GemmKernel:
                 Int32((pipe + _STAGES - 1) % _STAGES),
                 reduce_k_tile + fetch_tile,
                 block_valid_rows,
+                block_valid_rows1,
+                paired_m8,
                 a_gl_stride,
                 b_gl_stride,
                 s_gl_stride,
@@ -4017,13 +4627,17 @@ class W4A16GemmKernel:
         c_sh_rd: Int32,
         c_sh_rd_delta: Int32,
         block_valid_rows: Int32,
+        metadata_row_base: Int32,
         store_iters: cutlass.Constexpr[int],
     ):
         for _ in cutlass.range_constexpr(store_iters):
             row = c_gl_wr // c_gl_stride
             if row < block_valid_rows:
+                metadata_row = metadata_row_base + row
                 route_index = ld_shared_i32_relaxed(
-                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
+                    smem_base
+                    + Int32(self.sh_route_off * 16)
+                    + metadata_row * Int32(4)
                 )
                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(
                     c_gl_wr % c_gl_stride
@@ -4033,7 +4647,9 @@ class W4A16GemmKernel:
                 )
                 if cutlass.const_expr(self.mul_topk_weights):
                     scale_bf2 = ld_shared_u32(
-                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
+                        smem_base
+                        + Int32(self.sh_topk_off * 16)
+                        + metadata_row * Int32(4)
                     )
                     q0 = self._elem2_mul(q0, scale_bf2)
                     q1 = self._elem2_mul(q1, scale_bf2)
@@ -4083,14 +4699,18 @@ class W4A16GemmKernel:
         c_sh_rd: Int32,
         c_sh_rd_delta: Int32,
         block_valid_rows: Int32,
+        metadata_row_base: Int32,
         store_iters: cutlass.Constexpr[int],
     ):
         for _ in cutlass.range_constexpr(store_iters):
             row = c_gl_wr // c_gl_stride_covered
             col_word = c_gl_wr - row * c_gl_stride_covered
             if row < block_valid_rows and col_word < c_gl_stride:
+                metadata_row = metadata_row_base + row
                 route_index = ld_shared_i32_relaxed(
-                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
+                    smem_base
+                    + Int32(self.sh_route_off * 16)
+                    + metadata_row * Int32(4)
                 )
                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(col_word)
                 q0, q1, q2, q3 = ld_shared_v4_u32(
@@ -4098,7 +4718,9 @@ class W4A16GemmKernel:
                 )
                 if cutlass.const_expr(self.mul_topk_weights):
                     scale_bf2 = ld_shared_u32(
-                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
+                        smem_base
+                        + Int32(self.sh_topk_off * 16)
+                        + metadata_row * Int32(4)
                     )
                     q0 = self._elem2_mul(q0, scale_bf2)
                     q1 = self._elem2_mul(q1, scale_bf2)
@@ -4138,6 +4760,7 @@ class W4A16GemmKernel:
         tid: Int32,
         output_n_tile: Int32,
         block_valid_rows: Int32,
+        metadata_row_base: Int32,
         global_scale_f32: cutlass.Float32,
     ):
         if cutlass.const_expr(self.has_n_tile_tail):
@@ -4220,6 +4843,7 @@ class W4A16GemmKernel:
                 c_sh_rd,
                 c_sh_rd_delta,
                 block_valid_rows,
+                metadata_row_base,
                 store_iters,
             )
         else:
@@ -4232,6 +4856,7 @@ class W4A16GemmKernel:
                 c_sh_rd,
                 c_sh_rd_delta,
                 block_valid_rows,
+                metadata_row_base,
                 store_iters,
             )
 
@@ -4531,6 +5156,7 @@ class W4A16GemmKernel:
                 c_sh_rd,
                 c_sh_rd_delta,
                 block_valid_rows,
+                Int32(0),
                 store_iters,
             )
         else:
@@ -4543,6 +5169,7 @@ class W4A16GemmKernel:
                 c_sh_rd,
                 c_sh_rd_delta,
                 block_valid_rows,
+                Int32(0),
                 store_iters,
             )
 
@@ -4714,14 +5341,15 @@ class W4A16FusedMoeKernel:
         expected_fc2_schedule_factor = (
             self.moe_block_size // self.fc2_moe_block_size
         )
-        if self.fc2_schedule_route_block_factor not in (
-            1,
-            expected_fc2_schedule_factor,
+        if (
+            self.fc2_schedule_route_block_factor < 1
+            or expected_fc2_schedule_factor % self.fc2_schedule_route_block_factor
+            != 0
         ):
             raise ValueError(
-                "FC2 schedule factor must be one or cover one packed route "
-                f"block: factor={self.fc2_schedule_route_block_factor}, "
-                f"expected={expected_fc2_schedule_factor}"
+                "FC2 schedule factor must divide one packed route block: "
+                f"factor={self.fc2_schedule_route_block_factor}, "
+                f"maximum={expected_fc2_schedule_factor}"
             )
         self.activation = activation
         self.activation_is_gated = is_gated
@@ -4845,6 +5473,10 @@ class W4A16FusedMoeKernel:
             schedule_whole_tiles=self.schedule_whole_tiles,
             dynamic_num_experts=self.dynamic_num_experts,
             schedule_route_block_factor=self.fc2_schedule_route_block_factor,
+            paired_m8_routes=(
+                self.fc2_moe_block_size == 8
+                and self.fc2_schedule_route_block_factor == 2
+            ),
         )
         self.cta_threads = max(self.fc1.cta_threads, self.fc2.cta_threads)
         if self.fc1.cta_threads != self.fc2.cta_threads:
@@ -5418,7 +6050,6 @@ class W4A16FusedMoeKernel:
                 active_m,
             )
             self._grid_barrier(locks_i32_flat, tid, grid_x)
-
         if cutlass.const_expr(self.tc_decode_fused_sum):
             # The TC-decode FC2 epilogue atomically accumulates per-route
             # partials directly into the per-token output, so the output must be
@@ -5556,7 +6187,6 @@ class W4A16FusedMoeKernel:
             active_m * Int32(self.top_k),
             fc2_emit_tile,
         )
-
     @cute.jit
     def _grid_barrier(
         self,

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -600,6 +600,9 @@ class W4A16MixedTrellisKernel:
             intermediate_rotations,
             gate_suh,
             up_suh,
+            descriptor_map,
+            Int32(self.total_experts),
+            Int32(self.total_experts),
             smem_base,
             tid,
             cta,
@@ -1123,6 +1126,8 @@ def run_mixed_trellis(
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
+        Int32(launch.topk_sum.num_experts),
+        Int32(launch.topk_sum.route_num_experts),
         m,
         stream,
     )

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -57,6 +57,7 @@ class MixedTrellisCompileResult:
     moe_block_size: int
     fc2_moe_block_size: int
     fc2_schedule_route_block_factor: int
+    fc2_paired_m8_routes: bool
     max_m_blocks: int
     blocks_per_sm: int
     sms: int
@@ -111,7 +112,7 @@ class MixedTrellisTier(Protocol):
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
-    ABI_VERSION = 3
+    ABI_VERSION = 4
 
     def __init__(
         self,
@@ -155,6 +156,7 @@ class W4A16MixedTrellisKernel:
                     g.cta_threads,
                     g.moe_block_size,
                     g.schedule_route_block_factor,
+                    g.paired_m8_routes,
                 )
                 for g in gemms
             )
@@ -164,10 +166,17 @@ class W4A16MixedTrellisKernel:
                 )
         fc2_factor = int(driver.fc2.schedule_route_block_factor)
         expected_factor = int(driver.moe_block_size // driver.fc2.moe_block_size)
-        if fc2_factor not in (1, expected_factor):
+        if fc2_factor < 1 or expected_factor % fc2_factor != 0:
             raise ValueError(
-                "mixed Trellis FC2 schedule factor must be one or cover one "
-                f"packed route block: factor={fc2_factor}, expected={expected_factor}"
+                "mixed Trellis FC2 schedule factor must divide one packed "
+                f"route block: factor={fc2_factor}, maximum={expected_factor}"
+            )
+        expected_pair = fc2_factor == 2 and driver.fc2.moe_block_size == 8
+        if bool(driver.fc2.paired_m8_routes) != expected_pair:
+            raise ValueError(
+                "mixed Trellis FC2 pair contract mismatch: "
+                f"factor={fc2_factor}, m={driver.fc2.moe_block_size}, "
+                f"paired={driver.fc2.paired_m8_routes}"
             )
         if tier0.num_experts > 256 or tier1.num_experts > 256:
             raise ValueError("tier-local expert ids must fit in eight bits")
@@ -252,15 +261,12 @@ class W4A16MixedTrellisKernel:
                         gemm = self.tier0.fc1
                     else:
                         gemm = self.tier0.fc2
-                    for subtile in cutlass.range_constexpr(
-                        gemm.schedule_route_block_factor
-                    ):
+                    if cutlass.const_expr(gemm.paired_m8_routes):
                         tile_route_block_idx = (
                             route_block_idx
                             * Int32(gemm.schedule_route_block_factor)
-                            + Int32(subtile)
                         )
-                        gemm._run_tile(
+                        gemm._run_tile_m8_pair(
                             a_flat,
                             a_alt_flat,
                             t0_b_flat,
@@ -280,25 +286,54 @@ class W4A16MixedTrellisKernel:
                             reduce_tile_count,
                             reduce_slice_count,
                             reduce_slice_idx,
-                            lock_slot
-                            * Int32(gemm.schedule_route_block_factor)
-                            + Int32(subtile),
+                            lock_slot * Int32(gemm.schedule_route_block_factor),
                             active_size_m,
                         )
+                    else:
+                        for subtile in cutlass.range_constexpr(
+                            gemm.schedule_route_block_factor
+                        ):
+                            tile_route_block_idx = (
+                                route_block_idx
+                                * Int32(gemm.schedule_route_block_factor)
+                                + Int32(subtile)
+                            )
+                            gemm._run_tile(
+                                a_flat,
+                                a_alt_flat,
+                                t0_b_flat,
+                                c_flat,
+                                t0_scales_flat,
+                                t0_global_scale,
+                                packed_route_indices,
+                                topk_weights,
+                                c_tmp,
+                                locks,
+                                smem_base,
+                                tid,
+                                tile_route_block_idx,
+                                local_expert,
+                                output_n_tile,
+                                reduce_k_tile,
+                                reduce_tile_count,
+                                reduce_slice_count,
+                                reduce_slice_idx,
+                                lock_slot
+                                * Int32(gemm.schedule_route_block_factor)
+                                + Int32(subtile),
+                                active_size_m,
+                            )
                 elif tier == Int32(1) and local_expert < Int32(self.tier1.num_experts):
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier1.fc1
                     else:
                         gemm = self.tier1.fc2
-                    for subtile in cutlass.range_constexpr(
-                        gemm.schedule_route_block_factor
-                    ):
+                    if cutlass.const_expr(gemm.paired_m8_routes):
                         tile_route_block_idx = (
                             route_block_idx
                             * Int32(gemm.schedule_route_block_factor)
-                            + Int32(subtile)
                         )
-                        gemm._run_tile(
+                        gemm._run_tile_m8_pair(
                             a_flat,
                             a_alt_flat,
                             t1_b_flat,
@@ -318,11 +353,43 @@ class W4A16MixedTrellisKernel:
                             reduce_tile_count,
                             reduce_slice_count,
                             reduce_slice_idx,
-                            lock_slot
-                            * Int32(gemm.schedule_route_block_factor)
-                            + Int32(subtile),
+                            lock_slot * Int32(gemm.schedule_route_block_factor),
                             active_size_m,
                         )
+                    else:
+                        for subtile in cutlass.range_constexpr(
+                            gemm.schedule_route_block_factor
+                        ):
+                            tile_route_block_idx = (
+                                route_block_idx
+                                * Int32(gemm.schedule_route_block_factor)
+                                + Int32(subtile)
+                            )
+                            gemm._run_tile(
+                                a_flat,
+                                a_alt_flat,
+                                t1_b_flat,
+                                c_flat,
+                                t1_scales_flat,
+                                t1_global_scale,
+                                packed_route_indices,
+                                topk_weights,
+                                c_tmp,
+                                locks,
+                                smem_base,
+                                tid,
+                                tile_route_block_idx,
+                                local_expert,
+                                output_n_tile,
+                                reduce_k_tile,
+                                reduce_tile_count,
+                                reduce_slice_count,
+                                reduce_slice_idx,
+                                lock_slot
+                                * Int32(gemm.schedule_route_block_factor)
+                                + Int32(subtile),
+                                active_size_m,
+                            )
 
     @cute.jit
     def __call__(
@@ -605,7 +672,7 @@ def compile_mixed_trellis(
             moe_block_size=moe_block_size,
             max_m_blocks=max_m_blocks,
             fc2_moe_block_size=(8 if int(moe_block_size) == 64 else moe_block_size),
-            fc2_schedule_route_block_factor=(8 if int(moe_block_size) == 64 else 1),
+            fc2_schedule_route_block_factor=(2 if int(moe_block_size) == 64 else 1),
             element_dtype="fp16",
             weight_layout="trellis3_t256",
             scale_format="e4m3_k32",
@@ -757,6 +824,7 @@ def compile_mixed_trellis(
         fc2_schedule_route_block_factor=int(
             kernel.driver.fc2.schedule_route_block_factor
         ),
+        fc2_paired_m8_routes=bool(kernel.driver.fc2.paired_m8_routes),
         max_m_blocks=int(max_m_blocks),
         blocks_per_sm=int(kernel.blocks_per_sm),
         sms=int(sms),

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -212,6 +212,85 @@ class W4A16MixedTrellisKernel:
         )
 
     @cute.jit
+    def _dispatch_tier_gemm(
+        self,
+        gemm,
+        a_flat: cute.Tensor,
+        a_alt_flat: cute.Tensor,
+        b_flat: cute.Tensor,
+        c_flat: cute.Tensor,
+        scales_flat: cute.Tensor,
+        global_scale: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        topk_weights: cute.Tensor,
+        c_tmp: cute.Tensor,
+        locks: cute.Tensor,
+        smem_base: Int32,
+        tid: Int32,
+        route_block_idx: Int32,
+        local_expert: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+        active_size_m: Int32,
+    ):
+        factor = gemm.schedule_route_block_factor
+        first_route_block = route_block_idx * Int32(factor)
+        first_lock_slot = lock_slot * Int32(factor)
+        if cutlass.const_expr(gemm.paired_m8_routes):
+            gemm._run_tile_m8_pair(
+                a_flat,
+                a_alt_flat,
+                b_flat,
+                c_flat,
+                scales_flat,
+                global_scale,
+                packed_route_indices,
+                topk_weights,
+                c_tmp,
+                locks,
+                smem_base,
+                tid,
+                first_route_block,
+                local_expert,
+                output_n_tile,
+                reduce_k_tile,
+                reduce_tile_count,
+                reduce_slice_count,
+                reduce_slice_idx,
+                first_lock_slot,
+                active_size_m,
+            )
+        else:
+            for subtile in cutlass.range_constexpr(factor):
+                gemm._run_tile(
+                    a_flat,
+                    a_alt_flat,
+                    b_flat,
+                    c_flat,
+                    scales_flat,
+                    global_scale,
+                    packed_route_indices,
+                    topk_weights,
+                    c_tmp,
+                    locks,
+                    smem_base,
+                    tid,
+                    first_route_block + Int32(subtile),
+                    local_expert,
+                    output_n_tile,
+                    reduce_k_tile,
+                    reduce_tile_count,
+                    reduce_slice_count,
+                    reduce_slice_idx,
+                    first_lock_slot + Int32(subtile),
+                    active_size_m,
+                )
+
+    @cute.jit
     def _emit_tier_tile(
         self,
         is_fc1: cutlass.Constexpr,
@@ -261,135 +340,59 @@ class W4A16MixedTrellisKernel:
                         gemm = self.tier0.fc1
                     else:
                         gemm = self.tier0.fc2
-                    if cutlass.const_expr(gemm.paired_m8_routes):
-                        tile_route_block_idx = (
-                            route_block_idx
-                            * Int32(gemm.schedule_route_block_factor)
-                        )
-                        gemm._run_tile_m8_pair(
-                            a_flat,
-                            a_alt_flat,
-                            t0_b_flat,
-                            c_flat,
-                            t0_scales_flat,
-                            t0_global_scale,
-                            packed_route_indices,
-                            topk_weights,
-                            c_tmp,
-                            locks,
-                            smem_base,
-                            tid,
-                            tile_route_block_idx,
-                            local_expert,
-                            output_n_tile,
-                            reduce_k_tile,
-                            reduce_tile_count,
-                            reduce_slice_count,
-                            reduce_slice_idx,
-                            lock_slot * Int32(gemm.schedule_route_block_factor),
-                            active_size_m,
-                        )
-                    else:
-                        for subtile in cutlass.range_constexpr(
-                            gemm.schedule_route_block_factor
-                        ):
-                            tile_route_block_idx = (
-                                route_block_idx
-                                * Int32(gemm.schedule_route_block_factor)
-                                + Int32(subtile)
-                            )
-                            gemm._run_tile(
-                                a_flat,
-                                a_alt_flat,
-                                t0_b_flat,
-                                c_flat,
-                                t0_scales_flat,
-                                t0_global_scale,
-                                packed_route_indices,
-                                topk_weights,
-                                c_tmp,
-                                locks,
-                                smem_base,
-                                tid,
-                                tile_route_block_idx,
-                                local_expert,
-                                output_n_tile,
-                                reduce_k_tile,
-                                reduce_tile_count,
-                                reduce_slice_count,
-                                reduce_slice_idx,
-                                lock_slot
-                                * Int32(gemm.schedule_route_block_factor)
-                                + Int32(subtile),
-                                active_size_m,
-                            )
+                    self._dispatch_tier_gemm(
+                        gemm,
+                        a_flat,
+                        a_alt_flat,
+                        t0_b_flat,
+                        c_flat,
+                        t0_scales_flat,
+                        t0_global_scale,
+                        packed_route_indices,
+                        topk_weights,
+                        c_tmp,
+                        locks,
+                        smem_base,
+                        tid,
+                        route_block_idx,
+                        local_expert,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                        active_size_m,
+                    )
                 elif tier == Int32(1) and local_expert < Int32(self.tier1.num_experts):
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier1.fc1
                     else:
                         gemm = self.tier1.fc2
-                    if cutlass.const_expr(gemm.paired_m8_routes):
-                        tile_route_block_idx = (
-                            route_block_idx
-                            * Int32(gemm.schedule_route_block_factor)
-                        )
-                        gemm._run_tile_m8_pair(
-                            a_flat,
-                            a_alt_flat,
-                            t1_b_flat,
-                            c_flat,
-                            t1_scales_flat,
-                            t1_global_scale,
-                            packed_route_indices,
-                            topk_weights,
-                            c_tmp,
-                            locks,
-                            smem_base,
-                            tid,
-                            tile_route_block_idx,
-                            local_expert,
-                            output_n_tile,
-                            reduce_k_tile,
-                            reduce_tile_count,
-                            reduce_slice_count,
-                            reduce_slice_idx,
-                            lock_slot * Int32(gemm.schedule_route_block_factor),
-                            active_size_m,
-                        )
-                    else:
-                        for subtile in cutlass.range_constexpr(
-                            gemm.schedule_route_block_factor
-                        ):
-                            tile_route_block_idx = (
-                                route_block_idx
-                                * Int32(gemm.schedule_route_block_factor)
-                                + Int32(subtile)
-                            )
-                            gemm._run_tile(
-                                a_flat,
-                                a_alt_flat,
-                                t1_b_flat,
-                                c_flat,
-                                t1_scales_flat,
-                                t1_global_scale,
-                                packed_route_indices,
-                                topk_weights,
-                                c_tmp,
-                                locks,
-                                smem_base,
-                                tid,
-                                tile_route_block_idx,
-                                local_expert,
-                                output_n_tile,
-                                reduce_k_tile,
-                                reduce_tile_count,
-                                reduce_slice_count,
-                                reduce_slice_idx,
-                                lock_slot
-                                * Int32(gemm.schedule_route_block_factor)
-                                + Int32(subtile),
-                                active_size_m,
-                            )
+                    self._dispatch_tier_gemm(
+                        gemm,
+                        a_flat,
+                        a_alt_flat,
+                        t1_b_flat,
+                        c_flat,
+                        t1_scales_flat,
+                        t1_global_scale,
+                        packed_route_indices,
+                        topk_weights,
+                        c_tmp,
+                        locks,
+                        smem_base,
+                        tid,
+                        route_block_idx,
+                        local_expert,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                        active_size_m,
+                    )
 
     @cute.jit
     def __call__(

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -56,6 +56,7 @@ class MixedTrellisCompileResult:
     fc2_tile_n: int
     moe_block_size: int
     fc2_moe_block_size: int
+    fc2_schedule_route_block_factor: int
     max_m_blocks: int
     blocks_per_sm: int
     sms: int
@@ -110,7 +111,7 @@ class MixedTrellisTier(Protocol):
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
-    ABI_VERSION = 2
+    ABI_VERSION = 3
 
     def __init__(
         self,
@@ -153,6 +154,7 @@ class W4A16MixedTrellisKernel:
                     g.tile_k,
                     g.cta_threads,
                     g.moe_block_size,
+                    g.schedule_route_block_factor,
                 )
                 for g in gemms
             )
@@ -160,6 +162,13 @@ class W4A16MixedTrellisKernel:
                 raise ValueError(
                     f"mixed Trellis kernels disagree on {phase} geometry: {geometry}"
                 )
+        fc2_factor = int(driver.fc2.schedule_route_block_factor)
+        expected_factor = int(driver.moe_block_size // driver.fc2.moe_block_size)
+        if fc2_factor not in (1, expected_factor):
+            raise ValueError(
+                "mixed Trellis FC2 schedule factor must be one or cover one "
+                f"packed route block: factor={fc2_factor}, expected={expected_factor}"
+            )
         if tier0.num_experts > 256 or tier1.num_experts > 256:
             raise ValueError("tier-local expert ids must fit in eight bits")
         if driver.num_experts != tier0.num_experts + tier1.num_experts:
@@ -226,7 +235,11 @@ class W4A16MixedTrellisKernel:
         metadata_block_idx = route_block_idx
         if cutlass.const_expr(not is_fc1):
             metadata_block_idx = route_block_idx // Int32(
-                self.driver.moe_block_size // self.driver.fc2.moe_block_size
+                self.driver.moe_block_size
+                // (
+                    self.driver.fc2.moe_block_size
+                    * self.driver.fc2.schedule_route_block_factor
+                )
             )
         combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
         if combined_expert >= Int32(0) and combined_expert < Int32(self.total_experts):
@@ -239,57 +252,77 @@ class W4A16MixedTrellisKernel:
                         gemm = self.tier0.fc1
                     else:
                         gemm = self.tier0.fc2
-                    gemm._run_tile(
-                        a_flat,
-                        a_alt_flat,
-                        t0_b_flat,
-                        c_flat,
-                        t0_scales_flat,
-                        t0_global_scale,
-                        packed_route_indices,
-                        topk_weights,
-                        c_tmp,
-                        locks,
-                        smem_base,
-                        tid,
-                        route_block_idx,
-                        local_expert,
-                        output_n_tile,
-                        reduce_k_tile,
-                        reduce_tile_count,
-                        reduce_slice_count,
-                        reduce_slice_idx,
-                        lock_slot,
-                        active_size_m,
-                    )
+                    for subtile in cutlass.range_constexpr(
+                        gemm.schedule_route_block_factor
+                    ):
+                        tile_route_block_idx = (
+                            route_block_idx
+                            * Int32(gemm.schedule_route_block_factor)
+                            + Int32(subtile)
+                        )
+                        gemm._run_tile(
+                            a_flat,
+                            a_alt_flat,
+                            t0_b_flat,
+                            c_flat,
+                            t0_scales_flat,
+                            t0_global_scale,
+                            packed_route_indices,
+                            topk_weights,
+                            c_tmp,
+                            locks,
+                            smem_base,
+                            tid,
+                            tile_route_block_idx,
+                            local_expert,
+                            output_n_tile,
+                            reduce_k_tile,
+                            reduce_tile_count,
+                            reduce_slice_count,
+                            reduce_slice_idx,
+                            lock_slot
+                            * Int32(gemm.schedule_route_block_factor)
+                            + Int32(subtile),
+                            active_size_m,
+                        )
                 elif tier == Int32(1) and local_expert < Int32(self.tier1.num_experts):
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier1.fc1
                     else:
                         gemm = self.tier1.fc2
-                    gemm._run_tile(
-                        a_flat,
-                        a_alt_flat,
-                        t1_b_flat,
-                        c_flat,
-                        t1_scales_flat,
-                        t1_global_scale,
-                        packed_route_indices,
-                        topk_weights,
-                        c_tmp,
-                        locks,
-                        smem_base,
-                        tid,
-                        route_block_idx,
-                        local_expert,
-                        output_n_tile,
-                        reduce_k_tile,
-                        reduce_tile_count,
-                        reduce_slice_count,
-                        reduce_slice_idx,
-                        lock_slot,
-                        active_size_m,
-                    )
+                    for subtile in cutlass.range_constexpr(
+                        gemm.schedule_route_block_factor
+                    ):
+                        tile_route_block_idx = (
+                            route_block_idx
+                            * Int32(gemm.schedule_route_block_factor)
+                            + Int32(subtile)
+                        )
+                        gemm._run_tile(
+                            a_flat,
+                            a_alt_flat,
+                            t1_b_flat,
+                            c_flat,
+                            t1_scales_flat,
+                            t1_global_scale,
+                            packed_route_indices,
+                            topk_weights,
+                            c_tmp,
+                            locks,
+                            smem_base,
+                            tid,
+                            tile_route_block_idx,
+                            local_expert,
+                            output_n_tile,
+                            reduce_k_tile,
+                            reduce_tile_count,
+                            reduce_slice_count,
+                            reduce_slice_idx,
+                            lock_slot
+                            * Int32(gemm.schedule_route_block_factor)
+                            + Int32(subtile),
+                            active_size_m,
+                        )
 
     @cute.jit
     def __call__(
@@ -572,6 +605,7 @@ def compile_mixed_trellis(
             moe_block_size=moe_block_size,
             max_m_blocks=max_m_blocks,
             fc2_moe_block_size=(8 if int(moe_block_size) == 64 else moe_block_size),
+            fc2_schedule_route_block_factor=(8 if int(moe_block_size) == 64 else 1),
             element_dtype="fp16",
             weight_layout="trellis3_t256",
             scale_format="e4m3_k32",
@@ -720,6 +754,9 @@ def compile_mixed_trellis(
         fc2_tile_n=fc2_tile_n,
         moe_block_size=int(moe_block_size),
         fc2_moe_block_size=int(kernel.driver.fc2.moe_block_size),
+        fc2_schedule_route_block_factor=int(
+            kernel.driver.fc2.schedule_route_block_factor
+        ),
         max_m_blocks=int(max_m_blocks),
         blocks_per_sm=int(kernel.blocks_per_sm),
         sms=int(sms),

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -55,6 +55,7 @@ class MixedTrellisCompileResult:
     fc2_tile_k: int
     fc2_tile_n: int
     moe_block_size: int
+    fc2_moe_block_size: int
     max_m_blocks: int
     blocks_per_sm: int
     sms: int
@@ -109,7 +110,7 @@ class MixedTrellisTier(Protocol):
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
-    ABI_VERSION = 1
+    ABI_VERSION = 2
 
     def __init__(
         self,
@@ -145,7 +146,15 @@ class W4A16MixedTrellisKernel:
         for phase in ("fc1", "fc2"):
             gemms = tuple(getattr(moe, phase) for moe in (driver, tier0, tier1))
             geometry = tuple(
-                (g.n_tiles, g.k_tiles, g.tile_n, g.tile_k, g.cta_threads) for g in gemms
+                (
+                    g.n_tiles,
+                    g.k_tiles,
+                    g.tile_n,
+                    g.tile_k,
+                    g.cta_threads,
+                    g.moe_block_size,
+                )
+                for g in gemms
             )
             if geometry[1:] != geometry[:-1]:
                 raise ValueError(
@@ -214,7 +223,12 @@ class W4A16MixedTrellisKernel:
         reduce_slice_idx: Int32,
         lock_slot: Int32,
     ):
-        combined_expert = block_expert_ids[route_block_idx].to(Int32)
+        metadata_block_idx = route_block_idx
+        if cutlass.const_expr(not is_fc1):
+            metadata_block_idx = route_block_idx // Int32(
+                self.driver.moe_block_size // self.driver.fc2.moe_block_size
+            )
+        combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
         if combined_expert >= Int32(0) and combined_expert < Int32(self.total_experts):
             descriptor = descriptor_map[combined_expert].to(Int32)
             if descriptor >= Int32(0):
@@ -557,6 +571,7 @@ def compile_mixed_trellis(
             fc2_tile_k=fc2_tile_k,
             moe_block_size=moe_block_size,
             max_m_blocks=max_m_blocks,
+            fc2_moe_block_size=(8 if int(moe_block_size) == 64 else moe_block_size),
             element_dtype="fp16",
             weight_layout="trellis3_t256",
             scale_format="e4m3_k32",
@@ -573,9 +588,15 @@ def compile_mixed_trellis(
         tier0=make_kernel(int(tier0_num_experts), int(tier0_bits)),
         tier1=make_kernel(int(tier1_num_experts), int(tier1_bits)),
     )
-    if kernel.shared_words * 4 > int(max_shared_mem) - 512:
+    # shared_words is the complete dynamically allocated MemRange used by the
+    # cooperative kernel. CUDA permits a launch exactly at the device's
+    # opt-in shared-memory limit; rejecting an additional 512 bytes here
+    # unnecessarily excludes the stock mixed-K tile geometry at block-64.
+    if kernel.shared_words * 4 > int(max_shared_mem):
         raise ValueError(
-            "mixed Trellis shared-memory requirement exceeds the device limit"
+            "mixed Trellis shared-memory requirement exceeds the device limit: "
+            f"required={kernel.shared_words * 4} "
+            f"limit={int(max_shared_mem)}"
         )
     device = int(torch.cuda.current_device())
     cache_key = (
@@ -698,6 +719,7 @@ def compile_mixed_trellis(
         fc2_tile_k=fc2_tile_k,
         fc2_tile_n=fc2_tile_n,
         moe_block_size=int(moe_block_size),
+        fc2_moe_block_size=int(kernel.driver.fc2.moe_block_size),
         max_m_blocks=int(max_m_blocks),
         blocks_per_sm=int(kernel.blocks_per_sm),
         sms=int(sms),

--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -654,6 +654,7 @@ def compile_mixed_trellis(
             "large-M cross-tier partial reductions"
         )
     total_experts = int(tier0_num_experts) + int(tier1_num_experts)
+    paired_m8_fc2 = int(moe_block_size) in (32, 64)
 
     def make_kernel(num_experts: int, bits: int) -> W4A16FusedMoeKernel:
         return W4A16FusedMoeKernel(
@@ -671,8 +672,8 @@ def compile_mixed_trellis(
             fc2_tile_k=fc2_tile_k,
             moe_block_size=moe_block_size,
             max_m_blocks=max_m_blocks,
-            fc2_moe_block_size=(8 if int(moe_block_size) == 64 else moe_block_size),
-            fc2_schedule_route_block_factor=(2 if int(moe_block_size) == 64 else 1),
+            fc2_moe_block_size=(8 if paired_m8_fc2 else moe_block_size),
+            fc2_schedule_route_block_factor=(2 if paired_m8_fc2 else 1),
             element_dtype="fp16",
             weight_layout="trellis3_t256",
             scale_format="e4m3_k32",

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -1183,9 +1183,12 @@ def prepare_w4a16_e8m0_native_weights(
     w13_rows = shape.w13_rows
     is_gated = shape.is_gated
     allow_w2_k_tail = intermediate_size % 32 != 0
-    padded_w13_scale_n = (
-        _e8m0_logical_tail_scale_n(w13_rows) if allow_w2_k_tail else w13_rows
-    )
+    # Packed E8M0 scale rows are permuted in 64-row blocks independently of
+    # whether W2 has a compact K tail.  Ungated 32-aligned intermediates such
+    # as I=224 therefore still need W13's 224 scale rows padded to 256; tying
+    # this padding to ``allow_w2_k_tail`` advertised the direct shape and then
+    # rejected it during preparation.
+    padded_w13_scale_n = _e8m0_logical_tail_scale_n(w13_rows)
 
     w13_scale = _validate_e8m0_k32_scales(
         w13_e8m0_scale,

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -176,12 +176,15 @@ class PreparedTrellis256DenseWeight:
 
 
 def _make_workspace(
-    device: torch.device, *, max_blocks_per_sm: int = 4
+    device: torch.device,
+    *,
+    max_blocks_per_sm: int = 4,
+    min_elements: int = 0,
 ) -> torch.Tensor:
     props = torch.cuda.get_device_properties(device)
     sms = int(props.multi_processor_count)
     return torch.zeros(
-        (sms * int(max_blocks_per_sm) + 2,),
+        (max(sms * int(max_blocks_per_sm) + 2, int(min_elements)),),
         dtype=torch.int32,
         device=device,
     )
@@ -2150,7 +2153,11 @@ def prepare_trellis256_dense_weight(
         svh=svh,
         scale=dummy_scale,
         global_scale=torch.ones(1, dtype=torch.float32, device=device),
-        workspace=_make_workspace(device, max_blocks_per_sm=4),
+        workspace=_make_workspace(
+            device,
+            max_blocks_per_sm=4,
+            min_elements=out_features // 16,
+        ),
         in_features=in_features,
         out_features=out_features,
         params_dtype=params_dtype,

--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
@@ -669,6 +669,7 @@ def _permute_nvfp4_scales(
     size_n: int,
     a_dtype: torch.dtype,
     row_rotation: int | None = None,
+    output_size_n: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     combined_scale_factor = _nvfp4_compute_scale_factor(scales, a_dtype)
     packed_scales: torch.Tensor | None = None
@@ -684,6 +685,7 @@ def _permute_nvfp4_scales(
             size_k=size_k,
             size_n=size_n,
             group_size=16,
+            output_size_n=output_size_n,
         )
         expert_packed = _process_nvfp4_packed_scales(
             expert_scales,
@@ -697,8 +699,9 @@ def _permute_nvfp4_scales(
             )
         packed_scales[expert].copy_(expert_packed)
     if packed_scales is None:
+        packed_size_n = int(size_n) if output_size_n is None else int(output_size_n)
         packed_scales = torch.empty(
-            (0, size_k // _PACKED_TILE_SIZE, size_n // 2),
+            (0, size_k // _PACKED_TILE_SIZE, packed_size_n // 2),
             dtype=torch.float8_e4m3fn,
             device=scales.device,
         )
@@ -1098,6 +1101,24 @@ def prepare_w4a16_modelopt_native_weights(
         size_n=hidden_size,
         a_dtype=params_dtype,
     )
+    micro_w13_scale = packed_w13_scale
+    micro_w13_global_scale = packed_w13_global_scale
+    if w13_rows % _PACKED_TILE_N_SIZE != 0:
+        # The direct micro reader uses the native 64-row scale permutation.
+        # Keep the final tile intact: truncating it after permutation discards
+        # logical rows whose permuted columns land above ``w13_rows``.
+        micro_scale_n = (
+            (w13_rows + _PACKED_TILE_N_SIZE - 1) // _PACKED_TILE_N_SIZE
+        ) * _PACKED_TILE_N_SIZE
+        micro_w13_scale, micro_w13_global_scale = _permute_nvfp4_scales(
+            w13_scale,
+            native_w13_global_scale,
+            size_k=hidden_size,
+            size_n=w13_rows,
+            a_dtype=params_dtype,
+            row_rotation=w13_row_rotation,
+            output_size_n=micro_scale_n,
+        )
 
     return W4A16ModelOptWeights(
         w13=w13_fp4,
@@ -1113,9 +1134,9 @@ def prepare_w4a16_modelopt_native_weights(
         is_gated=is_gated,
         params_dtype=params_dtype,
         source_format=source_format,
-        micro_w13_scale=packed_w13_scale,
+        micro_w13_scale=micro_w13_scale,
         micro_w13_global_scale=_process_nvfp4_micro_global_scale_from_packed(
-            packed_w13_global_scale,
+            micro_w13_global_scale,
             a_dtype=params_dtype,
         ),
         micro_w2_scale=packed_w2_scale,

--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
@@ -303,13 +303,11 @@ def pack_topk_routes_by_expert(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     numel = int(topk_ids.numel())
     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
-    numel_capacity, capacity_packed_routes, capacity_route_blocks = (
-        route_pack_capacity(
-            numel,
-            int(block_size),
-            int(num_experts),
-            topk=topk,
-        )
+    numel_capacity, capacity_packed_routes, capacity_route_blocks = route_pack_capacity(
+        numel,
+        int(block_size),
+        int(num_experts),
+        topk=topk,
     )
     if packed_route_indices is not None and block_expert_ids is not None:
         if (
@@ -341,10 +339,7 @@ def pack_topk_routes_by_expert(
     if (
         provided_routes is not None
         and provided_blocks is not None
-        and (
-            provided_routes < max_packed_routes
-            or provided_blocks < max_route_blocks
-        )
+        and (provided_routes < max_packed_routes or provided_blocks < max_route_blocks)
     ):
         raise ValueError(
             "W4A16 route-packing workspace is too small: "

--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
@@ -6,10 +6,7 @@ import triton
 import triton.language as tl
 import torch
 
-from sparkinfer.moe._shared.kernels.w4a16.host import (
-    max_packed_route_slots,
-    route_pack_numel_capacity,
-)
+from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
 
 
 _COUNT_BLOCK_T = 256
@@ -306,25 +303,30 @@ def pack_topk_routes_by_expert(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     numel = int(topk_ids.numel())
     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
-    numel_capacity = route_pack_numel_capacity(numel, topk=topk)
-    capacity_packed_routes = max_packed_route_slots(
-        numel_capacity, int(block_size), int(num_experts)
-    )
-    capacity_route_blocks = (capacity_packed_routes + int(block_size) - 1) // int(
-        block_size
+    numel_capacity, capacity_packed_routes, capacity_route_blocks = (
+        route_pack_capacity(
+            numel,
+            int(block_size),
+            int(num_experts),
+            topk=topk,
+        )
     )
     if packed_route_indices is not None and block_expert_ids is not None:
         if (
             int(packed_route_indices.numel()) < capacity_packed_routes
             or int(block_expert_ids.numel()) < capacity_route_blocks
         ):
-            numel_capacity = numel
-            capacity_packed_routes = max_packed_route_slots(
-                numel, int(block_size), int(num_experts)
+            (
+                numel_capacity,
+                capacity_packed_routes,
+                capacity_route_blocks,
+            ) = route_pack_capacity(
+                numel,
+                int(block_size),
+                int(num_experts),
+                topk=topk,
+                bucket_tokens=False,
             )
-            capacity_route_blocks = (
-                capacity_packed_routes + int(block_size) - 1
-            ) // int(block_size)
     max_packed_routes = capacity_packed_routes
     max_route_blocks = capacity_route_blocks
     max_packed_routes = max(max_packed_routes, 1)

--- a/sparkinfer/moe/ep_moe/_impl.py
+++ b/sparkinfer/moe/ep_moe/_impl.py
@@ -32,9 +32,9 @@ from sparkinfer.moe._shared.kernels.activations import (
     moe_activation_w1_rows,
 )
 from sparkinfer.moe._shared.kernels.w4a16.host import (
-    _W4A16_ALLOWED_ROUTED_SIZES,
     max_packed_route_slots,
     packed_gemm_scratch_elements,
+    route_block_sizes_for_capacity,
     route_pack_token_capacity,
 )
 
@@ -379,7 +379,12 @@ def plan_ep_moe_scratch(caps: EPMoEScratchCaps) -> EPMoEScratchPlan:
     route_blocks = 1
     fc1_tmp = 1
     fc2_tmp = 1
-    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
+    block_sizes = route_block_sizes_for_capacity(
+        caps.max_tokens,
+        caps.num_topk,
+        caps.global_num_experts,
+    )
+    for block_size in block_sizes:
         slots = max_packed_route_slots(
             route_capacity_rows,
             int(block_size),

--- a/sparkinfer/moe/fused_moe/__init__.py
+++ b/sparkinfer/moe/fused_moe/__init__.py
@@ -14,6 +14,8 @@ Runtime lifecycle:
     ``plan(Caps)`` -> ``bind`` / ``bind_sparse`` / ``bind_route``
     (allocation-free views) -> ``run`` / ``run_sparse`` / ``route``
     (CUDA-graph capture safe)
+``required_nbytes(Caps)`` prices that scratch without compiling launches or
+retaining storage.
 ``route_topk`` is a standalone one-shot top-k router; ``run_sparse`` fuses
 gate -> top-k -> experts from router logits.
 
@@ -52,6 +54,7 @@ META = OpMeta(
         "Routing",
         "WeightsPlan",
         "plan",
+        "required_nbytes",
         "plan_execution",
         "plan_weights",
         "prepare_weights",
@@ -101,6 +104,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
         clear_caches,
         is_supported,
         plan,
+        required_nbytes,
         plan_execution,
         plan_weights,
         prepare_weights,

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -6615,7 +6615,7 @@ def _prewarm_w4a16_planned_launches(
     collect_activation_amax = bool(collect_activation_amax)
 
     from sparkinfer.moe._shared.kernels.w4a16.host import (
-        max_packed_route_slots,
+        route_pack_capacity,
         select_route_block_size_m,
     )
     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
@@ -6663,12 +6663,12 @@ def _prewarm_w4a16_planned_launches(
                 token_count, workspace.num_topk, workspace.route_E
             )
             routed_rows = int(token_count) * int(workspace.num_topk)
-            route_slots = max_packed_route_slots(
+            _, _, max_m_blocks = route_pack_capacity(
                 routed_rows,
                 block_size_m,
                 workspace.route_E,
+                topk=workspace.num_topk,
             )
-            max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
             fused_key = (
                 weight_layout,

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -2304,9 +2304,7 @@ def _build_tp_moe_fp4_binding_from_views(
             f"{m * num_topk} routed rows"
         )
     if output_expert_map is not None and not plan.full_rotation:
-        raise ValueError(
-            "output_expert_map requires a full-rotation Trellis plan"
-        )
+        raise ValueError("output_expert_map requires a full-rotation Trellis plan")
     if route_expert_map is not None and plan.implementation != "w4a16":
         raise ValueError("route_expert_map is only supported for W4A16 plans")
     for name, expert_map in (
@@ -2665,9 +2663,7 @@ def _plan_core_workspace(
                         route_E,
                     )
                 )
-                direct_route_slots = (
-                    direct_m * int(num_topk) * direct_block_size
-                )
+                direct_route_slots = direct_m * int(num_topk) * direct_block_size
                 fc1_c_tmp_elements = max(
                     fc1_c_tmp_elements,
                     packed_gemm_scratch_elements(
@@ -5879,9 +5875,7 @@ def _w4a16_preplanned_launches(
         _TC_DECODE_MAX_M,
     )
 
-    sum_uses_expert_map = bool(
-        use_output_expert_map or use_route_expert_map
-    )
+    sum_uses_expert_map = bool(use_output_expert_map or use_route_expert_map)
     if (
         use_route_expert_map
         and not collect_activation_amax
@@ -6461,6 +6455,29 @@ def _plan_full_rotation_w4a16_launches(
     return fused_launches, topk_sum_launches
 
 
+def _resolve_trellis_route_block_size(caps: TPMoEScratchCaps) -> int | None:
+    """Resolve the one route geometry shared by Trellis sizing and binding."""
+    if caps.w4a16_block_size_m is not None:
+        return int(caps.w4a16_block_size_m)
+    if caps.source_format != "exl3_trellis_mcg":
+        return None
+    from sparkinfer.moe._shared.kernels.w4a16.host import select_route_block_size_m
+
+    token_counts = _arena_core_token_counts(
+        max_tokens=caps.max_tokens,
+        num_topk=caps.num_topk,
+        core_token_counts=caps.core_token_counts,
+        quant_mode=caps.quant_mode,
+        bucket_w4a16_tokens=False,
+    )
+    route_experts = caps.route_num_experts or caps.weight_E
+    return select_route_block_size_m(
+        max(token_counts),
+        caps.num_topk,
+        route_experts,
+    )
+
+
 def _plan_tp_moe_arena_layout_from_caps(
     caps: TPMoEScratchCaps,
     *,
@@ -6485,7 +6502,7 @@ def _plan_tp_moe_arena_layout_from_caps(
         swiglu_beta=caps.swiglu_beta,
         collect_activation_amax=caps.collect_activation_amax,
         deterministic_output=deterministic_output,
-        w4a16_block_size_m=caps.w4a16_block_size_m,
+        w4a16_block_size_m=_resolve_trellis_route_block_size(caps),
     )
 
 
@@ -6513,6 +6530,7 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         apply_router_weight_on_input=caps.apply_router_weight_on_input,
         deterministic_output=deterministic_output,
     )
+    resolved_block_size_m = _resolve_trellis_route_block_size(caps)
     core_workspace_plan = _plan_core_workspace(
         launch_plan.implementation,
         launch_plan.quant_mode,
@@ -6533,7 +6551,7 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         w4a16_weight_layout=caps.w4a16_weight_layout,
         w4a16_scale_format=caps.w4a16_scale_format,
         route_num_experts=caps.route_num_experts,
-        w4a16_block_size_m=caps.w4a16_block_size_m,
+        w4a16_block_size_m=resolved_block_size_m,
         trellis_bits=caps.weight_plan.trellis_bits or 3,
         trellis_tile_config=caps.weight_plan.trellis_tile_config,
         apply_router_weight_on_input=caps.apply_router_weight_on_input,
@@ -6834,7 +6852,7 @@ def _prewarm_w4a16_planned_launches(
                         workspace.route_E,
                     )
                 )
-                for broadcast_suh in ((False, True) if full_rotation else (False,)):
+                for broadcast_suh in (False, True) if full_rotation else (False,):
                     resolved_mapped_direct = compile_w4a16_fused_moe(
                         size_m=direct_m,
                         hidden_size=workspace.k,
@@ -6842,9 +6860,7 @@ def _prewarm_w4a16_planned_launches(
                         num_experts=workspace.weight_E,
                         top_k=workspace.num_topk,
                         activation=workspace.activation,
-                        apply_router_weight_on_input=bool(
-                            apply_router_weight_on_input
-                        ),
+                        apply_router_weight_on_input=bool(apply_router_weight_on_input),
                         zero_fc2_output=False,
                         moe_block_size=direct_block_size_m,
                         max_m_blocks=direct_m * int(workspace.num_topk),
@@ -6869,9 +6885,7 @@ def _prewarm_w4a16_planned_launches(
                         broadcast_suh=broadcast_suh,
                     )
                     if not broadcast_suh:
-                        mapped_direct_launches[direct_m] = (
-                            resolved_mapped_direct
-                        )
+                        mapped_direct_launches[direct_m] = resolved_mapped_direct
                 if full_rotation:
                     for broadcast_svh in (False, True):
                         resolved_topk_sum = compile_w4a16_topk_sum(
@@ -6887,9 +6901,9 @@ def _prewarm_w4a16_planned_launches(
                             broadcast_svh=broadcast_svh,
                         )
                         if not broadcast_svh:
-                            topk_sum_launches[
-                                (direct_m, torch.int32, True)
-                            ] = resolved_topk_sum
+                            topk_sum_launches[(direct_m, torch.int32, True)] = (
+                                resolved_topk_sum
+                            )
 
         if build_tc_decode:
             # The capture/route-pack token counts above are powers of two, but the
@@ -6982,7 +6996,9 @@ def materialize_tp_moe_arena_workspaces(
         num_topk=num_topk,
         core_token_counts=caps.core_token_counts,
         quant_mode=quant_mode,
+        bucket_w4a16_tokens=source_format != "exl3_trellis_mcg",
     )
+    resolved_block_size_m = _resolve_trellis_route_block_size(caps)
     t_counts = time.perf_counter() if _SPARKINFER_TIMING else 0.0
     selected: dict[tuple, tuple[TPMoEPlan, _TPCoreWorkspacePlan, int]] = {}
     for token_count in core_token_counts:
@@ -7018,7 +7034,7 @@ def materialize_tp_moe_arena_workspaces(
             w4a16_weight_layout=w4a16_weight_layout,
             w4a16_scale_format=w4a16_scale_format,
             route_num_experts=caps.route_num_experts,
-            w4a16_block_size_m=caps.w4a16_block_size_m,
+            w4a16_block_size_m=resolved_block_size_m,
             trellis_bits=weight_plan.trellis_bits or 3,
             trellis_tile_config=weight_plan.trellis_tile_config,
             apply_router_weight_on_input=apply_router_weight_on_input,

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -6288,9 +6288,7 @@ def _plan_full_rotation_w4a16_launches(
     if torch.cuda.is_current_stream_capturing():
         raise RuntimeError("Trellis launch planning cannot run during capture")
 
-    from sparkinfer.moe._shared.kernels.w4a16.host import (
-        max_packed_route_slots,
-    )
+    from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
         _DEFAULT_MAX_SHARED_MEM,
         compile_w4a16_fused_moe,
@@ -6319,14 +6317,13 @@ def _plan_full_rotation_w4a16_launches(
             f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
         )
     w13_layout = "trellis3_t256_proj"
-    capacity_route_slots = max_packed_route_slots(
+    _, capacity_route_slots, capacity_m_blocks = route_pack_capacity(
         capacity_tokens * core_plan.num_topk,
         block_size_m,
         core_plan.route_E,
+        topk=core_plan.num_topk,
+        bucket_tokens=False,
     )
-    capacity_m_blocks = (
-        capacity_route_slots + block_size_m - 1
-    ) // block_size_m
     rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
 
     with torch.cuda.device(core_plan.device):
@@ -6668,6 +6665,7 @@ def _prewarm_w4a16_planned_launches(
                 block_size_m,
                 workspace.route_E,
                 topk=workspace.num_topk,
+                bucket_tokens=not full_rotation,
             )
             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
             fused_key = (

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -2537,12 +2537,13 @@ def _plan_core_workspace(
     )
     if implementation == "w4a16":
         from sparkinfer.moe._shared.kernels.w4a16.host import (
-            _W4A16_ALLOWED_ROUTED_SIZES,
             max_packed_route_slots,
             packed_gemm_scratch_elements,
+            route_block_sizes_for_capacity,
             select_route_block_size_m,
         )
         from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+            _MAX_DIRECT_TOPK_ROUTE_M,
             _TC_DECODE_MAX_M,
             _small_m_direct_supported,
         )
@@ -2558,8 +2559,9 @@ def _plan_core_workspace(
             if w4a16_weight_layout is not None
             else _w4a16_weight_layout_for_source(source_format)
         )
-        route_E = int(route_num_experts or weight_E)
+        requested_route_E = int(route_num_experts or weight_E)
         full_rotation = weight_layout == "trellis3_t256"
+        route_E = requested_route_E if full_rotation else int(weight_E)
         if full_rotation:
             if source_format != "exl3_trellis_mcg":
                 raise ValueError(
@@ -2580,16 +2582,41 @@ def _plan_core_workspace(
         fc1_c_tmp_elements = 1
         fc2_c_tmp_elements = 1
         sms = max(1, int(get_num_sm(device)))
+        topk = max(int(num_topk), 1)
+        token_capacity = (routed_capacity + topk - 1) // topk
+        direct_route_slots_by_block: dict[int, int] = {}
+        if weight_layout == "packed":
+            direct_m_cap = _MAX_DIRECT_TOPK_ROUTE_M
+            if dtype == torch.bfloat16 and is_gated_moe_activation(activation):
+                direct_m_cap = _TC_DECODE_MAX_M
+            for direct_m in range(1, min(token_capacity, direct_m_cap) + 1):
+                direct_block_size = (
+                    int(w4a16_block_size_m)
+                    if w4a16_block_size_m is not None
+                    else select_route_block_size_m(direct_m, topk, route_E)
+                )
+                direct_route_slots_by_block[direct_block_size] = max(
+                    direct_route_slots_by_block.get(direct_block_size, 0),
+                    direct_m * topk * direct_block_size,
+                )
         block_sizes = (
             (int(w4a16_block_size_m),)
             if w4a16_block_size_m is not None
-            else _W4A16_ALLOWED_ROUTED_SIZES
+            else route_block_sizes_for_capacity(
+                max_tokens=token_capacity,
+                topk=topk,
+                num_experts=route_E,
+            )
         )
         for block_size in block_sizes:
             route_slots = max_packed_route_slots(
                 routed_capacity,
                 int(block_size),
                 route_E,
+            )
+            scratch_route_slots = max(
+                route_slots,
+                direct_route_slots_by_block.get(int(block_size), 0),
             )
             route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
             route_slots_capacity = max(route_slots_capacity, route_slots)
@@ -2598,7 +2625,7 @@ def _plan_core_workspace(
                 fc1_c_tmp_elements,
                 packed_gemm_scratch_elements(
                     size_n=fc1_cols,
-                    route_slots=route_slots,
+                    route_slots=scratch_route_slots,
                     moe_block_size=int(block_size),
                     sms=sms,
                 ),
@@ -2607,7 +2634,7 @@ def _plan_core_workspace(
                 fc2_c_tmp_elements,
                 packed_gemm_scratch_elements(
                     size_n=int(k),
-                    route_slots=route_slots,
+                    route_slots=scratch_route_slots,
                     moe_block_size=int(block_size),
                     sms=sms,
                 ),
@@ -6441,14 +6468,16 @@ def _plan_full_rotation_w4a16_launches(
     return fused_launches, topk_sum_launches
 
 
-def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
-    deterministic_output = caps.deterministic_output
+def _plan_tp_moe_arena_layout_from_caps(
+    caps: TPMoEScratchCaps,
+    *,
+    deterministic_output: bool | None = None,
+) -> TPMoEArenaLayout:
+    if not isinstance(caps, TPMoEScratchCaps):
+        raise TypeError("caps must be a TPMoEScratchCaps")
     if deterministic_output is None:
-        deterministic_output = _dynamic_deterministic_output_enabled(
-            quant_mode=caps.quant_mode,
-            device=torch.device(caps.device),
-        )
-    layout = plan_tp_moe_arena_layout(
+        deterministic_output = caps.deterministic_output
+    return plan_tp_moe_arena_layout(
         max_tokens=caps.max_tokens,
         num_topk=caps.num_topk,
         device=caps.device,
@@ -6464,6 +6493,19 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
         collect_activation_amax=caps.collect_activation_amax,
         deterministic_output=deterministic_output,
         w4a16_block_size_m=caps.w4a16_block_size_m,
+    )
+
+
+def tp_moe_required_nbytes(caps: TPMoEScratchCaps) -> int:
+    """Return the planned arena bytes without compiling launches or retaining storage."""
+    return _plan_tp_moe_arena_layout_from_caps(caps).total_nbytes
+
+
+def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+    deterministic_output = caps.deterministic_output
+    layout = _plan_tp_moe_arena_layout_from_caps(
+        caps,
+        deterministic_output=deterministic_output,
     )
     capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
     launch_plan = plan_tp_moe_execution(

--- a/sparkinfer/moe/fused_moe/_impl.py
+++ b/sparkinfer/moe/fused_moe/_impl.py
@@ -865,9 +865,7 @@ class TPMoEScratchPlan:
     _prewarmed_fused_launches: tuple[tuple[int, object], ...] = field(
         default=(), repr=False
     )
-    _prewarmed_topk_sum_launches: tuple[
-        tuple[torch.dtype, bool, object], ...
-    ] = field(
+    _prewarmed_topk_sum_launches: tuple[tuple[torch.dtype, bool, object], ...] = field(
         default=(), repr=False
     )
 
@@ -6303,12 +6301,10 @@ def _plan_full_rotation_w4a16_launches(
         )
     block_size_m = int(core_plan.route_block_size_m)
     weight_layout = _normalize_w4a16_weight_layout(
-        caps.w4a16_weight_layout
-        or _w4a16_weight_layout_for_source(caps.source_format)
+        caps.w4a16_weight_layout or _w4a16_weight_layout_for_source(caps.source_format)
     )
     scale_format = _normalize_w4a16_scale_format(
-        caps.w4a16_scale_format
-        or _w4a16_scale_format_for_source(caps.source_format)
+        caps.w4a16_scale_format or _w4a16_scale_format_for_source(caps.source_format)
     )
     if weight_layout != "trellis3_t256" or scale_format != "e4m3_k32":
         raise RuntimeError(
@@ -6728,9 +6724,9 @@ def _prewarm_w4a16_planned_launches(
                                 broadcast_svh=broadcast_svh,
                             )
                             if not broadcast_svh:
-                                topk_sum_launches[
-                                    (token_count, ids_dtype, mapped)
-                                ] = resolved_topk_sum
+                                topk_sum_launches[(token_count, ids_dtype, mapped)] = (
+                                    resolved_topk_sum
+                                )
             else:
                 topk_sum_launches[token_count] = compile_w4a16_topk_sum(
                     m=token_count,

--- a/sparkinfer/moe/fused_moe/api.py
+++ b/sparkinfer/moe/fused_moe/api.py
@@ -52,6 +52,9 @@ from ._impl import (
     plan_tp_moe_scratch as plan,
 )
 from ._impl import (
+    tp_moe_required_nbytes as required_nbytes,
+)
+from ._impl import (
     prepare_sparkinfer_fp4_moe_weights as prepare_weights,
 )
 from ._impl import (
@@ -91,6 +94,7 @@ __all__ = [
     "Routing",
     "WeightsPlan",
     "plan",
+    "required_nbytes",
     "plan_execution",
     "plan_weights",
     "prepare_weights",

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -274,7 +274,7 @@ def test_uuid_unavailable_disables_disk_cache(monkeypatch):
     assert not compiler._cute_compile_disk_cache_enabled_for_payload(payload)
 
 
-def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
+def test_explicit_memory_cache_hit_skips_freeze_and_disk_payload(monkeypatch):
     cute = pytest.importorskip("cutlass.cute")
     compile_callable = object()
     compiled = object()
@@ -299,14 +299,55 @@ def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
             AssertionError("memory hit rebuilt the disk payload")
         ),
     )
+    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
 
-    assert (
-        compiler.compile(
-            test_explicit_memory_cache_hit_skips_disk_payload,
-            compile_spec=compile_spec,
+    runtime_control.freeze_kernel_resolution("cached compile remains launchable")
+    try:
+        assert (
+            compiler.compile(
+                test_explicit_memory_cache_hit_skips_freeze_and_disk_payload,
+                compile_spec=compile_spec,
+            )
+            is compiled
         )
-        is compiled
+    finally:
+        runtime_control.unfreeze_kernel_resolution()
+
+
+def test_frozen_memory_miss_rejects_before_disk_cache_load(monkeypatch):
+    cute = pytest.importorskip("cutlass.cute")
+    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
+    compile_spec = compiler.KernelCompileSpec.from_facts(
+        "test.freeze.disk_hit",
+        1,
+        ("rows", 8),
     )
+    monkeypatch.setattr(cute, "compile", object())
+    monkeypatch.setattr(compiler, "_memory_cache_get", lambda _key: None)
+    monkeypatch.setattr(
+        compiler,
+        "_compile_disk_cache_payload",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("frozen miss built a persistent-cache payload")
+        ),
+    )
+    monkeypatch.setattr(
+        compiler,
+        "_load_cute_compile_from_disk",
+        lambda _key: (_ for _ in ()).throw(
+            AssertionError("frozen miss loaded a persistent module")
+        ),
+    )
+
+    runtime_control.freeze_kernel_resolution("disk hits must not bypass freeze")
+    try:
+        with pytest.raises(runtime_control.KernelResolutionFrozenError):
+            compiler.compile(
+                test_frozen_memory_miss_rejects_before_disk_cache_load,
+                compile_spec=compile_spec,
+            )
+    finally:
+        runtime_control.unfreeze_kernel_resolution()
 
 
 def test_v6_semantic_payload_matches_independent_validators(monkeypatch):

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -7,6 +7,7 @@ import torch
 
 from sparkinfer.gemm import trellis_linear
 from sparkinfer.gemm.trellis_linear import api
+from sparkinfer.gemm.trellis_linear import _small_m
 from sparkinfer.gemm.trellis_linear._small_m import _default_num_sms
 from sparkinfer.moe._shared.kernels.w4a16.kernel import (
     _run_trellis_dense_hadamard128,
@@ -130,6 +131,18 @@ def test_k6_small_m_default_sms_preserves_glm_decode_overlap(
     expected: int,
 ) -> None:
     assert _default_num_sms(size_k, size_n, available_sms) == expected
+
+
+def test_k6_small_m_rejects_unsupported_arch_before_jit(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: (9, 0))
+    monkeypatch.setattr(
+        _small_m,
+        "_extension",
+        lambda: pytest.fail("extension must not compile for an unsupported GPU"),
+    )
+
+    with pytest.raises(NotImplementedError, match="built for sm_120 only"):
+        _small_m.run_k6_mcg(*(torch.empty(0) for _ in range(7)))
 
 
 @pytest.mark.parametrize(
@@ -272,6 +285,7 @@ def test_k6_small_m_cuda_graph_replay_is_stable() -> None:
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         captured = trellis_linear.run(x, weight, **kwargs)
+    output.fill_(float("nan"))
     graph.replay()
     torch.cuda.synchronize(device)
 

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -7,6 +7,11 @@ import torch
 
 from sparkinfer.gemm import trellis_linear
 from sparkinfer.gemm.trellis_linear import api
+from sparkinfer.gemm.trellis_linear._small_m import _default_num_sms
+from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+    _run_trellis_dense_hadamard128,
+    _trellis256_dense_launch_geometry,
+)
 
 
 def _sm12x_available() -> bool:
@@ -99,6 +104,178 @@ def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
     monkeypatch.setattr(api, "default_is_supported", fake_gate)
     assert trellis_linear.is_supported("cuda:3")
     assert seen == {"device": "cuda:3", "requires": trellis_linear.META.requires}
+
+
+@pytest.mark.parametrize(
+    ("size_k", "size_n", "available_sms", "expected"),
+    [
+        (2048, 4096, 188, 128),
+        (2048, 4096, 120, 120),
+        (6144, 1024, 188, 64),
+        (6144, 1024, 48, 48),
+        (512, 6144, 188, 96),
+        (512, 6144, 80, 80),
+        # The unsharded dimensions are deliberately not inferred from TP4.
+        (6144, 4096, 188, 188),
+        (2048, 6144, 188, 188),
+        (3072, 6144, 188, 188),
+        (4096, 6144, 188, 188),
+        (6144, 6144, 188, 188),
+    ],
+)
+def test_k6_small_m_default_sms_preserves_glm_decode_overlap(
+    size_k: int,
+    size_n: int,
+    available_sms: int,
+    expected: int,
+) -> None:
+    assert _default_num_sms(size_k, size_n, available_sms) == expected
+
+
+@pytest.mark.parametrize(
+    ("size_m", "size_k", "size_n", "expected"),
+    [
+        # Narrow profile: avoid a short spill by increasing both M and N work.
+        (512, 16384, 6144, (48, (64, 128))),
+        (1024, 16384, 6144, (48, (64, 256))),
+        # Wide model projection: N already supplies enough work. Splitting N is
+        # useful for the second wave, while M48 only adds scheduler overhead.
+        (192, 2048, 16384, (64, (64, 128))),
+        (384, 2048, 16384, (48, (64, 256))),
+        # A deeper K makes M48 scheduler overhead more expensive.
+        (384, 6144, 16384, (64, (64, 256))),
+        # Full waves retain the throughput-oriented default geometry.
+        (2048, 4096, 6144, (64, (64, 256))),
+    ],
+)
+def test_dense_launch_geometry_avoids_short_spill_waves(
+    size_m: int,
+    size_k: int,
+    size_n: int,
+    expected: tuple[int, tuple[int, int]],
+) -> None:
+    assert (
+        _trellis256_dense_launch_geometry(
+            size_m=size_m,
+            size_k=size_k,
+            size_n=size_n,
+            sms=188,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("m", "size_k", "size_n"),
+    [
+        (7, 128, 128),
+        (1, 2048, 4096),
+        (7, 6144, 1024),
+        (32, 512, 6144),
+    ],
+)
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_k6_small_m_matches_separate_cute_pipeline(
+    m: int,
+    size_k: int,
+    size_n: int,
+) -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    torch.manual_seed(0)
+    trellis = torch.randint(
+        -32768,
+        32767,
+        (size_k // 16, size_n // 16, 96),
+        dtype=torch.int16,
+        device=device,
+    )
+    suh = torch.randn((size_k,), dtype=torch.float16, device=device)
+    svh = torch.randn((size_n,), dtype=torch.float16, device=device)
+    weight = trellis_linear.prepare_weight(
+        trellis,
+        suh,
+        svh,
+        mcg=torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device),
+        params_dtype=torch.float16,
+    )
+    x = torch.randn((m, size_k), dtype=torch.float16, device=device)
+
+    def separate_hadamard(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        left_scale,
+        right_scale,
+        _scale: float,
+    ) -> None:
+        _run_trellis_dense_hadamard128(
+            source,
+            destination,
+            left_scale if left_scale is not None else right_scale,
+            scale_before=left_scale is not None,
+        )
+
+    expected = trellis_linear.run(
+        x,
+        weight,
+        hadamard_128=separate_hadamard,
+    ).clone()
+    weight.workspace.zero_()
+    actual = trellis_linear.run(x, weight).clone()
+    torch.cuda.synchronize(device)
+
+    # The cooperative kernel and CuTe fallback use different legal FP16 MMA
+    # accumulation orders. Compare their direction and normalized error rather
+    # than imposing a large absolute tolerance on values near zero.
+    actual_f32 = actual.float()
+    expected_f32 = expected.float()
+    delta = actual_f32 - expected_f32
+    relative_l2 = delta.norm() / expected_f32.norm().clamp_min(1e-12)
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_f32.flatten(), expected_f32.flatten(), dim=0
+    )
+    max_relative_to_range = delta.abs().max() / expected_f32.abs().max().clamp_min(
+        1e-12
+    )
+
+    assert float(relative_l2) < 1.5e-3
+    assert float(cosine) > 0.999998
+    assert float(max_relative_to_range) < 2e-3
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_k6_small_m_cuda_graph_replay_is_stable() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    m = 3
+    features = 128
+    trellis = torch.randint(
+        -32768,
+        32767,
+        (features // 16, features // 16, 96),
+        dtype=torch.int16,
+        device=device,
+    )
+    scale = torch.ones((features,), dtype=torch.float16, device=device)
+    weight = trellis_linear.prepare_weight(
+        trellis,
+        scale,
+        scale.clone(),
+        mcg=torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device),
+        params_dtype=torch.float16,
+    )
+    x = torch.randn((m, features), dtype=torch.float16, device=device)
+    output = torch.empty_like(x)
+    rotated_f16 = torch.empty_like(x)
+    kwargs = {"output": output, "rotated_f16": rotated_f16}
+
+    expected = trellis_linear.run(x, weight, **kwargs).clone()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = trellis_linear.run(x, weight, **kwargs)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.equal(captured, expected)
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/gemm/test_trellis_packaging.py
+++ b/tests/gemm/test_trellis_packaging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -10,8 +11,7 @@ TRELLIS_SOURCE_DIR = ROOT / "sparkinfer" / "gemm" / "trellis_linear" / "csrc"
 def test_trellis_runtime_sources_and_license_are_in_source_manifest() -> None:
     manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
     assert (
-        "recursive-include sparkinfer/gemm/trellis_linear/csrc "
-        "*.cu *.cuh *.h LICENSE*"
+        "recursive-include sparkinfer/gemm/trellis_linear/csrc *.cu *.cuh *.h LICENSE*"
     ) in manifest.splitlines()
 
     required = (
@@ -20,3 +20,18 @@ def test_trellis_runtime_sources_and_license_are_in_source_manifest() -> None:
         TRELLIS_SOURCE_DIR / "vendor" / "quant" / "exl3_gemm_kernel.cuh",
     )
     assert all(path.is_file() for path in required)
+    packaged_patterns = ("*.cu", "*.cuh", "*.h", "LICENSE*")
+    source_files = (path for path in TRELLIS_SOURCE_DIR.rglob("*") if path.is_file())
+    assert all(
+        any(fnmatch(path.name, pattern) for pattern in packaged_patterns)
+        for path in source_files
+    )
+    provenance = "Vendored from https://github.com/brandonmmusic-max/exllamav3"
+    vendor_sources = (
+        path
+        for path in (TRELLIS_SOURCE_DIR / "vendor").rglob("*")
+        if path.is_file() and not path.name.startswith("LICENSE")
+    )
+    assert all(
+        provenance in path.read_text(encoding="utf-8") for path in vendor_sources
+    )

--- a/tests/gemm/test_trellis_packaging.py
+++ b/tests/gemm/test_trellis_packaging.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+TRELLIS_SOURCE_DIR = ROOT / "sparkinfer" / "gemm" / "trellis_linear" / "csrc"
+
+
+def test_trellis_runtime_sources_and_license_are_in_source_manifest() -> None:
+    manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert (
+        "recursive-include sparkinfer/gemm/trellis_linear/csrc "
+        "*.cu *.cuh *.h LICENSE*"
+    ) in manifest.splitlines()
+
+    required = (
+        TRELLIS_SOURCE_DIR / "trellis_k6_small.cu",
+        TRELLIS_SOURCE_DIR / "vendor" / "LICENSE.exllamav3",
+        TRELLIS_SOURCE_DIR / "vendor" / "quant" / "exl3_gemm_kernel.cuh",
+    )
+    assert all(path.is_file() for path in required)

--- a/tests/moe/test_ep_moe_api.py
+++ b/tests/moe/test_ep_moe_api.py
@@ -15,6 +15,7 @@ from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
 from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
     route_block_sizes_for_capacity,
+    route_pack_token_capacity,
 )
 from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
 
@@ -125,11 +126,14 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
 
     layout = {spec.name: spec for spec in plan._layout}
     block_sizes = route_block_sizes_for_capacity(3, 2, 10)
+    capacity_rows = route_pack_token_capacity(3, 2) * 2
     expected_slots = max(
-        max_packed_route_slots(4 * 2, block_size, 10) for block_size in block_sizes
+        max_packed_route_slots(capacity_rows, block_size, 10)
+        for block_size in block_sizes
     )
     expected_blocks = max(
-        (max_packed_route_slots(4 * 2, block_size, 10) + block_size - 1) // block_size
+        (max_packed_route_slots(capacity_rows, block_size, 10) + block_size - 1)
+        // block_size
         for block_size in block_sizes
     )
     assert layout["packed_route_indices"].elements == expected_slots

--- a/tests/moe/test_ep_moe_api.py
+++ b/tests/moe/test_ep_moe_api.py
@@ -7,7 +7,10 @@ import sparkinfer.moe.ep_moe._impl as ep_moe
 from sparkinfer._lib.intrinsics import swizzle_block_scale
 from sparkinfer.moe.ep_moe._impl import EPMoEScratchCaps, plan_ep_moe_scratch, prepare_ep_expert_map, sparkinfer_ep_moe_fp4
 from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
-from sparkinfer.moe._shared.kernels.w4a16.host import max_w4a16_route_capacity
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    route_block_sizes_for_capacity,
+)
 from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
 
 
@@ -116,7 +119,20 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
     )
 
     layout = {spec.name: spec for spec in plan._layout}
-    expected_slots, expected_blocks = max_w4a16_route_capacity(4 * 2, 10)
+    block_sizes = route_block_sizes_for_capacity(3, 2, 10)
+    expected_slots = max(
+        max_packed_route_slots(4 * 2, block_size, 10)
+        for block_size in block_sizes
+    )
+    expected_blocks = max(
+        (
+            max_packed_route_slots(4 * 2, block_size, 10)
+            + block_size
+            - 1
+        )
+        // block_size
+        for block_size in block_sizes
+    )
     assert layout["packed_route_indices"].elements == expected_slots
     assert layout["block_expert_ids"].elements == expected_blocks
     assert layout["intermediate_cache2"].elements == 3 * 2 * 128

--- a/tests/moe/test_ep_moe_api.py
+++ b/tests/moe/test_ep_moe_api.py
@@ -5,7 +5,12 @@ import torch
 
 import sparkinfer.moe.ep_moe._impl as ep_moe
 from sparkinfer._lib.intrinsics import swizzle_block_scale
-from sparkinfer.moe.ep_moe._impl import EPMoEScratchCaps, plan_ep_moe_scratch, prepare_ep_expert_map, sparkinfer_ep_moe_fp4
+from sparkinfer.moe.ep_moe._impl import (
+    EPMoEScratchCaps,
+    plan_ep_moe_scratch,
+    prepare_ep_expert_map,
+    sparkinfer_ep_moe_fp4,
+)
 from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
 from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
@@ -121,16 +126,10 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
     layout = {spec.name: spec for spec in plan._layout}
     block_sizes = route_block_sizes_for_capacity(3, 2, 10)
     expected_slots = max(
-        max_packed_route_slots(4 * 2, block_size, 10)
-        for block_size in block_sizes
+        max_packed_route_slots(4 * 2, block_size, 10) for block_size in block_sizes
     )
     expected_blocks = max(
-        (
-            max_packed_route_slots(4 * 2, block_size, 10)
-            + block_size
-            - 1
-        )
-        // block_size
+        (max_packed_route_slots(4 * 2, block_size, 10) + block_size - 1) // block_size
         for block_size in block_sizes
     )
     assert layout["packed_route_indices"].elements == expected_slots
@@ -170,14 +169,18 @@ def _make_modelopt_weights(
         device="cuda",
     )
     w13_scale = swizzle_block_scale(
-        (torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
-         * 0.25
-         + 0.03125).to(torch.float8_e4m3fn)
+        (
+            torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
+            * 0.25
+            + 0.03125
+        ).to(torch.float8_e4m3fn)
     )
     w2_scale = swizzle_block_scale(
-        (torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
-         * 0.25
-         + 0.03125).to(torch.float8_e4m3fn)
+        (
+            torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
+            * 0.25
+            + 0.03125
+        ).to(torch.float8_e4m3fn)
     )
     w13_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
     w2_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
@@ -334,9 +337,11 @@ def test_ep_binding_replays_with_changed_routes_under_cuda_graph() -> None:
     global_ids = torch.tensor([0, 2])
     experts = _prepare_experts(a, weights, global_ids)
     expert_map = torch.tensor([0, -1, 1, -1], dtype=torch.int32, device="cuda")
-    topk_ids = torch.tensor([[1, 3]], dtype=torch.int32, device="cuda").expand(
-        m, -1
-    ).contiguous()
+    topk_ids = (
+        torch.tensor([[1, 3]], dtype=torch.int32, device="cuda")
+        .expand(m, -1)
+        .contiguous()
+    )
     topk_weights = torch.full((m, topk), 0.5, dtype=torch.float32, device="cuda")
     nonlocal_output, binding = _run_ep_rank(
         a=a,

--- a/tests/moe/test_fused_moe_planning.py
+++ b/tests/moe/test_fused_moe_planning.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sparkinfer.moe import fused_moe
+import sparkinfer.moe.fused_moe._impl as fused_moe_impl
+
+
+def _weight_plan() -> fused_moe.WeightsPlan:
+    return fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="modelopt_nvfp4",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=6144,
+        intermediate_size=512,
+        w13_layout="w13",
+    )
+
+
+def _caps(*, block_size_m: int | None) -> fused_moe.Caps:
+    return fused_moe.Caps(
+        max_tokens=64,
+        num_topk=8,
+        route_num_experts=160,
+        device="cpu",
+        weight_plan=_weight_plan(),
+        quant_mode="w4a16",
+        w4a16_block_size_m=block_size_m,
+    )
+
+
+def _trellis_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="exl3_trellis_mcg",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=6144,
+        intermediate_size=512,
+        w13_layout="w13",
+        trellis_bits=3,
+        trellis_tile_config=(64, 256, 64, 256),
+    )
+    return fused_moe.Caps(
+        max_tokens=3072,
+        num_topk=8,
+        route_num_experts=160,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+        w4a16_block_size_m=64,
+    )
+
+
+def _small_packed_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="compressed_tensors",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=16,
+        hidden_size=128,
+        intermediate_size=128,
+        w13_layout="w13",
+    )
+    return fused_moe.Caps(
+        max_tokens=4,
+        num_topk=8,
+        route_num_experts=16,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+
+def _subset_router_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="compressed_tensors",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=160,
+        hidden_size=128,
+        intermediate_size=128,
+        w13_layout="w13",
+    )
+    return fused_moe.Caps(
+        max_tokens=8,
+        num_topk=8,
+        route_num_experts=16,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+
+def test_required_nbytes_avoids_launch_prewarm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    def fail_launch_prewarm(**_kwargs) -> None:
+        raise AssertionError("launch prewarm called")
+
+    monkeypatch.setattr(
+        fused_moe_impl,
+        "_plan_full_rotation_w4a16_launches",
+        fail_launch_prewarm,
+    )
+    caps = _trellis_caps()
+
+    required = fused_moe.required_nbytes(caps)
+
+    assert required > 1024 * 1024 * 1024
+    assert "required_nbytes" in fused_moe.META.entry_points
+    with pytest.raises(TypeError, match="TPMoEScratchCaps"):
+        fused_moe.required_nbytes(object())
+
+
+def test_required_nbytes_matches_scratch_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+    caps = _caps(block_size_m=8)
+
+    plan = fused_moe.plan(caps)
+
+    assert fused_moe.required_nbytes(caps) == plan.scratch_specs()[0].shape[0]
+
+
+def test_small_packed_plan_covers_direct_topk_scratch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    plan = fused_moe.plan(_small_packed_caps())
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+
+    assert specs["fc1_c_tmp"].shape == (131072,)
+    assert specs["fc2_c_tmp"].shape == (65536,)
+
+
+def test_non_trellis_core_sizes_routes_for_weight_experts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    plan = fused_moe.plan(_subset_router_caps())
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+
+    assert plan._core_workspace_plan.route_E == 160
+    assert specs["packed_route_indices"].shape == (512,)
+    assert specs["block_expert_ids"].shape == (64,)
+    assert specs["expert_offsets"].shape == (161,)
+
+
+def test_unpinned_small_capacity_matches_reachable_block_8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    automatic = fused_moe.required_nbytes(_caps(block_size_m=None))
+    exact = fused_moe.required_nbytes(_caps(block_size_m=8))
+    oversized = fused_moe.required_nbytes(_caps(block_size_m=64))
+
+    assert automatic == exact
+    assert oversized - automatic > 64 * 1024 * 1024

--- a/tests/moe/test_tp_moe_scratch_bindings.py
+++ b/tests/moe/test_tp_moe_scratch_bindings.py
@@ -570,6 +570,43 @@ def test_trellis_scratch_plan_preserves_exact_fixed_capacity(
     assert plan.layout.total_nbytes == plan.layout.core_workspace_nbytes
 
 
+def test_trellis_scratch_plan_resolves_default_route_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
+    monkeypatch.setattr(
+        tp_moe_impl,
+        "_plan_full_rotation_w4a16_launches",
+        lambda **_kwargs: ((), ()),
+    )
+    weight_plan = plan_sparkinfer_fp4_moe_weights(
+        quant_modes="w4a16",
+        source_format="exl3_trellis_mcg",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size=512,
+        trellis_bits=3,
+        trellis_tile_config=(64, 256, 64, 256),
+    )
+    caps = TPMoEScratchCaps(
+        max_tokens=3072,
+        core_token_counts=(3072,),
+        num_topk=8,
+        route_num_experts=0,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+    plan = plan_tp_moe_scratch(caps)
+
+    assert plan._core_workspace_plan.route_block_size_m == 64
+    assert plan.layout.core_token_counts[0] == 3072
+    assert 4096 not in plan.layout.core_token_counts
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_trellis_launch_planner_compiles_fixed_launch_matrix() -> None:
     """The real planner must cover every fixed decode and route-pack variant."""
@@ -708,10 +745,7 @@ def test_w4a16_decode_scratch_covers_direct_topk_geometry(
             route_num_experts=0,
         )
     )
-    specs = {
-        spec.name: spec
-        for spec in plan._core_workspace_plan.tensor_specs
-    }
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
     block_size = select_route_block_size_m(tokens, topk, weight_plan.num_experts)
     packed_slots = max_packed_route_slots(
         tokens * topk,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -1101,7 +1101,7 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 224])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1198,6 +1198,11 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
         experts=w4a16_experts,
         topk_weights=topk_weights,
         topk_ids=topk_ids,
+        output=torch.empty(
+            (m, hidden_size),
+            dtype=x.dtype,
+            device=x.device,
+        ),
         quant_mode="w4a16",
     )
     expected = moe_reference_w4a16_f32(
@@ -1216,7 +1221,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
         activation=activation,
     )
 
-    first = binding.run()
+    first = binding.run().clone()
     torch.cuda.synchronize()
     first_metrics = compare_to_reference(first, expected)
     assert bool(torch.isfinite(first).all().item())
@@ -1226,13 +1231,29 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
     # and FC2 ignores every inactive lane on the same-binding replay.
     binding.intermediate_cache2.fill_(float("nan"))
-    replay = binding.run()
+    replay = binding.run().clone()
     torch.cuda.synchronize()
     replay_metrics = compare_to_reference(replay, expected)
     assert bool(torch.isfinite(replay).all().item())
     assert replay_metrics.cos > 0.999, replay_metrics
-    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
+
+    # Capture the same direct path once, then repeatedly replay it after
+    # poisoning the arena tail. Graph replay does not re-enter the Python spy,
+    # so three launches prove two eager calls plus one captured custom-op node.
+    graph = torch.cuda.CUDAGraph()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        graph_output = binding.run()
+    for _ in range(16):
+        binding.intermediate_cache2.fill_(float("nan"))
+        graph.replay()
+    torch.cuda.synchronize()
+    graph_metrics = compare_to_reference(graph_output, expected)
+    assert bool(torch.isfinite(graph_output).all().item())
+    assert graph_metrics.cos > 0.999, graph_metrics
+    torch.testing.assert_close(graph_output, first, atol=0.0, rtol=0.0)
+    assert direct_launches == [(m, intermediate_size)] * 3
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -249,9 +249,10 @@ def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
     assert len(fused_calls) == 2
     assert {call["size_m"] for call in fused_calls} == {3072}
     assert {call["max_m_blocks"] for call in fused_calls} == {542}
-    assert workspace.planned_fused_moe_launches[
-        ("trellis3_t256", "e4m3_k32", 3072, False)
-    ] is resolved_fused
+    assert (
+        workspace.planned_fused_moe_launches[("trellis3_t256", "e4m3_k32", 3072, False)]
+        is resolved_fused
+    )
 
 
 def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -46,6 +46,35 @@ from tests._reference.helpers import (
 from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
 
 
+def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    monkeypatch.setattr(w4a16_kernel, "_FUSED_CACHE", {})
+    monkeypatch.setattr(w4a16_kernel.torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(
+        RuntimeError,
+        match="W4A16 fused MoE launch is not resolved for CUDA graph capture",
+    ):
+        compile_w4a16_fused_moe(
+            size_m=16,
+            hidden_size=128,
+            intermediate_size=128,
+            num_experts=8,
+            top_k=2,
+            activation="silu",
+            apply_router_weight_on_input=False,
+            zero_fc2_output=False,
+            moe_block_size=8,
+            max_m_blocks=16,
+            sms=188,
+            max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
+            _require_cached=True,
+        )
+
+
 def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:
     return (torch.rand(shape, device="cuda") * 0.25 + 0.03125).to(torch.float8_e4m3fn)
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -21,11 +21,13 @@ from sparkinfer.moe._shared.kernels.reference import (
 )
 from sparkinfer.moe._shared.kernels.w4a16.host import (
     max_packed_route_slots,
+    route_pack_capacity,
     select_route_block_size_m,
 )
 from sparkinfer.moe._shared.kernels.w4a16.kernel import (
     _DEFAULT_MAX_SHARED_MEM,
     MoEMicroKernelW4A16SmallMDirect,
+    _w4a16_stream_is_capturing,
     _small_m_direct_supported,
     compile_w4a16_fused_moe,
     compile_w4a16_topk_sum,
@@ -73,6 +75,159 @@ def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
             max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
             _require_cached=True,
         )
+
+
+def test_w4a16_capture_guard_checks_selected_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    selected_stream = 22
+    queried: list[object] = []
+    monkeypatch.setattr(
+        w4a16_kernel.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel.cuda,
+        "cuStreamIsCapturing",
+        lambda stream: (
+            queried.append(stream) or w4a16_kernel.cuda.CUresult.CUDA_SUCCESS,
+            1,
+        ),
+    )
+
+    assert _w4a16_stream_is_capturing(selected_stream, current_stream=11)
+    assert queried == [selected_stream]
+
+
+def test_w4a16_capture_guard_preserves_current_stream_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    monkeypatch.setattr(
+        w4a16_kernel.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel.cuda,
+        "cuStreamIsCapturing",
+        lambda _stream: (_ for _ in ()).throw(
+            AssertionError("current-stream capture queried the selected stream")
+        ),
+    )
+
+    assert _w4a16_stream_is_capturing(22, current_stream=11)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "bucket_tokens"),
+    (
+        (1, 1),
+        (8, 8),
+        (9, 16),
+        (3072, 4096),
+        (4096, 4096),
+        (4097, 8192),
+    ),
+)
+def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
+    tokens: int,
+    bucket_tokens: int,
+) -> None:
+    topk = 8
+    block_size = 64
+    num_experts = 160
+    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
+        tokens * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+    )
+    expected_routes = bucket_tokens * topk
+    expected_packed = max_packed_route_slots(
+        expected_routes,
+        block_size,
+        num_experts,
+    )
+
+    assert routed_capacity == expected_routes
+    assert packed_routes == expected_packed
+    assert max_m_blocks == (expected_packed + block_size - 1) // block_size
+    if tokens == 3072:
+        assert max_m_blocks == 670
+
+
+def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from contextlib import nullcontext
+    from types import SimpleNamespace
+
+    from sparkinfer.moe.fused_moe import _impl as tp_moe_impl
+    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+
+    workspace = SimpleNamespace(
+        device=torch.device("cuda"),
+        dtype=torch.bfloat16,
+        full_rotation=False,
+        route_block_size_m=64,
+        num_topk=8,
+        route_E=160,
+        weight_E=160,
+        k=6144,
+        n=2048,
+        activation="silu",
+        trellis_bits=3,
+        trellis_tile_config=None,
+    )
+    fused_calls: list[dict[str, object]] = []
+    resolved_fused = object()
+    monkeypatch.setattr(tp_moe_impl.torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(
+        tp_moe_impl.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        tp_moe_impl.torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(
+            multi_processor_count=188,
+            shared_memory_per_block_optin=_DEFAULT_MAX_SHARED_MEM,
+        ),
+    )
+    monkeypatch.setattr(w4a16_kernel, "_rot_scales_dummy", lambda _device: None)
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "compile_w4a16_fused_moe",
+        lambda **kwargs: fused_calls.append(kwargs) or resolved_fused,
+    )
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "compile_w4a16_topk_sum",
+        lambda **_kwargs: object(),
+    )
+
+    tp_moe_impl._prewarm_w4a16_planned_launches(
+        workspace,
+        token_counts=(3072,),
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=1.0,
+        swiglu_beta=1.0,
+        collect_activation_amax=True,
+    )
+
+    assert len(fused_calls) == 1
+    assert fused_calls[0]["size_m"] == 3072
+    assert fused_calls[0]["max_m_blocks"] == 670
+    assert workspace.planned_fused_moe_launches[
+        ("packed", "e4m3_k16", 3072, True)
+    ] is resolved_fused
 
 
 def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -35,7 +35,11 @@ from sparkinfer.moe._shared.kernels.w4a16.prepare import (
     prepare_w4a16_modelopt_nvfp4_weights as prepare_w4a16_weights,
     prepare_w4a16_packed_weights,
 )
-from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
+from tests._reference.helpers import (
+    make_tp_moe_fp4_binding,
+    prepare_tp_moe_fp4_experts,
+    run_tp_moe_fp4,
+)
 from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
 
 
@@ -1044,6 +1048,94 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
             topk,
             ids_dtype,
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
+    activation: str,
+) -> None:
+    experts, hidden_size, intermediate_size = 8, 128, 128
+    m, topk = 3, 2
+    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0))
+    rows = intermediate_size * (2 if activation == "silu" else 1)
+    w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
+    w2_dense = (
+        torch.randn(experts, hidden_size, intermediate_size, device="cuda") * 0.12
+    )
+    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+        w13_dense,
+        w13_global_scale,
+    )
+    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
+        w2_dense,
+        w2_global_scale,
+    )
+    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
+    topk_ids = torch.randint(
+        0,
+        experts,
+        (m, topk),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
+    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w4a16_experts = prepare_tp_moe_fp4_experts(
+        a=x,
+        a1_gscale=a_gscale,
+        w1_fp4=w13,
+        w1_blockscale=w13_blockscale,
+        w1_alphas=w13_global_scale,
+        a2_gscale=a_gscale,
+        w2_fp4=w2,
+        w2_blockscale=w2_blockscale,
+        w2_alphas=w2_global_scale,
+        activation=activation,
+        quant_mode="w4a16",
+    )
+    prepared_w4a16 = w4a16_experts.representation_for("w4a16")
+    assert prepared_w4a16.weight_layout == "modelopt"
+    binding = make_tp_moe_fp4_binding(
+        a=x,
+        experts=w4a16_experts,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_mode="w4a16",
+    )
+    expected = moe_reference_w4a16_f32(
+        x,
+        w13,
+        w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation=activation,
+    )
+
+    first = binding.run()
+    torch.cuda.synchronize()
+    first_metrics = compare_to_reference(first, expected)
+    assert bool(torch.isfinite(first).all().item())
+    assert first_metrics.cos > 0.999, first_metrics
+
+    # The arena legitimately preserves the padded half of each 128-u32
+    # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
+    # and FC2 ignores every inactive lane on the same-binding replay.
+    binding.intermediate_cache2.fill_(float("nan"))
+    replay = binding.run()
+    torch.cuda.synchronize()
+    replay_metrics = compare_to_reference(replay, expected)
+    assert bool(torch.isfinite(replay).all().item())
+    assert replay_metrics.cos > 0.999, replay_metrics
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -267,7 +267,7 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("intermediate_size", [16, 144, 352])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -1256,8 +1256,22 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
     ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
     direct-FC2 implementations.
     """
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
     experts, hidden_size, topk = 1, 128, 1
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
+    direct_launches: list[tuple[int, int]] = []
+
+    def spy_direct_launch(*args, **kwargs) -> None:
+        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
+        real_direct_launch(*args, **kwargs)
+
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_w4a16_small_m_direct_launch_flat",
+        spy_direct_launch,
+    )
     torch.manual_seed(
         20260731
         + m
@@ -1362,6 +1376,7 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
         metrics = compare_to_reference(actual, expected)
         assert bool(torch.isfinite(actual).all().item())
         assert metrics.cos > 0.999, metrics
+    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(first, replay, rtol=0, atol=0)
 
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -134,7 +134,7 @@ def test_w4a16_capture_guard_preserves_current_stream_capture(
         (4097, 8192),
     ),
 )
-def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
+def test_generic_w4a16_planner_runtime_key_agrees_at_bucket_boundaries(
     tokens: int,
     bucket_tokens: int,
 ) -> None:
@@ -161,7 +161,28 @@ def test_w4a16_planner_runtime_route_key_agrees_at_bucket_boundaries(
         assert max_m_blocks == 670
 
 
-def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
+def test_trellis_w4a16_planner_runtime_key_preserves_exact_capacity() -> None:
+    topk = 8
+    block_size = 64
+    num_experts = 160
+    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
+        3072 * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+        bucket_tokens=False,
+    )
+
+    assert routed_capacity == 3072 * topk
+    assert packed_routes == max_packed_route_slots(
+        3072 * topk,
+        block_size,
+        num_experts,
+    )
+    assert max_m_blocks == 542
+
+
+def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from contextlib import nullcontext
@@ -173,7 +194,7 @@ def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
     workspace = SimpleNamespace(
         device=torch.device("cuda"),
         dtype=torch.bfloat16,
-        full_rotation=False,
+        full_rotation=True,
         route_block_size_m=64,
         num_topk=8,
         route_E=160,
@@ -219,14 +240,17 @@ def test_w4a16_capture_prewarm_uses_runtime_bucket_key(
         swiglu_limit=None,
         swiglu_alpha=1.0,
         swiglu_beta=1.0,
-        collect_activation_amax=True,
+        scale_format="e4m3_k32",
+        weight_layout="trellis3_t256",
+        w13_layout="trellis3_t256_proj",
+        collect_activation_amax=False,
     )
 
-    assert len(fused_calls) == 1
-    assert fused_calls[0]["size_m"] == 3072
-    assert fused_calls[0]["max_m_blocks"] == 670
+    assert len(fused_calls) == 2
+    assert {call["size_m"] for call in fused_calls} == {3072}
+    assert {call["max_m_blocks"] for call in fused_calls} == {542}
     assert workspace.planned_fused_moe_launches[
-        ("packed", "e4m3_k16", 3072, True)
+        ("trellis3_t256", "e4m3_k32", 3072, False)
     ] is resolved_fused
 
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -1123,6 +1123,12 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     )
     prepared_w4a16 = w4a16_experts.representation_for("w4a16")
     assert prepared_w4a16.weight_layout == "modelopt"
+    micro_w13_scale = prepared_w4a16.micro_w13_scale
+    assert micro_w13_scale is not None
+    expected_micro_w13_rows = ((rows + 63) // 64) * 64
+    assert int(micro_w13_scale.numel()) == (
+        experts * (hidden_size // 16) * expected_micro_w13_rows
+    )
     assert _small_m_direct_supported(
         m=m,
         hidden_size=hidden_size,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -1053,15 +1053,36 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 224])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
+    intermediate_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    experts, hidden_size, intermediate_size = 8, 128, 128
+    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    experts, hidden_size = 8, 128
     topk = 2
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
-    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0) + m)
+    torch.manual_seed(
+        20260730
+        + (1000 if activation == "silu" else 0)
+        + m
+        + intermediate_size
+    )
+    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
+    direct_launches: list[tuple[int, int]] = []
+
+    def spy_direct_launch(*args, **kwargs) -> None:
+        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
+        real_direct_launch(*args, **kwargs)
+
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_w4a16_small_m_direct_launch_flat",
+        spy_direct_launch,
+    )
     rows = intermediate_size * (2 if activation == "silu" else 1)
     w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
     w2_dense = (
@@ -1156,6 +1177,8 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     replay_metrics = compare_to_reference(replay, expected)
     assert bool(torch.isfinite(replay).all().item())
     assert replay_metrics.cos > 0.999, replay_metrics
+    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
+    torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -19,7 +19,10 @@ from sparkinfer.moe._shared.kernels.reference import (
     moe_reference_w4a16_f32,
     moe_reference_w4a16_fp4_e8m0_k32,
 )
-from sparkinfer.moe._shared.kernels.w4a16.host import max_packed_route_slots, select_route_block_size_m
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    max_packed_route_slots,
+    select_route_block_size_m,
+)
 from sparkinfer.moe._shared.kernels.w4a16.kernel import (
     _DEFAULT_MAX_SHARED_MEM,
     MoEMicroKernelW4A16SmallMDirect,
@@ -61,7 +64,7 @@ def _pattern_e8m0(shape: tuple[int, ...], *, offset: int = 0) -> torch.Tensor:
     numel = 1
     for dim in shape:
         numel *= int(dim)
-    storage = ((torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119)
+    storage = (torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119
     return storage.to(torch.uint8).reshape(shape).view(e8m0_dtype)
 
 
@@ -88,9 +91,7 @@ def _quantize_dense_moe_weight_storage(
             torch.float8_e4m3fn
         )
         scale = scale.to(torch.float32)
-        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(
-            min=1e-30
-        )
+        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(min=1e-30)
         clipped = torch.clamp(
             sliced * output_scale,
             -FLOAT4_E2M1_MAX,
@@ -110,7 +111,9 @@ def _make_weights(
     hidden_size: int,
     intermediate_size: int,
     activation: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
     is_gated = activation in {"silu", "situ"}
     w13_rows = intermediate_size * (2 if is_gated else 1)
     w13 = torch.randint(
@@ -133,8 +136,12 @@ def _make_weights(
     w2_blockscale = swizzle_block_scale(
         _positive_fp8((experts, hidden_size, intermediate_size // 16))
     )
-    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
-    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
+    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
+        torch.float32
+    )
+    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
+        torch.float32
+    )
     return w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale
 
 
@@ -615,12 +622,8 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
             share_expert_scales=True,
             single_token=True,
         )
-        e4m3 = MoEMicroKernelW4A16SmallMDirect(
-            scale_format="e4m3_k16", **common
-        )
-        e8m0 = MoEMicroKernelW4A16SmallMDirect(
-            scale_format="e8m0_k32", **common
-        )
+        e4m3 = MoEMicroKernelW4A16SmallMDirect(scale_format="e4m3_k16", **common)
+        e8m0 = MoEMicroKernelW4A16SmallMDirect(scale_format="e8m0_k32", **common)
         assert e4m3.__cache_key__ != e8m0.__cache_key__
     experts, hidden_size = 4, 128
     rows = intermediate_size * (2 if activation == "silu" else 1)
@@ -690,9 +693,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
         2 * m * fc2_n_chunks * 128 * topk, dtype=torch.bfloat16, device="cuda"
     )
     x = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
-    topk_ids = torch.randint(
-        0, experts, (m, topk), dtype=torch.int32, device="cuda"
-    )
+    topk_ids = torch.randint(0, experts, (m, topk), dtype=torch.int32, device="cuda")
     topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
 
     def launch() -> torch.Tensor:
@@ -986,20 +987,15 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
     for batch_size, seq_len, topk, ids_dtype, input_scale in cases:
         m = batch_size * seq_len
         torch.manual_seed(
-            20260525
-            + m * 31
-            + topk
-            + (1000 if activation == "silu" else 0)
+            20260525 + m * 31 + topk + (1000 if activation == "silu" else 0)
         )
         rows = intermediate_size * (2 if activation == "silu" else 1)
-        w13_dense = (
-            torch.randn(experts, rows, hidden_size, device="cuda")
-            * (0.18 if activation == "silu" else 0.08)
+        w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * (
+            0.18 if activation == "silu" else 0.08
         )
-        w2_dense = (
-            torch.randn(experts, hidden_size, intermediate_size, device="cuda")
-            * (0.18 if activation == "silu" else 0.08)
-        )
+        w2_dense = torch.randn(
+            experts, hidden_size, intermediate_size, device="cuda"
+        ) * (0.18 if activation == "silu" else 0.08)
         w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
         w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
         w13, w13_blockscale = _quantize_dense_moe_weight_storage(
@@ -1132,10 +1128,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     topk = 2
     monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
     torch.manual_seed(
-        20260730
-        + (1000 if activation == "silu" else 0)
-        + m
-        + intermediate_size
+        20260730 + (1000 if activation == "silu" else 0) + m + intermediate_size
     )
     real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
     direct_launches: list[tuple[int, int]] = []
@@ -1316,10 +1309,7 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
         spy_direct_launch,
     )
     torch.manual_seed(
-        20260731
-        + m
-        + intermediate_size
-        + (1000 if activation == "silu" else 0)
+        20260731 + m + intermediate_size + (1000 if activation == "silu" else 0)
     )
 
     rows = intermediate_size * (2 if activation == "silu" else 1)
@@ -2285,7 +2275,11 @@ def test_w4a16_modelopt_nvfp4_explicit_w13_layout_matches_oracle(
             [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
         ).contiguous()
 
-    prepare = prepare_w4a16_modelopt_native_weights if prepare_native else prepare_w4a16_weights
+    prepare = (
+        prepare_w4a16_modelopt_native_weights
+        if prepare_native
+        else prepare_w4a16_weights
+    )
     kwargs = {"source_format": "modelopt_nvfp4"} if prepare_native else {}
     prepared = prepare(
         source_w13,
@@ -2350,9 +2344,7 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
         activation=activation,
     )
     w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
-    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(
-        torch.float32
-    )
+    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
     w2_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
     a1_gscale = (1.0 / w13_input_scale).contiguous()
     a2_gscale = (1.0 / w2_input_scale).contiguous()
@@ -2396,8 +2388,9 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress(
-) -> None:
+def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress() -> (
+    None
+):
     torch.manual_seed(20260526)
     experts, hidden_size, intermediate_size = 8, 128, 128
     activation = "silu"
@@ -2408,9 +2401,7 @@ def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stres
         activation=activation,
     )
     reference_weights = tuple(t.clone() for t in weights)
-    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = (
-        weights
-    )
+    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
     a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
     weight_plan = plan_sparkinfer_fp4_moe_weights(
         quant_modes="w4a16",
@@ -2522,7 +2513,9 @@ def test_w4a16_moe_matches_oracle_with_expert_map(
     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
 
-    valid_global_ids = torch.arange(0, global_experts, 2, dtype=torch.int32, device="cuda")
+    valid_global_ids = torch.arange(
+        0, global_experts, 2, dtype=torch.int32, device="cuda"
+    )
     x = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
     topk_ids = valid_global_ids[
         torch.randint(0, local_experts, (m, topk), device="cuda")
@@ -2564,9 +2557,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
         activation=activation,
     )
     w13, w13_blockscale, _, w2, w2_blockscale, w2_global_scale = weights
-    w13_global_scale = torch.full(
-        (experts,), 8.0, dtype=torch.float32, device="cuda"
-    )
+    w13_global_scale = torch.full((experts,), 8.0, dtype=torch.float32, device="cuda")
     weights = (
         w13,
         w13_blockscale,
@@ -2654,9 +2645,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
     experts, hidden_size, intermediate_size = 8, 128, 128
     topk, live_m, capacity_m = 2, 24, 32
     activation = "relu2"
-    assert select_route_block_size_m(live_m, topk, experts) != select_route_block_size_m(
-        capacity_m, topk, experts
-    )
+    assert select_route_block_size_m(
+        live_m, topk, experts
+    ) != select_route_block_size_m(capacity_m, topk, experts)
     weights = _make_weights(
         experts=experts,
         hidden_size=hidden_size,
@@ -2664,7 +2655,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
         activation=activation,
     )
     x = (torch.randn(live_m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
-    topk_ids = torch.randint(0, experts, (live_m, topk), device="cuda", dtype=torch.int32)
+    topk_ids = torch.randint(
+        0, experts, (live_m, topk), device="cuda", dtype=torch.int32
+    )
     topk_weights = torch.softmax(torch.randn(live_m, topk, device="cuda"), dim=-1)
     prepared = prepare_w4a16_weights(
         *weights,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -267,7 +267,7 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [16, 144, 352])
+@pytest.mark.parametrize("intermediate_size", [16, 144, 352, 496])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -1113,7 +1113,7 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352])
+@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352, 496])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1269,7 +1269,7 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("intermediate_size", [144, 352, 496])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
@@ -1282,12 +1282,13 @@ def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
 
     I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
     values per W2 row while the ModelOpt scale grid pads its control geometry
-    to 24. I=352 exercises the wide two-chunk kernel, whose final chunk has
-    only 12 logical lanes. Selecting the only expert makes an unmasked tail
-    load on the final W2 row cross the tensor allocation instead of merely
-    reading the next expert. Run this test under compute-sanitizer with
-    ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
-    direct-FC2 implementations.
+    to 24. I=352 exercises a partial scale/control tail in the wide kernel.
+    I=496 is the boundary case where that padded control grid looks completely
+    full even though the final two activation lanes are unwritten. Selecting
+    the only expert makes an unmasked W2 tail load cross the tensor allocation
+    instead of merely reading the next expert. Run this test under
+    compute-sanitizer with ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit
+    m==1/m>=2 and ungated/gated direct-FC2 implementations.
     """
     import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
 

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -588,6 +588,7 @@ def test_w4a16_packed_runtime_expert_count_reuses_compiled_kernel(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("intermediate_size", [128, 224])
 @pytest.mark.parametrize("w13_layout", ["w13", "w31"])
 # 0.5 is small enough to actually engage the SwiGLU clamp at these scales.
 @pytest.mark.parametrize("swiglu_limit", [None, 0.5])
@@ -598,6 +599,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
     m: int,
     swiglu_limit: float | None,
     w13_layout: str,
+    intermediate_size: int,
 ) -> None:
     """Small-M micro decode path with native MXFP4 (E8M0 K/32) scales."""
     if swiglu_limit is not None and activation != "silu":
@@ -617,7 +619,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
             scale_format="e8m0_k32", **common
         )
         assert e4m3.__cache_key__ != e8m0.__cache_key__
-    experts, hidden_size, intermediate_size = 4, 128, 128
+    experts, hidden_size = 4, 128
     rows = intermediate_size * (2 if activation == "silu" else 1)
     topk = 2
     torch.manual_seed(20260601 + (1000 if activation == "silu" else 0) + m)

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -267,6 +267,54 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
+@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
+def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
+    m: int,
+    activation: str,
+    intermediate_size: int,
+) -> None:
+    """Native ModelOpt decode supports every 16-aligned intermediate shape."""
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=128,
+        intermediate_size=intermediate_size,
+        num_experts=1,
+        topk=1,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout="modelopt",
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
+    kernel = MoEMicroKernelW4A16SmallMDirect(
+        activation=activation,
+        fast_math=True,
+        share_input_across_experts=True,
+        share_expert_scales=True,
+        single_token=m == 1,
+    )
+    kernel.configure(
+        m=m,
+        k=128,
+        n=intermediate_size,
+        num_topk=1,
+        weight_E=1,
+        max_active_ctas=1,
+    )
+    assert kernel._cfg is not None
+    assert kernel._cfg.n % kernel._cfg.fc1_chunks == 0
+    assert kernel._cfg.i_chunk % 16 == 0
+    assert kernel._cfg.inter_blocks * 16 == kernel._cfg.i_chunk
+    if m > 1:
+        assert kernel._cfg.i_chunk <= 32
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
@@ -1185,6 +1233,136 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     assert replay_metrics.cos > 0.999, replay_metrics
     assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
     torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("intermediate_size", [144, 352])
+@pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
+def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
+    m: int,
+    activation: str,
+    intermediate_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the exact native row tail under CUDA memcheck.
+
+    I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
+    values per W2 row while the ModelOpt scale grid pads its control geometry
+    to 24. I=352 exercises the wide two-chunk kernel, whose final chunk has
+    only 12 logical lanes. Selecting the only expert makes an unmasked tail
+    load on the final W2 row cross the tensor allocation instead of merely
+    reading the next expert. Run this test under compute-sanitizer with
+    ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit m==1/m>=2 and ungated/gated
+    direct-FC2 implementations.
+    """
+    experts, hidden_size, topk = 1, 128, 1
+    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    torch.manual_seed(
+        20260731
+        + m
+        + intermediate_size
+        + (1000 if activation == "silu" else 0)
+    )
+
+    rows = intermediate_size * (2 if activation == "silu" else 1)
+    w13_dense = (
+        torch.randn(
+            experts,
+            rows,
+            hidden_size,
+            device="cuda",
+        )
+        * 0.12
+    )
+    w2_dense = (
+        torch.randn(
+            experts,
+            hidden_size,
+            intermediate_size,
+            device="cuda",
+        )
+        * 0.12
+    )
+    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+        w13_dense,
+        w13_global_scale,
+    )
+    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
+        w2_dense,
+        w2_global_scale,
+    )
+    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
+    topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int32)
+    topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
+    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+
+    experts_w4a16 = prepare_tp_moe_fp4_experts(
+        a=x,
+        a1_gscale=a_gscale,
+        w1_fp4=w13,
+        w1_blockscale=w13_blockscale,
+        w1_alphas=w13_global_scale,
+        a2_gscale=a_gscale,
+        w2_fp4=w2,
+        w2_blockscale=w2_blockscale,
+        w2_alphas=w2_global_scale,
+        activation=activation,
+        quant_mode="w4a16",
+    )
+    prepared = experts_w4a16.representation_for("w4a16")
+    assert prepared.weight_layout == "modelopt"
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout=prepared.weight_layout,
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
+
+    binding = make_tp_moe_fp4_binding(
+        a=x,
+        experts=experts_w4a16,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        quant_mode="w4a16",
+    )
+    expected = moe_reference_w4a16_f32(
+        x,
+        w13,
+        w13_blockscale,
+        w13_global_scale,
+        w2,
+        w2_blockscale,
+        w2_global_scale,
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation=activation,
+    )
+
+    first = binding.run().clone()
+    binding.intermediate_cache2.fill_(float("nan"))
+    replay = binding.run().clone()
+    torch.cuda.synchronize()
+    for actual in (first, replay):
+        metrics = compare_to_reference(actual, expected)
+        assert bool(torch.isfinite(actual).all().item())
+        assert metrics.cos > 0.999, metrics
+    torch.testing.assert_close(first, replay, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -1052,12 +1052,16 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
+@pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
+    m: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     experts, hidden_size, intermediate_size = 8, 128, 128
-    m, topk = 3, 2
-    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0))
+    topk = 2
+    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
+    torch.manual_seed(20260730 + (1000 if activation == "silu" else 0) + m)
     rows = intermediate_size * (2 if activation == "silu" else 1)
     w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
     w2_dense = (
@@ -1098,6 +1102,22 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     )
     prepared_w4a16 = w4a16_experts.representation_for("w4a16")
     assert prepared_w4a16.weight_layout == "modelopt"
+    assert _small_m_direct_supported(
+        m=m,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=experts,
+        topk=topk,
+        activation=activation,
+        apply_router_weight_on_input=False,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        element_dtype="bf16",
+        weight_layout=prepared_w4a16.weight_layout,
+        w13_layout="w13",
+        scale_format="e4m3_k16",
+    )
     binding = make_tp_moe_fp4_binding(
         a=x,
         experts=w4a16_experts,

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -267,7 +267,10 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
     )
 
 
-@pytest.mark.parametrize("intermediate_size", [16, 144, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [16, 144, 352, 464, 480, 496, 512],
+)
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
@@ -1113,7 +1116,10 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
-@pytest.mark.parametrize("intermediate_size", [32, 128, 144, 224, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [32, 128, 144, 224, 352, 464, 480, 496, 512],
+)
 def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
     activation: str,
     m: int,
@@ -1269,7 +1275,10 @@ def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-@pytest.mark.parametrize("intermediate_size", [144, 352, 496])
+@pytest.mark.parametrize(
+    "intermediate_size",
+    [144, 352, 464, 480, 496, 512],
+)
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 @pytest.mark.parametrize("m", [1, 3])
 def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -667,6 +667,16 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
         params_dtype=torch.bfloat16,
         w13_layout=w13_layout,
     )
+    expected_w13_scale_rows = ((rows + 63) // 64) * 64
+    assert tuple(prepared.w13_scale.shape) == (
+        experts,
+        hidden_size // 32,
+        expected_w13_scale_rows,
+    )
+    assert prepared.micro_w13_scale is not None
+    assert int(prepared.micro_w13_scale.numel()) == (
+        experts * (hidden_size // 32) * expected_w13_scale_rows
+    )
     buffers = make_w4a16_buffers(
         prepared, m=m, topk=topk, dtype=torch.bfloat16, device=torch.device("cuda")
     )

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -353,14 +353,17 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
         f"phases={phase_equal} final={torch.equal(candidate, reference)} "
         f"packed_block={candidate_launch.moe_block_size} "
         f"fc2_subtile={candidate_launch.fc2_moe_block_size} "
+        f"fc2_schedule_factor={candidate_launch.fc2_schedule_route_block_factor} "
         f"regs={candidate_launch.registers_per_thread} "
         f"local={candidate_launch.local_memory_bytes} "
         f"smem={candidate_launch.shared_memory_bytes}"
     )
     assert reference_launch.moe_block_size == 8
     assert reference_launch.fc2_moe_block_size == 8
+    assert reference_launch.fc2_schedule_route_block_factor == 1
     assert candidate_launch.moe_block_size == 64
     assert candidate_launch.fc2_moe_block_size == 8
+    assert candidate_launch.fc2_schedule_route_block_factor == 8
     assert phase_equal == (True, True, True)
     assert torch.equal(candidate, reference)
     assert candidate_launch.local_memory_bytes == 0

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -52,7 +52,7 @@ def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
     assert len(calls) == 1
 
     driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
-    assert len(calls[0].args) == len(driver_parameters) - 1
+    assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
     assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
         "descriptor_map",
         "Int32(self.total_experts)",
@@ -83,7 +83,7 @@ def test_mixed_runtime_tracks_topk_sum_contract() -> None:
     assert len(calls) == 1
 
     sum_parameters = inspect.signature(W4A16TopKSumKernel.__call__).parameters
-    assert len(calls[0].args) == len(sum_parameters) - 1
+    assert len(calls[0].args) + len(calls[0].keywords) == len(sum_parameters) - 1
     assert [ast.unparse(arg) for arg in calls[0].args[-4:]] == [
         "Int32(launch.topk_sum.num_experts)",
         "Int32(launch.topk_sum.route_num_experts)",
@@ -354,9 +354,11 @@ def test_one_grid_large_blocks_avoid_serial_prefill_drift(
     )
 
     x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
-    topk_ids = torch.tensor(
-        [0, 6, 1, 7, 2, 3, 4, 5], dtype=torch.int32, device=device
-    ).expand(m, -1).contiguous()
+    topk_ids = (
+        torch.tensor([0, 6, 1, 7, 2, 3, 4, 5], dtype=torch.int32, device=device)
+        .expand(m, -1)
+        .contiguous()
+    )
     topk_weights = torch.softmax(
         torch.randn((m, topk), dtype=torch.float32, device=device), dim=-1
     )
@@ -414,9 +416,7 @@ def test_one_grid_large_blocks_avoid_serial_prefill_drift(
             candidate_phases, reference_phases, strict=True
         )
     )
-    print(
-        "mixed_trellis_large_block_fc2_subtile_parity "
-        f"phases={phase_equal} final={torch.equal(candidate, reference)} "
+    geometry = (
         f"packed_block={candidate_launch.moe_block_size} "
         f"fc2_subtile={candidate_launch.fc2_moe_block_size} "
         f"fc2_schedule_factor={candidate_launch.fc2_schedule_route_block_factor} "
@@ -431,8 +431,8 @@ def test_one_grid_large_blocks_avoid_serial_prefill_drift(
     assert candidate_launch.fc2_moe_block_size == 8
     assert candidate_launch.fc2_schedule_route_block_factor == 2
     assert candidate_launch.fc2_paired_m8_routes is True
-    assert phase_equal == (True, True, True)
-    assert torch.equal(candidate, reference)
+    assert phase_equal == (True, True, True), geometry
+    assert torch.equal(candidate, reference), geometry
     assert candidate_launch.local_memory_bytes == 0
     assert candidate_launch.shared_memory_bytes <= int(
         props.shared_memory_per_block_optin

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 import torch
 
@@ -9,8 +13,13 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
     make_w4a16_packed_buffers,
     max_packed_route_slots,
 )
-from sparkinfer.moe._shared.kernels.w4a16.kernel import run_w4a16_moe
+from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+    W4A16FusedMoeKernel,
+    W4A16TopKSumKernel,
+    run_w4a16_moe,
+)
 from sparkinfer.moe._shared.kernels.w4a16.mixed_trellis import (
+    W4A16MixedTrellisKernel,
     build_tiered_maps,
     combine_trellis_rotations,
     compile_mixed_trellis,
@@ -27,6 +36,60 @@ def _sm12x_available() -> bool:
         return False
     major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
     return major == 12 and minor in (0, 1)
+
+
+def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
+    """Keep the direct CuTe call aligned with the shared driver's ABI."""
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(W4A16MixedTrellisKernel.kernel)))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_moe_body"
+    ]
+    assert len(calls) == 1
+
+    driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
+    assert len(calls[0].args) == len(driver_parameters) - 1
+    assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
+        "descriptor_map",
+        "Int32(self.total_experts)",
+        "Int32(self.total_experts)",
+        "smem_base",
+        "tid",
+        "cta",
+        "grid_x",
+        "active_m",
+        "fc1_emit",
+        "fc2_emit",
+    ]
+
+
+def test_mixed_runtime_tracks_topk_sum_contract() -> None:
+    """Keep the direct compiled top-k launch aligned with its runtime ABI."""
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(run_mixed_trellis)))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "compiled"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "topk_sum"
+    ]
+    assert len(calls) == 1
+
+    sum_parameters = inspect.signature(W4A16TopKSumKernel.__call__).parameters
+    assert len(calls[0].args) == len(sum_parameters) - 1
+    assert [ast.unparse(arg) for arg in calls[0].args[-4:]] == [
+        "Int32(launch.topk_sum.num_experts)",
+        "Int32(launch.topk_sum.route_num_experts)",
+        "m",
+        "stream",
+    ]
 
 
 def _prepared(

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -263,37 +263,29 @@ def test_build_tiered_maps_rejects_invalid_partitions() -> None:
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
 def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
-    """Keep block-64 routing without grouping K3 and K4 reductions."""
+    """Block-64 packing plus FC2 subtiles preserves stock one-grid arithmetic."""
 
     torch.manual_seed(20260801)
     device = torch.device("cuda", torch.cuda.current_device())
     m, hidden, intermediate, topk = 64, 512, 256, 8
-    reference_tiles = (128, 128, 32, 512)
-    block64_tiles = (128, 64, 64, 128)
+    tile_config = (128, 128, 32, 512)
     tier0_experts, tier1_experts = 6, 2
 
-    def tiers(tile_config: tuple[int, int, int, int]):
-        return tuple(
-            _prepared(
-                experts=experts,
-                hidden=hidden,
-                intermediate=intermediate,
-                bits=bits,
-                seed=seed,
-                device=device,
-                tile_config=tile_config,
-            )
-            for experts, bits, seed in (
-                (tier0_experts, 3, 301),
-                (tier1_experts, 4, 401),
-            )
+    prepared_tiers = tuple(
+        _prepared(
+            experts=experts,
+            hidden=hidden,
+            intermediate=intermediate,
+            bits=bits,
+            seed=seed,
+            device=device,
+            tile_config=tile_config,
         )
-
-    reference_tiers = tiers(reference_tiles)
-    block64_tiers = tiers(block64_tiles)
-    for reference, candidate in zip(reference_tiers, block64_tiers, strict=True):
-        assert torch.equal(reference.w13, candidate.w13)
-        assert torch.equal(reference.w2, candidate.w2)
+        for experts, bits, seed in (
+            (tier0_experts, 3, 301),
+            (tier1_experts, 4, 401),
+        )
+    )
 
     x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
     topk_ids = torch.tensor(
@@ -302,29 +294,14 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
     topk_weights = torch.softmax(
         torch.randn((m, topk), dtype=torch.float32, device=device), dim=-1
     )
-    map0 = torch.cat(
-        (
-            torch.arange(tier0_experts, dtype=torch.int32, device=device),
-            torch.full((tier1_experts,), -1, dtype=torch.int32, device=device),
-        )
-    )
-    map1 = torch.cat(
-        (
-            torch.full((tier0_experts,), -1, dtype=torch.int32, device=device),
-            torch.arange(tier1_experts, dtype=torch.int32, device=device),
-        )
-    )
-
     props = torch.cuda.get_device_properties(device)
     global_to_combined, descriptor = build_tiered_maps(
         range(tier0_experts), range(tier0_experts, 8), device=device
     )
 
     def one_grid(
-        prepared_tiers,
-        tile_config: tuple[int, int, int, int],
         block_size_m: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, object, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
         route_slots = max_packed_route_slots(m * topk, block_size_m, 8)
         launch = compile_mixed_trellis(
             size_m=m,
@@ -342,7 +319,7 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
         buffers = make_mixed_trellis_buffers(
             launch, device=device, sms=int(props.multi_processor_count)
         )
-        return run_mixed_trellis(
+        output = run_mixed_trellis(
             x,
             prepared_tiers[0],
             prepared_tiers[1],
@@ -354,41 +331,42 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
             launch,
             buffers,
         ).clone()
+        phase_outputs = (
+            buffers.fc1.clone(),
+            buffers.activated.clone(),
+            buffers.fc2.clone(),
+        )
+        return output, launch, phase_outputs
 
-    reference = one_grid(reference_tiers, reference_tiles, 8)
-    candidate = one_grid(block64_tiers, block64_tiles, 64)
-    serial_block8 = _serial_tier(
-        x, reference_tiers[0], topk_weights, topk_ids, map0, block_size_m=8
-    ).clone()
-    serial_block8.add_(
-        _serial_tier(
-            x, reference_tiers[1], topk_weights, topk_ids, map1, block_size_m=8
-        )
-    )
-    serial_block64 = _serial_tier(
-        x, block64_tiers[0], topk_weights, topk_ids, map0, block_size_m=64
-    ).clone()
-    serial_block64.add_(
-        _serial_tier(
-            x, block64_tiers[1], topk_weights, topk_ids, map1, block_size_m=64
-        )
-    )
+    reference, reference_launch, reference_phases = one_grid(8)
+    candidate, candidate_launch, candidate_phases = one_grid(64)
     torch.cuda.synchronize(device)
 
-    denominator = reference.norm().clamp_min(1.0e-12)
-    serial8_error = float((serial_block8 - reference).norm() / denominator)
-    serial64_error = float((serial_block64 - reference).norm() / denominator)
-    candidate_error = float((candidate - reference).norm() / denominator)
-    print(
-        "mixed_trellis_block64_numerics "
-        f"serial_block8={serial8_error:.9e} "
-        f"serial_block64={serial64_error:.9e} "
-        f"one_grid_block64={candidate_error:.9e}"
+    phase_equal = tuple(
+        torch.equal(candidate_phase, reference_phase)
+        for candidate_phase, reference_phase in zip(
+            candidate_phases, reference_phases, strict=True
+        )
     )
-    assert serial64_error > 5.0e-5
-    assert candidate_error < 2.0e-5
-    assert candidate_error < serial64_error * 0.2
-    assert abs(candidate_error - serial8_error) < 1.0e-6
+    print(
+        "mixed_trellis_block64_fc2_subtile_parity "
+        f"phases={phase_equal} final={torch.equal(candidate, reference)} "
+        f"packed_block={candidate_launch.moe_block_size} "
+        f"fc2_subtile={candidate_launch.fc2_moe_block_size} "
+        f"regs={candidate_launch.registers_per_thread} "
+        f"local={candidate_launch.local_memory_bytes} "
+        f"smem={candidate_launch.shared_memory_bytes}"
+    )
+    assert reference_launch.moe_block_size == 8
+    assert reference_launch.fc2_moe_block_size == 8
+    assert candidate_launch.moe_block_size == 64
+    assert candidate_launch.fc2_moe_block_size == 8
+    assert phase_equal == (True, True, True)
+    assert torch.equal(candidate, reference)
+    assert candidate_launch.local_memory_bytes == 0
+    assert candidate_launch.shared_memory_bytes <= int(
+        props.shared_memory_per_block_optin
+    )
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -363,7 +363,8 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
     assert reference_launch.fc2_schedule_route_block_factor == 1
     assert candidate_launch.moe_block_size == 64
     assert candidate_launch.fc2_moe_block_size == 8
-    assert candidate_launch.fc2_schedule_route_block_factor == 8
+    assert candidate_launch.fc2_schedule_route_block_factor == 2
+    assert candidate_launch.fc2_paired_m8_routes is True
     assert phase_equal == (True, True, True)
     assert torch.equal(candidate, reference)
     assert candidate_launch.local_memory_bytes == 0

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -72,6 +72,7 @@ def _serial_tier(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     expert_map: torch.Tensor,
+    block_size_m: int = 8,
 ) -> torch.Tensor:
     m, topk = int(topk_ids.shape[0]), int(topk_ids.shape[1])
     buffers = make_w4a16_packed_buffers(
@@ -82,7 +83,7 @@ def _serial_tier(
         device=x.device,
         route_num_experts=int(expert_map.numel()),
         full_rotation=True,
-        block_size_m=8,
+        block_size_m=block_size_m,
     )
     assert buffers.rotation_a_gate is not None
     assert buffers.rotation_a_up is not None
@@ -104,7 +105,7 @@ def _serial_tier(
         expert_counts=buffers.expert_counts,
         expert_map=expert_map,
         output_expert_map=expert_map,
-        route_block_size_m=8,
+        route_block_size_m=block_size_m,
         intermediate_rotation_scales=prepared.intermediate_rotations,
         full_rotation=True,
         suh_gate_table=prepared.gate_suh,
@@ -258,6 +259,136 @@ def test_build_tiered_maps_rejects_invalid_partitions() -> None:
         build_tiered_maps((0, 1), (1, 2), device=torch.device("cpu"))
     with pytest.raises(ValueError, match="disjoint partition"):
         build_tiered_maps((0, 4), (1, 2), device=torch.device("cpu"))
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
+    """Keep block-64 routing without grouping K3 and K4 reductions."""
+
+    torch.manual_seed(20260801)
+    device = torch.device("cuda", torch.cuda.current_device())
+    m, hidden, intermediate, topk = 64, 512, 256, 8
+    reference_tiles = (128, 128, 32, 512)
+    block64_tiles = (128, 64, 64, 128)
+    tier0_experts, tier1_experts = 6, 2
+
+    def tiers(tile_config: tuple[int, int, int, int]):
+        return tuple(
+            _prepared(
+                experts=experts,
+                hidden=hidden,
+                intermediate=intermediate,
+                bits=bits,
+                seed=seed,
+                device=device,
+                tile_config=tile_config,
+            )
+            for experts, bits, seed in (
+                (tier0_experts, 3, 301),
+                (tier1_experts, 4, 401),
+            )
+        )
+
+    reference_tiers = tiers(reference_tiles)
+    block64_tiers = tiers(block64_tiles)
+    for reference, candidate in zip(reference_tiers, block64_tiers, strict=True):
+        assert torch.equal(reference.w13, candidate.w13)
+        assert torch.equal(reference.w2, candidate.w2)
+
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor(
+        [0, 6, 1, 7, 2, 3, 4, 5], dtype=torch.int32, device=device
+    ).expand(m, -1).contiguous()
+    topk_weights = torch.softmax(
+        torch.randn((m, topk), dtype=torch.float32, device=device), dim=-1
+    )
+    map0 = torch.cat(
+        (
+            torch.arange(tier0_experts, dtype=torch.int32, device=device),
+            torch.full((tier1_experts,), -1, dtype=torch.int32, device=device),
+        )
+    )
+    map1 = torch.cat(
+        (
+            torch.full((tier0_experts,), -1, dtype=torch.int32, device=device),
+            torch.arange(tier1_experts, dtype=torch.int32, device=device),
+        )
+    )
+
+    props = torch.cuda.get_device_properties(device)
+    global_to_combined, descriptor = build_tiered_maps(
+        range(tier0_experts), range(tier0_experts, 8), device=device
+    )
+
+    def one_grid(
+        prepared_tiers,
+        tile_config: tuple[int, int, int, int],
+        block_size_m: int,
+    ) -> torch.Tensor:
+        route_slots = max_packed_route_slots(m * topk, block_size_m, 8)
+        launch = compile_mixed_trellis(
+            size_m=m,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            tier0_num_experts=tier0_experts,
+            tier1_num_experts=tier1_experts,
+            top_k=topk,
+            max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
+            moe_block_size=block_size_m,
+            sms=int(props.multi_processor_count),
+            max_shared_mem=int(props.shared_memory_per_block_optin),
+            force_tile_config=tile_config,
+        )
+        buffers = make_mixed_trellis_buffers(
+            launch, device=device, sms=int(props.multi_processor_count)
+        )
+        return run_mixed_trellis(
+            x,
+            prepared_tiers[0],
+            prepared_tiers[1],
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            combine_trellis_rotations(*prepared_tiers),
+            launch,
+            buffers,
+        ).clone()
+
+    reference = one_grid(reference_tiers, reference_tiles, 8)
+    candidate = one_grid(block64_tiers, block64_tiles, 64)
+    serial_block8 = _serial_tier(
+        x, reference_tiers[0], topk_weights, topk_ids, map0, block_size_m=8
+    ).clone()
+    serial_block8.add_(
+        _serial_tier(
+            x, reference_tiers[1], topk_weights, topk_ids, map1, block_size_m=8
+        )
+    )
+    serial_block64 = _serial_tier(
+        x, block64_tiers[0], topk_weights, topk_ids, map0, block_size_m=64
+    ).clone()
+    serial_block64.add_(
+        _serial_tier(
+            x, block64_tiers[1], topk_weights, topk_ids, map1, block_size_m=64
+        )
+    )
+    torch.cuda.synchronize(device)
+
+    denominator = reference.norm().clamp_min(1.0e-12)
+    serial8_error = float((serial_block8 - reference).norm() / denominator)
+    serial64_error = float((serial_block64 - reference).norm() / denominator)
+    candidate_error = float((candidate - reference).norm() / denominator)
+    print(
+        "mixed_trellis_block64_numerics "
+        f"serial_block8={serial8_error:.9e} "
+        f"serial_block64={serial64_error:.9e} "
+        f"one_grid_block64={candidate_error:.9e}"
+    )
+    assert serial64_error > 5.0e-5
+    assert candidate_error < 2.0e-5
+    assert candidate_error < serial64_error * 0.2
+    assert abs(candidate_error - serial8_error) < 1.0e-6
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -262,8 +262,11 @@ def test_build_tiered_maps_rejects_invalid_partitions() -> None:
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
-def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
-    """Block-64 packing plus FC2 subtiles preserves stock one-grid arithmetic."""
+@pytest.mark.parametrize("candidate_block_size", [32, 64])
+def test_one_grid_large_blocks_avoid_serial_prefill_drift(
+    candidate_block_size: int,
+) -> None:
+    """Large route blocks with paired-M8 FC2 preserve one-grid arithmetic."""
 
     torch.manual_seed(20260801)
     device = torch.device("cuda", torch.cuda.current_device())
@@ -339,7 +342,7 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
         return output, launch, phase_outputs
 
     reference, reference_launch, reference_phases = one_grid(8)
-    candidate, candidate_launch, candidate_phases = one_grid(64)
+    candidate, candidate_launch, candidate_phases = one_grid(candidate_block_size)
     torch.cuda.synchronize(device)
 
     phase_equal = tuple(
@@ -349,7 +352,7 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
         )
     )
     print(
-        "mixed_trellis_block64_fc2_subtile_parity "
+        "mixed_trellis_large_block_fc2_subtile_parity "
         f"phases={phase_equal} final={torch.equal(candidate, reference)} "
         f"packed_block={candidate_launch.moe_block_size} "
         f"fc2_subtile={candidate_launch.fc2_moe_block_size} "
@@ -361,7 +364,7 @@ def test_one_grid_block64_avoids_serial_prefill_drift() -> None:
     assert reference_launch.moe_block_size == 8
     assert reference_launch.fc2_moe_block_size == 8
     assert reference_launch.fc2_schedule_route_block_factor == 1
-    assert candidate_launch.moe_block_size == 64
+    assert candidate_launch.moe_block_size == candidate_block_size
     assert candidate_launch.fc2_moe_block_size == 8
     assert candidate_launch.fc2_schedule_route_block_factor == 2
     assert candidate_launch.fc2_paired_m8_routes is True

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -6,6 +6,44 @@ import pytest
 import torch
 
 from sparkinfer.moe._shared.kernels.w4a16.kernel import pack_topk_routes_by_expert
+from sparkinfer.moe._shared.kernels.w4a16.host import (
+    route_block_sizes_for_capacity,
+    select_route_block_size_m,
+)
+
+
+@pytest.mark.parametrize(
+    ("max_tokens", "topk", "num_experts"),
+    [
+        (1, 8, 160),
+        (64, 8, 160),
+        (144, 8, 160),
+        (1024, 8, 256),
+        (32, 64, 8),
+    ],
+)
+def test_capacity_block_sizes_cover_every_live_selection(
+    max_tokens: int,
+    topk: int,
+    num_experts: int,
+) -> None:
+    planned = route_block_sizes_for_capacity(max_tokens, topk, num_experts)
+    selected = {
+        select_route_block_size_m(m, topk, num_experts)
+        for m in range(1, max_tokens + 1)
+    }
+
+    assert selected.issubset(planned)
+    assert planned[0] == select_route_block_size_m(1, topk, num_experts)
+    assert planned[-1] == select_route_block_size_m(
+        max_tokens,
+        topk,
+        num_experts,
+    )
+
+
+def test_small_capacity_needs_only_block_8() -> None:
+    assert route_block_sizes_for_capacity(64, 8, 160) == (8,)
 
 
 def _expected_route_pack(

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -117,14 +117,19 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
         device="cuda",
     )
 
-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
-        topk_ids,
-        block_size,
-        num_experts,
+    local_packed_routes, local_block_experts, local_packed_route_count = (
+        pack_topk_routes_by_expert(
+            topk_ids,
+            block_size,
+            num_experts,
+        )
     )
-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
-        _expected_route_pack(topk_ids, block_size, num_experts)
-    )
+    (
+        expected_ids,
+        expected_valid,
+        expected_packed_route_count,
+        expected_block_experts,
+    ) = _expected_route_pack(topk_ids, block_size, num_experts)
 
     sentinel = int(topk_ids.numel())
     valid = int(expected_packed_route_count.item())
@@ -137,12 +142,18 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
     assert host_route_payload.numel() == int(expected_valid.sum().item())
     for expert in range(num_experts):
-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
+        actual = (
+            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+        )
+        expected = torch.nonzero(
+            expected_valid & (expected_ids == expert), as_tuple=False
+        )
         expected = expected.flatten().sort().values
         assert torch.equal(actual, expected), expert
 
-    host_block_experts = local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
+    host_block_experts = (
+        local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
+    )
     for block, expert in enumerate(host_block_experts.tolist()):
         block_routes = host_packed_routes[block * block_size : (block + 1) * block_size]
         payload = block_routes[block_routes < sentinel]
@@ -169,9 +180,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
             num_experts,
         )
     )
-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
-        _expected_route_pack(topk_ids, block_size, num_experts)
-    )
+    (
+        expected_ids,
+        expected_valid,
+        expected_packed_route_count,
+        expected_block_experts,
+    ) = _expected_route_pack(topk_ids, block_size, num_experts)
 
     sentinel = int(topk_ids.numel())
     valid = int(expected_packed_route_count.item())
@@ -184,8 +198,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
     assert host_route_payload.numel() == int(expected_valid.sum().item())
     for expert in range(num_experts):
-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
+        actual = (
+            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+        )
+        expected = torch.nonzero(
+            expected_valid & (expected_ids == expert), as_tuple=False
+        )
         expected = expected.flatten().sort().values
         assert torch.equal(actual, expected), expert
 
@@ -211,15 +229,20 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
 
-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
-        topk_ids,
-        block_size,
-        global_experts,
-        expert_map=expert_map,
+    local_packed_routes, local_block_experts, local_packed_route_count = (
+        pack_topk_routes_by_expert(
+            topk_ids,
+            block_size,
+            global_experts,
+            expert_map=expert_map,
+        )
     )
-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
-        _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
-    )
+    (
+        expected_ids,
+        expected_valid,
+        expected_packed_route_count,
+        expected_block_experts,
+    ) = _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
 
     sentinel = int(topk_ids.numel())
     valid = int(expected_packed_route_count.item())
@@ -232,7 +255,11 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
     assert host_route_payload.numel() == int(expected_valid.sum().item())
     for local_expert in range(local_experts):
-        actual = host_route_payload[expected_ids[host_route_payload] == local_expert].sort().values
+        actual = (
+            host_route_payload[expected_ids[host_route_payload] == local_expert]
+            .sort()
+            .values
+        )
         expected = torch.nonzero(
             expected_valid & (expected_ids == local_expert),
             as_tuple=False,
@@ -251,14 +278,19 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
     block_size = 4
     num_experts = 8
 
-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
-        topk_ids,
-        block_size,
-        num_experts,
+    local_packed_routes, local_block_experts, local_packed_route_count = (
+        pack_topk_routes_by_expert(
+            topk_ids,
+            block_size,
+            num_experts,
+        )
     )
-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
-        _expected_route_pack(topk_ids, block_size, num_experts)
-    )
+    (
+        expected_ids,
+        expected_valid,
+        expected_packed_route_count,
+        expected_block_experts,
+    ) = _expected_route_pack(topk_ids, block_size, num_experts)
 
     sentinel = int(topk_ids.numel())
     valid = int(expected_packed_route_count.item())
@@ -268,4 +300,6 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
     payload = local_packed_routes[:valid].detach().cpu().to(torch.int64)
     payload = payload[payload < sentinel]
     assert payload.numel() == int(expected_valid.sum().item())
-    assert torch.equal(payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5]))
+    assert torch.equal(
+        payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5])
+    )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,13 +10,10 @@ except ModuleNotFoundError:  # Python 3.10
 
 ROOT = Path(__file__).parents[1]
 PCIE_PACKAGE = "sparkinfer.comm.pcie"
-TRELLIS_PACKAGE = "sparkinfer.gemm.trellis_linear"
-TRELLIS_SOURCE_DIR = ROOT / "sparkinfer" / "gemm" / "trellis_linear" / "csrc"
 RUNTIME_CUDA_SOURCES = {
     "pcie_dcp_a2a.cu",
     "pcie_dcp_topk.cu",
     "pcie_dma.cu",
-    "pcie_hierarchical.cu",
     "pcie_oneshot.cu",
     "pcie_twoshot.cu",
 }
@@ -27,24 +24,6 @@ def test_runtime_cuda_sources_are_in_package_data() -> None:
     package_data = config["tool"]["setuptools"]["package-data"]
 
     assert package_data[PCIE_PACKAGE] == ["*.cu"]
-    packaged_sources = {
+    assert {
         path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
-    }
-    assert packaged_sources >= RUNTIME_CUDA_SOURCES
-
-
-def test_trellis_runtime_sources_and_license_are_packaged() -> None:
-    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
-    patterns = config["tool"]["setuptools"]["package-data"][TRELLIS_PACKAGE]
-    required = [
-        TRELLIS_SOURCE_DIR / "trellis_k6_small.cu",
-        TRELLIS_SOURCE_DIR / "vendor" / "LICENSE.exllamav3",
-        TRELLIS_SOURCE_DIR / "vendor" / "quant" / "exl3_gemm_kernel.cuh",
-    ]
-
-    for path in required:
-        assert path.is_file()
-        relative = path.relative_to(TRELLIS_SOURCE_DIR.parent)
-        assert any(relative.match(pattern) for pattern in patterns), (
-            f"{relative} is required by the Trellis JIT but is not package data"
-        )
+    } == RUNTIME_CUDA_SOURCES

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,6 +10,8 @@ except ModuleNotFoundError:  # Python 3.10
 
 ROOT = Path(__file__).parents[1]
 PCIE_PACKAGE = "sparkinfer.comm.pcie"
+TRELLIS_PACKAGE = "sparkinfer.gemm.trellis_linear"
+TRELLIS_SOURCE_DIR = ROOT / "sparkinfer" / "gemm" / "trellis_linear" / "csrc"
 RUNTIME_CUDA_SOURCES = {
     "pcie_dcp_a2a.cu",
     "pcie_dcp_topk.cu",
@@ -27,3 +29,20 @@ def test_runtime_cuda_sources_are_in_package_data() -> None:
     assert {
         path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
     } == RUNTIME_CUDA_SOURCES
+
+
+def test_trellis_runtime_sources_and_license_are_packaged() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    patterns = config["tool"]["setuptools"]["package-data"][TRELLIS_PACKAGE]
+    required = [
+        TRELLIS_SOURCE_DIR / "trellis_k6_small.cu",
+        TRELLIS_SOURCE_DIR / "vendor" / "LICENSE.exllamav3",
+        TRELLIS_SOURCE_DIR / "vendor" / "quant" / "exl3_gemm_kernel.cuh",
+    ]
+
+    for path in required:
+        assert path.is_file()
+        relative = path.relative_to(TRELLIS_SOURCE_DIR.parent)
+        assert any(relative.match(pattern) for pattern in patterns), (
+            f"{relative} is required by the Trellis JIT but is not package data"
+        )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -16,6 +16,7 @@ RUNTIME_CUDA_SOURCES = {
     "pcie_dcp_a2a.cu",
     "pcie_dcp_topk.cu",
     "pcie_dma.cu",
+    "pcie_hierarchical.cu",
     "pcie_oneshot.cu",
     "pcie_twoshot.cu",
 }
@@ -26,9 +27,10 @@ def test_runtime_cuda_sources_are_in_package_data() -> None:
     package_data = config["tool"]["setuptools"]["package-data"]
 
     assert package_data[PCIE_PACKAGE] == ["*.cu"]
-    assert {
+    packaged_sources = {
         path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
-    } == RUNTIME_CUDA_SOURCES
+    }
+    assert packaged_sources >= RUNTIME_CUDA_SOURCES
 
 
 def test_trellis_runtime_sources_and_license_are_packaged() -> None:


### PR DESCRIPTION
## Summary

Consolidate the EXL3/Trellis runtime required by the r20 release directly on
the current `master` branch. This supersedes the stacked integration roles of
#110 and #111 with one reviewable branch and retains the qualified changes:

- preserve the W4A16 planning, tail, and CUDA-graph safeguards from #110;
- preserve exact paired-M8 mixed K3/K4 prefill from #111;
- select block-32 for the qualified GLM-5.2 mixed K3/K4 production geometry;
- add the native dense Trellis K6 linear runtime used by online EXL3 B6;
- package all K6 JIT sources with pinned provenance and upstream license;
- keep arena sizing, materialization, and launch geometry on one fixed route
  block contract.

The branch is based directly on SparkInfer `59216fa`. During the rebase, the
current runtime expert-map ABI exposed two stale direct-call contracts in
mixed Trellis. The patch forwards the runtime expert-count fields to both the
shared MoE body and top-k sum launch. CPU ABI tests make future signature drift
fail before CUDA compilation.

## Scope and gating

- Existing non-EXL3 paths retain their prior dispatch.
- Block-32 is selected only for the validated mixed K3/K4 GLM geometry.
- Dense K6 is selected only for a one-expert Trellis K6 linear plan on sm_120.
- Unsupported architectures fail before JIT compilation.
- The experimental TMA producer-warp path is not shipped.

## Review hardening

- Validate CUDA placement, common device, K/N geometry, and sm_120 before K6
  launch.
- Derive K6 threads and the exact 24 KiB dynamic shared-memory request from
  the vendored kernel geometry; configure it once per process.
- Make the vendored accumulation mode build-overridable.
- Remove unused vendored error helpers and record source commit provenance.
- Deduplicate mixed-tier dispatch without changing route or lock indexing.
- Poison CUDA-graph output before replay so the test proves execution.

The PTX funnel-shift operand-order review was checked against PTX semantics:
`shf.r` forms `(b:a)`, so the existing low/high ordering is correct. The GPU
parity matrix also covers it; swapping the operands would be incorrect.

## Validation

- `git diff --check`, compileall, and changed-file Ruff: pass.
- Focused CPU tests: 68 passed, 14 skipped.
- Remote sm_120 K6 suite: 17 passed, including CUDA graph poison/replay and
  GLM-5.2 dense shapes.
- Remote sm_120 mixed K3/K4 suite: 5 passed, including block 32/48 and the
  GLM-5.2 large-M shape.
- Exact-smem microbenchmark versus the old 90 KiB request: within measurement
  noise for all tested M/K/N shapes.
- Prior matched TP4 E2E POC:
  - no online overlay: +2.8% at 8K and +1.9% at 64K prefill;
  - MXFP8 overlay: +3.5% at 8K and +2.7% at 64K prefill;
  - mixed-kernel time: -6.6%; scratch: -47.1 MiB/GPU;
  - decode remained at parity.

## Rejected experiment

The M=2048 TMA producer-warp specialization was implemented and measured, but
did not improve E2E performance and complicated shared-memory layout and cache
contracts. It was removed rather than retained as a dormant release knob.
Matched K6 prefill was 3,645.5/3,524.1 tok/s at 8K/64K without TMA versus
3,618.6/3,502.4 with TMA; decode was noise-equivalent.

Supersedes #110 and #111. No merge is requested until release validation is
complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized Trellis linear execution for small workloads on supported CUDA hardware.
  * Added adaptive MoE route-block sizing, paired execution, and configurable tile geometry.
  * Added a public scratch-memory sizing query for fused MoE operations.
  * Added native Hadamard-128 support and improved dense Trellis launch options.
* **Bug Fixes**
  * Improved handling of irregular dimensions, padded data, scale layouts, and CUDA graph capture.
  * Prevented invalid cache resolution when compilation is frozen.
* **Packaging**
  * Included required CUDA sources, headers, and licensing information in distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->