### PR TITLE
fix(pcie): rebase replay and IPC lifecycle hardening

### DIFF
--- a/benchmarks/benchmark_pcie_oneshot_control_node.py
+++ b/benchmarks/benchmark_pcie_oneshot_control_node.py
@@ -33,12 +33,13 @@ import torch.distributed as dist
 from cuda.bindings import runtime as cudart
 
 SCHEMA_NAME = "sparkinfer.pcie_oneshot_control_node.run"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 DTYPE_NAME = "bfloat16"
 TOP_LEVEL_KEYS = {
     "schema",
     "contract",
     "scope",
+    "correctness",
     "identity",
     "provenance",
     "software",
@@ -47,6 +48,7 @@ TOP_LEVEL_KEYS = {
     "per_rank",
     "distributed_critical_path",
 }
+CORRECTNESS_KEYS = {"verdict"}
 CONTRACT_KEYS = {
     "world_size",
     "numel",
@@ -263,7 +265,12 @@ def _verified_implementation(
     extension = module._load_extension()
     extension_path = Path(extension.__file__).resolve()
     build_root = extension_path.parent
-    expected_cache = Path(os.environ["TORCH_EXTENSIONS_DIR"]).resolve()
+    cache_value = os.environ.get("TORCH_EXTENSIONS_DIR")
+    if not cache_value:
+        raise RuntimeError(
+            "TORCH_EXTENSIONS_DIR must name a fresh per-run extension cache"
+        )
+    expected_cache = Path(cache_value).resolve()
     if not extension_path.is_relative_to(expected_cache):
         raise RuntimeError(
             f"loaded extension {extension_path} is outside fresh cache {expected_cache}"
@@ -412,6 +419,10 @@ class _NvidiaSmiSampler:
             raise RuntimeError("nvidia-smi sampler thread did not stop within 15s")
         self._phase = "final"
         self._sample()
+
+    @property
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
 
 
 def _environment_toggles() -> dict[str, str]:
@@ -740,6 +751,13 @@ def _device_metadata() -> list[dict[str, object]]:
     return devices
 
 
+def _validate_correctness(correctness: object) -> None:
+    if not isinstance(correctness, dict) or set(correctness) != CORRECTNESS_KEYS:
+        raise ValueError("benchmark correctness schema mismatch")
+    if correctness["verdict"] != "pass":
+        raise ValueError(f"benchmark correctness did not pass: {correctness}")
+
+
 def _validate_record(
     record: dict[str, object],
     contract: dict[str, object],
@@ -752,6 +770,7 @@ def _validate_record(
         )
     if record["schema"] != {"name": SCHEMA_NAME, "version": SCHEMA_VERSION}:
         raise ValueError(f"unsupported benchmark schema: {record['schema']}")
+    _validate_correctness(record["correctness"])
     if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
         raise ValueError(
             f"benchmark contract mismatch: {record['contract']} != {contract}"
@@ -1110,6 +1129,7 @@ def main() -> None:
                         "twoshot_all_gather",
                     ],
                 },
+                "correctness": {"verdict": "pass"},
                 "identity": {
                     "label": args.label,
                     "variant": args.variant,
@@ -1156,7 +1176,7 @@ def main() -> None:
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(rendered + "\n", encoding="utf-8")
     finally:
-        if sampler is not None and sampler._thread.is_alive():
+        if sampler is not None and sampler.is_alive:
             sampler.stop()
         if pool is not None:
             pool.close()

--- a/benchmarks/benchmark_pcie_oneshot_control_node.py
+++ b/benchmarks/benchmark_pcie_oneshot_control_node.py
@@ -1,0 +1,1167 @@
+"""Immutable one-run worker for the PCIe oneshot control-node A/B harness.
+
+Use ``run_pcie_oneshot_control_node_ab.py`` rather than comparing two ad-hoc
+JSON files. That external controller invokes this exact file for both source
+trees in an alternating AB/BA sequence and validates every recorded contract.
+
+This harness intentionally measures only the plain staged one-shot all-reduce
+at 64 KiB by default. A public-head comparison is a net algorithm comparison;
+it must not be described as isolated control-node launch overhead or generalized
+to fused RMSNorm / two-shot collectives without their own measurements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import math
+import os
+import platform
+import socket
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+import torch
+import torch.distributed as dist
+from cuda.bindings import runtime as cudart
+
+SCHEMA_NAME = "sparkinfer.pcie_oneshot_control_node.run"
+SCHEMA_VERSION = 2
+DTYPE_NAME = "bfloat16"
+TOP_LEVEL_KEYS = {
+    "schema",
+    "contract",
+    "scope",
+    "identity",
+    "provenance",
+    "software",
+    "hardware",
+    "environment",
+    "per_rank",
+    "distributed_critical_path",
+}
+CONTRACT_KEYS = {
+    "world_size",
+    "numel",
+    "dtype",
+    "warmup",
+    "iters",
+    "preflight_replays",
+}
+SCOPE_KEYS = {
+    "operation",
+    "staging",
+    "size_bytes",
+    "comparison_semantics",
+    "excluded_paths",
+}
+IDENTITY_KEYS = {
+    "label",
+    "variant",
+    "run_index",
+    "implementation_root",
+    "implementation_git_sha",
+    "implementation_git_dirty",
+    "harness_sha256",
+    "controller_sha256",
+    "controller_argv_sha256",
+    "worker_argv",
+    "worker_argv_sha256",
+    "started_at_utc",
+}
+PROVENANCE_KEYS = {
+    "module_path",
+    "module_sha256",
+    "cuda_source_path",
+    "cuda_source_sha256",
+    "extension_path",
+    "extension_sha256",
+    "extension_build_root",
+    "extension_build_manifest",
+    "extension_build_manifest_sha256",
+    "fresh_extension_cache",
+    "post_run_verified",
+}
+METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
+RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
+CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
+SOFTWARE_KEYS = {
+    "python",
+    "platform",
+    "torch",
+    "torch_cuda",
+    "cuda_runtime_version",
+    "cuda_driver_version",
+    "nvcc_version",
+}
+HARDWARE_KEYS = {
+    "hostname",
+    "devices",
+    "nvidia_smi_identity",
+    "nvidia_smi_sample_fields",
+    "nvidia_smi_samples",
+    "nvidia_smi_topology",
+}
+DEVICE_KEYS = {
+    "index",
+    "name",
+    "uuid",
+    "compute_capability",
+    "total_memory_bytes",
+    "multi_processor_count",
+}
+NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
+NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
+NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
+GRAPH_STRUCTURE_KEYS = {
+    "kernel_nodes",
+    "direct_control_worker_edge",
+    "control_grid",
+    "control_block",
+    "worker_grid",
+    "worker_block",
+}
+NVIDIA_IDENTITY_FIELDS = ("index", "uuid", "name", "driver_version")
+NVIDIA_SMI_FIELDS = (
+    "index",
+    "uuid",
+    "name",
+    "driver_version",
+    "pstate",
+    "power.limit",
+    "power.draw",
+    "clocks.current.sm",
+    "clocks.current.memory",
+    "clocks.max.sm",
+    "clocks.max.memory",
+    "utilization.gpu",
+    "utilization.memory",
+    "temperature.gpu",
+    "clocks_event_reasons.active",
+)
+EXPLICIT_ENV_KEYS = {
+    "CUDA_DEVICE_ORDER",
+    "CUDA_LAUNCH_BLOCKING",
+    "CUDA_MODULE_LOADING",
+    "CUDA_VISIBLE_DEVICES",
+    "CUBLAS_WORKSPACE_CONFIG",
+    "NCCL_P2P_DISABLE",
+    "NCCL_P2P_LEVEL",
+    "NVIDIA_VISIBLE_DEVICES",
+    "OMP_NUM_THREADS",
+    "PYTORCH_CUDA_ALLOC_CONF",
+    "TORCH_EXTENSIONS_DIR",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--variant", choices=("baseline", "candidate"), required=True)
+    parser.add_argument("--run-index", type=int, required=True)
+    parser.add_argument("--implementation-root", type=Path, required=True)
+    parser.add_argument("--expected-git-sha", required=True)
+    parser.add_argument("--expected-graph-kernel-nodes", type=int, required=True)
+    parser.add_argument("--numel", type=int, default=32768)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--iters", type=int, default=1000)
+    parser.add_argument("--sampler-interval", type=float, default=0.2)
+    parser.add_argument("--preflight-replays", type=int, default=4)
+    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
+    parser.add_argument("--controller-sha256", required=True)
+    parser.add_argument("--controller-argv-sha256", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--allow-dirty", action="store_true")
+    return parser.parse_args()
+
+
+def _run_command(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float = 30.0,
+) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    return result.stdout.strip()
+
+
+def _git_identity(root: Path) -> tuple[str, bool]:
+    sha = _run_command(["git", "rev-parse", "HEAD"], cwd=root)
+    dirty = bool(_run_command(["git", "status", "--porcelain=v1"], cwd=root))
+    return sha, dirty
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _json_sha256(value: object) -> str:
+    rendered = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(rendered).hexdigest()
+
+
+def _extension_build_manifest(build_root: Path) -> list[dict[str, object]]:
+    """Hash every durable input/output in one fresh JIT extension directory."""
+
+    entries = []
+    for path in sorted(build_root.rglob("*")):
+        if not path.is_file() or path.name in {".ninja_deps", ".ninja_log", "lock"}:
+            continue
+        entries.append(
+            {
+                "path": str(path.relative_to(build_root)),
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha256(path),
+            }
+        )
+    if not entries:
+        raise RuntimeError(f"extension build manifest is empty: {build_root}")
+    return entries
+
+
+def _verified_implementation(
+    implementation_root: Path,
+) -> tuple[object, type, dict[str, object]]:
+    """Import, build, and bind the implementation to exact source/binary hashes."""
+
+    module = importlib.import_module("sparkinfer.comm.pcie.pcie_oneshot")
+    module_path = Path(module.__file__).resolve()
+    expected_module = (
+        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
+    ).resolve()
+    if module_path != expected_module:
+        raise RuntimeError(
+            f"imported PCIe oneshot module {module_path} != {expected_module}"
+        )
+    cuda_source = module_path.with_suffix(".cu")
+    if not cuda_source.is_file():
+        raise RuntimeError(f"PCIe oneshot CUDA source is missing: {cuda_source}")
+
+    extension = module._load_extension()
+    extension_path = Path(extension.__file__).resolve()
+    build_root = extension_path.parent
+    expected_cache = Path(os.environ["TORCH_EXTENSIONS_DIR"]).resolve()
+    if not extension_path.is_relative_to(expected_cache):
+        raise RuntimeError(
+            f"loaded extension {extension_path} is outside fresh cache {expected_cache}"
+        )
+    manifest = _extension_build_manifest(build_root)
+    provenance = {
+        "module_path": str(module_path),
+        "module_sha256": _sha256(module_path),
+        "cuda_source_path": str(cuda_source),
+        "cuda_source_sha256": _sha256(cuda_source),
+        "extension_path": str(extension_path),
+        "extension_sha256": _sha256(extension_path),
+        "extension_build_root": str(build_root),
+        "extension_build_manifest": manifest,
+        "extension_build_manifest_sha256": _json_sha256(manifest),
+        "fresh_extension_cache": True,
+        "post_run_verified": False,
+    }
+    return module, module.PCIeOneshotAllReducePool, provenance
+
+
+def _verify_post_run_provenance(
+    provenance: dict[str, object],
+    *,
+    implementation_root: Path,
+    expected_git_sha: str,
+) -> None:
+    git_sha, git_dirty = _git_identity(implementation_root)
+    if git_sha != expected_git_sha or git_dirty:
+        raise RuntimeError("implementation Git identity changed during benchmark")
+    checks = (
+        ("module_path", "module_sha256"),
+        ("cuda_source_path", "cuda_source_sha256"),
+        ("extension_path", "extension_sha256"),
+    )
+    for path_key, digest_key in checks:
+        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
+            raise RuntimeError(f"{path_key} changed during benchmark")
+    manifest = _extension_build_manifest(Path(provenance["extension_build_root"]))
+    if manifest != provenance["extension_build_manifest"]:
+        raise RuntimeError("extension build manifest changed during benchmark")
+    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
+        raise RuntimeError("extension build manifest digest changed during benchmark")
+    provenance["post_run_verified"] = True
+
+
+def _cuda_version(call: Callable[[], tuple[object, int]]) -> int:
+    result, version = call()
+    if result != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"CUDA version query failed: {result}")
+    return int(version)
+
+
+def _nvidia_smi_query(fields: tuple[str, ...]) -> dict[str, object]:
+    command = [
+        "nvidia-smi",
+        f"--query-gpu={','.join(fields)}",
+        "--format=csv,noheader,nounits",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "fields": list(fields),
+            "returncode": -1,
+            "rows": [],
+            "stderr": f"nvidia-smi timed out after {exc.timeout}s",
+        }
+    return {
+        "fields": list(fields),
+        "returncode": result.returncode,
+        "rows": [
+            [value.strip() for value in line.split(",")]
+            for line in result.stdout.splitlines()
+            if line.strip()
+        ],
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _nvidia_smi_topology() -> dict[str, object]:
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "topo", "-m"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "returncode": -1,
+            "stdout": "",
+            "stderr": f"nvidia-smi topology timed out after {exc.timeout}s",
+        }
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout.rstrip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+class _NvidiaSmiSampler:
+    def __init__(self, interval: float) -> None:
+        self.interval = interval
+        self.samples: list[dict[str, object]] = []
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._phase = "unmarked"
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _sample(self) -> None:
+        sample = {
+            "monotonic_ns": time.monotonic_ns(),
+            "phase": self._phase,
+            "query": _nvidia_smi_query(NVIDIA_SMI_FIELDS),
+        }
+        with self._lock:
+            self.samples.append(sample)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._sample()
+            self._stop.wait(self.interval)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def mark_phase(self, phase: str) -> None:
+        self._phase = phase
+        # A short timing phase must still contribute telemetry.
+        self._sample()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=15)
+        if self._thread.is_alive():
+            raise RuntimeError("nvidia-smi sampler thread did not stop within 15s")
+        self._phase = "final"
+        self._sample()
+
+
+def _environment_toggles() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in sorted(os.environ.items())
+        if key in EXPLICIT_ENV_KEYS
+        or key.startswith("SPARKINFER_")
+        or key.startswith("NCCL_")
+        or key.startswith("TORCH_NCCL_")
+    }
+
+
+def _dim3_list(value: object) -> list[int]:
+    return [int(value.x), int(value.y), int(value.z)]
+
+
+def _graph_kernel_structure(
+    graph: torch.cuda.CUDAGraph,
+    *,
+    expected_kernel_nodes: int,
+) -> dict[str, object]:
+    """Prove the candidate's 1x1 control node directly orders its worker."""
+
+    graph_handle = graph.raw_cuda_graph()
+    result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
+    if result != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"cudaGraphGetNodes(size) failed: {result}")
+    result, nodes, returned_nodes = cudart.cudaGraphGetNodes(
+        graph_handle,
+        num_nodes,
+    )
+    if result != cudart.cudaError_t.cudaSuccess or returned_nodes != num_nodes:
+        raise RuntimeError(
+            f"cudaGraphGetNodes(data) failed: {result}, {returned_nodes=}, {num_nodes=}"
+        )
+    kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
+    kernel_nodes = []
+    for node in nodes[:num_nodes]:
+        result, node_type = cudart.cudaGraphNodeGetType(node)
+        if result != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaGraphNodeGetType failed: {result}")
+        if node_type == kernel_type:
+            kernel_nodes.append(node)
+    if len(kernel_nodes) != expected_kernel_nodes:
+        raise AssertionError(
+            f"graph has {len(kernel_nodes)} kernel nodes, expected "
+            f"{expected_kernel_nodes}"
+        )
+
+    edge_query = cudart.cudaGraphGetEdges(graph_handle)
+    if edge_query[0] != cudart.cudaError_t.cudaSuccess:
+        raise RuntimeError(f"cudaGraphGetEdges(size) failed: {edge_query[0]}")
+    num_edges = int(edge_query[-1])
+    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
+    result, from_nodes, to_nodes, returned_edges = (
+        edges[0],
+        edges[1],
+        edges[2],
+        edges[-1],
+    )
+    if result != cudart.cudaError_t.cudaSuccess or returned_edges != num_edges:
+        raise RuntimeError(
+            f"cudaGraphGetEdges(data) failed: {result}, {returned_edges=}, {num_edges=}"
+        )
+    kernel_edges = []
+    for source, destination in zip(
+        from_nodes[:num_edges],
+        to_nodes[:num_edges],
+        strict=True,
+    ):
+        result, source_type = cudart.cudaGraphNodeGetType(source)
+        if result != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"source cudaGraphNodeGetType failed: {result}")
+        result, destination_type = cudart.cudaGraphNodeGetType(destination)
+        if result != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"destination cudaGraphNodeGetType failed: {result}")
+        if source_type == kernel_type and destination_type == kernel_type:
+            kernel_edges.append((source, destination))
+
+    def geometry(node: object) -> tuple[list[int], list[int]]:
+        result, params = cudart.cudaGraphKernelNodeGetParams(node)
+        if result != cudart.cudaError_t.cudaSuccess and hasattr(
+            cudart, "cudaGraphNodeGetParams"
+        ):
+            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
+            if fallback_result != cudart.cudaError_t.cudaSuccess:
+                raise RuntimeError(
+                    "cudaGraphKernelNodeGetParams failed: "
+                    f"{result}; cudaGraphNodeGetParams failed: {fallback_result}"
+                )
+            result, params = fallback_result, node_params.kernel
+        if result != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaGraphKernelNodeGetParams failed: {result}")
+        return _dim3_list(params.gridDim), _dim3_list(params.blockDim)
+
+    if expected_kernel_nodes == 2:
+        if len(kernel_edges) != 1:
+            raise AssertionError(
+                "staged candidate graph must contain one direct control-to-worker "
+                f"kernel edge, found {len(kernel_edges)}"
+            )
+        control, worker = map(geometry, kernel_edges[0])
+        if control != ([1, 1, 1], [1, 1, 1]):
+            raise AssertionError(f"control kernel is not <<<1,1>>>: {control}")
+        if worker[0][0] <= 1 or worker[1][0] < 64:
+            raise AssertionError(f"worker launch geometry is implausible: {worker}")
+        direct_edge = True
+    elif expected_kernel_nodes == 1:
+        if kernel_edges:
+            raise AssertionError("one-kernel baseline graph has a kernel edge")
+        control = (None, None)
+        worker = geometry(kernel_nodes[0])
+        direct_edge = False
+    else:
+        raise AssertionError(
+            "plain staged A/B contract supports only one-node baseline and "
+            "two-node candidate graphs"
+        )
+    return {
+        "kernel_nodes": len(kernel_nodes),
+        "direct_control_worker_edge": direct_edge,
+        "control_grid": control[0],
+        "control_block": control[1],
+        "worker_grid": worker[0],
+        "worker_block": worker[1],
+    }
+
+
+def _measure(
+    operation: Callable[[], None],
+    *,
+    stream: torch.cuda.Stream,
+    warmup: int,
+    iters: int,
+) -> tuple[float, list[float]]:
+    cold_start = torch.cuda.Event(enable_timing=True)
+    cold_end = torch.cuda.Event(enable_timing=True)
+    cold_start.record(stream)
+    operation()
+    cold_end.record(stream)
+    stream.synchronize()
+    cold_us = float(cold_start.elapsed_time(cold_end) * 1000)
+
+    for _ in range(warmup):
+        operation()
+    stream.synchronize()
+
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for start, end in zip(starts, ends, strict=True):
+        start.record(stream)
+        operation()
+        end.record(stream)
+    stream.synchronize()
+    samples = [
+        float(start.elapsed_time(end) * 1000)
+        for start, end in zip(starts, ends, strict=True)
+    ]
+    return cold_us, samples
+
+
+def _mutating_replay_preflight(
+    operation: Callable[[], None],
+    *,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    stream: torch.cuda.Stream,
+    rank: int,
+    world_size: int,
+    replays: int,
+) -> None:
+    """Expose stale-slot reuse by validating changing data on both slot parities."""
+
+    if replays < 4:
+        raise ValueError("mutating preflight requires at least four replays")
+    rank_sum = world_size * (world_size + 1) // 2
+    for iteration in range(replays):
+        multiplier = iteration + 1
+        with torch.cuda.stream(stream):
+            inp.fill_(multiplier * (rank + 1))
+            operation()
+        stream.synchronize()
+        torch.testing.assert_close(
+            out,
+            torch.full_like(out, multiplier * rank_sum),
+            rtol=0,
+            atol=0,
+        )
+
+
+def _summary(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        raise ValueError("cannot summarize an empty latency vector")
+    ordered = sorted(samples)
+
+    def percentile(fraction: float) -> float:
+        index = max(0, math.ceil(fraction * len(ordered)) - 1)
+        return ordered[index]
+
+    return {
+        "mean_us": sum(ordered) / len(ordered),
+        "p50_us": percentile(0.50),
+        "p95_us": percentile(0.95),
+        "min_us": ordered[0],
+        "max_us": ordered[-1],
+    }
+
+
+def _gather_rank_metrics(
+    eager_cold_us: float,
+    eager_samples: list[float],
+    graph_cold_us: float,
+    graph_samples: list[float],
+    graph_structure: dict[str, object],
+    device: torch.device,
+) -> list[dict[str, object]]:
+    if len(eager_samples) != len(graph_samples) or not eager_samples:
+        raise ValueError("eager/graph latency vectors must be non-empty and aligned")
+    control_grid = graph_structure["control_grid"] or [0, 0, 0]
+    control_block = graph_structure["control_block"] or [0, 0, 0]
+    structure_values = [
+        float(graph_structure["kernel_nodes"]),
+        float(bool(graph_structure["direct_control_worker_edge"])),
+        *map(float, control_grid),
+        *map(float, control_block),
+        *map(float, graph_structure["worker_grid"]),
+        *map(float, graph_structure["worker_block"]),
+    ]
+    if len(structure_values) != 14:
+        raise AssertionError("graph structure encoding must contain 14 values")
+    local = torch.tensor(
+        [
+            eager_cold_us,
+            *eager_samples,
+            graph_cold_us,
+            *graph_samples,
+            *structure_values,
+        ],
+        device=device,
+        dtype=torch.float64,
+    )
+    gathered = [torch.empty_like(local) for _ in range(dist.get_world_size())]
+    dist.all_gather(gathered, local)
+
+    result = []
+    for rank, values_tensor in enumerate(gathered):
+        values = values_tensor.cpu().tolist()
+        iters = len(eager_samples)
+        rank_eager_samples = values[1 : 1 + iters]
+        graph_cold_index = 1 + iters
+        rank_graph_samples = values[graph_cold_index + 1 : graph_cold_index + 1 + iters]
+        structure = values[graph_cold_index + 1 + iters :]
+        eager_summary = _summary(rank_eager_samples)
+        graph_summary = _summary(rank_graph_samples)
+        has_control = bool(int(structure[1]))
+        result.append(
+            {
+                "rank": rank,
+                "eager": {
+                    "cold_us": values[0],
+                    **eager_summary,
+                    "samples_us": rank_eager_samples,
+                },
+                "graph": {
+                    "cold_us": values[graph_cold_index],
+                    **graph_summary,
+                    "samples_us": rank_graph_samples,
+                },
+                "graph_structure": {
+                    "kernel_nodes": int(structure[0]),
+                    "direct_control_worker_edge": has_control,
+                    "control_grid": [int(v) for v in structure[2:5]]
+                    if has_control
+                    else None,
+                    "control_block": [int(v) for v in structure[5:8]]
+                    if has_control
+                    else None,
+                    "worker_grid": [int(v) for v in structure[8:11]],
+                    "worker_block": [int(v) for v in structure[11:14]],
+                },
+            }
+        )
+    return result
+
+
+def _distributed_critical_path(
+    per_rank: Sequence[dict[str, object]],
+) -> dict[str, object]:
+    """Summarize max-rank latency at each aligned timed iteration."""
+
+    if not per_rank:
+        raise ValueError("distributed critical path requires at least one rank")
+    result: dict[str, object] = {}
+    for mode in ("eager", "graph"):
+        rank_vectors = [list(row[mode]["samples_us"]) for row in per_rank]
+        lengths = {len(samples) for samples in rank_vectors}
+        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
+            raise ValueError(f"{mode} rank latency vectors are empty or misaligned")
+        critical_samples = [
+            max(rank_samples[index] for rank_samples in rank_vectors)
+            for index in range(next(iter(lengths)))
+        ]
+        result[mode] = {
+            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
+            **_summary(critical_samples),
+            "samples_us": critical_samples,
+        }
+    return result
+
+
+def _device_metadata() -> list[dict[str, object]]:
+    devices = []
+    for index in range(torch.cuda.device_count()):
+        props = torch.cuda.get_device_properties(index)
+        devices.append(
+            {
+                "index": index,
+                "name": props.name,
+                "uuid": str(getattr(props, "uuid", "unavailable")),
+                "compute_capability": [props.major, props.minor],
+                "total_memory_bytes": props.total_memory,
+                "multi_processor_count": props.multi_processor_count,
+            }
+        )
+    return devices
+
+
+def _validate_record(
+    record: dict[str, object],
+    contract: dict[str, object],
+    *,
+    expected_graph_kernel_nodes: int,
+) -> None:
+    if set(record) != TOP_LEVEL_KEYS:
+        raise ValueError(
+            f"benchmark schema keys differ: {set(record) ^ TOP_LEVEL_KEYS}"
+        )
+    if record["schema"] != {"name": SCHEMA_NAME, "version": SCHEMA_VERSION}:
+        raise ValueError(f"unsupported benchmark schema: {record['schema']}")
+    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
+        raise ValueError(
+            f"benchmark contract mismatch: {record['contract']} != {contract}"
+        )
+    scope = record["scope"]
+    if set(scope) != SCOPE_KEYS:
+        raise ValueError("benchmark scope schema mismatch")
+    if (
+        scope["operation"] != "plain_oneshot_all_reduce"
+        or scope["staging"] != "double_buffered_eager_ipc"
+        or int(scope["size_bytes"]) != int(contract["numel"]) * torch.bfloat16.itemsize
+        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
+        or scope["excluded_paths"]
+        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
+    ):
+        raise ValueError(
+            f"benchmark scope is not the narrow staged-path contract: {scope}"
+        )
+    if set(record["identity"]) != IDENTITY_KEYS:
+        raise ValueError("benchmark identity schema mismatch")
+    if set(record["provenance"]) != PROVENANCE_KEYS:
+        raise ValueError("benchmark provenance schema mismatch")
+    provenance = record["provenance"]
+    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
+        raise ValueError("benchmark extension provenance was not freshly verified")
+    manifest = provenance["extension_build_manifest"]
+    if not isinstance(manifest, list) or not manifest:
+        raise ValueError("benchmark extension build manifest is empty")
+    for entry in manifest:
+        if set(entry) != {"path", "size_bytes", "sha256"}:
+            raise ValueError("benchmark extension manifest entry schema mismatch")
+    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
+        raise ValueError("benchmark extension manifest digest mismatch")
+    if set(record["software"]) != SOFTWARE_KEYS:
+        raise ValueError("benchmark software schema mismatch")
+    if set(record["hardware"]) != HARDWARE_KEYS:
+        raise ValueError("benchmark hardware schema mismatch")
+    if not isinstance(record["environment"], dict):
+        raise ValueError("benchmark environment must be an object")
+    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
+        contract["world_size"]
+    ):
+        raise ValueError("benchmark per-rank cardinality mismatch")
+    hardware = record["hardware"]
+    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
+        raise ValueError("benchmark device inventory must be a non-empty list")
+    for device in hardware["devices"]:
+        if set(device) != DEVICE_KEYS:
+            raise ValueError("benchmark device schema mismatch")
+    identity_query = hardware["nvidia_smi_identity"]
+    if set(identity_query) != NVIDIA_QUERY_KEYS:
+        raise ValueError("benchmark NVIDIA identity schema mismatch")
+    if identity_query["fields"] != list(NVIDIA_IDENTITY_FIELDS):
+        raise ValueError("benchmark NVIDIA identity field contract mismatch")
+    if identity_query["returncode"] != 0:
+        raise ValueError(f"benchmark NVIDIA identity query failed: {identity_query}")
+    if len(identity_query["rows"]) != len(hardware["devices"]):
+        raise ValueError("benchmark NVIDIA identity/device cardinality mismatch")
+    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
+        raise ValueError("benchmark NVIDIA identity row schema mismatch")
+    if hardware["nvidia_smi_sample_fields"] != list(NVIDIA_SMI_FIELDS):
+        raise ValueError("benchmark NVIDIA sample field contract mismatch")
+    if (
+        not isinstance(hardware["nvidia_smi_samples"], list)
+        or not hardware["nvidia_smi_samples"]
+    ):
+        raise ValueError("benchmark NVIDIA samples must be a non-empty list")
+    successful_samples = 0
+    successful_phases: set[str] = set()
+    for sample in hardware["nvidia_smi_samples"]:
+        if set(sample) != NVIDIA_SAMPLE_KEYS:
+            raise ValueError("benchmark NVIDIA sample schema mismatch")
+        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
+            raise ValueError("benchmark NVIDIA sample query schema mismatch")
+        if sample["query"]["fields"] != list(NVIDIA_SMI_FIELDS):
+            raise ValueError("benchmark NVIDIA sample query field mismatch")
+        if sample["query"]["returncode"] == 0:
+            successful_samples += 1
+            if not sample["query"]["rows"]:
+                raise ValueError("successful NVIDIA telemetry sample has zero rows")
+            successful_phases.add(str(sample["phase"]))
+            if any(
+                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
+            ):
+                raise ValueError("benchmark NVIDIA sample row schema mismatch")
+            if len(sample["query"]["rows"]) != len(hardware["devices"]):
+                raise ValueError("benchmark NVIDIA sample/device cardinality mismatch")
+    if successful_samples == 0:
+        raise ValueError("benchmark collected no successful NVIDIA telemetry samples")
+    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
+    if not required_phases <= successful_phases:
+        raise ValueError(
+            "benchmark lacks successful phase telemetry: "
+            f"{required_phases - successful_phases}"
+        )
+    topology = hardware["nvidia_smi_topology"]
+    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
+        raise ValueError("benchmark NVIDIA topology schema mismatch")
+    if topology["returncode"] != 0 or not topology["stdout"]:
+        raise ValueError(f"benchmark NVIDIA topology query failed: {topology}")
+    for row in record["per_rank"]:
+        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
+            raise ValueError("per-rank schema mismatch")
+        if set(row["eager"]) != RANK_MODE_KEYS:
+            raise ValueError("eager metric schema mismatch")
+        if set(row["graph"]) != RANK_MODE_KEYS:
+            raise ValueError("graph metric schema mismatch")
+        for mode in ("eager", "graph"):
+            samples = row[mode]["samples_us"]
+            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
+                raise ValueError(f"per-rank {mode} sample vector length mismatch")
+            if any(
+                not math.isfinite(float(value)) or float(value) <= 0
+                for value in samples
+            ):
+                raise ValueError(f"per-rank {mode} samples must be finite and positive")
+            expected_summary = _summary([float(value) for value in samples])
+            for key, expected in expected_summary.items():
+                if float(row[mode][key]) != expected:
+                    raise ValueError(f"per-rank {mode} {key} summary mismatch")
+        structure = row["graph_structure"]
+        if set(structure) != GRAPH_STRUCTURE_KEYS:
+            raise ValueError("graph structure schema mismatch")
+        if int(structure["kernel_nodes"]) != expected_graph_kernel_nodes:
+            raise ValueError("graph kernel-node count mismatch")
+        if expected_graph_kernel_nodes == 2:
+            if (
+                structure["direct_control_worker_edge"] is not True
+                or structure["control_grid"] != [1, 1, 1]
+                or structure["control_block"] != [1, 1, 1]
+            ):
+                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
+        elif (
+            structure["direct_control_worker_edge"] is not False
+            or structure["control_grid"] is not None
+            or structure["control_block"] is not None
+        ):
+            raise ValueError("baseline graph unexpectedly records a control node")
+    if {int(row["rank"]) for row in record["per_rank"]} != set(
+        range(int(contract["world_size"]))
+    ):
+        raise ValueError("per-rank identities do not match world size")
+    critical_path = record["distributed_critical_path"]
+    if set(critical_path) != {"eager", "graph"}:
+        raise ValueError("distributed critical-path mode schema mismatch")
+    for mode in ("eager", "graph"):
+        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
+            raise ValueError(f"distributed {mode} critical-path schema mismatch")
+    expected_critical_path = _distributed_critical_path(record["per_rank"])
+    if critical_path != expected_critical_path:
+        raise ValueError(
+            "distributed critical path was not derived from aligned rank maxima"
+        )
+
+
+def main() -> None:
+    args = _parse_args()
+    if (
+        args.iters <= 0
+        or args.warmup < 0
+        or args.numel != 32768
+        or args.run_index < 0
+        or args.expected_graph_kernel_nodes not in (1, 2)
+        or args.preflight_replays < 4
+        or args.distributed_timeout_seconds <= 0
+    ):
+        raise ValueError(
+            "this narrow harness requires 32,768 BF16 elements (64 KiB), "
+            "at least four preflight replays, one/two graph nodes, positive "
+            "iterations/timeout, and non-negative warmup/run-index"
+        )
+    if args.sampler_interval <= 0:
+        raise ValueError("sampler interval must be positive")
+
+    implementation_root = args.implementation_root.resolve()
+    git_sha, git_dirty = _git_identity(implementation_root)
+    if git_sha != args.expected_git_sha:
+        raise ValueError(f"implementation SHA {git_sha} != {args.expected_git_sha}")
+    if git_dirty and not args.allow_dirty:
+        raise ValueError(f"implementation worktree is dirty: {implementation_root}")
+
+    dist.init_process_group(
+        "nccl",
+        timeout=timedelta(seconds=args.distributed_timeout_seconds),
+    )
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+    _, pool_type, provenance = _verified_implementation(implementation_root)
+    contract = {
+        "world_size": world_size,
+        "numel": args.numel,
+        "dtype": DTYPE_NAME,
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "preflight_replays": args.preflight_replays,
+    }
+    started_at = datetime.now(timezone.utc).isoformat()
+    sampler = _NvidiaSmiSampler(args.sampler_interval) if rank == 0 else None
+
+    pool = None
+    try:
+        nbytes = args.numel * torch.bfloat16.itemsize
+        pool = pool_type.from_process_group(
+            process_group=dist.group.WORLD,
+            device=device,
+            max_input_bytes=nbytes,
+            max_size=nbytes,
+        )
+        eager_channel_id = "eager:control-node-benchmark"
+        graph_channel_id = "graph:control-node-benchmark"
+        pool.prepare_channels((eager_channel_id, graph_channel_id))
+        stream = torch.cuda.Stream(device=device)
+        channel = pool.for_stream(stream, channel_id=eager_channel_id)
+        eager_inp = torch.full(
+            (args.numel,),
+            rank + 1,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        eager_out = torch.empty_like(eager_inp)
+
+        def eager_operation() -> None:
+            with torch.cuda.stream(stream):
+                channel.all_reduce(eager_inp, out=eager_out)
+
+        graph_inp = torch.full_like(eager_inp, rank + 1)
+        graph_out = torch.empty_like(graph_inp)
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        with (
+            pool.capture(stream, channel_id=graph_channel_id) as graph_channel,
+            torch.cuda.graph(
+                graph,
+                stream=stream,
+            ),
+        ):
+            graph_channel.all_reduce(graph_inp, out=graph_out)
+        graph_structure = _graph_kernel_structure(
+            graph,
+            expected_kernel_nodes=args.expected_graph_kernel_nodes,
+        )
+
+        def graph_operation() -> None:
+            with torch.cuda.stream(stream):
+                graph.replay()
+
+        # JIT compilation and graph construction are complete. Telemetry starts
+        # here and every correctness/timing phase receives an explicit marker.
+        if sampler is not None:
+            sampler.start()
+            sampler.mark_phase("mutating_preflight")
+        _mutating_replay_preflight(
+            eager_operation,
+            inp=eager_inp,
+            out=eager_out,
+            stream=stream,
+            rank=rank,
+            world_size=world_size,
+            replays=args.preflight_replays,
+        )
+        _mutating_replay_preflight(
+            graph_operation,
+            inp=graph_inp,
+            out=graph_out,
+            stream=stream,
+            rank=rank,
+            world_size=world_size,
+            replays=args.preflight_replays,
+        )
+
+        with torch.cuda.stream(stream):
+            eager_inp.fill_(rank + 1)
+        stream.synchronize()
+        dist.barrier()
+        if sampler is not None:
+            sampler.mark_phase("eager_timing")
+        eager_cold_us, eager_samples = _measure(
+            eager_operation,
+            stream=stream,
+            warmup=args.warmup,
+            iters=args.iters,
+        )
+        expected = world_size * (world_size + 1) // 2
+        torch.testing.assert_close(
+            eager_out,
+            torch.full_like(eager_out, expected),
+            rtol=0,
+            atol=0,
+        )
+
+        with torch.cuda.stream(stream):
+            graph_inp.fill_(rank + 1)
+        stream.synchronize()
+        dist.barrier()
+        if sampler is not None:
+            sampler.mark_phase("graph_timing")
+        graph_cold_us, graph_samples = _measure(
+            graph_operation,
+            stream=stream,
+            warmup=args.warmup,
+            iters=args.iters,
+        )
+        torch.testing.assert_close(
+            graph_out,
+            torch.full_like(graph_out, expected),
+            rtol=0,
+            atol=0,
+        )
+
+        per_rank = _gather_rank_metrics(
+            eager_cold_us,
+            eager_samples,
+            graph_cold_us,
+            graph_samples,
+            graph_structure,
+            device,
+        )
+        observed_nodes = {
+            int(row["graph_structure"]["kernel_nodes"]) for row in per_rank
+        }
+        if observed_nodes != {args.expected_graph_kernel_nodes}:
+            raise AssertionError(
+                f"rank graph-node counts {observed_nodes} do not match "
+                f"{args.expected_graph_kernel_nodes}"
+            )
+        torch.cuda.synchronize(device)
+        dist.barrier()
+        _verify_post_run_provenance(
+            provenance,
+            implementation_root=implementation_root,
+            expected_git_sha=args.expected_git_sha,
+        )
+
+        if sampler is not None:
+            sampler.mark_phase("provenance_and_finalize")
+            sampler.stop()
+        if rank == 0:
+            harness_path = Path(__file__).resolve()
+            worker_argv = list(sys.argv)
+            record = {
+                "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
+                "contract": contract,
+                "scope": {
+                    "operation": "plain_oneshot_all_reduce",
+                    "staging": "double_buffered_eager_ipc",
+                    "size_bytes": nbytes,
+                    "comparison_semantics": (
+                        "net algorithm comparison between public baseline and "
+                        "candidate; not isolated launch overhead"
+                    ),
+                    "excluded_paths": [
+                        "fused_add_rms_norm",
+                        "twoshot_reduce_scatter",
+                        "twoshot_all_gather",
+                    ],
+                },
+                "identity": {
+                    "label": args.label,
+                    "variant": args.variant,
+                    "run_index": args.run_index,
+                    "implementation_root": str(implementation_root),
+                    "implementation_git_sha": git_sha,
+                    "implementation_git_dirty": git_dirty,
+                    "harness_sha256": _sha256(harness_path),
+                    "controller_sha256": args.controller_sha256,
+                    "controller_argv_sha256": args.controller_argv_sha256,
+                    "worker_argv": worker_argv,
+                    "worker_argv_sha256": _json_sha256(worker_argv),
+                    "started_at_utc": started_at,
+                },
+                "provenance": provenance,
+                "software": {
+                    "python": platform.python_version(),
+                    "platform": platform.platform(),
+                    "torch": torch.__version__,
+                    "torch_cuda": torch.version.cuda,
+                    "cuda_runtime_version": _cuda_version(cudart.cudaRuntimeGetVersion),
+                    "cuda_driver_version": _cuda_version(cudart.cudaDriverGetVersion),
+                    "nvcc_version": _run_command(["nvcc", "--version"]),
+                },
+                "hardware": {
+                    "hostname": socket.gethostname(),
+                    "devices": _device_metadata(),
+                    "nvidia_smi_identity": _nvidia_smi_query(NVIDIA_IDENTITY_FIELDS),
+                    "nvidia_smi_sample_fields": list(NVIDIA_SMI_FIELDS),
+                    "nvidia_smi_samples": sampler.samples,
+                    "nvidia_smi_topology": _nvidia_smi_topology(),
+                },
+                "environment": _environment_toggles(),
+                "per_rank": per_rank,
+                "distributed_critical_path": _distributed_critical_path(per_rank),
+            }
+            _validate_record(
+                record,
+                contract,
+                expected_graph_kernel_nodes=args.expected_graph_kernel_nodes,
+            )
+            rendered = json.dumps(record, indent=2, sort_keys=True)
+            print(rendered, flush=True)
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered + "\n", encoding="utf-8")
+    finally:
+        if sampler is not None and sampler._thread.is_alive():
+            sampler.stop()
+        if pool is not None:
+            pool.close()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_pcie_oneshot_control_node_ab.py
+++ b/benchmarks/run_pcie_oneshot_control_node_ab.py
@@ -21,12 +21,13 @@ from contextlib import suppress
 from pathlib import Path
 
 
-RUN_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.run", "version": 2}
-SUITE_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.ab_suite", "version": 2}
+RUN_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.run", "version": 3}
+SUITE_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.ab_suite", "version": 3}
 RUN_TOP_LEVEL_KEYS = {
     "schema",
     "contract",
     "scope",
+    "correctness",
     "identity",
     "provenance",
     "software",
@@ -35,6 +36,7 @@ RUN_TOP_LEVEL_KEYS = {
     "per_rank",
     "distributed_critical_path",
 }
+CORRECTNESS_KEYS = {"verdict"}
 CONTRACT_KEYS = {
     "world_size",
     "numel",
@@ -163,7 +165,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--candidate-worktree", type=Path, required=True)
     parser.add_argument("--pairs", type=int, default=4)
     parser.add_argument("--world-size", type=int, default=4)
-    parser.add_argument("--numel", type=int, default=32768)
+    parser.add_argument(
+        "--numel",
+        type=int,
+        default=32768,
+        help="fixed at 32768 BF16 elements (64 KiB); other values are rejected",
+    )
     parser.add_argument("--warmup", type=int, default=100)
     parser.add_argument("--iters", type=int, default=1000)
     parser.add_argument("--sampler-interval", type=float, default=0.2)
@@ -292,6 +299,13 @@ def _distributed_critical_path(
     return result
 
 
+def _validate_correctness(correctness: object) -> None:
+    if not isinstance(correctness, dict) or set(correctness) != CORRECTNESS_KEYS:
+        raise ValueError("run correctness schema mismatch")
+    if correctness["verdict"] != "pass":
+        raise ValueError(f"run correctness did not pass: {correctness}")
+
+
 def _validate_run(
     record: dict[str, object],
     *,
@@ -310,6 +324,7 @@ def _validate_run(
         raise ValueError(f"run schema keys differ: {set(record) ^ RUN_TOP_LEVEL_KEYS}")
     if record["schema"] != RUN_SCHEMA:
         raise ValueError(f"run schema mismatch: {record['schema']}")
+    _validate_correctness(record["correctness"])
     if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
         raise ValueError(f"run contract mismatch: {record['contract']} != {contract}")
     scope = record["scope"]
@@ -619,12 +634,12 @@ def main() -> None:
     controller_argv_sha256 = _json_sha256(controller_argv)
     baseline_root = args.baseline_worktree.resolve()
     candidate_root = args.candidate_worktree.resolve()
-    harness_source = args.harness.resolve()
     roots = (baseline_root, candidate_root)
     if baseline_root == candidate_root:
         raise ValueError("baseline and candidate worktrees must differ")
     output_dir = _outside_worktrees(args.output_dir, roots, "output directory")
     output = _outside_worktrees(args.output, roots, "suite output")
+    harness_source = _outside_worktrees(args.harness, roots, "harness")
     if not harness_source.is_file():
         raise ValueError(f"harness does not exist: {harness_source}")
     baseline_sha = _git_sha(baseline_root)

--- a/benchmarks/run_pcie_oneshot_control_node_ab.py
+++ b/benchmarks/run_pcie_oneshot_control_node_ab.py
@@ -1,0 +1,825 @@
+"""Run repeated immutable AB/BA measurements with one external harness.
+
+The measurement script lives outside both implementation worktrees and is
+hashed into every record. Each pair reverses execution order (AB, then BA) to
+reduce monotonic thermal/clock drift. Raw records are schema- and
+contract-validated before the aggregate report is written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import signal
+import statistics
+import subprocess
+import sys
+from contextlib import suppress
+from pathlib import Path
+
+
+RUN_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.run", "version": 2}
+SUITE_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.ab_suite", "version": 2}
+RUN_TOP_LEVEL_KEYS = {
+    "schema",
+    "contract",
+    "scope",
+    "identity",
+    "provenance",
+    "software",
+    "hardware",
+    "environment",
+    "per_rank",
+    "distributed_critical_path",
+}
+CONTRACT_KEYS = {
+    "world_size",
+    "numel",
+    "dtype",
+    "warmup",
+    "iters",
+    "preflight_replays",
+}
+SCOPE_KEYS = {
+    "operation",
+    "staging",
+    "size_bytes",
+    "comparison_semantics",
+    "excluded_paths",
+}
+METRICS = ("mean_us", "p50_us", "p95_us")
+IDENTITY_KEYS = {
+    "label",
+    "variant",
+    "run_index",
+    "implementation_root",
+    "implementation_git_sha",
+    "implementation_git_dirty",
+    "harness_sha256",
+    "controller_sha256",
+    "controller_argv_sha256",
+    "worker_argv",
+    "worker_argv_sha256",
+    "started_at_utc",
+}
+PROVENANCE_KEYS = {
+    "module_path",
+    "module_sha256",
+    "cuda_source_path",
+    "cuda_source_sha256",
+    "extension_path",
+    "extension_sha256",
+    "extension_build_root",
+    "extension_build_manifest",
+    "extension_build_manifest_sha256",
+    "fresh_extension_cache",
+    "post_run_verified",
+}
+SOFTWARE_KEYS = {
+    "python",
+    "platform",
+    "torch",
+    "torch_cuda",
+    "cuda_runtime_version",
+    "cuda_driver_version",
+    "nvcc_version",
+}
+HARDWARE_KEYS = {
+    "hostname",
+    "devices",
+    "nvidia_smi_identity",
+    "nvidia_smi_sample_fields",
+    "nvidia_smi_samples",
+    "nvidia_smi_topology",
+}
+METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
+RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
+CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
+GRAPH_STRUCTURE_KEYS = {
+    "kernel_nodes",
+    "direct_control_worker_edge",
+    "control_grid",
+    "control_block",
+    "worker_grid",
+    "worker_block",
+}
+DEVICE_KEYS = {
+    "index",
+    "name",
+    "uuid",
+    "compute_capability",
+    "total_memory_bytes",
+    "multi_processor_count",
+}
+NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
+NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
+NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
+NVIDIA_IDENTITY_FIELDS = ["index", "uuid", "name", "driver_version"]
+NVIDIA_SMI_FIELDS = [
+    "index",
+    "uuid",
+    "name",
+    "driver_version",
+    "pstate",
+    "power.limit",
+    "power.draw",
+    "clocks.current.sm",
+    "clocks.current.memory",
+    "clocks.max.sm",
+    "clocks.max.memory",
+    "utilization.gpu",
+    "utilization.memory",
+    "temperature.gpu",
+    "clocks_event_reasons.active",
+]
+SUITE_TOP_LEVEL_KEYS = {
+    "schema",
+    "contract",
+    "controller",
+    "harness",
+    "implementations",
+    "sequence",
+    "records",
+    "paired_deltas",
+    "paired_summary",
+    "aggregate",
+}
+CONTROLLER_KEYS = {"source_path", "sha256", "argv", "argv_sha256"}
+HARNESS_KEYS = {
+    "source_path",
+    "frozen_path",
+    "sha256",
+    "identical_for_all_runs",
+}
+IMPLEMENTATION_KEYS = {"root", "git_sha"}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline-worktree", type=Path, required=True)
+    parser.add_argument("--candidate-worktree", type=Path, required=True)
+    parser.add_argument("--pairs", type=int, default=4)
+    parser.add_argument("--world-size", type=int, default=4)
+    parser.add_argument("--numel", type=int, default=32768)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--iters", type=int, default=1000)
+    parser.add_argument("--sampler-interval", type=float, default=0.2)
+    parser.add_argument("--preflight-replays", type=int, default=4)
+    parser.add_argument("--run-timeout-seconds", type=float, default=1800.0)
+    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--harness",
+        type=Path,
+        default=Path(__file__).with_name("benchmark_pcie_oneshot_control_node.py"),
+    )
+    return parser.parse_args()
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float = 60.0,
+) -> str:
+    process = subprocess.Popen(
+        args,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        stdout, _ = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGTERM)
+        try:
+            stdout, _ = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            stdout, _ = process.communicate()
+        raise TimeoutError(
+            f"command exceeded {timeout:.1f}s and its process group was terminated: "
+            f"{' '.join(args)}\n{stdout}"
+        ) from None
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({process.returncode}): {' '.join(args)}\n{stdout}"
+        )
+    return stdout.strip()
+
+
+def _git_sha(worktree: Path) -> str:
+    sha = _run(["git", "rev-parse", "HEAD"], cwd=worktree)
+    dirty = _run(["git", "status", "--porcelain=v1"], cwd=worktree)
+    if dirty:
+        raise ValueError(f"benchmark worktree is dirty: {worktree}\n{dirty}")
+    return sha
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _json_sha256(value: object) -> str:
+    rendered = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(rendered).hexdigest()
+
+
+def _expected_contract(args: argparse.Namespace) -> dict[str, object]:
+    return {
+        "world_size": args.world_size,
+        "numel": args.numel,
+        "dtype": "bfloat16",
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "preflight_replays": args.preflight_replays,
+    }
+
+
+def _summary(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        raise ValueError("cannot summarize an empty latency vector")
+    ordered = sorted(float(value) for value in samples)
+
+    def percentile(fraction: float) -> float:
+        return ordered[max(0, math.ceil(fraction * len(ordered)) - 1)]
+
+    return {
+        "mean_us": sum(ordered) / len(ordered),
+        "p50_us": percentile(0.50),
+        "p95_us": percentile(0.95),
+        "min_us": ordered[0],
+        "max_us": ordered[-1],
+    }
+
+
+def _distributed_critical_path(
+    per_rank: list[dict[str, object]],
+) -> dict[str, object]:
+    result = {}
+    for mode in ("eager", "graph"):
+        vectors = [list(row[mode]["samples_us"]) for row in per_rank]
+        lengths = {len(vector) for vector in vectors}
+        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
+            raise ValueError(f"{mode} rank vectors are empty or misaligned")
+        critical = [
+            max(float(vector[index]) for vector in vectors)
+            for index in range(next(iter(lengths)))
+        ]
+        result[mode] = {
+            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
+            **_summary(critical),
+            "samples_us": critical,
+        }
+    return result
+
+
+def _validate_run(
+    record: dict[str, object],
+    *,
+    contract: dict[str, object],
+    variant: str,
+    sha: str,
+    run_index: int,
+    harness_sha256: str,
+    expected_nodes: int,
+    implementation_root: Path,
+    controller_sha256: str,
+    controller_argv_sha256: str,
+    extension_dir: Path,
+) -> None:
+    if set(record) != RUN_TOP_LEVEL_KEYS:
+        raise ValueError(f"run schema keys differ: {set(record) ^ RUN_TOP_LEVEL_KEYS}")
+    if record["schema"] != RUN_SCHEMA:
+        raise ValueError(f"run schema mismatch: {record['schema']}")
+    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
+        raise ValueError(f"run contract mismatch: {record['contract']} != {contract}")
+    scope = record["scope"]
+    if set(scope) != SCOPE_KEYS:
+        raise ValueError("run scope schema mismatch")
+    if (
+        scope["operation"] != "plain_oneshot_all_reduce"
+        or scope["staging"] != "double_buffered_eager_ipc"
+        or int(scope["size_bytes"]) != int(contract["numel"]) * 2
+        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
+        or scope["excluded_paths"]
+        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
+    ):
+        raise ValueError(f"run scope is too broad or malformed: {scope}")
+    identity = record["identity"]
+    if set(identity) != IDENTITY_KEYS:
+        raise ValueError("run identity schema mismatch")
+    expected_identity = {
+        "label": f"{variant}-{sha[:12]}-{run_index}",
+        "variant": variant,
+        "run_index": run_index,
+        "implementation_root": str(implementation_root),
+        "implementation_git_sha": sha,
+        "implementation_git_dirty": False,
+        "harness_sha256": harness_sha256,
+        "controller_sha256": controller_sha256,
+        "controller_argv_sha256": controller_argv_sha256,
+    }
+    for key, expected in expected_identity.items():
+        if identity[key] != expected:
+            raise ValueError(f"identity {key}={identity[key]!r}, expected {expected!r}")
+    if _json_sha256(identity["worker_argv"]) != identity["worker_argv_sha256"]:
+        raise ValueError("worker argv digest mismatch")
+    provenance = record["provenance"]
+    if set(provenance) != PROVENANCE_KEYS:
+        raise ValueError("run provenance schema mismatch")
+    expected_module = (
+        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
+    ).resolve()
+    expected_source = expected_module.with_suffix(".cu")
+    if Path(provenance["module_path"]).resolve() != expected_module:
+        raise ValueError("run imported module does not belong to implementation root")
+    if Path(provenance["cuda_source_path"]).resolve() != expected_source:
+        raise ValueError("run CUDA source does not belong to implementation root")
+    if (
+        not Path(provenance["extension_path"])
+        .resolve()
+        .is_relative_to(extension_dir.resolve())
+    ):
+        raise ValueError("run extension binary is outside its fresh cache")
+    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
+        raise ValueError("run extension provenance was not freshly post-verified")
+    for path_key, digest_key in (
+        ("module_path", "module_sha256"),
+        ("cuda_source_path", "cuda_source_sha256"),
+        ("extension_path", "extension_sha256"),
+    ):
+        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
+            raise ValueError(f"run {path_key} digest mismatch")
+    manifest = provenance["extension_build_manifest"]
+    if not isinstance(manifest, list) or not manifest:
+        raise ValueError("run extension build manifest is empty")
+    for entry in manifest:
+        if set(entry) != {"path", "size_bytes", "sha256"}:
+            raise ValueError("run extension manifest entry schema mismatch")
+    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
+        raise ValueError("run extension build manifest digest mismatch")
+    if set(record["software"]) != SOFTWARE_KEYS:
+        raise ValueError("run software schema mismatch")
+    if set(record["hardware"]) != HARDWARE_KEYS:
+        raise ValueError("run hardware schema mismatch")
+    if not isinstance(record["environment"], dict):
+        raise ValueError("run environment must be an object")
+    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
+        contract["world_size"]
+    ):
+        raise ValueError("run per-rank cardinality mismatch")
+    hardware = record["hardware"]
+    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
+        raise ValueError("run device inventory must be a non-empty list")
+    for device in hardware["devices"]:
+        if set(device) != DEVICE_KEYS:
+            raise ValueError("run device schema mismatch")
+    identity_query = hardware["nvidia_smi_identity"]
+    if set(identity_query) != NVIDIA_QUERY_KEYS:
+        raise ValueError("run NVIDIA identity schema mismatch")
+    if identity_query["fields"] != NVIDIA_IDENTITY_FIELDS:
+        raise ValueError("run NVIDIA identity field contract mismatch")
+    if identity_query["returncode"] != 0:
+        raise ValueError(f"run NVIDIA identity query failed: {identity_query}")
+    if len(identity_query["rows"]) != len(hardware["devices"]):
+        raise ValueError("run NVIDIA identity/device cardinality mismatch")
+    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
+        raise ValueError("run NVIDIA identity row schema mismatch")
+    if hardware["nvidia_smi_sample_fields"] != NVIDIA_SMI_FIELDS:
+        raise ValueError("run NVIDIA sample field contract mismatch")
+    if (
+        not isinstance(hardware["nvidia_smi_samples"], list)
+        or not hardware["nvidia_smi_samples"]
+    ):
+        raise ValueError("run NVIDIA samples must be a non-empty list")
+    successful_samples = 0
+    successful_phases: set[str] = set()
+    for sample in hardware["nvidia_smi_samples"]:
+        if set(sample) != NVIDIA_SAMPLE_KEYS:
+            raise ValueError("run NVIDIA sample schema mismatch")
+        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
+            raise ValueError("run NVIDIA sample query schema mismatch")
+        if sample["query"]["fields"] != NVIDIA_SMI_FIELDS:
+            raise ValueError("run NVIDIA sample query field mismatch")
+        if sample["query"]["returncode"] == 0:
+            successful_samples += 1
+            if not sample["query"]["rows"]:
+                raise ValueError("successful NVIDIA sample has zero rows")
+            successful_phases.add(str(sample["phase"]))
+            if any(
+                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
+            ):
+                raise ValueError("run NVIDIA sample row schema mismatch")
+            if len(sample["query"]["rows"]) != len(hardware["devices"]):
+                raise ValueError("run NVIDIA sample/device cardinality mismatch")
+    if successful_samples == 0:
+        raise ValueError("run collected no successful NVIDIA telemetry samples")
+    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
+    if not required_phases <= successful_phases:
+        raise ValueError(
+            f"run lacks successful phase telemetry: {required_phases - successful_phases}"
+        )
+    topology = hardware["nvidia_smi_topology"]
+    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
+        raise ValueError("run NVIDIA topology schema mismatch")
+    if topology["returncode"] != 0 or not topology["stdout"]:
+        raise ValueError(f"run NVIDIA topology query failed: {topology}")
+    for row in record["per_rank"]:
+        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
+            raise ValueError("run per-rank schema mismatch")
+        if set(row["eager"]) != RANK_MODE_KEYS:
+            raise ValueError("run per-rank eager metric schema mismatch")
+        if set(row["graph"]) != RANK_MODE_KEYS:
+            raise ValueError("run per-rank graph metric schema mismatch")
+        for mode in ("eager", "graph"):
+            samples = row[mode]["samples_us"]
+            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
+                raise ValueError(f"run per-rank {mode} sample length mismatch")
+            if any(
+                not math.isfinite(float(value)) or float(value) <= 0
+                for value in samples
+            ):
+                raise ValueError(f"run per-rank {mode} samples are invalid")
+            expected_summary = _summary(samples)
+            for key, expected in expected_summary.items():
+                if float(row[mode][key]) != expected:
+                    raise ValueError(f"run per-rank {mode} {key} mismatch")
+        structure = row["graph_structure"]
+        if set(structure) != GRAPH_STRUCTURE_KEYS:
+            raise ValueError("run graph structure schema mismatch")
+        if int(structure["kernel_nodes"]) != expected_nodes:
+            raise ValueError("observed graph-node count differs across ranks")
+        if expected_nodes == 2:
+            if (
+                structure["direct_control_worker_edge"] is not True
+                or structure["control_grid"] != [1, 1, 1]
+                or structure["control_block"] != [1, 1, 1]
+            ):
+                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
+        elif (
+            structure["direct_control_worker_edge"] is not False
+            or structure["control_grid"] is not None
+            or structure["control_block"] is not None
+        ):
+            raise ValueError("baseline graph unexpectedly records a control node")
+    if {int(row["rank"]) for row in record["per_rank"]} != set(
+        range(int(contract["world_size"]))
+    ):
+        raise ValueError("run rank identities do not match world size")
+    critical_path = record["distributed_critical_path"]
+    if set(critical_path) != {"eager", "graph"}:
+        raise ValueError("run distributed critical-path mode schema mismatch")
+    for mode in ("eager", "graph"):
+        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
+            raise ValueError(f"run distributed {mode} schema mismatch")
+    if critical_path != _distributed_critical_path(record["per_rank"]):
+        raise ValueError("run critical path is not the aligned per-iteration rank MAX")
+
+
+def _outside_worktrees(path: Path, roots: tuple[Path, ...], label: str) -> Path:
+    resolved = path.resolve()
+    for root in roots:
+        if resolved == root or resolved.is_relative_to(root):
+            raise ValueError(f"{label} must be outside measured worktree {root}")
+    return resolved
+
+
+def _stable_environment(record: dict[str, object]) -> dict[str, object]:
+    environment = dict(record["environment"])
+    environment.pop("TORCH_EXTENSIONS_DIR", None)
+    return environment
+
+
+def _stable_hardware(record: dict[str, object]) -> dict[str, object]:
+    hardware = record["hardware"]
+    return {
+        "hostname": hardware["hostname"],
+        "devices": hardware["devices"],
+        "nvidia_smi_identity": hardware["nvidia_smi_identity"],
+        "nvidia_smi_sample_fields": hardware["nvidia_smi_sample_fields"],
+        "nvidia_smi_topology": hardware["nvidia_smi_topology"],
+    }
+
+
+def _paired_deltas(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    deltas = []
+    for pair_index in range(len(records) // 2):
+        pair = records[2 * pair_index : 2 * pair_index + 2]
+        by_variant = {record["identity"]["variant"]: record for record in pair}
+        if set(by_variant) != {"baseline", "candidate"}:
+            raise ValueError(f"pair {pair_index} does not contain one A and one B")
+        delta = {"pair_index": pair_index, "metrics": {}}
+        for mode in ("eager", "graph"):
+            delta["metrics"][mode] = {}
+            for metric in METRICS:
+                before = float(
+                    by_variant["baseline"]["distributed_critical_path"][mode][metric]
+                )
+                after = float(
+                    by_variant["candidate"]["distributed_critical_path"][mode][metric]
+                )
+                delta["metrics"][mode][metric] = {
+                    "baseline_us": before,
+                    "candidate_us": after,
+                    "delta_us": after - before,
+                    "delta_percent": (after / before - 1) * 100,
+                }
+        deltas.append(delta)
+    return deltas
+
+
+def _paired_summary(deltas: list[dict[str, object]]) -> dict[str, object]:
+    """Descriptive paired uncertainty; this harness makes no significance claim."""
+
+    result = {}
+    for mode in ("eager", "graph"):
+        result[mode] = {}
+        for metric in METRICS:
+            values = [
+                float(delta["metrics"][mode][metric]["delta_us"]) for delta in deltas
+            ]
+            mean = statistics.mean(values)
+            stdev = statistics.stdev(values) if len(values) > 1 else 0.0
+            margin = 1.96 * stdev / math.sqrt(len(values)) if len(values) > 1 else None
+            result[mode][metric] = {
+                "pairs": len(values),
+                "mean_delta_us": mean,
+                "sample_stdev_us": stdev,
+                "normal_approx_95ci_us": [mean - margin, mean + margin]
+                if margin is not None
+                else None,
+                "interpretation": "descriptive_only",
+            }
+    return result
+
+
+def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
+    result = {}
+    for variant in ("baseline", "candidate"):
+        variant_records = [
+            record for record in records if record["identity"]["variant"] == variant
+        ]
+        result[variant] = {}
+        for mode in ("eager", "graph"):
+            result[variant][mode] = {}
+            for metric in METRICS:
+                values = [
+                    float(record["distributed_critical_path"][mode][metric])
+                    for record in variant_records
+                ]
+                result[variant][mode][metric] = {
+                    "mean_us": statistics.mean(values),
+                    "median_us": statistics.median(values),
+                    "min_us": min(values),
+                    "max_us": max(values),
+                }
+    return result
+
+
+def main() -> None:
+    args = _parse_args()
+    if (
+        args.pairs <= 0
+        or args.world_size <= 0
+        or args.numel != 32768
+        or args.warmup < 0
+        or args.iters <= 0
+        or args.sampler_interval <= 0
+        or args.preflight_replays < 4
+        or args.run_timeout_seconds <= 0
+        or args.distributed_timeout_seconds <= 0
+    ):
+        raise ValueError(
+            "invalid A/B contract: this harness is scoped to 32,768 BF16 "
+            "elements (64 KiB) and requires positive timeouts/iterations plus "
+            "at least four mutating preflight replays"
+        )
+    controller_path = Path(__file__).resolve()
+    controller_sha256 = _sha256(controller_path)
+    controller_argv = list(sys.argv)
+    controller_argv_sha256 = _json_sha256(controller_argv)
+    baseline_root = args.baseline_worktree.resolve()
+    candidate_root = args.candidate_worktree.resolve()
+    harness_source = args.harness.resolve()
+    roots = (baseline_root, candidate_root)
+    if baseline_root == candidate_root:
+        raise ValueError("baseline and candidate worktrees must differ")
+    output_dir = _outside_worktrees(args.output_dir, roots, "output directory")
+    output = _outside_worktrees(args.output, roots, "suite output")
+    if not harness_source.is_file():
+        raise ValueError(f"harness does not exist: {harness_source}")
+    baseline_sha = _git_sha(baseline_root)
+    candidate_sha = _git_sha(candidate_root)
+    if baseline_sha == candidate_sha:
+        raise ValueError("baseline and candidate Git SHAs must differ")
+    harness_sha256 = _sha256(harness_source)
+    contract = _expected_contract(args)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    harness = output_dir / f"harness-{harness_sha256[:16]}.py"
+    harness_bytes = harness_source.read_bytes()
+    if harness.exists() and harness.read_bytes() != harness_bytes:
+        raise ValueError(f"frozen harness collision at {harness}")
+    if not harness.exists():
+        harness.write_bytes(harness_bytes)
+    if _sha256(harness) != harness_sha256:
+        raise ValueError("frozen harness hash differs from source harness")
+
+    variants = {
+        "baseline": {
+            "root": baseline_root,
+            "sha": baseline_sha,
+            "expected_nodes": 1,
+        },
+        "candidate": {
+            "root": candidate_root,
+            "sha": candidate_sha,
+            "expected_nodes": 2,
+        },
+    }
+    records = []
+    sequence = []
+    for pair_index in range(args.pairs):
+        order = (
+            ("baseline", "candidate")
+            if pair_index % 2 == 0
+            else ("candidate", "baseline")
+        )
+        for variant in order:
+            run_index = len(sequence)
+            sequence.append(variant)
+            config = variants[variant]
+            raw_path = output_dir / f"{run_index:02d}-{variant}.json"
+            extension_dir = (
+                output_dir
+                / "torch-extensions"
+                / f"{run_index:02d}-{variant}-{config['sha'][:12]}"
+            )
+            extension_dir.parent.mkdir(parents=True, exist_ok=True)
+            extension_dir.mkdir(exist_ok=False)
+            env = dict(os.environ)
+            existing_pythonpath = env.get("PYTHONPATH")
+            env["PYTHONPATH"] = str(config["root"]) + (
+                os.pathsep + existing_pythonpath if existing_pythonpath else ""
+            )
+            env["TORCH_EXTENSIONS_DIR"] = str(extension_dir)
+            command = [
+                sys.executable,
+                "-m",
+                "torch.distributed.run",
+                "--standalone",
+                f"--nproc-per-node={args.world_size}",
+                str(harness),
+                "--label",
+                f"{variant}-{config['sha'][:12]}-{run_index}",
+                "--variant",
+                variant,
+                "--run-index",
+                str(run_index),
+                "--implementation-root",
+                str(config["root"]),
+                "--expected-git-sha",
+                config["sha"],
+                "--expected-graph-kernel-nodes",
+                str(config["expected_nodes"]),
+                "--numel",
+                str(args.numel),
+                "--warmup",
+                str(args.warmup),
+                "--iters",
+                str(args.iters),
+                "--sampler-interval",
+                str(args.sampler_interval),
+                "--preflight-replays",
+                str(args.preflight_replays),
+                "--distributed-timeout-seconds",
+                str(args.distributed_timeout_seconds),
+                "--controller-sha256",
+                controller_sha256,
+                "--controller-argv-sha256",
+                controller_argv_sha256,
+                "--output",
+                str(raw_path),
+            ]
+            print(
+                f"[{run_index + 1}/{2 * args.pairs}] {variant} {config['sha'][:12]}",
+                flush=True,
+            )
+            _run(
+                command,
+                cwd=config["root"],
+                env=env,
+                timeout=args.run_timeout_seconds,
+            )
+            record = json.loads(raw_path.read_text(encoding="utf-8"))
+            _validate_run(
+                record,
+                contract=contract,
+                variant=variant,
+                sha=config["sha"],
+                run_index=run_index,
+                harness_sha256=harness_sha256,
+                expected_nodes=config["expected_nodes"],
+                implementation_root=config["root"],
+                controller_sha256=controller_sha256,
+                controller_argv_sha256=controller_argv_sha256,
+                extension_dir=extension_dir,
+            )
+            records.append(record)
+
+    software_fingerprints = {
+        json.dumps(record["software"], sort_keys=True) for record in records
+    }
+    hardware_fingerprints = {
+        json.dumps(_stable_hardware(record), sort_keys=True) for record in records
+    }
+    environment_fingerprints = {
+        json.dumps(_stable_environment(record), sort_keys=True) for record in records
+    }
+    if len(software_fingerprints) != 1:
+        raise ValueError("software stack changed during alternating A/B suite")
+    if len(hardware_fingerprints) != 1:
+        raise ValueError(
+            "hardware/driver/topology changed during alternating A/B suite"
+        )
+    if len(environment_fingerprints) != 1:
+        raise ValueError("environment toggles changed during alternating A/B suite")
+
+    paired_deltas = _paired_deltas(records)
+    suite = {
+        "schema": SUITE_SCHEMA,
+        "contract": contract,
+        "controller": {
+            "source_path": str(controller_path),
+            "sha256": controller_sha256,
+            "argv": controller_argv,
+            "argv_sha256": controller_argv_sha256,
+        },
+        "harness": {
+            "source_path": str(harness_source),
+            "frozen_path": str(harness),
+            "sha256": harness_sha256,
+            "identical_for_all_runs": True,
+        },
+        "implementations": {
+            "baseline": {"root": str(baseline_root), "git_sha": baseline_sha},
+            "candidate": {"root": str(candidate_root), "git_sha": candidate_sha},
+        },
+        "sequence": sequence,
+        "records": records,
+        "paired_deltas": paired_deltas,
+        "paired_summary": _paired_summary(paired_deltas),
+        "aggregate": _aggregate(records),
+    }
+    if set(suite) != SUITE_TOP_LEVEL_KEYS:
+        raise ValueError("suite top-level schema mismatch")
+    if suite["schema"] != SUITE_SCHEMA or suite["contract"] != contract:
+        raise ValueError("suite identity/contract mismatch")
+    if set(suite["controller"]) != CONTROLLER_KEYS:
+        raise ValueError("suite controller schema mismatch")
+    if (
+        _sha256(Path(suite["controller"]["source_path"]))
+        != suite["controller"]["sha256"]
+    ):
+        raise ValueError("suite controller source digest mismatch")
+    if _json_sha256(suite["controller"]["argv"]) != suite["controller"]["argv_sha256"]:
+        raise ValueError("suite controller argv digest mismatch")
+    if set(suite["harness"]) != HARNESS_KEYS:
+        raise ValueError("suite harness schema mismatch")
+    if set(suite["implementations"]) != {"baseline", "candidate"}:
+        raise ValueError("suite implementation variants mismatch")
+    for implementation in suite["implementations"].values():
+        if set(implementation) != IMPLEMENTATION_KEYS:
+            raise ValueError("suite implementation schema mismatch")
+    if len(suite["sequence"]) != args.pairs * 2:
+        raise ValueError("suite sequence cardinality mismatch")
+    if len(suite["records"]) != args.pairs * 2:
+        raise ValueError("suite record cardinality mismatch")
+    if len(suite["paired_deltas"]) != args.pairs:
+        raise ValueError("suite paired-delta cardinality mismatch")
+    rendered = json.dumps(suite, indent=2, sort_keys=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ where = ["."]
 include = ["sparkinfer*"]
 
 [tool.setuptools.package-data]
-"sparkinfer.comm.pcie" = ["*.cu"]
+"sparkinfer.comm.pcie" = ["*.cu", "*.h"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "SIM"]

--- a/sparkinfer/comm/pcie/ipc_handle_registry.h
+++ b/sparkinfer/comm/pcie/ipc_handle_registry.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <map>
+#include <utility>
+
+namespace sparkinfer::pcie {
+
+// Owns imported IPC handles whose close routine reports an error code instead
+// of throwing. Successful closes clear their entries so repeated cleanup is
+// idempotent; failed entries remain available to an explicit retry.
+template <typename Key, typename Handle, typename Error, Error Success>
+class IpcHandleRegistry {
+ public:
+  using CloseFn = Error (*)(Handle) noexcept;
+  using Map = std::map<Key, Handle>;
+  using iterator = typename Map::iterator;
+
+  explicit IpcHandleRegistry(CloseFn close) noexcept : close_(close) {}
+
+  IpcHandleRegistry(const IpcHandleRegistry&) = delete;
+  IpcHandleRegistry& operator=(const IpcHandleRegistry&) = delete;
+  IpcHandleRegistry(IpcHandleRegistry&&) = delete;
+  IpcHandleRegistry& operator=(IpcHandleRegistry&&) = delete;
+
+  ~IpcHandleRegistry() noexcept {
+    (void)close_all_noexcept();
+  }
+
+  iterator find(const Key& key) {
+    return handles_.find(key);
+  }
+
+  iterator end() {
+    return handles_.end();
+  }
+
+  std::pair<iterator, bool> emplace(const Key& key, Handle handle) {
+    return handles_.emplace(key, handle);
+  }
+
+  Error close_all_noexcept() noexcept {
+    Error first_error = Success;
+    for (auto& entry : handles_) {
+      Handle& handle = entry.second;
+      if (handle == Handle{}) {
+        continue;
+      }
+      const Error error = close_(handle);
+      if (error == Success) {
+        handle = Handle{};
+      } else if (first_error == Success) {
+        first_error = error;
+      }
+    }
+    return first_error;
+  }
+
+ private:
+  Map handles_;
+  CloseFn close_;
+};
+
+}  // namespace sparkinfer::pcie

--- a/sparkinfer/comm/pcie/ipc_handle_registry.h
+++ b/sparkinfer/comm/pcie/ipc_handle_registry.h
@@ -40,16 +40,19 @@ class IpcHandleRegistry {
 
   Error close_all_noexcept() noexcept {
     Error first_error = Success;
-    for (auto& entry : handles_) {
-      Handle& handle = entry.second;
-      if (handle == Handle{}) {
+    for (auto it = handles_.begin(); it != handles_.end();) {
+      if (it->second == Handle{}) {
+        it = handles_.erase(it);
         continue;
       }
-      const Error error = close_(handle);
+      const Error error = close_(it->second);
       if (error == Success) {
-        handle = Handle{};
-      } else if (first_error == Success) {
-        first_error = error;
+        it = handles_.erase(it);
+      } else {
+        if (first_error == Success) {
+          first_error = error;
+        }
+        ++it;
       }
     }
     return first_error;

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <sstream>
 #include <stdexcept>
@@ -66,6 +67,8 @@ static int dcp_block_limit_override() {
 }
 
 struct Signal {
+  alignas(128) FlagType staging_generation;
+  FlagType active_staging_slot;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
 };
@@ -76,6 +79,10 @@ struct RankSignals {
 
 struct RankStaging {
   void *ptrs[kMaxRanks];
+};
+
+struct DoubleStaging {
+  RankStaging slots[2];
 };
 
 template <typename T> struct __align__(16) Pack {
@@ -97,6 +104,40 @@ static DINLINE FlagType load_flag(FlagType *address) {
   return value;
 }
 
+static DINLINE FlagType load_flag_gpu(FlagType *address) {
+  FlagType value;
+  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];"
+               : "=r"(value)
+               : "l"(address)
+               : "memory");
+  return value;
+}
+
+__global__ void advance_staging_slot_kernel(Signal *self) {
+  if (threadIdx.x == 0) {
+    const FlagType generation = self->staging_generation;
+    self->active_staging_slot = generation & FlagType{1};
+    self->staging_generation = generation + FlagType{1};
+  }
+}
+
+template <int world_size>
+DINLINE void select_staging(RankStaging &staging,
+                            const DoubleStaging &staging_options,
+                            Signal *self) {
+  if (threadIdx.x == 0) {
+    // The one-CTA control node runs earlier on this stream.  Every worker CTA
+    // therefore observes one operation-wide slot regardless of worker grid
+    // size or rank launch skew.
+    const int slot = int(load_flag_gpu(&self->active_staging_slot) & FlagType{1});
+#pragma unroll
+    for (int peer = 0; peer < world_size; ++peer) {
+      staging.ptrs[peer] = staging_options.slots[slot].ptrs[peer];
+    }
+  }
+  __syncthreads();
+}
+
 // pre_sync orders in-kernel staging stores (from every warp of the block)
 // before the flag post; without staging the flags can go out immediately.
 template <int world_size, bool pre_sync>
@@ -112,6 +153,16 @@ DINLINE void start_barrier(const RankSignals &signals, Signal *self, int rank) {
         &self->peer_counter[value % 2][blockIdx.x][threadIdx.x * kFlagStride];
     store_flag(peer, value);
     while (load_flag(mine) != value) {
+    }
+  }
+  __syncthreads();
+}
+
+DINLINE void test_post_barrier_delay(int rank, int delayed_rank,
+                                     uint64_t delay_cycles) {
+  if (delay_cycles != 0 && rank == delayed_rank && threadIdx.x == 0) {
+    const uint64_t start = clock64();
+    while (clock64() - start < delay_cycles) {
     }
   }
   __syncthreads();
@@ -149,14 +200,15 @@ template <typename T, int world_size>
 __global__ void __launch_bounds__(512, 1)
     dcp_lse_reduce_kernel(const T *__restrict__ local_output,
                           const float *__restrict__ local_lse,
-                          RankStaging staging, int64_t lse_offset,
+                          DoubleStaging staging_options, int64_t lse_offset,
                           RankSignals signals, Signal *self,
                           T *__restrict__ output, int rank, int batch,
                           int total_heads, int head_dim,
                           int64_t input_stride_batch,
                           int64_t input_stride_head,
                           int64_t output_stride_batch,
-                          int64_t output_stride_head, bool natural_log) {
+                          int64_t output_stride_head, bool natural_log,
+                          int delayed_rank, uint64_t delay_cycles) {
   constexpr int kPackElems = 8;
   const int heads_per_rank = total_heads / world_size;
   const int packs_per_head = head_dim / kPackElems;
@@ -168,6 +220,9 @@ __global__ void __launch_bounds__(512, 1)
 
   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_output);
   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+
+  __shared__ RankStaging staging;
+  select_staging<world_size>(staging, staging_options, self);
 
   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
   auto *staging_lse = reinterpret_cast<float *>(
@@ -192,6 +247,7 @@ __global__ void __launch_bounds__(512, 1)
     }
   }
   start_barrier<world_size, true>(signals, self, rank);
+  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
 
   // Rotated source pointers so every later access uses a compile-time
   // index; the self source reads the local tensors directly (still hot in
@@ -286,9 +342,10 @@ __global__ void __launch_bounds__(512, 1)
 template <typename T, int world_size>
 __global__ void __launch_bounds__(512, 1)
     all_gather_heads_kernel(const T *__restrict__ local_input,
-                            RankStaging staging, RankSignals signals,
+                            DoubleStaging staging_options, RankSignals signals,
                             Signal *self, T *__restrict__ output, int rank,
-                            int batch, int local_heads, int head_dim) {
+                            int batch, int local_heads, int head_dim,
+                            int delayed_rank, uint64_t delay_cycles) {
   constexpr int kPackElems = 8;
   const int packs_per_head = head_dim / kPackElems;
   const int total_heads = local_heads * world_size;
@@ -298,6 +355,9 @@ __global__ void __launch_bounds__(512, 1)
   const int warp_first = blockIdx.x * warps_per_block + (threadIdx.x >> 5);
   const int warp_stride = gridDim.x * warps_per_block;
   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_input);
+
+  __shared__ RankStaging staging;
+  select_staging<world_size>(staging, staging_options, self);
 
   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
   for (int row = warp_first; row < rows; row += warp_stride) {
@@ -313,6 +373,7 @@ __global__ void __launch_bounds__(512, 1)
     }
   }
   start_barrier<world_size, true>(signals, self, rank);
+  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
 
   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
   for (int row = warp_first; row < rows; row += warp_stride) {
@@ -339,11 +400,11 @@ public:
   int world_size_;
   RankSignals signals_{};
   Signal *self_signal_;
-  RankStaging staging_[2]{};
+  DoubleStaging staging_{};
   int64_t output_capacity_elems_;
   int64_t lse_offset_;
   int64_t lse_capacity_;
-  int slot_ = 0;
+
 
   PCIeDCPA2A(Signal **signals,
              const std::vector<std::array<void *, 2>> &staging,
@@ -354,8 +415,8 @@ public:
         lse_capacity_(lse_capacity) {
     for (int peer = 0; peer < world_size_; ++peer) {
       signals_.signals[peer] = signals[peer];
-      staging_[0].ptrs[peer] = staging[peer][0];
-      staging_[1].ptrs[peer] = staging[peer][1];
+      staging_.slots[0].ptrs[peer] = staging[peer][0];
+      staging_.slots[1].ptrs[peer] = staging[peer][1];
     }
   }
 
@@ -394,21 +455,27 @@ public:
       throw std::runtime_error("threads must be a multiple of 32");
     }
 
-    // Staging happens inside the kernel (warp-per-row, before the start
-    // barrier); no host staging memcpys are issued.
-    const int slot = slot_++ % 2;
+    // Select one staging slot per execution in a graph-capturable device node.
+    // Worker CTA count may change large -> small -> large without leaving
+    // dormant per-block parity counters behind.
     const int heads_per_rank = total_heads / world_size_;
     const int rows = batch * heads_per_rank;
     const int warps_per_block = threads / 32;
     const int blocks = std::max(
         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
+    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
+    const int delayed_rank =
+        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
+    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
+        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
 
 #define LAUNCH(world)                                                          \
   dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
-      partial_output, partial_lse, staging_[slot], lse_offset_, signals_,      \
-      self_signal_, output, rank_, batch, total_heads, head_dim,               \
+      partial_output, partial_lse, staging_, lse_offset_, signals_,           \
+      self_signal_, output, rank_, batch, total_heads, head_dim,              \
       input_stride_batch, input_stride_head, output_stride_batch,              \
-      output_stride_head, natural_log)
+      output_stride_head, natural_log, delayed_rank, delay_cycles)
     switch (world_size_) {
     case 2:
       LAUNCH(2);
@@ -455,18 +522,23 @@ public:
       throw std::runtime_error("threads must be a multiple of 32");
     }
 
-    // Staging happens inside the kernel (warp-per-row, before the start
-    // barrier); no host staging memcpy is issued.
-    const int slot = slot_++ % 2;
+    // Slot ownership is published by a device control node, including for
+    // back-to-back eager launches and every CUDA graph replay.
     const int rows = batch * total_heads;
     const int warps_per_block = threads / 32;
     const int blocks = std::max(
         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
+    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
+    const int delayed_rank =
+        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
+    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
+        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
 
 #define LAUNCH(world)                                                          \
   all_gather_heads_kernel<T, world><<<blocks, threads, 0, stream>>>(           \
-      local_input, staging_[slot], signals_, self_signal_, output, rank_,      \
-      batch, local_heads, head_dim)
+      local_input, staging_, signals_, self_signal_, output, rank_, batch,    \
+      local_heads, head_dim, delayed_rank, delay_cycles)
     switch (world_size_) {
     case 2:
       LAUNCH(2);

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -66,6 +66,17 @@ static int dcp_block_limit_override() {
   return value;
 }
 
+static int dcp_test_delay_rank() {
+  static const int value = env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
+  return value;
+}
+
+static uint64_t dcp_test_delay_cycles() {
+  static const uint64_t value = static_cast<uint64_t>(std::max(
+      0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
+  return value;
+}
+
 struct Signal {
   alignas(128) FlagType staging_generation;
   FlagType active_staging_slot;
@@ -465,10 +476,8 @@ public:
         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
     advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
     CHECK_CUDA_SUCCESS(cudaGetLastError());
-    const int delayed_rank =
-        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
-    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
-        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
+    const int delayed_rank = dcp_test_delay_rank();
+    const uint64_t delay_cycles = dcp_test_delay_cycles();
 
 #define LAUNCH(world)                                                          \
   dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
@@ -530,10 +539,8 @@ public:
         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
     advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
     CHECK_CUDA_SUCCESS(cudaGetLastError());
-    const int delayed_rank =
-        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
-    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
-        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
+    const int delayed_rank = dcp_test_delay_rank();
+    const uint64_t delay_cycles = dcp_test_delay_cycles();
 
 #define LAUNCH(world)                                                          \
   all_gather_heads_kernel<T, world><<<blocks, threads, 0, stream>>>(           \

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -16,19 +16,32 @@ from torch.utils.cpp_extension import load
 
 from ._cuda_ipc import CudaRTLibrary
 from .pcie_oneshot import (
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    _SINGLE_CHANNEL_ID,
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
+    _finish_collective_runtime_setup,
+    _raise_local_cleanup_errors,
     _align_up,
+    _broadcast_gather_object,
+    _collective_capture_needs_preparation,
     _coordinated_close_channels,
     _current_stream_key,
+    _cuda_device_index,
     _is_current_stream_capturing,
     _normalize_device,
+    _normalize_logical_channel_id,
     _OwnedSharedBuffer,
+    _finish_collective_unowned_runtime_setup,
+    _require_collective_contract,
+    _require_full_grid_residency,
+    _run_collective_preallocation_setup,
 )
 
 
 SUPPORTED_WORLD_SIZES = (2, 4, 8)
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+DCP_A2A_REQUIRED_SMS = 64
 
 
 def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
@@ -37,15 +50,15 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         return False
     batch, heads, head_dim = (int(value) for value in tensor.shape)
     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
-    packed_token_major = (
-        stride_batch == heads * head_dim and stride_head == head_dim
-    )
+    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
     capacity_strided_head_major = (
         stride_batch == head_dim
         and stride_head >= batch * head_dim
         and stride_head % 8 == 0
     )
     return packed_token_major or capacity_strided_head_major
+
+
 @dataclass(frozen=True)
 class _StagingLayout:
     signal_bytes: int
@@ -189,49 +202,252 @@ class PCIeDCPA2A:
         ext_module=None,
         stream_affine: bool = True,
     ) -> None:
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
-        if not 0 <= rank < world_size:
-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
-        if (
-            len(signal_ptrs) != world_size
-            or len(staging0_ptrs) != world_size
-            or len(staging1_ptrs) != world_size
-        ):
-            raise ValueError("signal and staging pointers must match world size")
-        if total_heads <= 0 or total_heads % world_size != 0:
-            raise ValueError("total_heads must be divisible by world_size")
-        if head_dim <= 0 or head_dim % 8 != 0:
-            raise ValueError("head_dim must be a positive multiple of 8")
+        def normalize_and_validate():
+            device_obj = _normalize_device(device)
+            normalized_rank = int(rank)
+            normalized_world_size = int(world_size)
+            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
+            normalized_staging0 = tuple(int(ptr) for ptr in staging0_ptrs)
+            normalized_staging1 = tuple(int(ptr) for ptr in staging1_ptrs)
+            normalized_max_batch = int(max_batch_size)
+            normalized_total_heads = int(total_heads)
+            normalized_head_dim = int(head_dim)
+            normalized_query_dim = int(
+                head_dim if query_head_dim is None else query_head_dim
+            )
+            normalized_output_capacity = int(output_capacity_elems)
+            normalized_lse_offset = int(lse_offset)
+            normalized_lse_capacity = int(lse_capacity)
+            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {normalized_world_size}")
+            if not 0 <= normalized_rank < normalized_world_size:
+                raise ValueError(
+                    f"invalid rank {normalized_rank} for world size "
+                    f"{normalized_world_size}"
+                )
+            if (
+                len(normalized_signals) != normalized_world_size
+                or len(normalized_staging0) != normalized_world_size
+                or len(normalized_staging1) != normalized_world_size
+            ):
+                raise ValueError("signal and staging pointers must match world size")
+            if normalized_max_batch <= 0:
+                raise ValueError("max_batch_size must be positive")
+            if (
+                normalized_total_heads <= 0
+                or normalized_total_heads % normalized_world_size != 0
+            ):
+                raise ValueError("total_heads must be divisible by world_size")
+            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
+                raise ValueError("head_dim must be a positive multiple of 8")
+            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
+                raise ValueError("query_head_dim must be a positive multiple of 8")
+            required_output = (
+                normalized_max_batch
+                * normalized_total_heads
+                * max(normalized_head_dim, normalized_query_dim)
+            )
+            if normalized_output_capacity < required_output:
+                raise ValueError("output capacity is smaller than configured shape")
+            if normalized_lse_offset < 0:
+                raise ValueError("lse_offset must be non-negative")
+            if normalized_lse_capacity < normalized_max_batch * normalized_total_heads:
+                raise ValueError("LSE capacity is smaller than configured shape")
+            if ext_module is None and device_obj.type != "cuda":
+                raise ValueError("PCIe DCP A2A requires a CUDA device")
+            if device_obj.type == "cuda" and exchange_group is None:
+                raise ValueError(
+                    "exchange_group is required for a CUDA PCIe DCP A2A runtime; "
+                    "use from_exchange_group()"
+                )
+            if exchange_group is not None:
+                if device_obj.type != "cuda":
+                    raise ValueError("distributed PCIe DCP A2A requires a CUDA device")
+                group_rank = dist.get_rank(group=exchange_group)
+                group_world_size = dist.get_world_size(group=exchange_group)
+                if normalized_rank != group_rank:
+                    raise ValueError(
+                        f"supplied rank {normalized_rank} does not match process "
+                        f"group rank {group_rank}"
+                    )
+                if normalized_world_size != group_world_size:
+                    raise ValueError(
+                        f"supplied world size {normalized_world_size} does not "
+                        f"match process group size {group_world_size}"
+                    )
+            return (
+                device_obj,
+                normalized_rank,
+                normalized_world_size,
+                normalized_signals,
+                normalized_staging0,
+                normalized_staging1,
+                normalized_max_batch,
+                normalized_total_heads,
+                normalized_head_dim,
+                normalized_query_dim,
+                normalized_output_capacity,
+                normalized_lse_offset,
+                normalized_lse_capacity,
+            )
 
+        if exchange_group is not None:
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe DCP A2A direct constructor argument validation",
+                exchange_group=exchange_group,
+                setup=normalize_and_validate,
+            )
+        else:
+            normalized = normalize_and_validate()
+
+        self._initialize_prepared_state(
+            rank=normalized[1],
+            world_size=normalized[2],
+            device=normalized[0],
+            signal_ptrs=normalized[3],
+            staging0_ptrs=normalized[4],
+            staging1_ptrs=normalized[5],
+            max_batch_size=normalized[6],
+            total_heads=normalized[7],
+            head_dim=normalized[8],
+            query_head_dim=normalized[9],
+            output_capacity_elems=normalized[10],
+            lse_offset=normalized[11],
+            lse_capacity=normalized[12],
+            exchange_group=exchange_group,
+            ipc=ipc,
+            owned_buffers=owned_buffers,
+            ext_module=ext_module,
+            stream_affine=stream_affine,
+        )
+
+        if self.device.type == "cuda":
+            _require_full_grid_residency(
+                owner="PCIe DCP A2A direct constructor",
+                required_sms=DCP_A2A_REQUIRED_SMS,
+                device=self.device,
+                exchange_group=self.exchange_group,
+            )
+
+            def prepare():
+                return ext_module or _load_extension()
+
+            if self.exchange_group is None:
+                self._ext = prepare()
+            else:
+                self._ext = _run_collective_preallocation_setup(
+                    owner="PCIe DCP A2A direct constructor",
+                    exchange_group=self.exchange_group,
+                    setup=prepare,
+                )
+        else:
+            self._ext = self._ext or _load_extension()
+
+        if self.device.type == "cuda" and self.exchange_group is not None:
+            _require_collective_contract(
+                owner="PCIe DCP A2A direct constructor",
+                exchange_group=self.exchange_group,
+                contract=(
+                    self.world_size,
+                    self.max_batch_size,
+                    self.total_heads,
+                    self.head_dim,
+                    self.query_head_dim,
+                    self.output_capacity_elems,
+                    self.lse_offset,
+                    self.lse_capacity,
+                ),
+            )
+
+        init_error = self._initialize_native_runtime()
+        if self.device.type == "cuda" and self.exchange_group is not None:
+
+            def abort_native_runtime() -> None:
+                if self._ptr:
+                    self._ext.dispose(self._ptr)
+                    self._ptr = 0
+
+            _finish_collective_unowned_runtime_setup(
+                owner="PCIe DCP A2A direct constructor",
+                exchange_group=self.exchange_group,
+                local_error=init_error,
+                local_cleanup=abort_native_runtime,
+            )
+        elif init_error is not None:
+            raise init_error
+
+    def _initialize_prepared_state(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device,
+        signal_ptrs: Sequence[int],
+        staging0_ptrs: Sequence[int],
+        staging1_ptrs: Sequence[int],
+        max_batch_size: int,
+        total_heads: int,
+        head_dim: int,
+        query_head_dim: int,
+        output_capacity_elems: int,
+        lse_offset: int,
+        lse_capacity: int,
+        exchange_group: Optional[ProcessGroup],
+        ipc: Optional[CudaRTLibrary],
+        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
+        ext_module,
+        stream_affine: bool,
+    ) -> None:
         self.rank = int(rank)
         self.world_size = int(world_size)
-        self.device = _normalize_device(device)
+        self.device = device
         self.exchange_group = exchange_group
         self.max_batch_size = int(max_batch_size)
         self.total_heads = int(total_heads)
         self.head_dim = int(head_dim)
-        self.query_head_dim = int(query_head_dim or head_dim)
-        if self.query_head_dim <= 0 or self.query_head_dim % 8 != 0:
-            raise ValueError("query_head_dim must be a positive multiple of 8")
+        self.query_head_dim = int(query_head_dim)
         self.heads_per_rank = self.total_heads // self.world_size
+        self.output_capacity_elems = int(output_capacity_elems)
+        self.lse_offset = int(lse_offset)
+        self.lse_capacity = int(lse_capacity)
+        self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
+        self._staging0_ptrs = tuple(int(ptr) for ptr in staging0_ptrs)
+        self._staging1_ptrs = tuple(int(ptr) for ptr in staging1_ptrs)
         self._ipc = ipc
         self._owned_buffers = list(owned_buffers or ())
-        self._ext = ext_module or _load_extension()
+        self._ext = ext_module
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
         self._ipc_imports_closed = False
         self._ipc_exports_freed = False
-        self._ptr = self._ext.init_dcp_a2a(
-            list(signal_ptrs),
-            list(staging0_ptrs),
-            list(staging1_ptrs),
-            int(output_capacity_elems),
-            int(lse_offset),
-            int(lse_capacity),
-            self.rank,
-        )
+        self._coordinated_close_complete = False
+        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
+        self._ptr = 0
+
+    def _initialize_native_runtime(self) -> BaseException | None:
+        init_error: BaseException | None = None
+        try:
+            self._ptr = self._ext.init_dcp_a2a(
+                list(self._signal_ptrs),
+                list(self._staging0_ptrs),
+                list(self._staging1_ptrs),
+                self.output_capacity_elems,
+                self.lse_offset,
+                self.lse_capacity,
+                self.rank,
+            )
+        except Exception as exc:
+            init_error = exc
+        return init_error
+
+    @classmethod
+    def _from_prepared_factory(
+        cls, **kwargs
+    ) -> tuple["PCIeDCPA2A", BaseException | None]:
+        runtime = object.__new__(cls)
+        runtime._initialize_prepared_state(**kwargs)
+        return runtime, runtime._initialize_native_runtime()
 
     @classmethod
     def from_exchange_group(
@@ -248,62 +464,130 @@ class PCIeDCPA2A:
     ) -> "PCIeDCPA2A":
         rank = dist.get_rank(group=exchange_group)
         world_size = dist.get_world_size(group=exchange_group)
-        device_obj = _normalize_device(device)
-        if device_obj.type != "cuda":
-            raise ValueError("PCIe DCP A2A requires a CUDA device")
 
-        ipc = CudaRTLibrary()
-        ipc.cudaSetDevice(device_obj.index or 0)
-        ext = ext_module or _load_extension()
-        layout = _staging_layout(
-            signal_bytes=int(ext.meta_size()),
-            world_size=world_size,
-            max_batch_size=max_batch_size,
-            total_heads=total_heads,
-            head_dim=head_dim,
-            query_head_dim=query_head_dim,
-        )
-        owned: list[_OwnedSharedBuffer] = []
-        try:
-            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
-                exchange_group,
-                layout.slab_bytes,
-                zero_fill=True,
-                ipc=ipc,
+        def validate_factory_arguments():
+            device_obj = _normalize_device(device)
+            normalized_max_batch = int(max_batch_size)
+            normalized_total_heads = int(total_heads)
+            normalized_head_dim = int(head_dim)
+            normalized_query_dim = int(
+                head_dim if query_head_dim is None else query_head_dim
             )
-            owned.append(slab)
-            return cls(
-                rank=rank,
+            if world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {world_size}")
+            if device_obj.type != "cuda":
+                raise ValueError("PCIe DCP A2A requires a CUDA device")
+            if normalized_max_batch <= 0:
+                raise ValueError("max_batch_size must be positive")
+            if normalized_total_heads <= 0 or normalized_total_heads % world_size != 0:
+                raise ValueError("total_heads must be divisible by world_size")
+            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
+                raise ValueError("head_dim must be a positive multiple of 8")
+            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
+                raise ValueError("query_head_dim must be a positive multiple of 8")
+            return (
+                device_obj,
+                normalized_max_batch,
+                normalized_total_heads,
+                normalized_head_dim,
+                normalized_query_dim,
+            )
+
+        (
+            device_obj,
+            max_batch_size,
+            total_heads,
+            head_dim,
+            query_head_dim,
+        ) = _run_collective_preallocation_setup(
+            owner="PCIe DCP A2A argument validation",
+            exchange_group=exchange_group,
+            setup=validate_factory_arguments,
+        )
+
+        _require_full_grid_residency(
+            owner="PCIe DCP A2A",
+            required_sms=DCP_A2A_REQUIRED_SMS,
+            device=device_obj,
+            exchange_group=exchange_group,
+        )
+
+        def prepare():
+            prepared_ipc = CudaRTLibrary()
+            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
+            prepared_ext = ext_module or _load_extension()
+            layout = _staging_layout(
+                signal_bytes=int(prepared_ext.meta_size()),
                 world_size=world_size,
-                device=device_obj,
-                signal_ptrs=slab.peer_ptrs,
-                staging0_ptrs=tuple(
-                    ptr + layout.staging0_offset for ptr in slab.peer_ptrs
-                ),
-                staging1_ptrs=tuple(
-                    ptr + layout.staging1_offset for ptr in slab.peer_ptrs
-                ),
                 max_batch_size=max_batch_size,
                 total_heads=total_heads,
                 head_dim=head_dim,
-                output_capacity_elems=layout.output_capacity_elems,
-                lse_offset=layout.lse_offset,
-                lse_capacity=layout.lse_capacity,
                 query_head_dim=query_head_dim,
-                exchange_group=exchange_group,
-                ipc=ipc,
-                owned_buffers=owned,
-                ext_module=ext,
-                stream_affine=stream_affine,
             )
-        except Exception:
-            for shared in owned:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        ipc.cudaIpcCloseMemHandle(ptr)
-                with suppress(Exception):
-                    ipc.cudaFree(shared.local_ptr)
-            raise
+            return prepared_ipc, prepared_ext, layout
+
+        ipc, ext, layout = _run_collective_preallocation_setup(
+            owner="PCIe DCP A2A",
+            exchange_group=exchange_group,
+            setup=prepare,
+        )
+        _require_collective_contract(
+            owner="PCIe DCP A2A channel layout",
+            exchange_group=exchange_group,
+            contract=(
+                int(max_batch_size),
+                int(total_heads),
+                int(head_dim),
+                int(query_head_dim),
+                layout,
+            ),
+        )
+        slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group,
+            layout.slab_bytes,
+            zero_fill=True,
+            ipc=ipc,
+        )
+        runtime, init_error = cls._from_prepared_factory(
+            rank=rank,
+            world_size=world_size,
+            device=device_obj,
+            signal_ptrs=slab.peer_ptrs,
+            staging0_ptrs=tuple(ptr + layout.staging0_offset for ptr in slab.peer_ptrs),
+            staging1_ptrs=tuple(ptr + layout.staging1_offset for ptr in slab.peer_ptrs),
+            max_batch_size=max_batch_size,
+            total_heads=total_heads,
+            head_dim=head_dim,
+            output_capacity_elems=layout.output_capacity_elems,
+            lse_offset=layout.lse_offset,
+            lse_capacity=layout.lse_capacity,
+            query_head_dim=query_head_dim,
+            exchange_group=exchange_group,
+            ipc=ipc,
+            owned_buffers=[slab],
+            ext_module=ext,
+            stream_affine=stream_affine,
+        )
+
+        def abort_native_runtime() -> None:
+            pointer = getattr(runtime, "_ptr", 0)
+            if pointer:
+                ext.dispose(pointer)
+                runtime._ptr = 0
+
+        def detach_shared_ownership() -> None:
+            runtime._owned_buffers.clear()
+
+        _finish_collective_runtime_setup(
+            owner="PCIe DCP A2A",
+            exchange_group=exchange_group,
+            ipc=ipc,
+            shared=slab,
+            local_error=init_error,
+            local_cleanup=abort_native_runtime,
+            detach_shared_ownership=detach_shared_ownership,
+        )
+        return runtime
 
     @classmethod
     def from_process_group(
@@ -386,9 +670,7 @@ class PCIeDCPA2A:
                 f"output shape must be {expected_out}, got {tuple(out.shape)}"
             )
         if not _is_supported_bhd_layout(partial_output):
-            raise ValueError(
-                "partial_output must be packed token-major or head-major"
-            )
+            raise ValueError("partial_output must be packed token-major or head-major")
         if not partial_lse.is_contiguous():
             raise ValueError("partial_lse must be contiguous")
         if not _is_supported_bhd_layout(out):
@@ -480,39 +762,112 @@ class PCIeDCPA2A:
         )
         return out
 
-    def _close_ipc_imports(self) -> None:
+    def _closed_import_indices(self) -> set[tuple[int, int]]:
+        closed = getattr(self, "_closed_ipc_import_indices", None)
+        if closed is None:
+            closed = set()
+            self._closed_ipc_import_indices = closed
+        return closed
+
+    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
+        if self._ipc is None:
+            return not any(shared.remote_ptrs for shared in self._owned_buffers)
+        return all(
+            (buffer_index, remote_index) in closed
+            for buffer_index, shared in enumerate(self._owned_buffers)
+            for remote_index, _ in enumerate(shared.remote_ptrs)
+        )
+
+    def _close_ipc_imports_strict(self) -> None:
         if self._ipc_imports_closed:
             return
         self._closed = True
+        failures: list[tuple[str, Exception]] = []
         if getattr(self, "_ptr", 0):
-            with suppress(Exception):
+            try:
                 self._ext.dispose(self._ptr)
-            self._ptr = 0
-        if self._ipc is not None:
-            for shared in self._owned_buffers:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        self._ipc.cudaIpcCloseMemHandle(ptr)
-        self._ipc_imports_closed = True
+            except Exception as exc:
+                failures.append(("native runtime", exc))
+            else:
+                self._ptr = 0
 
-    def _free_ipc_exports(self) -> None:
+        closed = self._closed_import_indices()
+        if self._ipc is not None:
+            for buffer_index, shared in enumerate(self._owned_buffers):
+                for remote_index, ptr in enumerate(shared.remote_ptrs):
+                    key = (buffer_index, remote_index)
+                    if key in closed:
+                        continue
+                    try:
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                    except Exception as exc:
+                        failures.append((f"CUDA IPC import {ptr}", exc))
+                    else:
+                        closed.add(key)
+        elif any(shared.remote_ptrs for shared in self._owned_buffers):
+            failures.append(
+                (
+                    "CUDA IPC imports",
+                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
+                )
+            )
+
+        if (
+            not failures
+            and not getattr(self, "_ptr", 0)
+            and self._all_python_ipc_imports_closed(closed)
+        ):
+            self._ipc_imports_closed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC import close", failures)
+
+    def _free_ipc_exports_strict(self) -> None:
         if self._ipc_exports_freed:
             return
-        self._close_ipc_imports()
+        self._close_ipc_imports_strict()
+        failures: list[tuple[str, Exception]] = []
+        remaining = []
         if self._ipc is not None:
             for shared in self._owned_buffers:
-                with suppress(Exception):
+                try:
                     self._ipc.cudaFree(shared.local_ptr)
-        self._owned_buffers.clear()
-        self._ipc_exports_freed = True
+                except Exception as exc:
+                    remaining.append(shared)
+                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
+        elif self._owned_buffers:
+            remaining = list(self._owned_buffers)
+            failures.append(
+                (
+                    "CUDA IPC exports",
+                    RuntimeError("CUDA runtime is unavailable for export free"),
+                )
+            )
+        self._owned_buffers = remaining
+        if not remaining:
+            self._ipc_exports_freed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC export free", failures)
 
     def close(self) -> None:
-        self._close_ipc_imports()
-        self._free_ipc_exports()
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        _coordinated_close_channels(
+            (self,),
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
-    def __del__(self) -> None:
-        with suppress(Exception):
-            self.close()
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # Never unmap potentially in-flight CUDA work from GC. Retaining the
+        # complete object preserves both native ownership and Python IPC maps;
+        # explicit close() is the only synchronized teardown path.
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        if getattr(self, "_ptr", 0) or getattr(self, "_owned_buffers", ()):
+            _quarantine[id(self)] = self
 
 
 class PCIeDCPA2APool:
@@ -531,27 +886,115 @@ class PCIeDCPA2APool:
         exchange_group: Optional[ProcessGroup] = None,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
         channel_factory: Optional[Callable[[Optional[int]], PCIeDCPA2A]] = None,
     ) -> None:
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
-        self.rank = int(rank)
-        self.world_size = int(world_size)
-        self.device = _normalize_device(device)
-        self.max_batch_size = int(max_batch_size)
-        self.total_heads = int(total_heads)
-        self.head_dim = int(head_dim)
-        self.query_head_dim = int(query_head_dim or head_dim)
+        def normalize_and_validate():
+            normalized_rank = int(rank)
+            normalized_world_size = int(world_size)
+            device_obj = _normalize_device(device)
+            normalized_max_batch = int(max_batch_size)
+            normalized_total_heads = int(total_heads)
+            normalized_head_dim = int(head_dim)
+            normalized_query_dim = int(
+                head_dim if query_head_dim is None else query_head_dim
+            )
+            normalized_single_channel = bool(single_channel)
+            normalized_max_concurrent_channels = int(max_concurrent_channels)
+            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {normalized_world_size}")
+            if not 0 <= normalized_rank < normalized_world_size:
+                raise ValueError(
+                    f"invalid rank {normalized_rank} for world size "
+                    f"{normalized_world_size}"
+                )
+            if normalized_max_batch <= 0:
+                raise ValueError("max_batch_size must be positive")
+            if (
+                normalized_total_heads <= 0
+                or normalized_total_heads % normalized_world_size != 0
+            ):
+                raise ValueError("total_heads must be divisible by world_size")
+            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
+                raise ValueError("head_dim must be a positive multiple of 8")
+            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
+                raise ValueError("query_head_dim must be a positive multiple of 8")
+            if normalized_max_concurrent_channels <= 0:
+                raise ValueError("max_concurrent_channels must be positive")
+            if channel_factory is None:
+                if exchange_group is None:
+                    raise ValueError(
+                        "exchange_group is required unless channel_factory is set"
+                    )
+                if device_obj.type != "cuda":
+                    raise ValueError("PCIe DCP A2A pool requires a CUDA device")
+                group_rank = dist.get_rank(group=exchange_group)
+                group_world_size = dist.get_world_size(group=exchange_group)
+                if normalized_rank != group_rank:
+                    raise ValueError(
+                        f"supplied rank {normalized_rank} does not match process "
+                        f"group rank {group_rank}"
+                    )
+                if normalized_world_size != group_world_size:
+                    raise ValueError(
+                        f"supplied world size {normalized_world_size} does not "
+                        f"match process group size {group_world_size}"
+                    )
+            return (
+                normalized_rank,
+                normalized_world_size,
+                device_obj,
+                normalized_max_batch,
+                normalized_total_heads,
+                normalized_head_dim,
+                normalized_query_dim,
+                normalized_single_channel,
+                normalized_max_concurrent_channels,
+            )
+
+        if channel_factory is None and exchange_group is not None:
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe DCP A2A pool argument validation",
+                exchange_group=exchange_group,
+                setup=normalize_and_validate,
+            )
+        else:
+            normalized = normalize_and_validate()
+        (
+            self.rank,
+            self.world_size,
+            self.device,
+            self.max_batch_size,
+            self.total_heads,
+            self.head_dim,
+            self.query_head_dim,
+            self.single_channel,
+            self.max_concurrent_channels,
+        ) = normalized
         self.exchange_group = exchange_group
         self._ext = ext_module
-        self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeDCPA2A] = {}
+        self._logical_channels: dict[str, PCIeDCPA2A] = {}
+        self._captured_channel_ids: set[str] = set()
         self._all_channels: list[PCIeDCPA2A] = []
         self._capture_channel_stack: list[PCIeDCPA2A] = []
         self._closed = False
-        if channel_factory is None and exchange_group is None:
-            raise ValueError("exchange_group is required unless channel_factory is set")
+        if channel_factory is None:
+            assert self.exchange_group is not None
+            _require_collective_contract(
+                owner="PCIe DCP A2A pool overlap contract",
+                exchange_group=self.exchange_group,
+                contract=self.max_concurrent_channels,
+            )
+            _require_full_grid_residency(
+                owner="PCIe DCP A2A pool",
+                required_sms=(DCP_A2A_REQUIRED_SMS * self.max_concurrent_channels),
+                device=self.device,
+                exchange_group=self.exchange_group,
+            )
+        if channel_factory is None and self.single_channel:
+            self.prepare_channels((_SINGLE_CHANNEL_ID,))
 
     @classmethod
     def from_exchange_group(
@@ -565,6 +1008,7 @@ class PCIeDCPA2APool:
         query_head_dim: Optional[int] = None,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeDCPA2APool":
         return cls(
             rank=dist.get_rank(group=exchange_group),
@@ -577,6 +1021,7 @@ class PCIeDCPA2APool:
             exchange_group=exchange_group,
             ext_module=ext_module,
             single_channel=single_channel,
+            max_concurrent_channels=max_concurrent_channels,
         )
 
     @classmethod
@@ -591,6 +1036,7 @@ class PCIeDCPA2APool:
         query_head_dim: Optional[int] = None,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeDCPA2APool":
         return cls.from_exchange_group(
             exchange_group=process_group,
@@ -601,6 +1047,7 @@ class PCIeDCPA2APool:
             query_head_dim=query_head_dim,
             ext_module=ext_module,
             single_channel=single_channel,
+            max_concurrent_channels=max_concurrent_channels,
         )
 
     def _new_channel(self, stream_key: Optional[int]) -> PCIeDCPA2A:
@@ -622,17 +1069,71 @@ class PCIeDCPA2APool:
         self._all_channels.append(channel)
         return channel
 
-    def checkpoint_channels(self) -> tuple[int, dict[int, PCIeDCPA2A]]:
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        """Collectively allocate globally named channels in canonical order."""
+
+        if self._channel_factory is None:
+            assert self.exchange_group is not None
+
+            def normalize_and_validate() -> tuple[str, ...]:
+                if self._closed:
+                    raise RuntimeError("PCIeDCPA2APool is closed")
+                return tuple(
+                    sorted(
+                        {_normalize_logical_channel_id(value) for value in channel_ids}
+                    )
+                )
+
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe DCP A2A logical channel validation",
+                exchange_group=self.exchange_group,
+                setup=normalize_and_validate,
+            )
+            local_state = (normalized, tuple(sorted(self._logical_channels)))
+            gathered = _broadcast_gather_object(local_state, self.exchange_group)
+            if any(state != local_state for state in gathered):
+                raise RuntimeError(
+                    "PCIe DCP A2A logical channel preparation differs across "
+                    f"ranks: {gathered}"
+                )
+        else:
+            if self._closed:
+                raise RuntimeError("PCIeDCPA2APool is closed")
+            normalized = tuple(
+                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
+            )
+
+        if not normalized:
+            return
+
+        for channel_id in normalized:
+            if channel_id in self._logical_channels:
+                continue
+            self._logical_channels[channel_id] = self._new_channel(None)
+
+    def checkpoint_channels(
+        self,
+    ) -> tuple[
+        int,
+        dict[int, PCIeDCPA2A],
+        dict[str, PCIeDCPA2A],
+        set[str],
+    ]:
         """Snapshot channel ownership before a throwaway graph capture."""
         if self._closed:
             raise RuntimeError("PCIeDCPA2APool is closed")
         if self._capture_channel_stack:
             raise RuntimeError("cannot checkpoint channels during capture")
-        return len(self._all_channels), dict(self._channels)
+        return (
+            len(self._all_channels),
+            dict(self._channels),
+            dict(self._logical_channels),
+            set(self._captured_channel_ids),
+        )
 
     def rollback_channels(
         self,
-        checkpoint: tuple[int, dict[int, PCIeDCPA2A]],
+        checkpoint: tuple,
     ) -> None:
         """Close channels created after ``checkpoint`` and restore mappings.
 
@@ -643,15 +1144,25 @@ class PCIeDCPA2APool:
             raise RuntimeError("PCIeDCPA2APool is closed")
         if self._capture_channel_stack:
             raise RuntimeError("cannot roll back channels during capture")
-        all_channels_len, channels = checkpoint
+        if len(checkpoint) == 2:
+            all_channels_len, channels = checkpoint
+            logical_channels = dict(self._logical_channels)
+            captured_channel_ids = set(self._captured_channel_ids)
+        elif len(checkpoint) == 4:
+            (
+                all_channels_len,
+                channels,
+                logical_channels,
+                captured_channel_ids,
+            ) = checkpoint
+        else:
+            raise ValueError("invalid channel checkpoint")
         if not 0 <= all_channels_len <= len(self._all_channels):
             raise ValueError("channel checkpoint does not belong to this pool")
 
         retained = self._all_channels[:all_channels_len]
         retained_ids = {id(channel) for channel in retained}
         transient = self._all_channels[all_channels_len:]
-        self._all_channels = retained
-        self._channels = dict(channels)
 
         channels_to_close = tuple(
             dict.fromkeys(
@@ -663,8 +1174,19 @@ class PCIeDCPA2APool:
             exchange_group=self.exchange_group,
             device=self.device,
         )
+        # Ownership changes only after coordinated teardown succeeds.  A
+        # failed unmap/free remains reachable for an explicit retry.
+        self._all_channels = retained
+        self._channels = dict(channels)
+        self._logical_channels = dict(logical_channels)
+        self._captured_channel_ids = set(captured_channel_ids)
 
-    def for_stream(self, stream: object = None) -> PCIeDCPA2A:
+    def for_stream(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ) -> PCIeDCPA2A:
         if self._closed:
             raise RuntimeError("PCIeDCPA2APool is closed")
         if self.single_channel:
@@ -673,15 +1195,36 @@ class PCIeDCPA2APool:
         else:
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)
-        if (
-            not self.single_channel
-            and _is_current_stream_capturing(self.device)
-            and self._capture_channel_stack
-        ):
-            # Independent graph managers may reuse a torch-owned nested stream
-            # key. The enclosing capture, not a stale key mapping, determines
-            # which IPC channel is safe for this graph.
+        if not self.single_channel and self._capture_channel_stack:
+            # The semantic capture scope also owns vLLM's eager pre-capture
+            # warmup. During actual CUDA capture torch may use an ephemeral
+            # nested stream key, which must remain only a temporary alias;
+            # outside CUDA capture retain the normal stream-affinity check.
             channel = self._capture_channel_stack[-1]
+            if not _is_current_stream_capturing(self.device):
+                channel._bind_stream_key(stream_key)
+            self._channels[key] = channel
+            return channel
+        if self._channel_factory is None:
+            if channel_id is None:
+                raise RuntimeError(
+                    "distributed PCIe DCP A2A eager use requires an explicit "
+                    "semantic channel_id shared by every rank"
+                )
+            logical_id = _normalize_logical_channel_id(channel_id)
+            channel = self._logical_channels.get(logical_id)
+            if channel is None:
+                raise RuntimeError(
+                    f"logical channel {logical_id!r} is not prepared; call "
+                    "prepare_channels() collectively before use"
+                )
+            mapped = self._channels.get(key)
+            if mapped is not None and mapped is not channel:
+                raise RuntimeError(
+                    f"CUDA stream key {key} is already bound to another logical "
+                    "PCIe DCP A2A channel"
+                )
+            channel._bind_stream_key(stream_key)
             self._channels[key] = channel
             return channel
         channel = self._channels.get(key)
@@ -717,8 +1260,9 @@ class PCIeDCPA2APool:
         threads: int = 256,
         block_limit: int = 16,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> torch.Tensor:
-        channel = self.for_stream(stream)
+        channel = self.for_stream(stream, channel_id=channel_id)
         if stream is not None and self.device.type == "cuda":
             with torch.cuda.stream(stream):
                 return channel.lse_reduce_scatter(
@@ -746,8 +1290,9 @@ class PCIeDCPA2APool:
         threads: int = 256,
         block_limit: int = 16,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> torch.Tensor:
-        channel = self.for_stream(stream)
+        channel = self.for_stream(stream, channel_id=channel_id)
         if stream is not None and self.device.type == "cuda":
             with torch.cuda.stream(stream):
                 return channel.all_gather_heads(
@@ -764,16 +1309,70 @@ class PCIeDCPA2APool:
         )
 
     @contextmanager
-    def capture(self, stream: object = None):
-        """Bind nested CUDA captures to the enclosing stream's channel."""
+    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
+        """Bind capture to a globally named channel.
+
+        Explicit unknown ids are prepared collectively and fail closed when
+        rank ids differ. Production callers should pre-prepare the full set of
+        independently replayable graph ids before entering any capture; after
+        that collective preparation, ranks may capture members of the agreed
+        catalog in different orders. Each graph must still replay with its
+        same-id peers using collectively compatible kernel sequences and
+        shapes.
+
+        Distributed pools require this semantic id. Local ordinals and stream
+        handles cannot identify target versus draft graphs across ranks.
+        """
+        previous_channels: Optional[dict[int, PCIeDCPA2A]] = None
+        if not self.single_channel and _is_current_stream_capturing(self.device):
+            raise RuntimeError(
+                "PCIe DCP A2A capture context must be entered before CUDA graph "
+                "capture starts"
+            )
         if self.single_channel:
-            channel = self.for_stream(stream)
+            channel = self.for_stream(
+                stream,
+                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
+            )
+        elif self._channel_factory is None:
+            assert self.exchange_group is not None
+
+            def validate_capture_id() -> str:
+                if channel_id is None:
+                    raise RuntimeError(
+                        "distributed PCIe DCP A2A capture requires a stable "
+                        "semantic channel_id shared by every rank"
+                    )
+                logical_id = _normalize_logical_channel_id(channel_id)
+                if logical_id in self._captured_channel_ids:
+                    raise RuntimeError(
+                        f"logical channel {logical_id!r} was already captured; "
+                        "each independently replayable graph requires a unique id"
+                    )
+                return logical_id
+
+            logical_id = _run_collective_preallocation_setup(
+                owner="PCIe DCP A2A capture channel validation",
+                exchange_group=self.exchange_group,
+                setup=validate_capture_id,
+            )
+            needs_preparation = _collective_capture_needs_preparation(
+                owner="PCIe DCP A2A",
+                logical_id=logical_id,
+                prepared_channel_ids=self._logical_channels,
+                exchange_group=self.exchange_group,
+            )
+            if needs_preparation:
+                self.prepare_channels((logical_id,))
+            previous_channels = dict(self._channels)
+            stream_key = _current_stream_key(self.device, stream)
+            key = 0 if stream_key is None else int(stream_key)
+            channel = self._logical_channels[logical_id]
+            channel._bind_stream_key(stream_key)
+            self._channels[key] = channel
+            self._captured_channel_ids.add(logical_id)
         else:
-            if _is_current_stream_capturing(self.device):
-                raise RuntimeError(
-                    "PCIe DCP A2A capture context must be entered before CUDA "
-                    "graph capture starts"
-                )
+            previous_channels = dict(self._channels)
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)
             # Keep a graph-owned channel even when CUDA recycles the enclosing
@@ -787,22 +1386,48 @@ class PCIeDCPA2APool:
             popped = self._capture_channel_stack.pop()
             if popped is not channel:
                 raise RuntimeError("PCIe DCP A2A capture channel stack corrupted")
+            if previous_channels is not None:
+                # Captured graph nodes retain the channel through
+                # ``_all_channels``. Restore eager mappings and discard every
+                # nested capture-stream alias so a recycled stream key cannot
+                # hand this graph-owned channel to a later unwrapped capture.
+                for key, mapped in tuple(self._channels.items()):
+                    if mapped is not channel:
+                        continue
+                    previous = previous_channels.get(key)
+                    if previous is None:
+                        del self._channels[key]
+                    else:
+                        self._channels[key] = previous
 
     def close(self) -> None:
         if self._closed:
             return
-        self._closed = True
         seen: set[int] = set()
+        channels = []
         for channel in (*self._all_channels, *self._channels.values()):
             if id(channel) not in seen:
                 seen.add(id(channel))
-                channel.close()
+                channels.append(channel)
+        _coordinated_close_channels(
+            channels,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
+        self._closed = True
         self._all_channels.clear()
         self._channels.clear()
+        self._logical_channels.clear()
+        self._captured_channel_ids.clear()
 
-    def __del__(self) -> None:
-        with suppress(Exception):
-            self.close()
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # Graphs may retain these channels after Python ownership disappears.
+        # Explicit close() is required for synchronization and peer teardown.
+        if not getattr(self, "_closed", True):
+            _quarantine[id(self)] = self
 
 
 __all__ = [

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -300,20 +300,35 @@ class PCIeDCPA2A:
         else:
             normalized = normalize_and_validate()
 
+        (
+            prepared_device,
+            prepared_rank,
+            prepared_world_size,
+            prepared_signals,
+            prepared_staging0,
+            prepared_staging1,
+            prepared_max_batch,
+            prepared_total_heads,
+            prepared_head_dim,
+            prepared_query_dim,
+            prepared_output_capacity,
+            prepared_lse_offset,
+            prepared_lse_capacity,
+        ) = normalized
         self._initialize_prepared_state(
-            rank=normalized[1],
-            world_size=normalized[2],
-            device=normalized[0],
-            signal_ptrs=normalized[3],
-            staging0_ptrs=normalized[4],
-            staging1_ptrs=normalized[5],
-            max_batch_size=normalized[6],
-            total_heads=normalized[7],
-            head_dim=normalized[8],
-            query_head_dim=normalized[9],
-            output_capacity_elems=normalized[10],
-            lse_offset=normalized[11],
-            lse_capacity=normalized[12],
+            rank=prepared_rank,
+            world_size=prepared_world_size,
+            device=prepared_device,
+            signal_ptrs=prepared_signals,
+            staging0_ptrs=prepared_staging0,
+            staging1_ptrs=prepared_staging1,
+            max_batch_size=prepared_max_batch,
+            total_heads=prepared_total_heads,
+            head_dim=prepared_head_dim,
+            query_head_dim=prepared_query_dim,
+            output_capacity_elems=prepared_output_capacity,
+            lse_offset=prepared_lse_offset,
+            lse_capacity=prepared_lse_capacity,
             exchange_group=exchange_group,
             ipc=ipc,
             owned_buffers=owned_buffers,
@@ -1192,6 +1207,8 @@ class PCIeDCPA2APool:
         if self.single_channel:
             key = 0
             stream_key = None
+            if self._channel_factory is None and channel_id is None:
+                channel_id = _SINGLE_CHANNEL_ID
         else:
             stream_key = _current_stream_key(self.device, stream)
             key = 0 if stream_key is None else int(stream_key)

--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
+++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
@@ -23,6 +23,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ipc_handle_registry.h"
+
 #define CHECK_CUDA_SUCCESS(cmd)                                         \
   do {                                                                  \
     cudaError_t e = cmd;                                                \
@@ -76,6 +78,8 @@ static bool oneshot_push_enabled() {
 }
 
 struct Signal {
+  alignas(128) FlagType staging_generation;
+  FlagType active_staging_slot;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
   alignas(128) FlagType rms_arrive[kMaxBlocks];
@@ -85,6 +89,10 @@ struct Signal {
 
 struct __align__(16) RankData {
   const void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct DoubleRankData {
+  RankData* slots[2];
 };
 
 struct __align__(16) RankSignals {
@@ -189,6 +197,28 @@ static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
   return flag;
 }
 
+__global__ void advance_staging_slot_kernel(Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    const FlagType generation = self_sg->staging_generation;
+    self_sg->active_staging_slot = generation & FlagType{1};
+    self_sg->staging_generation = generation + FlagType{1};
+  }
+}
+
+template <int ngpus>
+DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    // A one-CTA control kernel publishes the slot on this same stream before
+    // the worker launch. Kernel completion is the ordering edge, so every CTA
+    // observes one launch-wide slot without a grid rendezvous.
+    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
+    const RankData* source = options.slots[slot];
+#pragma unroll
+    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
+  }
+  __syncthreads();
+}
+
 template <int ngpus, bool is_start>
 DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
   if constexpr (!is_start) __syncthreads();
@@ -253,17 +283,23 @@ DINLINE float block_reduce_sum(float value, float* warp_sums) {
 // sufficient for staging visibility.
 template <typename T, int ngpus, bool stage_input>
 __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
-    RankData* _dp,
+    DoubleRankData data_options,
     RankSignals sg,
     Signal* self_sg,
     const T* __restrict__ input,
     T* __restrict__ result,
-    T* __restrict__ self_staging,
     int rank,
     int size) {
   using P = typename packed_t<T>::P;
   using A = typename packed_t<T>::A;
-  auto dp = *_dp;
+  RankData dp;
+  if constexpr (stage_input) {
+    __shared__ RankData selected;
+    select_rank_data<ngpus>(selected, data_options, self_sg);
+    dp = selected;
+  } else {
+    dp = *data_options.slots[0];
+  }
   const P* rotated[ngpus];
 #pragma unroll
   for (int i = 0; i < ngpus; i++) {
@@ -271,7 +307,8 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
   }
   if constexpr (stage_input) {
     const P* input_p = reinterpret_cast<const P*>(input);
-    P* staging_p = reinterpret_cast<P*>(self_staging);
+    P* staging_p =
+        reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
     for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
       staging_p[idx] = input_p[idx];
     }
@@ -304,7 +341,9 @@ constexpr int kModeRegistered = 0;
 constexpr int kModeStagePull = 1;
 constexpr int kModeStagePush = 2;
 
-// Complete the allreduce, residual add, and RMSNorm in one launch.
+// Complete the allreduce, residual add, and RMSNorm in one worker launch.
+// Staged paths prepend one 1-CTA slot-control launch; the registered path
+// remains a single worker launch.
 //
 // Geometry is uniform: gridDim.x == rows * ctas_per_row and block b serves
 // row b / ctas_per_row, owning columns {(b % ctas_per_row) * blockDim.x +
@@ -323,12 +362,12 @@ constexpr int kModeStagePush = 2;
 // only. Otherwise each CTA publishes one fp32 square-sum partial, crosses a
 // sense-reversing per-row generation barrier, and normalizes its own columns
 // from registers, so no CTA re-reads the row it just wrote. All CTAs of a
-// row spin, which is safe for the same reason the cross-rank start barrier
-// is: the grid never exceeds kMaxBlocks <= SM count, so every block is
-// resident.
+// row spin. The host derives the concrete kernel's resident-grid capacity
+// from CUDA occupancy before capture and caps the multi-CTA grid to that
+// device-specific value; no SM-count or full-GPU assumption is baked in.
 template <typename T, int ngpus, bool single_cta, int mode>
 __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kernel(
-    RankData* _dp,
+    DoubleRankData data_options,
     RankSignals sg,
     Signal* self_sg,
     const T* __restrict__ input,
@@ -336,7 +375,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
     const T* __restrict__ weight,
     T* __restrict__ output,
     T* __restrict__ residual_output,
-    T* __restrict__ self_staging,
     int rank,
     int hidden_packs,
     int ctas_per_row,
@@ -346,6 +384,14 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   using A = typename packed_t<T>::A;
   __shared__ float warp_sums[32];
   __shared__ float s_inv_rms;
+  RankData dp;
+  if constexpr (mode == kModeRegistered) {
+    dp = *data_options.slots[0];
+  } else {
+    __shared__ RankData selected;
+    select_rank_data<ngpus>(selected, data_options, self_sg);
+    dp = selected;
+  }
 
   const int row = single_cta ? blockIdx.x : blockIdx.x / ctas_per_row;
   const int row_cta = single_cta ? 0 : blockIdx.x - row * ctas_per_row;
@@ -355,7 +401,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   const int max_packs = (hidden_packs + col_stride - 1) / col_stride;
   const bool reg_norm = max_packs <= kRegPacks;
 
-  auto dp = *_dp;
   const P* rotated[ngpus];
 #pragma unroll
   for (int i = 0; i < ngpus; i++) {
@@ -367,7 +412,7 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   const P* weight_p = reinterpret_cast<const P*>(weight);
   P* output_p = reinterpret_cast<P*>(output);
   P* residual_output_p = reinterpret_cast<P*>(residual_output);
-  P* staging_p = reinterpret_cast<P*>(self_staging);
+  P* staging_p = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
 
   // Sense-reversing row barrier: latch the generation before arriving.
   // Launches are stream-serialized, so this read cannot race a peer CTA's
@@ -550,10 +595,51 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
   }
 }
 
+template <typename T, int ngpus, int mode>
+int fused_resident_grid_capacity(int threads) {
+  int blocks_per_sm = 0;
+  CHECK_CUDA_SUCCESS(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_sm,
+      pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, false, mode>,
+      threads,
+      0));
+  int device = 0;
+  int sm_count = 0;
+  CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
+  CHECK_CUDA_SUCCESS(
+      cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
+  if (blocks_per_sm <= 0 || sm_count <= 0) {
+    throw std::runtime_error(
+        "CUDA reported no resident capacity for fused PCIe RMSNorm");
+  }
+  return blocks_per_sm * sm_count;
+}
+
+template <typename T, int ngpus>
+std::array<int, 3> fused_resident_capacities(int threads) {
+  return {
+      fused_resident_grid_capacity<T, ngpus, kModeRegistered>(threads),
+      fused_resident_grid_capacity<T, ngpus, kModeStagePull>(threads),
+      fused_resident_grid_capacity<T, ngpus, kModeStagePush>(threads),
+  };
+}
+
+static int cap_fused_ctas_per_row(int requested, int rows,
+                                  int resident_capacity) {
+  if (rows <= 0 || resident_capacity <= 0) {
+    throw std::runtime_error("invalid fused PCIe resident-grid capacity");
+  }
+  return std::max(
+      1, std::min(requested, std::max(1, resident_capacity / rows)));
+}
+
 using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
 
 class PCIeAllreduce {
  public:
+  using IPCHandles =
+      sparkinfer::pcie::IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>;
+
   int rank_;
   int world_size_;
 
@@ -563,31 +649,108 @@ class PCIeAllreduce {
 
   RankData *d_rank_data_base_, *d_rank_data_end_;
   std::vector<void*> graph_unreg_buffers_;
-  std::map<IPC_KEY, char*> ipc_handles_;
+  IPCHandles ipc_handles_;
+
+  // [float, half, bf16][registered, pull, push], queried once during native
+  // runtime construction (outside CUDA graph capture) and reused by captures.
+  std::array<std::array<int, 3>, 3> fused_resident_capacity_{};
 
   bool dbuf_enabled_ = false;
-  int dbuf_slot_ = 0;
-  void* dbuf_raw_[2][kMaxRanks] = {};
-  RankData* dbuf_rd_[2] = {};
+  DoubleRankData dbuf_data_ = {};
 
   PCIeAllreduce(Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size)
       : rank_(rank),
         world_size_(world_size),
         self_sg_(signals[rank]),
         d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
-        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
+        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)),
+        ipc_handles_(&PCIeAllreduce::close_ipc_handle) {
     for (int i = 0; i < world_size_; i++) sg_.signals[i] = signals[i];
+    const int threads = fused_threads();
+#define CACHE_CAPACITY(ngpus)                                                   \
+    do {                                                                        \
+      fused_resident_capacity_[0] = fused_resident_capacities<float, ngpus>(threads); \
+      fused_resident_capacity_[1] = fused_resident_capacities<half, ngpus>(threads);  \
+      fused_resident_capacity_[2] =                                             \
+          fused_resident_capacities<nv_bfloat16, ngpus>(threads);               \
+    } while (0)
+    switch (world_size_) {
+      case 2: CACHE_CAPACITY(2); break;
+      case 4: CACHE_CAPACITY(4); break;
+      case 6: CACHE_CAPACITY(6); break;
+      case 8: CACHE_CAPACITY(8); break;
+      case 10: CACHE_CAPACITY(10); break;
+      default:
+        throw std::invalid_argument("unsupported PCIe allreduce world size");
+    }
+#undef CACHE_CAPACITY
+    // Deterministic reduced-capacity/MIG-like validation may lower (never
+    // raise) CUDA's measured capacity. This is a test-only safety override.
+    const int test_capacity =
+        env_int("SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY", 0);
+    if (test_capacity > 0) {
+      for (auto& dtype_capacities : fused_resident_capacity_) {
+        for (int& capacity : dtype_capacities) {
+          capacity = std::min(capacity, test_capacity);
+        }
+      }
+    }
+  }
+
+  template <typename T>
+  int fused_resident_capacity(int mode) const {
+    constexpr int dtype_index = std::is_same<T, float>::value
+                                    ? 0
+                                    : (std::is_same<T, half>::value ? 1 : 2);
+    if (mode < kModeRegistered || mode > kModeStagePush) {
+      throw std::runtime_error("invalid fused PCIe transport mode");
+    }
+    return fused_resident_capacity_[dtype_index][mode];
+  }
+
+  static cudaError_t close_ipc_handle(char* ptr) noexcept {
+    return cudaIpcCloseMemHandle(ptr);
   }
 
   char* open_ipc_handle(const void* ipc_handle) {
-    auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
-    if (new_handle) {
-      char* ipc_ptr;
-      CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
-          (void**)&ipc_ptr, *((const cudaIpcMemHandle_t*)ipc_handle), cudaIpcMemLazyEnablePeerAccess));
-      it->second = ipc_ptr;
+    const auto& key = *reinterpret_cast<const IPC_KEY*>(ipc_handle);
+    auto existing = ipc_handles_.find(key);
+    if (existing != ipc_handles_.end()) {
+      return existing->second;
     }
-    return it->second;
+
+    char* ipc_ptr;
+    CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
+        reinterpret_cast<void**>(&ipc_ptr),
+        *reinterpret_cast<const cudaIpcMemHandle_t*>(ipc_handle),
+        cudaIpcMemLazyEnablePeerAccess));
+    try {
+      auto [inserted, is_new] = ipc_handles_.emplace(key, ipc_ptr);
+      if (!is_new) {
+        // Defensively avoid double ownership if this insertion path changes.
+        (void)cudaIpcCloseMemHandle(ipc_ptr);
+        return inserted->second;
+      }
+      return inserted->second;
+    } catch (...) {
+      // Do not leak a successfully opened mapping if map allocation fails.
+      (void)cudaIpcCloseMemHandle(ipc_ptr);
+      throw;
+    }
+  }
+
+  cudaError_t close_ipc_handles_noexcept() noexcept {
+    return ipc_handles_.close_all_noexcept();
+  }
+
+  void close_ipc_handles_strict() {
+    const cudaError_t error = close_ipc_handles_noexcept();
+    if (error != cudaSuccess) {
+      const char* description = cudaGetErrorString(error);
+      throw std::runtime_error(
+          std::string("cudaIpcCloseMemHandle failed while disposing PCIe allreduce: ") +
+          (description == nullptr ? "unknown CUDA error" : description));
+    }
   }
 
   std::pair<std::string, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
@@ -616,17 +779,14 @@ class PCIeAllreduce {
     for (int s = 0; s < 2; s++) {
       void** ptrs = s == 0 ? ptrs0 : ptrs1;
       RankData data;
-      for (int i = 0; i < world_size_; i++) {
-        data.ptrs[i] = ptrs[i];
-        dbuf_raw_[s][i] = ptrs[i];
-      }
-      dbuf_rd_[s] = d_rank_data_base_++;
-      CHECK_CUDA_SUCCESS(cudaMemcpy(dbuf_rd_[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
+      for (int i = 0; i < world_size_; i++) data.ptrs[i] = ptrs[i];
+      dbuf_data_.slots[s] = d_rank_data_base_++;
+      CHECK_CUDA_SUCCESS(
+          cudaMemcpy(dbuf_data_.slots[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
     }
-    buffers_[ptrs0[rank_]] = dbuf_rd_[0];
-    buffers_[ptrs1[rank_]] = dbuf_rd_[1];
+    buffers_[ptrs0[rank_]] = dbuf_data_.slots[0];
+    buffers_[ptrs1[rank_]] = dbuf_data_.slots[1];
     dbuf_enabled_ = true;
-    dbuf_slot_ = 0;
   }
 
   void register_buffer(void** ptrs) {
@@ -678,18 +838,16 @@ class PCIeAllreduce {
     if (block_limit > kMaxBlocks)
       throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks));
 
-    RankData* ptrs;
-    T* staging = nullptr;
+    DoubleRankData data_options = {};
+    bool stage_input = false;
     cudaStreamCaptureStatus status;
     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
 
     if (dbuf_enabled_) {
-      // The kernel stages the input into the eager slot itself; no host
-      // staging memcpy is issued.
-      int slot = dbuf_slot_ % 2;
-      dbuf_slot_++;
-      ptrs = dbuf_rd_[slot];
-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+      // A captured control kernel advances the active eager slab on every
+      // execution, including CUDA graph replay.
+      data_options = dbuf_data_;
+      stage_input = true;
     } else if (status == cudaStreamCaptureStatusActive) {
       throw std::runtime_error(
           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
@@ -699,22 +857,27 @@ class PCIeAllreduce {
       if (it == buffers_.end())
         throw std::runtime_error(
             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
-      ptrs = it->second;
+      data_options.slots[0] = it->second;
+      data_options.slots[1] = it->second;
     }
 
     size /= d;
     int blocks = std::min(block_limit, (size + threads - 1) / threads);
     blocks = std::max(blocks, 1);
+    if (stage_input) {
+      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
+      CHECK_CUDA_SUCCESS(cudaGetLastError());
+    }
 
 #define KL(ngpus)                                                                                                     \
   do {                                                                                                               \
-    if (staging != nullptr) {                                                                                        \
+    if (stage_input) {                                                                                               \
       pcie_allreduce_kernel<T, ngpus, true>                                                                          \
-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
     } else {                                                                                                         \
       pcie_allreduce_kernel<T, ngpus, false>                                                                         \
-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
-    }                                                                                                                 \
+          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
+    }                                                                                                                \
   } while (0)
     switch (world_size_) {
       case 2:
@@ -735,6 +898,7 @@ class PCIeAllreduce {
       default:
         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
     }
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
 #undef KL
   }
 
@@ -757,17 +921,15 @@ class PCIeAllreduce {
       throw std::runtime_error(
           "fused allreduce RMSNorm requires hidden size to be a multiple of " + std::to_string(pack_size));
 
-    RankData* ptrs;
-    T* staging = nullptr;
+    DoubleRankData data_options = {};
+    bool use_eager_staging = false;
     cudaStreamCaptureStatus status;
     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
     if (dbuf_enabled_) {
-      // The kernel stages the input into the eager slot itself; no host
-      // staging memcpy is issued.
-      int slot = dbuf_slot_ % 2;
-      dbuf_slot_++;
-      ptrs = dbuf_rd_[slot];
-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
+      // A captured control kernel advances the active eager slab on every
+      // execution, including CUDA graph replay.
+      data_options = dbuf_data_;
+      use_eager_staging = true;
     } else if (status == cudaStreamCaptureStatusActive) {
       throw std::runtime_error(
           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
@@ -777,7 +939,8 @@ class PCIeAllreduce {
       if (it == buffers_.end())
         throw std::runtime_error(
             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
-      ptrs = it->second;
+      data_options.slots[0] = it->second;
+      data_options.slots[1] = it->second;
     }
 
     int rows = size / hidden_size;
@@ -797,17 +960,27 @@ class PCIeAllreduce {
       ctas_per_row = std::max(std::max(1, 3 / rows), min_ctas);
     }
     ctas_per_row = std::max(1, std::min(ctas_per_row, kMaxBlocks / rows));
+    const int mode = !use_eager_staging   ? kModeRegistered
+                     : oneshot_push_enabled() ? kModeStagePush
+                                              : kModeStagePull;
+    const int resident_capacity = fused_resident_capacity<T>(mode);
+    // Multi-CTA row barriers can only be used when the complete grid is
+    // simultaneously resident. This also handles reduced/MIG-like devices;
+    // fall back to the barrier-free single-CTA path when capacity is tight.
+    ctas_per_row =
+        cap_fused_ctas_per_row(ctas_per_row, rows, resident_capacity);
     const int blocks = rows * ctas_per_row;
     const bool single = ctas_per_row == 1;
     const int shard_packs = size / pack_size;
-    const int mode = staging == nullptr ? kModeRegistered
-                     : oneshot_push_enabled() ? kModeStagePush
-                                              : kModeStagePull;
+    if (use_eager_staging) {
+      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
+      CHECK_CUDA_SUCCESS(cudaGetLastError());
+    }
 
 #define KL(ngpus, SINGLE, MODE)                                                                                       \
-  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \
-      ptrs, sg_, self_sg_, input, residual, weight, output, residual_output, staging, rank_, hidden_packs,            \
-      ctas_per_row, shard_packs, epsilon);
+  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE>                                                    \
+      <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, residual, weight, output,                \
+                                       residual_output, rank_, hidden_packs, ctas_per_row, shard_packs, epsilon);
 #define DISPATCH_MODE(ngpus, SINGLE)                                                                                  \
   do {                                                                                                               \
     if (mode == kModeStagePush) {                                                                                    \
@@ -845,14 +1018,13 @@ class PCIeAllreduce {
       default:
         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
     }
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
 #undef DISPATCH
 #undef DISPATCH_MODE
 #undef KL
   }
 
-  ~PCIeAllreduce() {
-    for (auto [_, ptr] : ipc_handles_) CHECK_CUDA_SUCCESS(cudaIpcCloseMemHandle(ptr));
-  }
+  ~PCIeAllreduce() noexcept = default;
 };
 
 }  // namespace pcie_allreduce
@@ -995,7 +1167,18 @@ static void all_reduce_fused_add_rms_norm(
 }
 
 static void dispose(fptr_t _fa) {
-  delete reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  if (fa == nullptr) return;
+  fa->close_ipc_handles_strict();
+  delete fa;
+}
+
+static bool dispose_best_effort(fptr_t _fa) noexcept {
+  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
+  if (fa == nullptr) return true;
+  const cudaError_t error = fa->close_ipc_handles_noexcept();
+  delete fa;
+  return error == cudaSuccess;
 }
 
 static int64_t meta_size() {
@@ -1046,7 +1229,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       "all_reduce_fused_add_rms_norm",
       &all_reduce_fused_add_rms_norm,
       "PCIe allreduce fused with residual add and RMSNorm");
-  m.def("dispose", &dispose, "dispose PCIe allreduce");
+  m.def(
+      "dispose",
+      &dispose,
+      "strictly dispose PCIe allreduce; retain it for retry if an IPC close fails");
+  m.def(
+      "dispose_best_effort",
+      &dispose_best_effort,
+      "nonthrowing PCIe allreduce dispose; return whether every native IPC import closed");
   m.def("meta_size", &meta_size, "signal metadata size");
   m.def("register_buffer", &register_buffer, "register IPC buffer");
   m.def("register_pcie_buffers", &register_pcie_buffers, "register double-buffered IPC buffers");

--- a/sparkinfer/comm/pcie/pcie_oneshot.py
+++ b/sparkinfer/comm/pcie/pcie_oneshot.py
@@ -992,9 +992,8 @@ def _coordinated_close_channels(
             torch.cuda.synchronize(device)
         dist.barrier(group=exchange_group)
 
-    # Older DCP channels still expose the legacy best-effort protocol. Keep
-    # their existing ordering until they receive their own lifecycle migration;
-    # oneshot and twoshot opt into the strict peer-status protocol below.
+    # Channels with strict cleanup report local unmap status before any rank
+    # releases exports. Legacy channels retain their original ordered close.
     uses_strict_protocol = any(
         hasattr(channel, "_close_ipc_imports_strict") for channel in unique_channels
     )
@@ -1471,7 +1470,6 @@ class PCIeOneshotAllReduce:
         self._ipc_imports_closed = False
         self._ipc_exports_freed = False
         self._coordinated_close_complete = False
-        self._native_ipc_import_close_failed = False
         self._closed_ipc_import_indices: set[tuple[int, int]] = set()
         self._ptr = 0
         self._eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
@@ -2306,16 +2304,6 @@ class PCIeOneshotAllReduce:
             return
         self._closed = True
         failures: list[tuple[str, Exception]] = []
-        if getattr(self, "_native_ipc_import_close_failed", False):
-            failures.append(
-                (
-                    "native runtime",
-                    RuntimeError(
-                        "a native IPC import failed during best-effort teardown "
-                        "and can no longer be retried"
-                    ),
-                )
-            )
         if getattr(self, "_ptr", 0):
             try:
                 self._ext.dispose(self._ptr)
@@ -2353,49 +2341,6 @@ class PCIeOneshotAllReduce:
             self._ipc_imports_closed = True
         if failures:
             _raise_local_cleanup_errors("PCIe oneshot", "IPC import close", failures)
-
-    def _close_ipc_imports_best_effort(self) -> None:
-        if self._ipc_imports_closed:
-            return
-        self._closed = True
-        native_imports_closed = not getattr(self, "_ptr", 0)
-        if getattr(self, "_ptr", 0):
-            dispose = getattr(self._ext, "dispose_best_effort", None)
-            if dispose is None:
-                dispose = self._ext.dispose
-            try:
-                result = dispose(self._ptr)
-            except Exception:
-                pass
-            else:
-                self._ptr = 0
-                # The native best-effort binding reports whether every graph
-                # import closed. Legacy/fake dispose methods return None and
-                # report failure by raising.
-                native_imports_closed = result is not False
-                if not native_imports_closed:
-                    self._native_ipc_import_close_failed = True
-
-        closed = self._closed_import_indices()
-        if self._ipc is not None:
-            for buffer_index, shared in enumerate(self._owned_buffers):
-                for remote_index, ptr in enumerate(shared.remote_ptrs):
-                    key = (buffer_index, remote_index)
-                    if key in closed:
-                        continue
-                    try:
-                        self._ipc.cudaIpcCloseMemHandle(ptr)
-                    except Exception:
-                        pass
-                    else:
-                        closed.add(key)
-
-        if (
-            native_imports_closed
-            and not getattr(self, "_ptr", 0)
-            and self._all_python_ipc_imports_closed(closed)
-        ):
-            self._ipc_imports_closed = True
 
     def _free_ipc_exports_strict(self) -> None:
         if self._ipc_exports_freed:

--- a/sparkinfer/comm/pcie/pcie_oneshot.py
+++ b/sparkinfer/comm/pcie/pcie_oneshot.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import os
 import time
-from contextlib import contextmanager, suppress
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from functools import lru_cache
+from itertools import count
 from pathlib import Path
-from typing import Callable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence, TypeVar
 
 import torch
 import torch.distributed as dist
@@ -28,6 +29,18 @@ DEFAULT_RANK_DATA_BYTES = 8 * 1024 * 1024
 AUTOTUNE_CEILING = 1 * 1024 * 1024
 AUTOTUNE_FINE_STEP = 8 * 1024
 IPC_SLAB_ALIGNMENT = 256
+ONESHOT_REQUIRED_SMS = 36
+_SINGLE_CHANNEL_ID = "__single__"
+
+# CUDA graph nodes and the native runtime retain raw pointers into rank_data.
+# GC cannot synchronize arbitrary streams, so an abandoned runtime must keep
+# its complete Python ownership graph alive until process teardown.  Explicit
+# close() is the only path that removes this need.  A dict makes manual/finalizer
+# re-entry idempotent while the retained object prevents id reuse.
+_ABANDONED_PCIE_RUNTIME_QUARANTINE: dict[int, object] = {}
+_RETAINED_FAILED_IPC_EXPORTS: dict[tuple[int, int], "_RetryableIPCExport"] = {}
+_RETAINED_IPC_SETUP_GENERATIONS = count(1)
+_SetupResult = TypeVar("_SetupResult")
 
 
 def parse_pcie_oneshot_max_size(value: str | int | None) -> Optional[int]:
@@ -58,6 +71,12 @@ def _normalize_device(device: torch.device | int | str) -> torch.device:
     if isinstance(device, int):
         return torch.device(f"cuda:{device}")
     return torch.device(device)
+
+
+def _cuda_device_index(device: torch.device) -> int:
+    if device.type != "cuda":
+        raise ValueError("expected a CUDA device")
+    return torch.cuda.current_device() if device.index is None else int(device.index)
 
 
 def _current_stream_key(
@@ -110,13 +129,88 @@ def _resolve_exchange_group(
     return exchange_group if exchange_group is not None else process_group
 
 
+def _normalize_logical_channel_id(channel_id: str) -> str:
+    if not isinstance(channel_id, str):
+        raise TypeError("logical channel id must be a string")
+    normalized = channel_id.strip()
+    if not normalized:
+        raise ValueError("logical channel id must not be empty")
+    return normalized
+
+
+def _collective_capture_needs_preparation(
+    *,
+    owner: str,
+    logical_id: str,
+    prepared_channel_ids: Iterable[str],
+    exchange_group: ProcessGroup,
+) -> bool:
+    """Decide whether capture may use the prepared catalog without allocation.
+
+    Once every rank has prepared the same complete graph catalog, ranks may
+    capture those graphs in different orders.  Allocation remains collective:
+    a same-id unknown channel may use the convenience preparation path, while
+    any differing request that includes an unknown id fails before allocation.
+    """
+
+    catalog = tuple(sorted(prepared_channel_ids))
+    local_state = (logical_id, catalog)
+    gathered = _broadcast_gather_object(local_state, exchange_group)
+    if not gathered:
+        raise RuntimeError(f"{owner} capture contract returned no rank states")
+
+    requested_ids: list[str] = []
+    for group_rank, state in enumerate(gathered):
+        if not isinstance(state, (tuple, list)) or len(state) != 2:
+            raise RuntimeError(
+                f"invalid {owner} capture contract from group rank {group_rank}"
+            )
+        requested_id, peer_catalog = state
+        if not isinstance(requested_id, str) or not isinstance(
+            peer_catalog, (tuple, list)
+        ):
+            raise RuntimeError(
+                f"invalid {owner} capture contract from group rank {group_rank}"
+            )
+        peer_catalog = tuple(peer_catalog)
+        if any(not isinstance(value, str) for value in peer_catalog):
+            raise RuntimeError(
+                f"invalid {owner} capture contract from group rank {group_rank}"
+            )
+        if peer_catalog != catalog:
+            raise RuntimeError(
+                f"{owner} prepared channel catalog differs across ranks: {gathered}"
+            )
+        requested_ids.append(requested_id)
+
+    if all(requested_id in catalog for requested_id in requested_ids):
+        # The canonical catalog already fixed allocation order.  Current graph
+        # capture order is process-local and need not agree across ranks.
+        return False
+    if all(requested_id == requested_ids[0] for requested_id in requested_ids):
+        # Preserve the collective same-id convenience allocation path.
+        return True
+    raise RuntimeError(
+        f"{owner} capture requested unprepared logical channels in differing "
+        f"rank order: requested={tuple(requested_ids)}, prepared={catalog}; call "
+        "prepare_channels() collectively with the complete graph set first"
+    )
+
+
 def _group_ranks(group: ProcessGroup) -> list[int]:
     world_size = dist.get_world_size(group=group)
     if hasattr(dist, "get_process_group_ranks"):
-        ranks = sorted(dist.get_process_group_ranks(group=group))
+        # Process-group rank is an index into the order returned here.  Sorting
+        # silently changes that mapping for non-monotonic groups and makes the
+        # handle in slot N belong to a different peer than group rank N.
+        ranks = list(dist.get_process_group_ranks(group=group))
         if len(ranks) != world_size:
             raise RuntimeError("process-group rank list does not match world size")
         return ranks
+    if hasattr(dist, "get_global_rank"):
+        return [
+            dist.get_global_rank(group, group_rank) for group_rank in range(world_size)
+        ]
     return list(range(world_size))
 
 
@@ -162,28 +256,885 @@ class _OwnedSharedBuffer:
     remote_ptrs: tuple[int, ...]
 
 
+@dataclass
+class _RetryableIPCExport:
+    """Own a failed collective IPC setup until a coordinated retry succeeds.
+
+    The historical name is retained for compatibility with callers that only
+    need to retry a failed ``cudaFree``.  A setup can also own still-open peer
+    imports, a native runtime cleanup callback, and a collective participation
+    ticket after this rank has already released its local export.  Keeping the
+    ticket is important: a rank that succeeded locally must still join the
+    retry verdict so a peer can safely finish its rollback.
+    """
+
+    ipc: CudaRTLibrary
+    local_ptr: int
+    exchange_group: Optional[ProcessGroup] = None
+    owner: str = "PCIe shared buffer"
+    phase: str = "rollback"
+    remote_ptrs: list[int] = field(default_factory=list)
+    local_cleanup: Optional[Callable[[], None]] = None
+    state: str = "free"
+    _registry_key: tuple[int, int] | None = None
+
+    @property
+    def key(self) -> tuple[int, int]:
+        if self._registry_key is not None:
+            return self._registry_key
+        return id(self.ipc), int(self.local_ptr)
+
+    def retry(self) -> None:
+        key = self.key
+        if key not in _RETAINED_FAILED_IPC_EXPORTS:
+            return
+
+        if self.state == "native":
+            native_error: BaseException | None = None
+            if self.local_cleanup is not None:
+                try:
+                    self.local_cleanup()
+                except Exception as exc:
+                    native_error = exc
+                else:
+                    self.local_cleanup = None
+
+            if self.exchange_group is None:
+                if native_error is not None:
+                    raise RuntimeError(
+                        f"{self.owner} {self.phase} retry native cleanup failed; "
+                        "CUDA IPC ownership remains retained"
+                    ) from native_error
+            else:
+                native_statuses = _exchange_setup_failures(
+                    native_error,
+                    exchange_group=self.exchange_group,
+                    phase=f"{self.phase} retry native cleanup",
+                )
+                if any(native_statuses):
+                    raise RuntimeError(
+                        _setup_failure_message(
+                            self.owner,
+                            f"{self.phase} retry native cleanup",
+                            native_statuses,
+                            exports_retained=True,
+                        )
+                    ) from native_error
+            self.state = "unmap"
+
+        if self.state == "unmap":
+            failures: list[str] = []
+
+            remaining_remote_ptrs: list[int] = []
+            for ptr in self.remote_ptrs:
+                try:
+                    self.ipc.cudaIpcCloseMemHandle(ptr)
+                except Exception as exc:
+                    remaining_remote_ptrs.append(ptr)
+                    failures.append(
+                        f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}"
+                    )
+            self.remote_ptrs = remaining_remote_ptrs
+
+            local_error = RuntimeError(" | ".join(failures)) if failures else None
+            if self.exchange_group is None:
+                if local_error is not None:
+                    raise RuntimeError(
+                        f"{self.owner} {self.phase} retry failed; CUDA IPC "
+                        "ownership remains retained"
+                    ) from local_error
+            else:
+                statuses = _exchange_setup_failures(
+                    local_error,
+                    exchange_group=self.exchange_group,
+                    phase=f"{self.phase} retry unmap",
+                )
+                if any(statuses):
+                    raise RuntimeError(
+                        _setup_failure_message(
+                            self.owner,
+                            f"{self.phase} retry unmap",
+                            statuses,
+                            exports_retained=True,
+                        )
+                    ) from local_error
+            self.state = "free"
+
+        free_error: BaseException | None = None
+        if self.local_ptr:
+            ptr = self.local_ptr
+            try:
+                self.ipc.cudaFree(ptr)
+            except Exception as exc:
+                free_error = exc
+            else:
+                self.local_ptr = 0
+
+        if self.exchange_group is None:
+            if free_error is not None:
+                raise RuntimeError(
+                    f"{self.owner} {self.phase} retry export free failed; CUDA "
+                    "IPC ownership remains retained"
+                ) from free_error
+        else:
+            free_statuses = _exchange_setup_failures(
+                free_error,
+                exchange_group=self.exchange_group,
+                phase=f"{self.phase} retry export free",
+            )
+            if any(free_statuses):
+                raise RuntimeError(
+                    _setup_failure_message(
+                        self.owner,
+                        f"{self.phase} retry export free",
+                        free_statuses,
+                        exports_retained=True,
+                    )
+                ) from free_error
+
+        _RETAINED_FAILED_IPC_EXPORTS.pop(key, None)
+
+
+def _retain_failed_ipc_export(
+    ipc: CudaRTLibrary, local_ptr: int
+) -> _RetryableIPCExport:
+    key = id(ipc), int(local_ptr)
+    retained = _RETAINED_FAILED_IPC_EXPORTS.get(key)
+    if retained is None:
+        retained = _RetryableIPCExport(
+            ipc=ipc,
+            local_ptr=int(local_ptr),
+            _registry_key=key,
+        )
+        _RETAINED_FAILED_IPC_EXPORTS[key] = retained
+    return retained
+
+
+def _retain_failed_ipc_setup(
+    *,
+    ipc: CudaRTLibrary,
+    local_ptr: int,
+    exchange_group: ProcessGroup,
+    owner: str,
+    phase: str,
+    remote_ptrs: Sequence[int] = (),
+    local_cleanup: Optional[Callable[[], None]] = None,
+    state: str = "unmap",
+) -> _RetryableIPCExport:
+    """Retain every local resource and the rank's collective retry ticket."""
+
+    # A CUDA address is not an attempt identity: it may already have been freed
+    # on this rank while a peer still owns its export, then be reused by CUDA for
+    # a second failed setup.  Every collective failure therefore receives an
+    # independent process-local generation ticket.  The ticket need not match
+    # across ranks; it only keeps this rank participating in the same retry call.
+    key = id(ipc), -next(_RETAINED_IPC_SETUP_GENERATIONS)
+    retained = _RetryableIPCExport(
+        ipc=ipc,
+        local_ptr=int(local_ptr),
+        exchange_group=exchange_group,
+        owner=owner,
+        phase=phase,
+        remote_ptrs=list(dict.fromkeys(int(ptr) for ptr in remote_ptrs)),
+        local_cleanup=local_cleanup,
+        state=state,
+        _registry_key=key,
+    )
+    _RETAINED_FAILED_IPC_EXPORTS[key] = retained
+    return retained
+
+
+def _attach_retryable_setup(
+    error: RuntimeError, retained: _RetryableIPCExport
+) -> RuntimeError:
+    # Keep the old attribute for downstream code/tests and expose the broader
+    # meaning under a name that does not imply only cudaFree ownership.
+    error.retryable_export = retained  # type: ignore[attr-defined]
+    error.retryable_setup = retained  # type: ignore[attr-defined]
+    return error
+
+
+def _require_no_retained_ipc_setup(exchange_group: ProcessGroup) -> None:
+    """Serialize collective setup generations until rollback completes.
+
+    Retry tickets are process-local ownership objects, so allowing another IPC
+    setup on the same group would make it possible for ranks to retry different
+    generations in a different order.  Reject the new attempt collectively
+    before it allocates anything instead.
+    """
+
+    outstanding = tuple(
+        retained.key
+        for retained in _RETAINED_FAILED_IPC_EXPORTS.values()
+        if retained.exchange_group is exchange_group
+    )
+    local_error: BaseException | None = None
+    if outstanding:
+        local_error = RuntimeError(
+            "complete the retained CUDA IPC setup retry before starting "
+            f"another setup on this process group (tickets={outstanding})"
+        )
+    statuses = _exchange_setup_failures(
+        local_error,
+        exchange_group=exchange_group,
+        phase="retained CUDA IPC setup gate",
+    )
+    if any(statuses):
+        raise RuntimeError(
+            _setup_failure_message(
+                "PCIe shared buffer",
+                "retained CUDA IPC setup gate",
+                statuses,
+                exports_retained=True,
+            )
+        ) from local_error
+
+
+def _format_setup_error(error: BaseException | None) -> tuple[str, ...]:
+    if error is None:
+        return ()
+    return (f"{type(error).__name__}: {error}",)
+
+
+def _exchange_setup_failures(
+    local_error: BaseException | None,
+    *,
+    exchange_group: ProcessGroup,
+    phase: str,
+    exports_retained_on_exchange_failure: bool = True,
+) -> tuple[tuple[str, ...], ...]:
+    """Collect a setup verdict without allowing one rank to return early."""
+
+    try:
+        gathered = _broadcast_gather_object(
+            _format_setup_error(local_error), exchange_group
+        )
+    except Exception as exc:
+        retention = (
+            "; CUDA IPC exports were retained"
+            if exports_retained_on_exchange_failure
+            else ""
+        )
+        raise RuntimeError(
+            f"failed to exchange peer {phase} status{retention}"
+        ) from exc
+
+    statuses: list[tuple[str, ...]] = []
+    for group_rank, status in enumerate(gathered):
+        if not isinstance(status, (tuple, list)):
+            retention = (
+                "; CUDA IPC exports were retained"
+                if exports_retained_on_exchange_failure
+                else ""
+            )
+            raise RuntimeError(
+                f"invalid peer {phase} status from group rank {group_rank}{retention}"
+            )
+        statuses.append(tuple(str(item) for item in status))
+    return tuple(statuses)
+
+
+def _require_full_grid_residency(
+    *,
+    owner: str,
+    required_sms: int,
+    device: torch.device,
+    exchange_group: Optional[ProcessGroup],
+) -> None:
+    """Reject devices where a peer-waiting worker grid may not all reside.
+
+    The PCIe worker kernels use ``__launch_bounds__(512, 1)`` and zero dynamic
+    shared memory, so every visible SM can host at least one worker CTA.  A
+    device with at least the extension's maximum block count can therefore
+    make the complete grid resident regardless of block scheduling order.  We
+    intentionally reject smaller/MIG-like slices instead of assuming CUDA
+    schedules matching block indices in the same order on every rank.
+    """
+
+    local_error: BaseException | None = None
+    visible_sms = 0
+    try:
+        visible_sms = int(
+            torch.cuda.get_device_properties(device).multi_processor_count
+        )
+        test_visible_sms = int(
+            os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
+        )
+        if test_visible_sms > 0:
+            visible_sms = min(visible_sms, test_visible_sms)
+        if visible_sms < required_sms:
+            raise RuntimeError(
+                f"{owner} requires at least {required_sms} visible SMs so every "
+                "peer-waiting CTA can be resident; this device/MIG slice exposes "
+                f"{visible_sms}"
+            )
+    except Exception as exc:
+        local_error = exc
+
+    if exchange_group is None:
+        if local_error is not None:
+            raise local_error
+        return
+
+    statuses = _exchange_setup_failures(
+        local_error,
+        exchange_group=exchange_group,
+        phase=f"{owner} resident-grid capability",
+        exports_retained_on_exchange_failure=False,
+    )
+    if any(statuses):
+        raise RuntimeError(
+            _setup_failure_message(
+                owner,
+                "resident-grid capability",
+                statuses,
+                exports_retained=False,
+            )
+        ) from local_error
+
+
+def _run_collective_preallocation_setup(
+    *,
+    owner: str,
+    exchange_group: ProcessGroup,
+    setup: Callable[[], _SetupResult],
+) -> _SetupResult:
+    """Run fallible local setup before any rank creates a CUDA IPC export."""
+
+    result: Optional[_SetupResult] = None
+    local_error: BaseException | None = None
+    try:
+        result = setup()
+    except Exception as exc:
+        local_error = exc
+
+    statuses = _exchange_setup_failures(
+        local_error,
+        exchange_group=exchange_group,
+        phase=f"{owner} pre-allocation setup",
+        exports_retained_on_exchange_failure=False,
+    )
+    if any(statuses):
+        raise RuntimeError(
+            _setup_failure_message(
+                owner,
+                "pre-allocation setup",
+                statuses,
+                exports_retained=False,
+            )
+        ) from local_error
+    assert result is not None
+    return result
+
+
+def _require_collective_contract(
+    *, owner: str, exchange_group: ProcessGroup, contract: object
+) -> None:
+    """Reject divergent rank-local layout/channel inputs before allocation."""
+
+    gathered = _broadcast_gather_object(contract, exchange_group)
+    if any(peer != contract for peer in gathered):
+        raise RuntimeError(f"{owner} contract differs across ranks: {gathered}")
+
+
+def _finish_collective_unowned_runtime_setup(
+    *,
+    owner: str,
+    exchange_group: ProcessGroup,
+    local_error: BaseException | None,
+    local_cleanup: Callable[[], None],
+) -> None:
+    """Coordinate direct-constructor init when pointer ownership is external."""
+
+    statuses = _exchange_setup_failures(
+        local_error,
+        exchange_group=exchange_group,
+        phase=f"{owner} native initialization",
+        exports_retained_on_exchange_failure=False,
+    )
+    if not any(statuses):
+        return
+
+    cleanup_error: BaseException | None = None
+    try:
+        local_cleanup()
+    except Exception as exc:
+        cleanup_error = exc
+    cleanup_statuses = _exchange_setup_failures(
+        cleanup_error,
+        exchange_group=exchange_group,
+        phase=f"{owner} native initialization rollback",
+        exports_retained_on_exchange_failure=False,
+    )
+    if any(cleanup_statuses):
+        raise RuntimeError(
+            _setup_failure_message(
+                owner,
+                "native initialization rollback",
+                cleanup_statuses,
+                exports_retained=False,
+            )
+        ) from (cleanup_error or local_error)
+    raise RuntimeError(
+        _setup_failure_message(
+            owner,
+            "native initialization",
+            statuses,
+            exports_retained=False,
+        )
+    ) from local_error
+
+
+def _setup_failure_message(
+    owner: str,
+    phase: str,
+    statuses: Sequence[Sequence[str]],
+    *,
+    exports_retained: bool,
+) -> str:
+    details = [
+        f"group rank {group_rank}: " + " | ".join(failures)
+        for group_rank, failures in enumerate(statuses)
+        if failures
+    ]
+    retention = "; CUDA IPC exports were retained" if exports_retained else ""
+    return f"{owner} {phase} failed{retention}: " + "; ".join(details)
+
+
+def _abort_collective_ipc_setup(
+    *,
+    owner: str,
+    setup_phase: str,
+    setup_statuses: Sequence[Sequence[str]],
+    exchange_group: ProcessGroup,
+    ipc: CudaRTLibrary,
+    local_ptr: int | None,
+    remote_ptrs: Sequence[int],
+    local_error: BaseException | None,
+    local_cleanup: Optional[Callable[[], None]] = None,
+) -> None:
+    """Undo a failed collective IPC setup without freeing a mapped export.
+
+    Every rank calls this function.  Each successfully opened import is closed
+    exactly once.  Export ownership is released only after every group rank
+    reports that all of its imports were unmapped; otherwise the raw CUDA
+    allocation is deliberately retained until context teardown.
+    """
+
+    retained_cleanup = local_cleanup
+    if local_cleanup is not None:
+        native_error: BaseException | None = None
+        try:
+            local_cleanup()
+        except Exception as exc:
+            native_error = exc
+        else:
+            retained_cleanup = None
+        try:
+            native_statuses = _exchange_setup_failures(
+                native_error,
+                exchange_group=exchange_group,
+                phase=f"{setup_phase} rollback native cleanup",
+            )
+        except Exception as exchange_error:
+            assert local_ptr is not None
+            retained = _retain_failed_ipc_setup(
+                ipc=ipc,
+                local_ptr=local_ptr,
+                exchange_group=exchange_group,
+                owner=owner,
+                phase=setup_phase,
+                remote_ptrs=remote_ptrs,
+                local_cleanup=retained_cleanup,
+                state="native",
+            )
+            error = RuntimeError(
+                _setup_failure_message(
+                    owner,
+                    f"{setup_phase} rollback native cleanup status exchange",
+                    setup_statuses,
+                    exports_retained=True,
+                )
+            )
+            raise _attach_retryable_setup(error, retained) from (
+                native_error or local_error or exchange_error
+            )
+        if any(native_statuses):
+            assert local_ptr is not None
+            retained = _retain_failed_ipc_setup(
+                ipc=ipc,
+                local_ptr=local_ptr,
+                exchange_group=exchange_group,
+                owner=owner,
+                phase=setup_phase,
+                remote_ptrs=remote_ptrs,
+                local_cleanup=retained_cleanup,
+                state="native",
+            )
+            error = RuntimeError(
+                _setup_failure_message(
+                    owner,
+                    f"{setup_phase} rollback native cleanup",
+                    native_statuses,
+                    exports_retained=True,
+                )
+            )
+            raise _attach_retryable_setup(error, retained) from (
+                native_error or local_error
+            )
+
+    unmap_failures: list[str] = []
+    remaining_remote_ptrs: list[int] = []
+    for ptr in remote_ptrs:
+        try:
+            ipc.cudaIpcCloseMemHandle(ptr)
+        except Exception as exc:
+            remaining_remote_ptrs.append(ptr)
+            unmap_failures.append(f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}")
+
+    try:
+        unmap_statuses = _exchange_setup_failures(
+            RuntimeError(" | ".join(unmap_failures)) if unmap_failures else None,
+            exchange_group=exchange_group,
+            phase=f"{setup_phase} rollback unmap",
+        )
+    except Exception as exchange_error:
+        assert local_ptr is not None
+        retained = _retain_failed_ipc_setup(
+            ipc=ipc,
+            local_ptr=local_ptr,
+            exchange_group=exchange_group,
+            owner=owner,
+            phase=setup_phase,
+            remote_ptrs=remaining_remote_ptrs,
+            local_cleanup=retained_cleanup,
+            state="unmap",
+        )
+        error = RuntimeError(
+            _setup_failure_message(
+                owner,
+                setup_phase,
+                setup_statuses,
+                exports_retained=True,
+            )
+        )
+        raise _attach_retryable_setup(error, retained) from (
+            local_error or exchange_error
+        )
+
+    if any(unmap_statuses):
+        assert local_ptr is not None
+        retained = _retain_failed_ipc_setup(
+            ipc=ipc,
+            local_ptr=local_ptr,
+            exchange_group=exchange_group,
+            owner=owner,
+            phase=setup_phase,
+            remote_ptrs=remaining_remote_ptrs,
+            local_cleanup=retained_cleanup,
+            state="unmap",
+        )
+        error = RuntimeError(
+            _setup_failure_message(
+                owner,
+                f"{setup_phase} rollback unmap",
+                unmap_statuses,
+                exports_retained=True,
+            )
+        )
+        raise _attach_retryable_setup(error, retained) from local_error
+
+    free_error: BaseException | None = None
+    live_local_ptr = int(local_ptr or 0)
+    if local_ptr is not None:
+        try:
+            ipc.cudaFree(local_ptr)
+        except Exception as exc:
+            free_error = exc
+        else:
+            live_local_ptr = 0
+    try:
+        free_statuses = _exchange_setup_failures(
+            free_error,
+            exchange_group=exchange_group,
+            phase=f"{setup_phase} rollback export free",
+        )
+    except Exception as exchange_error:
+        retained_export = _retain_failed_ipc_setup(
+            ipc=ipc,
+            local_ptr=live_local_ptr,
+            exchange_group=exchange_group,
+            owner=owner,
+            phase=setup_phase,
+            state="free",
+        )
+        error = RuntimeError(
+            _setup_failure_message(
+                owner,
+                f"{setup_phase} rollback export free status exchange",
+                setup_statuses,
+                exports_retained=True,
+            )
+        )
+        raise _attach_retryable_setup(error, retained_export) from (
+            free_error or local_error or exchange_error
+        )
+    if any(free_statuses):
+        retained_export = _retain_failed_ipc_setup(
+            ipc=ipc,
+            local_ptr=live_local_ptr,
+            exchange_group=exchange_group,
+            owner=owner,
+            phase=setup_phase,
+            state="free",
+        )
+        error = RuntimeError(
+            _setup_failure_message(
+                owner,
+                f"{setup_phase} rollback export free",
+                free_statuses,
+                exports_retained=True,
+            )
+        )
+        raise _attach_retryable_setup(error, retained_export) from (
+            local_error or free_error
+        )
+
+    error = RuntimeError(
+        _setup_failure_message(
+            owner,
+            setup_phase,
+            setup_statuses,
+            exports_retained=False,
+        )
+    )
+    raise error from local_error
+
+
+def _finish_collective_runtime_setup(
+    *,
+    owner: str,
+    exchange_group: ProcessGroup,
+    ipc: CudaRTLibrary,
+    shared: _OwnedSharedBuffer,
+    local_error: BaseException | None,
+    local_cleanup: Optional[Callable[[], None]] = None,
+    detach_shared_ownership: Optional[Callable[[], None]] = None,
+) -> None:
+    """Require every rank to construct its native runtime before returning."""
+
+    try:
+        statuses = _exchange_setup_failures(
+            local_error,
+            exchange_group=exchange_group,
+            phase=f"{owner} native initialization",
+        )
+    except Exception as exchange_error:
+        # A failed first verdict exchange cannot establish whether every rank
+        # observed the same outcome.  Do not locally dispose, unmap, or free:
+        # retain the complete native/import/export ownership set and the
+        # same-group generation gate until the caller deliberately coordinates
+        # retry() on every participating rank.  This is especially important
+        # for twoshot, whose runtime object is not constructed until after this
+        # verdict succeeds.
+        retained = _retain_failed_ipc_setup(
+            ipc=ipc,
+            local_ptr=shared.local_ptr,
+            exchange_group=exchange_group,
+            owner=owner,
+            phase="native initialization status exchange",
+            remote_ptrs=shared.remote_ptrs,
+            local_cleanup=local_cleanup,
+            state="native",
+        )
+        if detach_shared_ownership is not None:
+            detach_shared_ownership()
+        error = RuntimeError(
+            f"{owner} native initialization status exchange failed; CUDA IPC "
+            "native/import/export ownership was retained and retry must be "
+            "coordinated by every rank"
+        )
+        raise _attach_retryable_setup(error, retained) from exchange_error
+    if any(statuses):
+        try:
+            _abort_collective_ipc_setup(
+                owner=owner,
+                setup_phase="native initialization",
+                setup_statuses=statuses,
+                exchange_group=exchange_group,
+                ipc=ipc,
+                local_ptr=shared.local_ptr,
+                remote_ptrs=shared.remote_ptrs,
+                local_error=local_error,
+                local_cleanup=local_cleanup,
+            )
+        finally:
+            # Rollback either released the shared allocation or transferred it
+            # to a _RetryableIPCExport.  Prevent a partially constructed runtime
+            # finalizer from retaining or releasing the same resources again.
+            if detach_shared_ownership is not None:
+                detach_shared_ownership()
+
+
 def _coordinated_close_channels(
     channels: Sequence[object],
     *,
     exchange_group: Optional[ProcessGroup],
     device: torch.device,
 ) -> None:
-    """Release exported CUDA IPC allocations after every peer unmaps them."""
+    """Strictly release exports only after every peer reports successful unmap."""
     unique_channels = tuple(dict.fromkeys(channels))
-    if exchange_group is None:
-        for channel in unique_channels:
-            channel.close()
+    if not unique_channels:
         return
 
-    if device.type == "cuda":
-        torch.cuda.synchronize(device)
-    dist.barrier(group=exchange_group)
+    if exchange_group is not None:
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+        dist.barrier(group=exchange_group)
+
+    # Older DCP channels still expose the legacy best-effort protocol. Keep
+    # their existing ordering until they receive their own lifecycle migration;
+    # oneshot and twoshot opt into the strict peer-status protocol below.
+    uses_strict_protocol = any(
+        hasattr(channel, "_close_ipc_imports_strict") for channel in unique_channels
+    )
+    if not uses_strict_protocol:
+        for channel in unique_channels:
+            channel._close_ipc_imports()
+        if exchange_group is not None:
+            dist.barrier(group=exchange_group)
+        for channel in unique_channels:
+            channel._free_ipc_exports()
+        if exchange_group is not None:
+            dist.barrier(group=exchange_group)
+        return
+
+    unmap_errors = _run_close_phase(
+        unique_channels,
+        strict_method="_close_ipc_imports_strict",
+        legacy_method="_close_ipc_imports",
+    )
+    unmap_status = _exchange_close_failures(
+        tuple(_format_close_error(index, error) for index, error in unmap_errors),
+        exchange_group=exchange_group,
+        phase="IPC unmap",
+    )
+    if any(unmap_status):
+        _raise_coordinated_close_error(
+            "IPC unmap",
+            unmap_status,
+            local_errors=unmap_errors,
+            exports_retained=True,
+        )
+
+    if exchange_group is not None:
+        dist.barrier(group=exchange_group)
+
+    free_errors = _run_close_phase(
+        unique_channels,
+        strict_method="_free_ipc_exports_strict",
+        legacy_method="_free_ipc_exports",
+    )
+    free_status = _exchange_close_failures(
+        tuple(_format_close_error(index, error) for index, error in free_errors),
+        exchange_group=exchange_group,
+        phase="IPC export free",
+    )
+    if any(free_status):
+        _raise_coordinated_close_error(
+            "IPC export free",
+            free_status,
+            local_errors=free_errors,
+            exports_retained=False,
+        )
+
+    if exchange_group is not None:
+        dist.barrier(group=exchange_group)
     for channel in unique_channels:
-        channel._close_ipc_imports()
-    dist.barrier(group=exchange_group)
-    for channel in unique_channels:
-        channel._free_ipc_exports()
-    dist.barrier(group=exchange_group)
+        if hasattr(channel, "_close_ipc_imports_strict"):
+            channel._coordinated_close_complete = True
+
+
+def _run_close_phase(
+    channels: Sequence[object],
+    *,
+    strict_method: str,
+    legacy_method: str,
+) -> list[tuple[int, Exception]]:
+    errors: list[tuple[int, Exception]] = []
+    for index, channel in enumerate(channels):
+        method = getattr(channel, strict_method, None)
+        if method is None:
+            method = getattr(channel, legacy_method)
+        try:
+            method()
+        except Exception as exc:
+            errors.append((index, exc))
+    return errors
+
+
+def _format_close_error(index: int, error: Exception) -> str:
+    return f"channel {index}: {type(error).__name__}: {error}"
+
+
+def _exchange_close_failures(
+    local_failures: tuple[str, ...],
+    *,
+    exchange_group: Optional[ProcessGroup],
+    phase: str,
+) -> tuple[tuple[str, ...], ...]:
+    if exchange_group is None:
+        return (local_failures,)
+    try:
+        gathered = _broadcast_gather_object(local_failures, exchange_group)
+    except Exception as exc:
+        raise RuntimeError(
+            f"failed to exchange peer {phase} status; exported IPC allocations "
+            "were not freed"
+        ) from exc
+
+    statuses: list[tuple[str, ...]] = []
+    for rank_index, status in enumerate(gathered):
+        if not isinstance(status, (tuple, list)):
+            raise RuntimeError(
+                f"invalid peer {phase} status from group rank {rank_index}; "
+                "exported IPC allocations were not freed"
+            )
+        statuses.append(tuple(str(item) for item in status))
+    return tuple(statuses)
+
+
+def _raise_coordinated_close_error(
+    phase: str,
+    statuses: Sequence[Sequence[str]],
+    *,
+    local_errors: Sequence[tuple[int, Exception]],
+    exports_retained: bool,
+) -> None:
+    peer_details = []
+    for rank_index, failures in enumerate(statuses):
+        if failures:
+            peer_details.append(f"group rank {rank_index}: " + " | ".join(failures))
+    retention = "; exported IPC allocations were not freed" if exports_retained else ""
+    error = RuntimeError(
+        f"coordinated PCIe close failed during {phase}{retention}: "
+        + "; ".join(peer_details)
+    )
+    if local_errors:
+        raise error from local_errors[0][1]
+    raise error
+
+
+def _raise_local_cleanup_errors(
+    owner: str,
+    phase: str,
+    failures: Sequence[tuple[str, Exception]],
+) -> None:
+    details = "; ".join(
+        f"{resource}: {type(error).__name__}: {error}" for resource, error in failures
+    )
+    error = RuntimeError(f"{owner} {phase} failed: {details}")
+    raise error from failures[0][1]
 
 
 @dataclass(frozen=True)
@@ -276,6 +1227,7 @@ class PCIeOneshotAllReduce:
         signal_ptrs: Sequence[int],
         eager_buffer_ptrs0: Optional[Sequence[int]] = None,
         eager_buffer_ptrs1: Optional[Sequence[int]] = None,
+        eager_buffer_bytes: Optional[int] = None,
         exchange_group: Optional[ProcessGroup] = None,
         process_group: Optional[ProcessGroup] = None,
         ipc: Optional[CudaRTLibrary] = None,
@@ -285,31 +1237,232 @@ class PCIeOneshotAllReduce:
         ext_module=None,
         stream_affine: bool = True,
     ):
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
-        if rank < 0 or rank >= world_size:
-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
-        if len(signal_ptrs) != world_size:
-            raise ValueError("signal_ptrs must match world size")
-        if (eager_buffer_ptrs0 is None) != (eager_buffer_ptrs1 is None):
-            raise ValueError("eager buffers must be provided as a pair")
-        if eager_buffer_ptrs0 is not None and len(eager_buffer_ptrs0) != world_size:
-            raise ValueError("eager_buffer_ptrs0 must match world size")
-        if eager_buffer_ptrs1 is not None and len(eager_buffer_ptrs1) != world_size:
-            raise ValueError("eager_buffer_ptrs1 must match world size")
+        resolved_group = _resolve_exchange_group(exchange_group, process_group)
 
+        def normalize_and_validate():
+            device_obj = _normalize_device(device)
+            normalized_rank = int(rank)
+            normalized_world_size = int(world_size)
+            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
+            normalized_eager0 = (
+                None
+                if eager_buffer_ptrs0 is None
+                else tuple(int(ptr) for ptr in eager_buffer_ptrs0)
+            )
+            normalized_eager1 = (
+                None
+                if eager_buffer_ptrs1 is None
+                else tuple(int(ptr) for ptr in eager_buffer_ptrs1)
+            )
+            normalized_max_size = int(max_size)
+            normalized_rank_data_bytes = int(rank_data_bytes)
+            normalized_eager_bytes = (
+                None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+            )
+            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {normalized_world_size}")
+            if not 0 <= normalized_rank < normalized_world_size:
+                raise ValueError(
+                    f"invalid rank {normalized_rank} for world size "
+                    f"{normalized_world_size}"
+                )
+            if len(normalized_signals) != normalized_world_size:
+                raise ValueError("signal_ptrs must match world size")
+            if (normalized_eager0 is None) != (normalized_eager1 is None):
+                raise ValueError("eager buffers must be provided as a pair")
+            if (
+                normalized_eager0 is not None
+                and len(normalized_eager0) != normalized_world_size
+            ):
+                raise ValueError("eager_buffer_ptrs0 must match world size")
+            if (
+                normalized_eager1 is not None
+                and len(normalized_eager1) != normalized_world_size
+            ):
+                raise ValueError("eager_buffer_ptrs1 must match world size")
+            if normalized_max_size <= 0:
+                raise ValueError("max_size must be positive")
+            if normalized_rank_data_bytes <= 0:
+                raise ValueError("rank_data_bytes must be positive")
+            if normalized_eager0 is not None:
+                if normalized_eager_bytes is None:
+                    raise ValueError(
+                        "eager_buffer_bytes is required with eager buffer pointers"
+                    )
+                if normalized_eager_bytes <= 0:
+                    raise ValueError("eager_buffer_bytes must be positive")
+                if normalized_max_size > normalized_eager_bytes:
+                    raise ValueError("max_size exceeds eager buffer capacity")
+            if ext_module is None and device_obj.type != "cuda":
+                raise ValueError("PCIe oneshot allreduce requires a CUDA device")
+            if device_obj.type == "cuda" and resolved_group is None:
+                raise ValueError(
+                    "exchange_group is required for a CUDA PCIe oneshot runtime; "
+                    "use from_exchange_group()"
+                )
+            if resolved_group is not None:
+                if device_obj.type != "cuda":
+                    raise ValueError(
+                        "distributed PCIe oneshot allreduce requires a CUDA device"
+                    )
+                group_rank = dist.get_rank(group=resolved_group)
+                group_world_size = dist.get_world_size(group=resolved_group)
+                if normalized_rank != group_rank:
+                    raise ValueError(
+                        f"supplied rank {normalized_rank} does not match process "
+                        f"group rank {group_rank}"
+                    )
+                if normalized_world_size != group_world_size:
+                    raise ValueError(
+                        f"supplied world size {normalized_world_size} does not "
+                        f"match process group size {group_world_size}"
+                    )
+            return (
+                device_obj,
+                normalized_rank,
+                normalized_world_size,
+                normalized_signals,
+                normalized_eager0,
+                normalized_eager1,
+                normalized_eager_bytes,
+                normalized_max_size,
+                normalized_rank_data_bytes,
+            )
+
+        if resolved_group is not None:
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe oneshot direct constructor argument validation",
+                exchange_group=resolved_group,
+                setup=normalize_and_validate,
+            )
+        else:
+            normalized = normalize_and_validate()
+
+        (
+            device_obj,
+            normalized_rank,
+            normalized_world_size,
+            normalized_signals,
+            normalized_eager0,
+            normalized_eager1,
+            normalized_eager_bytes,
+            normalized_max_size,
+            normalized_rank_data_bytes,
+        ) = normalized
+
+        self._initialize_prepared_state(
+            rank=normalized_rank,
+            world_size=normalized_world_size,
+            device=device_obj,
+            signal_ptrs=normalized_signals,
+            eager_buffer_ptrs0=normalized_eager0,
+            eager_buffer_ptrs1=normalized_eager1,
+            eager_buffer_bytes=normalized_eager_bytes,
+            exchange_group=resolved_group,
+            ipc=ipc,
+            owned_buffers=owned_buffers,
+            max_size=normalized_max_size,
+            rank_data_bytes=normalized_rank_data_bytes,
+            ext_module=ext_module,
+            stream_affine=stream_affine,
+        )
+
+        if self.device.type == "cuda":
+            _require_full_grid_residency(
+                owner="PCIe oneshot direct constructor",
+                required_sms=ONESHOT_REQUIRED_SMS,
+                device=self.device,
+                exchange_group=self.exchange_group,
+            )
+
+            def prepare() -> tuple[Optional[CudaRTLibrary], object]:
+                prepared_ipc = self._ipc
+                if prepared_ipc is None and (ext_module is None or owned_buffers):
+                    prepared_ipc = CudaRTLibrary()
+                if prepared_ipc is not None:
+                    prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
+                return prepared_ipc, ext_module or _load_extension()
+
+            if self.exchange_group is None:
+                self._ipc, self._ext = prepare()
+            else:
+                self._ipc, self._ext = _run_collective_preallocation_setup(
+                    owner="PCIe oneshot direct constructor",
+                    exchange_group=self.exchange_group,
+                    setup=prepare,
+                )
+        else:
+            self._ext = self._ext or _load_extension()
+
+        if self.device.type == "cuda" and self.exchange_group is not None:
+            _require_collective_contract(
+                owner="PCIe oneshot direct constructor",
+                exchange_group=self.exchange_group,
+                contract=(
+                    self.world_size,
+                    self.max_size,
+                    self.rank_data_bytes,
+                    self.eager_buffer_bytes,
+                    self._pending_eager_ptrs is not None,
+                ),
+            )
+
+        init_error = self._initialize_native_runtime()
+        if self.device.type == "cuda" and self.exchange_group is not None:
+
+            def abort_native_runtime() -> None:
+                if self._ptr:
+                    self._ext.dispose(self._ptr)
+                    self._ptr = 0
+
+            _finish_collective_unowned_runtime_setup(
+                owner="PCIe oneshot direct constructor",
+                exchange_group=self.exchange_group,
+                local_error=init_error,
+                local_cleanup=abort_native_runtime,
+            )
+        elif init_error is not None:
+            raise init_error
+
+    def _initialize_prepared_state(
+        self,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device,
+        signal_ptrs: Sequence[int],
+        eager_buffer_ptrs0: Optional[Sequence[int]],
+        eager_buffer_ptrs1: Optional[Sequence[int]],
+        eager_buffer_bytes: Optional[int],
+        exchange_group: Optional[ProcessGroup],
+        ipc: Optional[CudaRTLibrary],
+        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
+        max_size: int,
+        rank_data_bytes: int,
+        ext_module,
+        stream_affine: bool,
+    ) -> None:
         self.rank = int(rank)
         self.world_size = int(world_size)
-        self.device = _normalize_device(device)
-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
-        # Compatibility alias for older callers that still refer to this as
-        # `process_group`.
-        self.process_group = self.exchange_group
+        self.device = device
+        self.exchange_group = exchange_group
+        self.process_group = exchange_group
         self.max_size = int(max_size)
+        self.rank_data_bytes = int(rank_data_bytes)
+        self.eager_buffer_bytes = (
+            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+        )
         self._ipc = ipc
-        if self._ipc is None and (ext_module is None or owned_buffers):
-            self._ipc = CudaRTLibrary()
+        self._ext = ext_module
         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
+        self._pending_eager_ptrs = (
+            None
+            if eager_buffer_ptrs0 is None or eager_buffer_ptrs1 is None
+            else (
+                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
+                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
+            )
+        )
         self._owned_buffers = list(owned_buffers or [])
         self._registered_input_ptrs: dict[int, tuple[int, ...]] = {}
         self._stream_affine = bool(stream_affine)
@@ -317,29 +1470,43 @@ class PCIeOneshotAllReduce:
         self._closed = False
         self._ipc_imports_closed = False
         self._ipc_exports_freed = False
-        self._ext = ext_module or _load_extension()
-
-        if ext_module is None and self.device.type != "cuda":
-            raise ValueError("PCIe oneshot allreduce requires a CUDA device")
-
-        self.rank_data = torch.empty(
-            rank_data_bytes, dtype=torch.uint8, device=self.device
-        )
-        self._ptr = self._ext.init_custom_ar(
-            list(self._signal_ptrs), self.rank_data, self.rank
-        )
-
+        self._coordinated_close_complete = False
+        self._native_ipc_import_close_failed = False
+        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
+        self._ptr = 0
         self._eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
-        if eager_buffer_ptrs0 is not None and eager_buffer_ptrs1 is not None:
-            self._eager_ptrs = (
-                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
-                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
+
+    def _initialize_native_runtime(self) -> BaseException | None:
+        init_error: BaseException | None = None
+        try:
+            self.rank_data = torch.empty(
+                self.rank_data_bytes, dtype=torch.uint8, device=self.device
             )
-            self._ext.register_pcie_buffers(
-                self._ptr,
-                list(self._eager_ptrs[0]),
-                list(self._eager_ptrs[1]),
+            self._ptr = self._ext.init_custom_ar(
+                list(self._signal_ptrs), self.rank_data, self.rank
             )
+            if self._pending_eager_ptrs is not None:
+                self._eager_ptrs = self._pending_eager_ptrs
+                self._ext.register_pcie_buffers(
+                    self._ptr,
+                    list(self._eager_ptrs[0]),
+                    list(self._eager_ptrs[1]),
+                )
+        except Exception as exc:
+            init_error = exc
+        finally:
+            self._pending_eager_ptrs = None
+        return init_error
+
+    @classmethod
+    def _from_prepared_factory(
+        cls,
+        **kwargs,
+    ) -> tuple["PCIeOneshotAllReduce", BaseException | None]:
+        runtime = object.__new__(cls)
+        runtime._initialize_prepared_state(**kwargs)
+        init_error = runtime._initialize_native_runtime()
+        return runtime, init_error
 
     @classmethod
     def from_ipc(
@@ -351,6 +1518,7 @@ class PCIeOneshotAllReduce:
         signal_ptrs: Sequence[int],
         eager_buffer_ptrs0: Optional[Sequence[int]] = None,
         eager_buffer_ptrs1: Optional[Sequence[int]] = None,
+        eager_buffer_bytes: Optional[int] = None,
         exchange_group: Optional[ProcessGroup] = None,
         process_group: Optional[ProcessGroup] = None,
         max_size: int = DEFAULT_MAX_SIZE,
@@ -365,6 +1533,7 @@ class PCIeOneshotAllReduce:
             signal_ptrs=signal_ptrs,
             eager_buffer_ptrs0=eager_buffer_ptrs0,
             eager_buffer_ptrs1=eager_buffer_ptrs1,
+            eager_buffer_bytes=eager_buffer_bytes,
             exchange_group=exchange_group,
             process_group=process_group,
             max_size=max_size,
@@ -387,50 +1556,114 @@ class PCIeOneshotAllReduce:
     ) -> "PCIeOneshotAllReduce":
         rank = dist.get_rank(group=exchange_group)
         world_size = dist.get_world_size(group=exchange_group)
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
 
-        device_obj = _normalize_device(device)
-        if device_obj.type != "cuda":
-            raise ValueError("PCIe oneshot requires a CUDA device")
-
-        ipc = CudaRTLibrary()
-        ipc.cudaSetDevice(device_obj.index or 0)
-        ext = ext_module or _load_extension()
-
-        owned_buffers: list[_OwnedSharedBuffer] = []
-        try:
-            channel_buffers = cls._allocate_eager_channel_buffers(
-                exchange_group,
-                signal_bytes=ext.meta_size(),
-                eager_buffer_bytes=eager_buffer_bytes,
-                ipc=ipc,
+        def validate_factory_arguments():
+            device_obj = _normalize_device(device)
+            normalized_eager_bytes = int(eager_buffer_bytes)
+            normalized_max_size = int(max_size)
+            normalized_rank_data_bytes = int(rank_data_bytes)
+            if world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {world_size}")
+            if device_obj.type != "cuda":
+                raise ValueError("PCIe oneshot requires a CUDA device")
+            if normalized_eager_bytes <= 0:
+                raise ValueError("eager_buffer_bytes must be positive")
+            if normalized_max_size <= 0:
+                raise ValueError("max_size must be positive")
+            if normalized_max_size > normalized_eager_bytes:
+                raise ValueError("max_size exceeds eager buffer capacity")
+            if normalized_rank_data_bytes <= 0:
+                raise ValueError("rank_data_bytes must be positive")
+            return (
+                device_obj,
+                normalized_eager_bytes,
+                normalized_max_size,
+                normalized_rank_data_bytes,
             )
-            owned_buffers.append(channel_buffers.owned_buffer)
 
-            return cls(
-                rank=rank,
-                world_size=world_size,
-                device=device_obj,
-                signal_ptrs=channel_buffers.signal_ptrs,
-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
+            _run_collective_preallocation_setup(
+                owner="PCIe oneshot argument validation",
                 exchange_group=exchange_group,
-                ipc=ipc,
-                owned_buffers=owned_buffers,
-                max_size=max_size,
-                rank_data_bytes=rank_data_bytes,
-                ext_module=ext,
-                stream_affine=stream_affine,
+                setup=validate_factory_arguments,
             )
-        except Exception:
-            for shared in owned_buffers:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        ipc.cudaIpcCloseMemHandle(ptr)
-                with suppress(Exception):
-                    ipc.cudaFree(shared.local_ptr)
-            raise
+        )
+
+        _require_full_grid_residency(
+            owner="PCIe oneshot",
+            required_sms=ONESHOT_REQUIRED_SMS,
+            device=device_obj,
+            exchange_group=exchange_group,
+        )
+
+        def prepare() -> tuple[CudaRTLibrary, object, int]:
+            prepared_ipc = CudaRTLibrary()
+            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
+            prepared_ext = ext_module or _load_extension()
+            return prepared_ipc, prepared_ext, int(prepared_ext.meta_size())
+
+        ipc, ext, signal_bytes = _run_collective_preallocation_setup(
+            owner="PCIe oneshot",
+            exchange_group=exchange_group,
+            setup=prepare,
+        )
+        _require_collective_contract(
+            owner="PCIe oneshot channel layout",
+            exchange_group=exchange_group,
+            contract=(
+                signal_bytes,
+                eager_buffer_bytes,
+                max_size,
+                rank_data_bytes,
+                _push_mode_enabled(),
+            ),
+        )
+
+        channel_buffers = cls._allocate_eager_channel_buffers(
+            exchange_group,
+            signal_bytes=signal_bytes,
+            eager_buffer_bytes=eager_buffer_bytes,
+            ipc=ipc,
+        )
+        owned_buffers = [channel_buffers.owned_buffer]
+        runtime, init_error = cls._from_prepared_factory(
+            rank=rank,
+            world_size=world_size,
+            device=device_obj,
+            signal_ptrs=channel_buffers.signal_ptrs,
+            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+            eager_buffer_bytes=eager_buffer_bytes,
+            exchange_group=exchange_group,
+            ipc=ipc,
+            owned_buffers=owned_buffers,
+            max_size=max_size,
+            rank_data_bytes=rank_data_bytes,
+            ext_module=ext,
+            stream_affine=stream_affine,
+        )
+
+        def abort_native_runtime() -> None:
+            pointer = getattr(runtime, "_ptr", 0)
+            if pointer:
+                ext.dispose(pointer)
+                runtime._ptr = 0
+            if hasattr(runtime, "rank_data"):
+                del runtime.rank_data
+
+        def detach_shared_ownership() -> None:
+            runtime._owned_buffers.clear()
+
+        _finish_collective_runtime_setup(
+            owner="PCIe oneshot",
+            exchange_group=exchange_group,
+            ipc=ipc,
+            shared=channel_buffers.owned_buffer,
+            local_error=init_error,
+            local_cleanup=abort_native_runtime,
+            detach_shared_ownership=detach_shared_ownership,
+        )
+        return runtime
 
     @classmethod
     def from_process_group(
@@ -440,7 +1673,7 @@ class PCIeOneshotAllReduce:
         device: torch.device | int | str,
         max_input_bytes: int = DEFAULT_MAX_SIZE,
         eager_buffer_bytes: Optional[int] = None,
-        max_size: int = DEFAULT_MAX_SIZE,
+        max_size: Optional[int] = None,
         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
         ext_module=None,
         stream_affine: bool = True,
@@ -451,7 +1684,7 @@ class PCIeOneshotAllReduce:
             eager_buffer_bytes=max_input_bytes
             if eager_buffer_bytes is None
             else eager_buffer_bytes,
-            max_size=max_size,
+            max_size=max_input_bytes if max_size is None else max_size,
             rank_data_bytes=rank_data_bytes,
             ext_module=ext_module,
             stream_affine=stream_affine,
@@ -465,42 +1698,193 @@ class PCIeOneshotAllReduce:
         zero_fill: bool,
         ipc: CudaRTLibrary,
     ) -> _OwnedSharedBuffer:
-        local_ptr = ipc.cudaMalloc(size_in_bytes)
-        peer_ptrs: list[int] = []
-        remote_ptrs: list[int] = []
+        _require_no_retained_ipc_setup(exchange_group)
+        local_ptr: int | None = None
+        local_handle: bytes | None = None
+        prepare_error: BaseException | None = None
         try:
+            local_ptr = ipc.cudaMalloc(size_in_bytes)
             if zero_fill:
                 ipc.cudaMemset(local_ptr, 0, size_in_bytes)
             local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
+        except Exception as exc:
+            prepare_error = exc
+
+        # A rank that cannot allocate or publish its export must not leave its
+        # peers blocked in the handle exchange.  No imports exist yet, so
+        # successful ranks can safely release their local allocation.
+        try:
+            prepare_statuses = _exchange_setup_failures(
+                prepare_error,
+                exchange_group=exchange_group,
+                phase="CUDA IPC export preparation",
+            )
+        except Exception as exchange_error:
+            retained = _retain_failed_ipc_setup(
+                ipc=ipc,
+                local_ptr=int(local_ptr or 0),
+                exchange_group=exchange_group,
+                owner="PCIe shared buffer",
+                phase="CUDA IPC export preparation",
+                state="unmap",
+            )
+            error = RuntimeError(
+                "failed to exchange CUDA IPC export preparation status; "
+                "CUDA IPC ownership was retained"
+            )
+            raise _attach_retryable_setup(error, retained) from (
+                prepare_error or exchange_error
+            )
+        if any(prepare_statuses):
+            free_error: BaseException | None = None
+            live_local_ptr = int(local_ptr or 0)
+            if local_ptr is not None:
+                try:
+                    ipc.cudaFree(local_ptr)
+                except Exception as exc:
+                    free_error = exc
+                else:
+                    live_local_ptr = 0
+            try:
+                free_statuses = _exchange_setup_failures(
+                    free_error,
+                    exchange_group=exchange_group,
+                    phase="CUDA IPC export preparation rollback",
+                )
+            except Exception as exchange_error:
+                retained_export = _retain_failed_ipc_setup(
+                    ipc=ipc,
+                    local_ptr=live_local_ptr,
+                    exchange_group=exchange_group,
+                    owner="PCIe shared buffer",
+                    phase="CUDA IPC export preparation",
+                    state="free",
+                )
+                error = RuntimeError(
+                    "failed to exchange CUDA IPC export rollback status; "
+                    "CUDA IPC ownership was retained"
+                )
+                raise _attach_retryable_setup(error, retained_export) from (
+                    free_error or prepare_error or exchange_error
+                )
+            if any(free_statuses):
+                retained_export = _retain_failed_ipc_setup(
+                    ipc=ipc,
+                    local_ptr=live_local_ptr,
+                    exchange_group=exchange_group,
+                    owner="PCIe shared buffer",
+                    phase="CUDA IPC export preparation",
+                    state="free",
+                )
+                error = RuntimeError(
+                    _setup_failure_message(
+                        "PCIe shared buffer",
+                        "export preparation rollback",
+                        free_statuses,
+                        exports_retained=True,
+                    )
+                )
+                raise _attach_retryable_setup(error, retained_export) from (
+                    prepare_error or free_error
+                )
+            raise RuntimeError(
+                _setup_failure_message(
+                    "PCIe shared buffer",
+                    "export preparation",
+                    prepare_statuses,
+                    exports_retained=False,
+                )
+            ) from prepare_error
+
+        assert local_ptr is not None
+        assert local_handle is not None
+        peer_ptrs: list[int] = []
+        remote_ptrs: list[int] = []
+        try:
             world_size = dist.get_world_size(group=exchange_group)
             rank = dist.get_rank(group=exchange_group)
             handles = _broadcast_gather_object(local_handle, exchange_group)
-            for idx, handle in enumerate(handles):
-                if idx == rank:
-                    peer_ptrs.append(local_ptr)
-                else:
-                    try:
-                        remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
-                    except Exception as exc:
-                        raise RuntimeError(
-                            f"failed to open CUDA IPC handle for peer rank {idx}"
-                        ) from exc
-                    peer_ptrs.append(remote_ptr)
-                    remote_ptrs.append(remote_ptr)
-            if len(peer_ptrs) != world_size:
-                raise RuntimeError("failed to gather IPC handles for all ranks")
-            return _OwnedSharedBuffer(
+        except Exception as exchange_error:
+            # No rank has opened an import before handle exchange completes.
+            # Retain both ownership and a collective retry ticket if progress
+            # is uncertain; peers may have completed the exchange already.
+            retained = _retain_failed_ipc_setup(
+                ipc=ipc,
                 local_ptr=local_ptr,
-                peer_ptrs=tuple(peer_ptrs),
-                remote_ptrs=tuple(remote_ptrs),
+                exchange_group=exchange_group,
+                owner="PCIe shared buffer",
+                phase="CUDA IPC handle exchange",
+                state="unmap",
             )
-        except Exception:
-            for ptr in remote_ptrs:
-                with suppress(Exception):
-                    ipc.cudaIpcCloseMemHandle(ptr)
-            with suppress(Exception):
-                ipc.cudaFree(local_ptr)
-            raise
+            error = RuntimeError(
+                "CUDA IPC handle exchange failed; CUDA IPC ownership was retained"
+            )
+            raise _attach_retryable_setup(error, retained) from exchange_error
+
+        open_error: BaseException | None = None
+        for idx, handle in enumerate(handles):
+            if idx == rank:
+                peer_ptrs.append(local_ptr)
+                continue
+            try:
+                remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+            except Exception as exc:
+                if open_error is None:
+                    open_error = RuntimeError(
+                        f"failed to open CUDA IPC handle for peer group rank {idx}"
+                    )
+                    open_error.__cause__ = exc
+                # Preserve group-rank indexing while every rank completes the
+                # same open loop and reaches the collective verdict.
+                peer_ptrs.append(0)
+            else:
+                peer_ptrs.append(remote_ptr)
+                remote_ptrs.append(remote_ptr)
+
+        if len(handles) != world_size or len(peer_ptrs) != world_size:
+            open_error = open_error or RuntimeError(
+                "failed to gather CUDA IPC handles for every group rank"
+            )
+        try:
+            open_statuses = _exchange_setup_failures(
+                open_error,
+                exchange_group=exchange_group,
+                phase="CUDA IPC import open",
+            )
+        except Exception as exchange_error:
+            retained = _retain_failed_ipc_setup(
+                ipc=ipc,
+                local_ptr=local_ptr,
+                exchange_group=exchange_group,
+                owner="PCIe shared buffer",
+                phase="CUDA IPC import open",
+                remote_ptrs=remote_ptrs,
+                state="unmap",
+            )
+            error = RuntimeError(
+                "failed to exchange CUDA IPC import-open status; CUDA IPC "
+                "ownership was retained"
+            )
+            raise _attach_retryable_setup(error, retained) from (
+                open_error or exchange_error
+            )
+        if any(open_statuses):
+            _abort_collective_ipc_setup(
+                owner="PCIe shared buffer",
+                setup_phase="CUDA IPC import open",
+                setup_statuses=open_statuses,
+                exchange_group=exchange_group,
+                ipc=ipc,
+                local_ptr=local_ptr,
+                remote_ptrs=remote_ptrs,
+                local_error=open_error,
+            )
+
+        return _OwnedSharedBuffer(
+            local_ptr=local_ptr,
+            peer_ptrs=tuple(peer_ptrs),
+            remote_ptrs=tuple(remote_ptrs),
+        )
 
     @classmethod
     def _allocate_eager_channel_buffers(
@@ -860,6 +2244,9 @@ class PCIeOneshotAllReduce:
         if self.device.type != "cuda":
             raise ValueError("autotune requires a CUDA device")
         bench_stream = torch.cuda.Stream(device=self.device)
+        effective_ceiling = int(ceiling_bytes)
+        if self.eager_buffer_bytes is not None:
+            effective_ceiling = min(effective_ceiling, self.eager_buffer_bytes)
         crossover, results = _compute_crossover_size(
             lambda size_bytes: self._bench_graph_latency(
                 size_bytes,
@@ -868,9 +2255,11 @@ class PCIeOneshotAllReduce:
                 warmup,
                 iters,
             ),
-            ceiling_bytes=ceiling_bytes,
+            ceiling_bytes=effective_ceiling,
             fine_step_bytes=fine_step_bytes,
         )
+        if self.eager_buffer_bytes is not None:
+            crossover = min(crossover, self.eager_buffer_bytes)
         self.max_size = crossover
 
         if self.rank == 0:
@@ -896,40 +2285,172 @@ class PCIeOneshotAllReduce:
             logger.info("\n".join(lines))
         return crossover
 
-    def _close_ipc_imports(self) -> None:
+    def _closed_import_indices(self) -> set[tuple[int, int]]:
+        closed = getattr(self, "_closed_ipc_import_indices", None)
+        if closed is None:
+            closed = set()
+            self._closed_ipc_import_indices = closed
+        return closed
+
+    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
+        if self._ipc is None:
+            return not any(shared.remote_ptrs for shared in self._owned_buffers)
+        return all(
+            (buffer_index, remote_index) in closed
+            for buffer_index, shared in enumerate(self._owned_buffers)
+            for remote_index, _ in enumerate(shared.remote_ptrs)
+        )
+
+    def _close_ipc_imports_strict(self) -> None:
         if self._ipc_imports_closed:
             return
         self._closed = True
+        failures: list[tuple[str, Exception]] = []
+        if getattr(self, "_native_ipc_import_close_failed", False):
+            failures.append(
+                (
+                    "native runtime",
+                    RuntimeError(
+                        "a native IPC import failed during best-effort teardown "
+                        "and can no longer be retried"
+                    ),
+                )
+            )
         if getattr(self, "_ptr", 0):
-            with suppress(Exception):
+            try:
                 self._ext.dispose(self._ptr)
-            self._ptr = 0
-        if self._ipc is not None:
-            for shared in self._owned_buffers:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        self._ipc.cudaIpcCloseMemHandle(ptr)
-        self._ipc_imports_closed = True
+            except Exception as exc:
+                failures.append(("native runtime", exc))
+            else:
+                self._ptr = 0
 
-    def _free_ipc_exports(self) -> None:
+        closed = self._closed_import_indices()
+        if self._ipc is not None:
+            for buffer_index, shared in enumerate(self._owned_buffers):
+                for remote_index, ptr in enumerate(shared.remote_ptrs):
+                    key = (buffer_index, remote_index)
+                    if key in closed:
+                        continue
+                    try:
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                    except Exception as exc:
+                        failures.append((f"CUDA IPC import {ptr}", exc))
+                    else:
+                        closed.add(key)
+        elif any(shared.remote_ptrs for shared in self._owned_buffers):
+            failures.append(
+                (
+                    "CUDA IPC imports",
+                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
+                )
+            )
+
+        if (
+            not failures
+            and not getattr(self, "_ptr", 0)
+            and self._all_python_ipc_imports_closed(closed)
+        ):
+            self._ipc_imports_closed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe oneshot", "IPC import close", failures)
+
+    def _close_ipc_imports_best_effort(self) -> None:
+        if self._ipc_imports_closed:
+            return
+        self._closed = True
+        native_imports_closed = not getattr(self, "_ptr", 0)
+        if getattr(self, "_ptr", 0):
+            dispose = getattr(self._ext, "dispose_best_effort", None)
+            if dispose is None:
+                dispose = self._ext.dispose
+            try:
+                result = dispose(self._ptr)
+            except Exception:
+                pass
+            else:
+                self._ptr = 0
+                # The native best-effort binding reports whether every graph
+                # import closed. Legacy/fake dispose methods return None and
+                # report failure by raising.
+                native_imports_closed = result is not False
+                if not native_imports_closed:
+                    self._native_ipc_import_close_failed = True
+
+        closed = self._closed_import_indices()
+        if self._ipc is not None:
+            for buffer_index, shared in enumerate(self._owned_buffers):
+                for remote_index, ptr in enumerate(shared.remote_ptrs):
+                    key = (buffer_index, remote_index)
+                    if key in closed:
+                        continue
+                    try:
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                    except Exception:
+                        pass
+                    else:
+                        closed.add(key)
+
+        if (
+            native_imports_closed
+            and not getattr(self, "_ptr", 0)
+            and self._all_python_ipc_imports_closed(closed)
+        ):
+            self._ipc_imports_closed = True
+
+    def _free_ipc_exports_strict(self) -> None:
         if self._ipc_exports_freed:
             return
-        self._close_ipc_imports()
+        self._close_ipc_imports_strict()
+        failures: list[tuple[str, Exception]] = []
+        remaining = []
         if self._ipc is not None:
             for shared in self._owned_buffers:
-                with suppress(Exception):
+                try:
                     self._ipc.cudaFree(shared.local_ptr)
-        self._owned_buffers.clear()
-        self._registered_input_ptrs.clear()
-        self._ipc_exports_freed = True
+                except Exception as exc:
+                    remaining.append(shared)
+                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
+        elif self._owned_buffers:
+            remaining = list(self._owned_buffers)
+            failures.append(
+                (
+                    "CUDA IPC exports",
+                    RuntimeError("CUDA runtime is unavailable for export free"),
+                )
+            )
+        self._owned_buffers = remaining
+        if not remaining:
+            self._registered_input_ptrs.clear()
+            self._ipc_exports_freed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe oneshot", "IPC export free", failures)
 
     def close(self) -> None:
-        self._close_ipc_imports()
-        self._free_ipc_exports()
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        _coordinated_close_channels(
+            (self,),
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
 
-    def __del__(self) -> None:
-        with suppress(Exception):
-            self.close()
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # GC cannot prove that work queued on an arbitrary CUDA stream has
+        # completed, and it must not synchronize or enter a distributed
+        # barrier.  Retain the whole runtime: rank_data is a torch allocation
+        # whose raw pointer is stored in the native object and captured graph
+        # arguments, so retaining only IPC mappings/exports is insufficient.
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        if (
+            getattr(self, "_ptr", 0)
+            or hasattr(self, "rank_data")
+            or getattr(self, "_owned_buffers", ())
+        ):
+            _quarantine[id(self)] = self
 
 
 def _is_current_stream_capturing(device: torch.device) -> bool:
@@ -964,42 +2485,145 @@ class PCIeOneshotAllReducePool:
         ext_module=None,
         ipc: Optional[CudaRTLibrary] = None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
         channel_factory: Optional[
             Callable[[Optional[int]], PCIeOneshotAllReduce]
         ] = None,
     ):
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
-        if rank < 0 or rank >= world_size:
-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        resolved_group = _resolve_exchange_group(exchange_group, process_group)
 
-        self.rank = int(rank)
-        self.world_size = int(world_size)
-        self.device = _normalize_device(device)
-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
+        def normalize_and_validate():
+            normalized_rank = int(rank)
+            normalized_world_size = int(world_size)
+            device_obj = _normalize_device(device)
+            normalized_eager_bytes = int(eager_buffer_bytes)
+            normalized_max_size = int(max_size)
+            normalized_rank_data_bytes = int(rank_data_bytes)
+            normalized_single_channel = bool(single_channel)
+            normalized_max_concurrent_channels = int(max_concurrent_channels)
+            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {normalized_world_size}")
+            if not 0 <= normalized_rank < normalized_world_size:
+                raise ValueError(
+                    f"invalid rank {normalized_rank} for world size "
+                    f"{normalized_world_size}"
+                )
+            if normalized_eager_bytes <= 0:
+                raise ValueError("eager_buffer_bytes must be positive")
+            if normalized_max_size <= 0:
+                raise ValueError("max_size must be positive")
+            if normalized_max_size > normalized_eager_bytes:
+                raise ValueError("max_size exceeds eager buffer capacity")
+            if normalized_rank_data_bytes <= 0:
+                raise ValueError("rank_data_bytes must be positive")
+            if normalized_max_concurrent_channels <= 0:
+                raise ValueError("max_concurrent_channels must be positive")
+            if channel_factory is None:
+                if resolved_group is None:
+                    raise ValueError(
+                        "exchange_group is required unless channel_factory is provided"
+                    )
+                if device_obj.type != "cuda":
+                    raise ValueError("PCIe oneshot pool requires a CUDA device")
+                group_rank = dist.get_rank(group=resolved_group)
+                group_world_size = dist.get_world_size(group=resolved_group)
+                if normalized_rank != group_rank:
+                    raise ValueError(
+                        f"supplied rank {normalized_rank} does not match process "
+                        f"group rank {group_rank}"
+                    )
+                if normalized_world_size != group_world_size:
+                    raise ValueError(
+                        f"supplied world size {normalized_world_size} does not "
+                        f"match process group size {group_world_size}"
+                    )
+            return (
+                normalized_rank,
+                normalized_world_size,
+                device_obj,
+                normalized_eager_bytes,
+                normalized_max_size,
+                normalized_rank_data_bytes,
+                normalized_single_channel,
+                normalized_max_concurrent_channels,
+            )
+
+        if channel_factory is None and resolved_group is not None:
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe oneshot pool argument validation",
+                exchange_group=resolved_group,
+                setup=normalize_and_validate,
+            )
+        else:
+            normalized = normalize_and_validate()
+
+        (
+            self.rank,
+            self.world_size,
+            self.device,
+            self.eager_buffer_bytes,
+            self.max_size,
+            self.rank_data_bytes,
+            self.single_channel,
+            self.max_concurrent_channels,
+        ) = normalized
+        self.exchange_group = resolved_group
         self.process_group = self.exchange_group
-        self.eager_buffer_bytes = int(eager_buffer_bytes)
-        self.max_size = int(max_size)
-        self.rank_data_bytes = int(rank_data_bytes)
-        self.single_channel = bool(single_channel)
         self._channel_factory = channel_factory
         self._channels: dict[int, PCIeOneshotAllReduce] = {}
+        self._logical_channels: dict[str, PCIeOneshotAllReduce] = {}
+        self._captured_channel_ids: set[str] = set()
         self._all_channels: list[PCIeOneshotAllReduce] = []
         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
         self._closed = False
 
         self._ipc = ipc
         self._ext = ext_module
+        self._signal_bytes = 0
         if self._channel_factory is None:
-            if self.exchange_group is None:
-                raise ValueError(
-                    "exchange_group is required unless channel_factory is provided"
+            assert self.exchange_group is not None
+            _require_full_grid_residency(
+                owner="PCIe oneshot",
+                required_sms=(ONESHOT_REQUIRED_SMS * self.max_concurrent_channels),
+                device=self.device,
+                exchange_group=self.exchange_group,
+            )
+
+            def prepare() -> tuple[CudaRTLibrary, object, int]:
+                prepared_ipc = self._ipc or CudaRTLibrary()
+                prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
+                prepared_ext = self._ext or _load_extension()
+                return (
+                    prepared_ipc,
+                    prepared_ext,
+                    int(prepared_ext.meta_size()),
                 )
-            if self.device.type != "cuda":
-                raise ValueError("PCIe oneshot pool requires a CUDA device")
-            self._ipc = self._ipc or CudaRTLibrary()
-            self._ipc.cudaSetDevice(self.device.index or 0)
-            self._ext = self._ext or _load_extension()
+
+            self._ipc, self._ext, self._signal_bytes = (
+                _run_collective_preallocation_setup(
+                    owner="PCIe oneshot pool",
+                    exchange_group=self.exchange_group,
+                    setup=prepare,
+                )
+            )
+            _require_collective_contract(
+                owner="PCIe oneshot pool channel layout",
+                exchange_group=self.exchange_group,
+                contract=(
+                    self._signal_bytes,
+                    self.eager_buffer_bytes,
+                    self.max_size,
+                    self.rank_data_bytes,
+                    self.single_channel,
+                    self.max_concurrent_channels,
+                    _push_mode_enabled(),
+                ),
+            )
+            # A genuine single-channel pool has no independent eager/graph
+            # owners to name. Multi-channel distributed callers must prepare
+            # explicit semantic ids before their first eager operation.
+            if self.single_channel:
+                self.prepare_channels((_SINGLE_CHANNEL_ID,))
 
     @classmethod
     def from_exchange_group(
@@ -1012,6 +2636,7 @@ class PCIeOneshotAllReducePool:
         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeOneshotAllReducePool":
         return cls(
             rank=dist.get_rank(group=exchange_group),
@@ -1023,6 +2648,7 @@ class PCIeOneshotAllReducePool:
             rank_data_bytes=rank_data_bytes,
             ext_module=ext_module,
             single_channel=single_channel,
+            max_concurrent_channels=max_concurrent_channels,
         )
 
     @classmethod
@@ -1033,10 +2659,11 @@ class PCIeOneshotAllReducePool:
         device: torch.device | int | str,
         max_input_bytes: int = DEFAULT_MAX_SIZE,
         eager_buffer_bytes: Optional[int] = None,
-        max_size: int = DEFAULT_MAX_SIZE,
+        max_size: Optional[int] = None,
         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeOneshotAllReducePool":
         return cls.from_exchange_group(
             exchange_group=process_group,
@@ -1044,10 +2671,11 @@ class PCIeOneshotAllReducePool:
             eager_buffer_bytes=max_input_bytes
             if eager_buffer_bytes is None
             else eager_buffer_bytes,
-            max_size=max_size,
+            max_size=max_input_bytes if max_size is None else max_size,
             rank_data_bytes=rank_data_bytes,
             ext_module=ext_module,
             single_channel=single_channel,
+            max_concurrent_channels=max_concurrent_channels,
         )
 
     def _new_channel(self, stream_key: Optional[int]) -> PCIeOneshotAllReduce:
@@ -1062,56 +2690,127 @@ class PCIeOneshotAllReducePool:
         if self.exchange_group is None or self._ipc is None or self._ext is None:
             raise RuntimeError("pool is not configured to allocate channels")
 
-        owned_buffers: list[_OwnedSharedBuffer] = []
-        try:
-            channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
-                self.exchange_group,
-                signal_bytes=self._ext.meta_size(),
-                eager_buffer_bytes=self.eager_buffer_bytes,
-                ipc=self._ipc,
-            )
-            owned_buffers.append(channel_buffers.owned_buffer)
+        channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+            self.exchange_group,
+            signal_bytes=self._signal_bytes,
+            eager_buffer_bytes=self.eager_buffer_bytes,
+            ipc=self._ipc,
+        )
+        owned_buffers = [channel_buffers.owned_buffer]
+        channel, init_error = PCIeOneshotAllReduce._from_prepared_factory(
+            rank=self.rank,
+            world_size=self.world_size,
+            device=self.device,
+            signal_ptrs=channel_buffers.signal_ptrs,
+            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+            eager_buffer_bytes=self.eager_buffer_bytes,
+            exchange_group=self.exchange_group,
+            ipc=self._ipc,
+            owned_buffers=owned_buffers,
+            max_size=self.max_size,
+            rank_data_bytes=self.rank_data_bytes,
+            ext_module=self._ext,
+            stream_affine=not self.single_channel,
+        )
 
-            channel = PCIeOneshotAllReduce(
-                rank=self.rank,
-                world_size=self.world_size,
-                device=self.device,
-                signal_ptrs=channel_buffers.signal_ptrs,
-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
-                exchange_group=self.exchange_group,
-                ipc=self._ipc,
-                owned_buffers=owned_buffers,
-                max_size=self.max_size,
-                rank_data_bytes=self.rank_data_bytes,
-                ext_module=self._ext,
-                stream_affine=not self.single_channel,
-            )
-        except Exception:
-            for shared in owned_buffers:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        self._ipc.cudaIpcCloseMemHandle(ptr)
-                with suppress(Exception):
-                    self._ipc.cudaFree(shared.local_ptr)
-            raise
+        def abort_native_runtime() -> None:
+            pointer = getattr(channel, "_ptr", 0)
+            if pointer:
+                self._ext.dispose(pointer)
+                channel._ptr = 0
+            if hasattr(channel, "rank_data"):
+                del channel.rank_data
+
+        def detach_shared_ownership() -> None:
+            channel._owned_buffers.clear()
+
+        _finish_collective_runtime_setup(
+            owner="PCIe oneshot pool channel",
+            exchange_group=self.exchange_group,
+            ipc=self._ipc,
+            shared=channel_buffers.owned_buffer,
+            local_error=init_error,
+            local_cleanup=abort_native_runtime,
+            detach_shared_ownership=detach_shared_ownership,
+        )
         channel._bind_stream_key(stream_key)
         self._all_channels.append(channel)
         return channel
 
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        """Collectively allocate named channels in canonical order.
+
+        Local CUDA stream handles are process-local and cannot identify a
+        distributed channel. Every rank may supply the same set in any order;
+        the sorted logical ids define identical IPC allocation order.
+        """
+
+        if self._channel_factory is None:
+            assert self.exchange_group is not None
+
+            def normalize_and_validate() -> tuple[str, ...]:
+                if self._closed:
+                    raise RuntimeError("pool is closed")
+                return tuple(
+                    sorted(
+                        {_normalize_logical_channel_id(value) for value in channel_ids}
+                    )
+                )
+
+            # Normalize and validate through a status collective first.  A
+            # rank-local empty/invalid id must not return or raise while peers
+            # enter the subsequent contract exchange or IPC allocation.
+            normalized = _run_collective_preallocation_setup(
+                owner="PCIe oneshot logical channel validation",
+                exchange_group=self.exchange_group,
+                setup=normalize_and_validate,
+            )
+            local_state = (normalized, tuple(sorted(self._logical_channels)))
+            gathered = _broadcast_gather_object(local_state, self.exchange_group)
+            if any(state != local_state for state in gathered):
+                raise RuntimeError(
+                    "PCIe oneshot logical channel preparation differs across "
+                    f"ranks: {gathered}"
+                )
+        else:
+            if self._closed:
+                raise RuntimeError("pool is closed")
+            normalized = tuple(
+                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
+            )
+
+        if not normalized:
+            return
+
+        for channel_id in normalized:
+            if channel_id in self._logical_channels:
+                continue
+            self._logical_channels[channel_id] = self._new_channel(None)
+
     def checkpoint_channels(
         self,
-    ) -> tuple[int, dict[int, PCIeOneshotAllReduce]]:
+    ) -> tuple[
+        int,
+        dict[int, PCIeOneshotAllReduce],
+        dict[str, PCIeOneshotAllReduce],
+        set[str],
+    ]:
         """Snapshot channel ownership before a throwaway graph capture."""
         if self._closed:
             raise RuntimeError("pool is closed")
         if self._capture_channel_stack:
             raise RuntimeError("cannot checkpoint channels during capture")
-        return len(self._all_channels), dict(self._channels)
+        return (
+            len(self._all_channels),
+            dict(self._channels),
+            dict(self._logical_channels),
+            set(self._captured_channel_ids),
+        )
 
     def rollback_channels(
         self,
-        checkpoint: tuple[int, dict[int, PCIeOneshotAllReduce]],
+        checkpoint: tuple,
     ) -> None:
         """Close channels created after ``checkpoint`` and restore mappings.
 
@@ -1122,15 +2821,25 @@ class PCIeOneshotAllReducePool:
             raise RuntimeError("pool is closed")
         if self._capture_channel_stack:
             raise RuntimeError("cannot roll back channels during capture")
-        all_channels_len, channels = checkpoint
+        if len(checkpoint) == 2:
+            all_channels_len, channels = checkpoint
+            logical_channels = dict(self._logical_channels)
+            captured_channel_ids = set(self._captured_channel_ids)
+        elif len(checkpoint) == 4:
+            (
+                all_channels_len,
+                channels,
+                logical_channels,
+                captured_channel_ids,
+            ) = checkpoint
+        else:
+            raise ValueError("invalid channel checkpoint")
         if not 0 <= all_channels_len <= len(self._all_channels):
             raise ValueError("channel checkpoint does not belong to this pool")
 
         retained = self._all_channels[:all_channels_len]
         retained_ids = {id(channel) for channel in retained}
         transient = self._all_channels[all_channels_len:]
-        self._all_channels = retained
-        self._channels = dict(channels)
 
         channels_to_close = tuple(
             dict.fromkeys(
@@ -1142,13 +2851,26 @@ class PCIeOneshotAllReducePool:
             exchange_group=self.exchange_group,
             device=self.device,
         )
+        self._all_channels = retained
+        self._channels = dict(channels)
+        self._logical_channels = dict(logical_channels)
+        self._captured_channel_ids = set(captured_channel_ids)
 
-    def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
+    def for_stream(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ) -> PCIeOneshotAllReduce:
         if self._closed:
             raise RuntimeError("pool is closed")
         if self.single_channel:
             channel = self._channels.get(0)
             if channel is not None:
+                return channel
+            if self._channel_factory is None:
+                channel = self._logical_channels[_SINGLE_CHANNEL_ID]
+                self._channels[0] = channel
                 return channel
             if _is_current_stream_capturing(self.device):
                 raise RuntimeError(
@@ -1162,12 +2884,40 @@ class PCIeOneshotAllReducePool:
 
         stream_key = _current_stream_key(self.device, stream)
         channel_key = 0 if stream_key is None else int(stream_key)
-        if _is_current_stream_capturing(self.device) and self._capture_channel_stack:
-            # CUDA and torch/Inductor may recycle a nested capture stream key
-            # between independent target and draft graph managers. The active
-            # enclosing capture owns the channel even if that key still maps
-            # to a channel captured by an earlier manager.
+        if self._capture_channel_stack:
+            # The semantic capture scope starts before vLLM's eager graph
+            # warmup. Route that warmup through the graph-owned channel too,
+            # even though CUDA capture has not started yet. Once CUDA capture
+            # begins, torch/Inductor may replace the enclosing stream with an
+            # ephemeral nested capture stream; that key is deliberately not
+            # made the channel's permanent owner because graph replay runs on
+            # the enclosing stream.
             channel = self._capture_channel_stack[-1]
+            if not _is_current_stream_capturing(self.device):
+                channel._bind_stream_key(stream_key)
+            self._channels[channel_key] = channel
+            return channel
+
+        if self._channel_factory is None:
+            if channel_id is None:
+                raise RuntimeError(
+                    "distributed PCIe oneshot eager use requires an explicit "
+                    "semantic channel_id shared by every rank"
+                )
+            logical_id = _normalize_logical_channel_id(channel_id)
+            channel = self._logical_channels.get(logical_id)
+            if channel is None:
+                raise RuntimeError(
+                    f"logical channel {logical_id!r} is not prepared; call "
+                    "prepare_channels() collectively before use"
+                )
+            mapped = self._channels.get(channel_key)
+            if mapped is not None and mapped is not channel:
+                raise RuntimeError(
+                    f"CUDA stream key {channel_key} is already bound to another "
+                    "logical PCIe oneshot channel"
+                )
+            channel._bind_stream_key(stream_key)
             self._channels[channel_key] = channel
             return channel
         channel = self._channels.get(channel_key)
@@ -1208,8 +2958,9 @@ class PCIeOneshotAllReducePool:
         out: Optional[torch.Tensor] = None,
         peer_input_ptrs: Optional[Sequence[int]] = None,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> torch.Tensor:
-        channel = self.for_stream(stream)
+        channel = self.for_stream(stream, channel_id=channel_id)
         if stream is not None and self.device.type == "cuda":
             with torch.cuda.stream(stream):
                 return channel.all_reduce(inp, out=out, peer_input_ptrs=peer_input_ptrs)
@@ -1226,8 +2977,9 @@ class PCIeOneshotAllReducePool:
         residual_out: Optional[torch.Tensor] = None,
         peer_input_ptrs: Optional[Sequence[int]] = None,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        channel = self.for_stream(stream)
+        channel = self.for_stream(stream, channel_id=channel_id)
 
         def run() -> tuple[torch.Tensor, torch.Tensor]:
             return channel.all_reduce_fused_add_rms_norm(
@@ -1246,21 +2998,78 @@ class PCIeOneshotAllReducePool:
         return run()
 
     @contextmanager
-    def capture(self, stream: object = None):
+    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
+        """Capture on a globally named channel.
+
+        An explicit id names an independently replayable graph. First use of
+        an unprepared explicit id is a collective convenience path: every rank
+        must enter with the same id or all ranks fail closed. Production
+        callers that know the full graph set should call prepare_channels()
+        once before capture; after that collective preparation, ranks may
+        capture members of the agreed catalog in different orders. Each graph
+        must still replay with its same-id peers using collectively compatible
+        kernel sequences and shapes.
+
+        Distributed pools require this semantic id. A local capture ordinal or
+        CUDA stream handle cannot distinguish target and draft graphs when
+        ranks construct them in a different order, so guessing is unsafe.
+        """
+        previous_channels: Optional[dict[int, PCIeOneshotAllReduce]] = None
+        if not self.single_channel and _is_current_stream_capturing(self.device):
+            raise RuntimeError(
+                "PCIe oneshot capture context must be entered before CUDA graph "
+                "capture starts"
+            )
         if self.single_channel:
-            channel = self.for_stream(stream)
+            channel = self.for_stream(
+                stream,
+                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
+            )
+        elif self._channel_factory is None:
+            assert self.exchange_group is not None
+
+            def validate_capture_id() -> str:
+                if channel_id is None:
+                    raise RuntimeError(
+                        "distributed PCIe oneshot capture requires a stable "
+                        "semantic channel_id shared by every rank"
+                    )
+                logical_id = _normalize_logical_channel_id(channel_id)
+                if logical_id in self._captured_channel_ids:
+                    raise RuntimeError(
+                        f"logical channel {logical_id!r} was already captured; "
+                        "each independently replayable graph requires a unique id"
+                    )
+                return logical_id
+
+            logical_id = _run_collective_preallocation_setup(
+                owner="PCIe oneshot capture channel validation",
+                exchange_group=self.exchange_group,
+                setup=validate_capture_id,
+            )
+            needs_preparation = _collective_capture_needs_preparation(
+                owner="PCIe oneshot",
+                logical_id=logical_id,
+                prepared_channel_ids=self._logical_channels,
+                exchange_group=self.exchange_group,
+            )
+            if needs_preparation:
+                self.prepare_channels((logical_id,))
+            previous_channels = dict(self._channels)
+            stream_key = _current_stream_key(self.device, stream)
+            channel_key = 0 if stream_key is None else int(stream_key)
+            channel = self._logical_channels[logical_id]
+            channel._bind_stream_key(stream_key)
+            self._channels[channel_key] = channel
+            self._captured_channel_ids.add(logical_id)
         else:
-            if _is_current_stream_capturing(self.device):
-                raise RuntimeError(
-                    "PCIe oneshot capture context must be entered before CUDA "
-                    "graph capture starts"
-                )
             stream_key = _current_stream_key(self.device, stream)
             channel_key = 0 if stream_key is None else int(stream_key)
             # A CUDA stream handle can be recycled after one graph manager
             # finishes capture. Graphs retain the channel pointers, so a new
             # manager must receive a fresh channel even when the numeric stream
             # key is identical. _all_channels keeps replaced channels alive.
+            previous_channels = dict(self._channels)
             channel = self._new_channel(stream_key)
             self._channels[channel_key] = channel
         with channel.capture(stream=stream):
@@ -1271,22 +3080,50 @@ class PCIeOneshotAllReducePool:
                 popped = self._capture_channel_stack.pop()
                 if popped is not channel:
                     raise RuntimeError("PCIe oneshot capture channel stack corrupted")
+                if previous_channels is not None:
+                    # Graph nodes retain this channel through _all_channels.
+                    # Restore every alias in strict LIFO order so nested or
+                    # recycled torch capture-stream keys cannot escape into a
+                    # later independent/unwrapped capture.
+                    for key, mapped in tuple(self._channels.items()):
+                        if mapped is not channel:
+                            continue
+                        previous = previous_channels.get(key)
+                        if previous is None:
+                            del self._channels[key]
+                        else:
+                            self._channels[key] = previous
 
     def close(self) -> None:
         if self._closed:
             return
-        self._closed = True
         seen: set[int] = set()
+        channels = []
         for channel in (*self._all_channels, *self._channels.values()):
             if id(channel) not in seen:
                 seen.add(id(channel))
-                channel.close()
+                channels.append(channel)
+        _coordinated_close_channels(
+            channels,
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
+        self._closed = True
         self._all_channels.clear()
         self._channels.clear()
+        self._logical_channels.clear()
+        self._captured_channel_ids.clear()
 
-    def __del__(self) -> None:
-        with suppress(Exception):
-            self.close()
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # A pool may be collected while graph or stream work still references
+        # its channels.  Keep the whole pool (and therefore every channel and
+        # rank_data tensor) alive; never unmap, synchronize, or communicate
+        # from GC. Explicit close() clears ownership before finalization.
+        if not getattr(self, "_closed", True):
+            _quarantine[id(self)] = self
 
 
 __all__ = [

--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
+++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
@@ -31,6 +31,7 @@
 #include <torch/all.h>
 #include <torch/extension.h>
 
+#include <algorithm>
 #include <array>
 #include <sstream>
 #include <stdexcept>
@@ -57,12 +58,18 @@ using FlagType = uint32_t;
 constexpr int kFlagStride = 32;
 
 struct Signal {
+  alignas(128) FlagType staging_generation;
+  FlagType active_staging_slot;
   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
 };
 
 struct __align__(16) RankPtrs {
   void* __restrict__ ptrs[kMaxRanks];
+};
+
+struct DoubleRankPtrs {
+  RankPtrs slots[2];
 };
 
 struct RankSignals {
@@ -79,6 +86,33 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
   FlagType flag;
   asm volatile("ld.relaxed.sys.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr));
   return flag;
+}
+
+static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
+  FlagType flag;
+  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
+  return flag;
+}
+
+__global__ void advance_staging_slot_kernel(Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    const FlagType generation = self_sg->staging_generation;
+    self_sg->active_staging_slot = generation & FlagType{1};
+    self_sg->staging_generation = generation + FlagType{1};
+  }
+}
+
+template <int ngpus>
+DINLINE void select_rank_ptrs(RankPtrs& selected, const DoubleRankPtrs& options, Signal* self_sg) {
+  if (threadIdx.x == 0) {
+    // A one-CTA control kernel publishes the slot on this same stream before
+    // the worker launch. Kernel completion is the ordering edge, so every CTA
+    // observes one launch-wide slot without a grid rendezvous.
+    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
+#pragma unroll
+    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = options.slots[slot].ptrs[peer];
+  }
+  __syncthreads();
 }
 
 // Block-pairwise barrier: after it returns, all prior writes from every
@@ -146,9 +180,11 @@ DINLINE void block_range(int64_t total, int64_t& begin, int64_t& end) {
 template <int ngpus>
 __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
-    int rows_per_rank, int row_elems) {
+    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
+    int64_t scale_stride, RankSignals sg, Signal* self_sg,
+    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
+  __shared__ RankPtrs staging;
+  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
   const int packs_per_row = row_elems / 16;
   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
   int64_t begin, end;
@@ -200,9 +236,11 @@ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
 template <int ngpus>
 __global__ void __launch_bounds__(512, 1) ag_fp8_kernel(
     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
-    int rows_per_rank, int row_elems) {
+    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
+    int64_t scale_stride, RankSignals sg, Signal* self_sg,
+    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
+  __shared__ RankPtrs staging;
+  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
   const int packs_per_row = row_elems / 16;
   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
   int64_t begin, end;
@@ -256,12 +294,11 @@ class PCIeTwoShot {
   RankSignals sg_;
   Signal* self_sg_;
 
-  RankPtrs staging_[2];
+  DoubleRankPtrs staging_;
   int64_t pack_stride_;   // Fp8Packs per src region
   int64_t scale_offset_;  // bytes
   int64_t scale_stride_;  // floats per src region
   int64_t max_shard_packs_;
-  int slot_ = 0;
 
   PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
               int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
@@ -275,7 +312,7 @@ class PCIeTwoShot {
         max_shard_packs_(pack_stride) {
     for (int i = 0; i < world_size_; i++) {
       sg_.signals[i] = signals[i];
-      for (int s = 0; s < 2; s++) staging_[s].ptrs[i] = staging[i][s];
+      for (int s = 0; s < 2; s++) staging_.slots[s].ptrs[i] = staging[i][s];
     }
   }
 
@@ -306,40 +343,56 @@ class PCIeTwoShot {
       throw std::runtime_error("pcie_twoshot scale capacity exceeded");
   }
 
+  void check_launch_config(int threads, int block_limit) const {
+    if (threads < world_size_ || threads > 1024 || threads % 32 != 0)
+      throw std::runtime_error(
+          "pcie_twoshot threads must be a multiple of 32 in [world size, 1024]");
+    if (block_limit <= 0)
+      throw std::runtime_error("pcie_twoshot block limit must be positive");
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error("pcie_twoshot block limit exceeds signal capacity");
+  }
+
   void reduce_scatter(cudaStream_t stream, const void* payload, const void* scale, void* out,
                       int64_t num_rows, int64_t row_elems, int threads, int block_limit) {
+    check_launch_config(threads, block_limit);
     if (num_rows % world_size_ != 0)
       throw std::runtime_error("num_rows must be divisible by world size");
     const int64_t rows_per_rank = num_rows / world_size_;
     check_shard(rows_per_rank, row_elems);
-    const int s = slot_ % 2;
-    slot_++;
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
+          reinterpret_cast<const Fp8Pack*>(payload),
+          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
+          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
+          int(rows_per_rank), int(row_elems));
+      CHECK_CUDA_SUCCESS(cudaGetLastError());
     });
   }
 
   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
+    check_launch_config(threads, block_limit);
     check_shard(rows_per_rank, row_elems);
-    const int s = slot_ % 2;
-    slot_++;
     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
     int blocks =
         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
+    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
+    CHECK_CUDA_SUCCESS(cudaGetLastError());
     dispatch([&](auto ng) {
       constexpr int ngpus = decltype(ng)::value;
       ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
+          reinterpret_cast<const Fp8Pack*>(payload),
+          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
+          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
+          int(rows_per_rank), int(row_elems));
+      CHECK_CUDA_SUCCESS(cudaGetLastError());
     });
   }
 };

--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
+++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
@@ -306,6 +306,7 @@ class PCIeTwoShot {
       : rank_(rank),
         world_size_(world_size),
         self_sg_(signals[rank]),
+        staging_{},
         pack_stride_(pack_stride),
         scale_offset_(scale_offset),
         scale_stride_(scale_stride),

--- a/sparkinfer/comm/pcie/pcie_twoshot.py
+++ b/sparkinfer/comm/pcie/pcie_twoshot.py
@@ -11,7 +11,6 @@ a runtime instance must not be shared concurrently across CUDA streams.
 from __future__ import annotations
 
 import os
-from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional, Sequence
@@ -23,15 +22,24 @@ from torch.utils.cpp_extension import load
 
 from ._cuda_ipc import CudaRTLibrary
 from .pcie_oneshot import (
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
     IPC_SLAB_ALIGNMENT,
+    PCIeOneshotAllReduce,
+    _finish_collective_runtime_setup,
+    _raise_local_cleanup_errors,
     _align_up,
-    _broadcast_gather_object,
+    _coordinated_close_channels,
+    _cuda_device_index,
     _normalize_device,
     _OwnedSharedBuffer,
+    _require_collective_contract,
+    _require_full_grid_residency,
+    _run_collective_preallocation_setup,
 )
 
 SUPPORTED_WORLD_SIZES = (2, 4, 8)
 FP8_MAX = 448.0
+TWOSHOT_REQUIRED_SMS = 64
 
 
 @lru_cache(maxsize=1)
@@ -59,8 +67,12 @@ def quantize_per_row(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
 class PCIeTwoShotSP:
     """Two-shot fp8-transport reduce_scatter / all_gather runtime."""
 
-    def __init__(
-        self,
+    def __init__(self, *args, **kwargs) -> None:
+        raise RuntimeError("use PCIeTwoShotSP.from_exchange_group()")
+
+    @classmethod
+    def _from_prepared_factory(
+        cls,
         *,
         rank: int,
         world_size: int,
@@ -69,9 +81,11 @@ class PCIeTwoShotSP:
         fptr: int,
         owned_buffers: Sequence[_OwnedSharedBuffer],
         ipc: CudaRTLibrary,
+        exchange_group: ProcessGroup,
         max_rows: int,
         row_elems: int,
-    ) -> None:
+    ) -> "PCIeTwoShotSP":
+        self = object.__new__(cls)
         self.rank = rank
         self.world_size = world_size
         self.device = device
@@ -79,9 +93,15 @@ class PCIeTwoShotSP:
         self._fptr = fptr
         self._owned_buffers = list(owned_buffers)
         self._ipc = ipc
+        self.exchange_group = exchange_group
         self.max_rows = max_rows
         self.row_elems = row_elems
         self._closed = False
+        self._ipc_imports_closed = False
+        self._ipc_exports_freed = False
+        self._coordinated_close_complete = False
+        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
+        return self
 
     @classmethod
     def from_exchange_group(
@@ -95,64 +115,107 @@ class PCIeTwoShotSP:
     ) -> "PCIeTwoShotSP":
         rank = dist.get_rank(group=exchange_group)
         world_size = dist.get_world_size(group=exchange_group)
-        if world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(f"unsupported world size {world_size}")
-        if row_elems % 16 != 0:
-            raise ValueError("row_elems must be a multiple of 16")
-        if max_rows % world_size != 0:
-            raise ValueError("max_rows must be divisible by world size")
 
-        device_obj = _normalize_device(device)
-        if device_obj.type != "cuda":
-            raise ValueError("PCIe twoshot requires a CUDA device")
+        def validate_factory_arguments():
+            device_obj = _normalize_device(device)
+            normalized_max_rows = int(max_rows)
+            normalized_row_elems = int(row_elems)
+            if world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {world_size}")
+            if device_obj.type != "cuda":
+                raise ValueError("PCIe twoshot requires a CUDA device")
+            if normalized_max_rows <= 0:
+                raise ValueError("max_rows must be positive")
+            if normalized_row_elems <= 0 or normalized_row_elems % 16 != 0:
+                raise ValueError("row_elems must be a positive multiple of 16")
+            if normalized_max_rows % world_size != 0:
+                raise ValueError("max_rows must be divisible by world size")
+            return device_obj, normalized_max_rows, normalized_row_elems
 
-        ipc = CudaRTLibrary()
-        ipc.cudaSetDevice(device_obj.index or 0)
-        ext = ext_module or _load_extension()
-
-        # Per-slot staging: [world][pack_stride] Fp8Packs then
-        # [world][scale_stride] fp32 scales, regions 256B-aligned.
-        max_rows_per_rank = max_rows // world_size
-        packs_per_row = row_elems // 16
-        pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
-        payload_bytes = world_size * pack_stride * 16
-        scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
-        scale_stride = _align_up(max_rows_per_rank, 64)
-        slot_bytes = _align_up(
-            scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
+        device_obj, max_rows, row_elems = _run_collective_preallocation_setup(
+            owner="PCIe twoshot argument validation",
+            exchange_group=exchange_group,
+            setup=validate_factory_arguments,
         )
-        signal_bytes = _align_up(int(ext.meta_size()), IPC_SLAB_ALIGNMENT)
-        slab_bytes = signal_bytes + 2 * slot_bytes
 
-        local_ptr = ipc.cudaMalloc(slab_bytes)
-        owned: list[_OwnedSharedBuffer] = []
-        try:
-            # Signals must start zeroed.
-            ipc.cudaMemset(local_ptr, 0, signal_bytes)
-            local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
-            handles = _broadcast_gather_object(local_handle, exchange_group)
+        _require_full_grid_residency(
+            owner="PCIe twoshot",
+            required_sms=TWOSHOT_REQUIRED_SMS,
+            device=device_obj,
+            exchange_group=exchange_group,
+        )
 
-            peer_ptrs: list[int] = []
-            remote_ptrs: list[int] = []
-            for idx, handle in enumerate(handles):
-                if idx == rank:
-                    peer_ptrs.append(local_ptr)
-                else:
-                    remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
-                    peer_ptrs.append(remote_ptr)
-                    remote_ptrs.append(remote_ptr)
-            owned.append(
-                _OwnedSharedBuffer(
-                    local_ptr=local_ptr,
-                    peer_ptrs=tuple(peer_ptrs),
-                    remote_ptrs=tuple(remote_ptrs),
-                )
+        def prepare():
+            prepared_ipc = CudaRTLibrary()
+            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
+            prepared_ext = ext_module or _load_extension()
+
+            # Per-slot staging: [world][pack_stride] Fp8Packs then
+            # [world][scale_stride] fp32 scales, regions 256B-aligned.
+            max_rows_per_rank = max_rows // world_size
+            packs_per_row = row_elems // 16
+            pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
+            payload_bytes = world_size * pack_stride * 16
+            scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
+            scale_stride = _align_up(max_rows_per_rank, 64)
+            slot_bytes = _align_up(
+                scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
+            )
+            signal_bytes = _align_up(int(prepared_ext.meta_size()), IPC_SLAB_ALIGNMENT)
+            slab_bytes = signal_bytes + 2 * slot_bytes
+            return (
+                prepared_ipc,
+                prepared_ext,
+                pack_stride,
+                scale_offset,
+                scale_stride,
+                signal_bytes,
+                slot_bytes,
+                slab_bytes,
             )
 
-            signal_ptrs = [p for p in peer_ptrs]
-            staging0 = [p + signal_bytes for p in peer_ptrs]
-            staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
+        (
+            ipc,
+            ext,
+            pack_stride,
+            scale_offset,
+            scale_stride,
+            signal_bytes,
+            slot_bytes,
+            slab_bytes,
+        ) = _run_collective_preallocation_setup(
+            owner="PCIe twoshot",
+            exchange_group=exchange_group,
+            setup=prepare,
+        )
+        _require_collective_contract(
+            owner="PCIe twoshot channel layout",
+            exchange_group=exchange_group,
+            contract=(
+                int(max_rows),
+                int(row_elems),
+                int(pack_stride),
+                int(scale_offset),
+                int(scale_stride),
+                int(signal_bytes),
+                int(slab_bytes),
+            ),
+        )
 
+        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group,
+            slab_bytes,
+            zero_fill=True,
+            ipc=ipc,
+        )
+        peer_ptrs = list(shared.peer_ptrs)
+        signal_ptrs = peer_ptrs
+        staging0 = [p + signal_bytes for p in peer_ptrs]
+        staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
+
+        fptr = 0
+        init_error: BaseException | None = None
+        try:
             fptr = ext.init_twoshot(
                 signal_ptrs,
                 staging0,
@@ -162,25 +225,35 @@ class PCIeTwoShotSP:
                 scale_stride,
                 rank,
             )
-            return cls(
-                rank=rank,
-                world_size=world_size,
-                device=device_obj,
-                ext_module=ext,
-                fptr=fptr,
-                owned_buffers=owned,
-                ipc=ipc,
-                max_rows=max_rows,
-                row_elems=row_elems,
-            )
-        except Exception:
-            for shared in owned:
-                for ptr in shared.remote_ptrs:
-                    with suppress(Exception):
-                        ipc.cudaIpcCloseMemHandle(ptr)
-            with suppress(Exception):
-                ipc.cudaFree(local_ptr)
-            raise
+        except Exception as exc:
+            init_error = exc
+
+        def abort_native_runtime() -> None:
+            nonlocal fptr
+            if fptr:
+                ext.dispose(fptr)
+                fptr = 0
+
+        _finish_collective_runtime_setup(
+            owner="PCIe twoshot",
+            exchange_group=exchange_group,
+            ipc=ipc,
+            shared=shared,
+            local_error=init_error,
+            local_cleanup=abort_native_runtime,
+        )
+        return cls._from_prepared_factory(
+            rank=rank,
+            world_size=world_size,
+            device=device_obj,
+            ext_module=ext,
+            fptr=fptr,
+            owned_buffers=[shared],
+            ipc=ipc,
+            exchange_group=exchange_group,
+            max_rows=max_rows,
+            row_elems=row_elems,
+        )
 
     def _check(self, payload: torch.Tensor, scale: torch.Tensor, rows: int) -> None:
         if self._closed:
@@ -240,16 +313,123 @@ class PCIeTwoShotSP:
         self._ext.all_gather_fp8(self._fptr, payload, scale, out, threads, block_limit)
         return out
 
-    def close(self) -> None:
-        if self._closed:
+    def _closed_import_indices(self) -> set[tuple[int, int]]:
+        closed = getattr(self, "_closed_ipc_import_indices", None)
+        if closed is None:
+            closed = set()
+            self._closed_ipc_import_indices = closed
+        return closed
+
+    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
+        return all(
+            (buffer_index, remote_index) in closed
+            for buffer_index, shared in enumerate(self._owned_buffers)
+            for remote_index, _ in enumerate(shared.remote_ptrs)
+        )
+
+    def _close_ipc_imports_strict(self) -> None:
+        if self._ipc_imports_closed:
             return
         self._closed = True
-        with suppress(Exception):
-            self._ext.dispose(self._fptr)
-        for shared in self._owned_buffers:
-            for ptr in shared.remote_ptrs:
-                with suppress(Exception):
+        failures: list[tuple[str, Exception]] = []
+        if self._fptr:
+            try:
+                self._ext.dispose(self._fptr)
+            except Exception as exc:
+                failures.append(("native runtime", exc))
+            else:
+                self._fptr = 0
+
+        closed = self._closed_import_indices()
+        for buffer_index, shared in enumerate(self._owned_buffers):
+            for remote_index, ptr in enumerate(shared.remote_ptrs):
+                key = (buffer_index, remote_index)
+                if key in closed:
+                    continue
+                try:
                     self._ipc.cudaIpcCloseMemHandle(ptr)
-            with suppress(Exception):
+                except Exception as exc:
+                    failures.append((f"CUDA IPC import {ptr}", exc))
+                else:
+                    closed.add(key)
+
+        if (
+            not failures
+            and not self._fptr
+            and self._all_python_ipc_imports_closed(closed)
+        ):
+            self._ipc_imports_closed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe twoshot", "IPC import close", failures)
+
+    def _close_ipc_imports_best_effort(self) -> None:
+        if self._ipc_imports_closed:
+            return
+        self._closed = True
+        native_imports_closed = not self._fptr
+        if self._fptr:
+            try:
+                self._ext.dispose(self._fptr)
+            except Exception:
+                pass
+            else:
+                self._fptr = 0
+                native_imports_closed = True
+
+        closed = self._closed_import_indices()
+        for buffer_index, shared in enumerate(self._owned_buffers):
+            for remote_index, ptr in enumerate(shared.remote_ptrs):
+                key = (buffer_index, remote_index)
+                if key in closed:
+                    continue
+                try:
+                    self._ipc.cudaIpcCloseMemHandle(ptr)
+                except Exception:
+                    pass
+                else:
+                    closed.add(key)
+
+        if (
+            native_imports_closed
+            and not self._fptr
+            and self._all_python_ipc_imports_closed(closed)
+        ):
+            self._ipc_imports_closed = True
+
+    def _free_ipc_exports_strict(self) -> None:
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports_strict()
+        failures: list[tuple[str, Exception]] = []
+        remaining = []
+        for shared in self._owned_buffers:
+            try:
                 self._ipc.cudaFree(shared.local_ptr)
-        self._owned_buffers.clear()
+            except Exception as exc:
+                remaining.append(shared)
+                failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
+        self._owned_buffers = remaining
+        if not remaining:
+            self._ipc_exports_freed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe twoshot", "IPC export free", failures)
+
+    def close(self) -> None:
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        _coordinated_close_channels(
+            (self,),
+            exchange_group=self.exchange_group,
+            device=self.device,
+        )
+
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # GC cannot prove queued CUDA work is complete.  Explicit close() is the
+        # only path allowed to synchronize, unmap imports, and free exports.
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        if getattr(self, "_fptr", 0) or getattr(self, "_owned_buffers", ()):
+            _quarantine[id(self)] = self

--- a/sparkinfer/comm/pcie/pcie_twoshot.py
+++ b/sparkinfer/comm/pcie/pcie_twoshot.py
@@ -362,40 +362,6 @@ class PCIeTwoShotSP:
         if failures:
             _raise_local_cleanup_errors("PCIe twoshot", "IPC import close", failures)
 
-    def _close_ipc_imports_best_effort(self) -> None:
-        if self._ipc_imports_closed:
-            return
-        self._closed = True
-        native_imports_closed = not self._fptr
-        if self._fptr:
-            try:
-                self._ext.dispose(self._fptr)
-            except Exception:
-                pass
-            else:
-                self._fptr = 0
-                native_imports_closed = True
-
-        closed = self._closed_import_indices()
-        for buffer_index, shared in enumerate(self._owned_buffers):
-            for remote_index, ptr in enumerate(shared.remote_ptrs):
-                key = (buffer_index, remote_index)
-                if key in closed:
-                    continue
-                try:
-                    self._ipc.cudaIpcCloseMemHandle(ptr)
-                except Exception:
-                    pass
-                else:
-                    closed.add(key)
-
-        if (
-            native_imports_closed
-            and not self._fptr
-            and self._all_python_ipc_imports_closed(closed)
-        ):
-            self._ipc_imports_closed = True
-
     def _free_ipc_exports_strict(self) -> None:
         if self._ipc_exports_freed:
             return

--- a/tests/comm/test_pcie.py
+++ b/tests/comm/test_pcie.py
@@ -103,6 +103,7 @@ def _make_runtime(
     if eager:
         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
+        kwargs["eager_buffer_bytes"] = max_size
     return PCIeOneshotAllReduce(
         rank=rank,
         world_size=world_size,

--- a/tests/comm/test_pcie_collective_validation_gpu.py
+++ b/tests/comm/test_pcie_collective_validation_gpu.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+import socket
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A
+from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
+from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _expect_collective_rejection(operation) -> None:
+    with pytest.raises(RuntimeError, match="argument validation"):
+        operation()
+    # Prove every rank left the same failed setup round and can enter the next.
+    dist.barrier()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=90),
+    )
+    group = dist.group.WORLD
+    try:
+        _expect_collective_rejection(
+            lambda: PCIeOneshotAllReduce.from_exchange_group(
+                exchange_group=group,
+                device=device,
+                eager_buffer_bytes=1 << 20,
+                max_size=(2 << 20) if rank == 0 else (1 << 20),
+                ext_module=object(),
+            )
+        )
+        _expect_collective_rejection(
+            lambda: PCIeDCPA2A.from_exchange_group(
+                exchange_group=group,
+                device=device,
+                max_batch_size=8,
+                total_heads=16,
+                head_dim=64,
+                query_head_dim=7 if rank == 0 else 64,
+                ext_module=object(),
+            )
+        )
+        _expect_collective_rejection(
+            lambda: PCIeDCPA2A.from_exchange_group(
+                exchange_group=group,
+                device=torch.device("cpu") if rank == 0 else device,
+                max_batch_size=8,
+                total_heads=16,
+                head_dim=64,
+                ext_module=object(),
+            )
+        )
+        _expect_collective_rejection(
+            lambda: PCIeTwoShotSP.from_exchange_group(
+                exchange_group=group,
+                device=device,
+                max_rows=8,
+                row_elems=17 if rank == 0 else 16,
+                ext_module=object(),
+            )
+        )
+        _expect_collective_rejection(
+            lambda: PCIeOneshotAllReduce(
+                rank=1 if rank == 0 else rank,
+                world_size=world_size,
+                device=device,
+                signal_ptrs=tuple(0 for _ in range(world_size)),
+                exchange_group=group,
+                ext_module=object(),
+            )
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def test_asymmetric_argument_failures_reject_all_ranks_before_ipc() -> None:
+    if os.getenv("SPARKINFER_PCIE_TEST_COLLECTIVE_VALIDATION") != "1":
+        pytest.skip("set the collective-validation GPU gate to run this test")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    world_size = 2
+    if torch.cuda.device_count() < world_size:
+        pytest.skip("two CUDA devices are required")
+    mp.spawn(
+        _worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/comm/test_pcie_control_node_benchmark_contract.py
+++ b/tests/comm/test_pcie_control_node_benchmark_contract.py
@@ -41,6 +41,7 @@ def _load_functions(relative_path: str, names: set[str]) -> dict[str, object]:
     module = ast.Module(body=selected, type_ignores=[])
     ast.fix_missing_locations(module)
     namespace: dict[str, object] = {
+        "CORRECTNESS_KEYS": {"verdict"},
         "math": math,
         "METRICS": ("mean_us", "p50_us", "p95_us"),
         "os": os,
@@ -50,8 +51,29 @@ def _load_functions(relative_path: str, names: set[str]) -> dict[str, object]:
         "subprocess": subprocess,
         "suppress": suppress,
     }
+    # Execute only the selected, dependency-injected helpers from the benchmark.
     exec(compile(module, str(path), "exec"), namespace)
     return namespace
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "benchmarks/benchmark_pcie_oneshot_control_node.py",
+        "benchmarks/run_pcie_oneshot_control_node_ab.py",
+    ],
+)
+def test_benchmark_correctness_contract_requires_an_explicit_pass(
+    relative_path: str,
+) -> None:
+    functions = _load_functions(relative_path, {"_validate_correctness"})
+    validate = functions["_validate_correctness"]
+
+    validate({"verdict": "pass"})
+    with pytest.raises(ValueError, match="correctness did not pass"):
+        validate({"verdict": "fail"})
+    with pytest.raises(ValueError, match="correctness schema mismatch"):
+        validate({"verdict": "pass", "details": "unexpected"})
 
 
 def test_distributed_critical_path_uses_aligned_iteration_maxima() -> None:

--- a/tests/comm/test_pcie_control_node_benchmark_contract.py
+++ b/tests/comm/test_pcie_control_node_benchmark_contract.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import ast
+import math
+import os
+import signal
+import subprocess
+import sys
+from contextlib import suppress
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_benchmark_prepares_distinct_stable_eager_and_graph_channels() -> None:
+    source = (
+        _ROOT / "benchmarks" / "benchmark_pcie_oneshot_control_node.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'eager_channel_id = "eager:control-node-benchmark"' in source
+    assert 'graph_channel_id = "graph:control-node-benchmark"' in source
+    assert "pool.prepare_channels((eager_channel_id, graph_channel_id))" in source
+    assert "pool.for_stream(stream, channel_id=eager_channel_id)" in source
+    assert "pool.capture(stream, channel_id=graph_channel_id)" in source
+
+
+def _load_functions(relative_path: str, names: set[str]) -> dict[str, object]:
+    path = _ROOT / relative_path
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in names
+    ]
+    assert {node.name for node in selected} == names
+    module = ast.Module(body=selected, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, object] = {
+        "math": math,
+        "METRICS": ("mean_us", "p50_us", "p95_us"),
+        "os": os,
+        "Path": Path,
+        "Sequence": Sequence,
+        "signal": signal,
+        "subprocess": subprocess,
+        "suppress": suppress,
+    }
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace
+
+
+def test_distributed_critical_path_uses_aligned_iteration_maxima() -> None:
+    worker = _load_functions(
+        "benchmarks/benchmark_pcie_oneshot_control_node.py",
+        {"_summary", "_distributed_critical_path"},
+    )
+    per_rank = [
+        {
+            "eager": {"cold_us": 11.0, "samples_us": [10.0, 1.0, 10.0, 1.0]},
+            "graph": {"cold_us": 7.0, "samples_us": [6.0, 2.0, 6.0, 2.0]},
+        },
+        {
+            "eager": {"cold_us": 12.0, "samples_us": [1.0, 10.0, 1.0, 10.0]},
+            "graph": {"cold_us": 8.0, "samples_us": [2.0, 6.0, 2.0, 6.0]},
+        },
+    ]
+
+    result = worker["_distributed_critical_path"](per_rank)
+
+    # The old max(mean(rank)) aggregation reports 5.5us / 4us. The actual
+    # collective critical path changes rank each iteration and is 10us / 6us.
+    assert max(sum(row["eager"]["samples_us"]) / 4 for row in per_rank) == 5.5
+    assert result["eager"]["samples_us"] == [10.0, 10.0, 10.0, 10.0]
+    assert result["eager"]["mean_us"] == 10.0
+    assert result["eager"]["cold_us"] == 12.0
+    assert result["graph"]["samples_us"] == [6.0, 6.0, 6.0, 6.0]
+    assert result["graph"]["mean_us"] == 6.0
+    assert result["graph"]["cold_us"] == 8.0
+
+
+def test_controller_paired_deltas_use_distributed_critical_path() -> None:
+    controller = _load_functions(
+        "benchmarks/run_pcie_oneshot_control_node_ab.py",
+        {"_paired_deltas"},
+    )
+
+    def record(variant: str, eager: float, graph: float) -> dict[str, object]:
+        def mode(value: float) -> dict[str, float | list[float]]:
+            return {
+                "cold_us": value,
+                "mean_us": value,
+                "p50_us": value,
+                "p95_us": value,
+                "min_us": value,
+                "max_us": value,
+                "samples_us": [value],
+            }
+
+        return {
+            "identity": {"variant": variant},
+            "distributed_critical_path": {
+                "eager": mode(eager),
+                "graph": mode(graph),
+            },
+        }
+
+    deltas = controller["_paired_deltas"](
+        [
+            record("baseline", 10.0, 20.0),
+            record("candidate", 12.0, 18.0),
+        ]
+    )
+
+    assert deltas[0]["metrics"]["eager"]["mean_us"]["delta_us"] == 2.0
+    assert deltas[0]["metrics"]["graph"]["p95_us"]["delta_us"] == -2.0
+
+
+def test_controller_timeout_terminates_the_command_process_group() -> None:
+    controller = _load_functions(
+        "benchmarks/run_pcie_oneshot_control_node_ab.py",
+        {"_run"},
+    )
+
+    with pytest.raises(TimeoutError, match="process group was terminated"):
+        controller["_run"](
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            timeout=0.05,
+        )

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -6,6 +6,7 @@ import torch
 from sparkinfer.comm.pcie.pcie_dcp_a2a import (
     PCIeDCPA2A,
     PCIeDCPA2APool,
+    _SINGLE_CHANNEL_ID,
     _staging_layout,
     lse_reduce_scatter_reference,
 )
@@ -383,7 +384,7 @@ def test_pool_rejects_logical_channel_set_mismatch_before_allocation(monkeypatch
     def gather(local_state, group):
         if not local_state or isinstance(local_state[0], str):
             return [local_state, ()]
-        requested, existing = local_state
+        _requested, existing = local_state
         return [(("other",), existing), local_state]
 
     monkeypatch.setattr(
@@ -449,6 +450,26 @@ def test_pool_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
     assert pool.for_stream(7, channel_id="eager:dcp") is eager
     with pytest.raises(RuntimeError, match="stream-affine"):
         pool.for_stream(8, channel_id="eager:dcp")
+
+
+def test_distributed_single_channel_pool_uses_prepared_default() -> None:
+    eager = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        single_channel=True,
+        channel_factory=lambda stream_key: eager,
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels[_SINGLE_CHANNEL_ID] = eager
+
+    assert pool.for_stream() is eager
+    assert pool._channels == {0: eager}
 
 
 def test_pool_capture_requires_stable_semantic_id(monkeypatch):

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -187,9 +187,7 @@ def test_runtime_validates_and_dispatches_to_extension():
 def test_runtime_accepts_head_major_input_and_output():
     ext = _FakeExt()
     runtime = _make_runtime(ext)
-    input_storage = torch.arange(
-        32 * 4 * 64, dtype=torch.bfloat16
-    ).reshape(32, 4, 64)
+    input_storage = torch.arange(32 * 4 * 64, dtype=torch.bfloat16).reshape(32, 4, 64)
     partial_output = input_storage.transpose(0, 1)[:2]
     partial_lse = torch.zeros(2, 32, dtype=torch.float32)
     output_storage = torch.empty(16, 2, 64, dtype=torch.bfloat16)
@@ -224,6 +222,54 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
         runtime.all_gather_heads(good_output[:, :8])
     with pytest.raises(ValueError, match="exceeds configured capacity"):
         runtime.all_gather_heads(torch.zeros(5, 16, 64, dtype=torch.bfloat16))
+
+
+def test_constructor_rejects_invalid_query_and_staging_capacity():
+    common = dict(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        signal_ptrs=(100, 200),
+        staging0_ptrs=(300, 400),
+        staging1_ptrs=(500, 600),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        lse_offset=4 * 32 * 64 * 2,
+        lse_capacity=4 * 32,
+        ext_module=_FakeExt(),
+    )
+    with pytest.raises(ValueError, match="query_head_dim"):
+        PCIeDCPA2A(
+            **common,
+            query_head_dim=0,
+            output_capacity_elems=4 * 32 * 64,
+        )
+    with pytest.raises(ValueError, match="output capacity"):
+        PCIeDCPA2A(
+            **common,
+            query_head_dim=32,
+            output_capacity_elems=4 * 32 * 32,
+        )
+
+
+def test_cuda_direct_runtime_requires_collective_factory():
+    with pytest.raises(ValueError, match="exchange_group is required"):
+        PCIeDCPA2A(
+            rank=0,
+            world_size=2,
+            device=torch.device("cuda:0"),
+            signal_ptrs=(100, 200),
+            staging0_ptrs=(300, 400),
+            staging1_ptrs=(500, 600),
+            max_batch_size=4,
+            total_heads=32,
+            head_dim=64,
+            output_capacity_elems=4 * 32 * 64,
+            lse_offset=4 * 32 * 64 * 2,
+            lse_capacity=4 * 32,
+            ext_module=_FakeExt(),
+        )
 
 
 def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
@@ -269,9 +315,362 @@ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
         capturing[0] = False
 
     assert target_channel is not draft_channel
-    assert pool._channels[70] is target_channel
-    assert pool._channels[80] is draft_channel
+    assert pool._channels == {}
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
     assert [entry[0] for entry in created] == [7, 8]
+
+    capturing[0] = True
+    current_stream[0] = 70
+    with pytest.raises(RuntimeError, match="no channel during CUDA graph capture"):
+        pool.for_stream()
+
+
+def test_pool_collectively_prepares_logical_channels_in_canonical_order(
+    monkeypatch,
+):
+    created = []
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: created.append(stream_key) or object(),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, local_status],
+    )
+
+    pool.prepare_channels(("target", "draft"))
+    pool.prepare_channels(("draft", "target"))
+
+    assert list(pool._logical_channels) == ["draft", "target"]
+    assert created == [None, None]
+
+
+def test_pool_rejects_logical_channel_set_mismatch_before_allocation(monkeypatch):
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if not local_state or isinstance(local_state[0], str):
+            return [local_state, ()]
+        requested, existing = local_state
+        return [(("other",), existing), local_state]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object", gather
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with pytest.raises(RuntimeError, match="differs across ranks"):
+        pool.prepare_channels(("target",))
+
+
+def test_pool_invalid_logical_id_is_rejected_collectively(monkeypatch):
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    with pytest.raises(RuntimeError, match="must not be empty"):
+        pool.prepare_channels(("",))
+
+
+def test_pool_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
+    monkeypatch,
+):
+    eager = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: eager,
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["eager:dcp"] = eager
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+
+    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
+        pool.for_stream(7)
+    assert pool.for_stream(7, channel_id="eager:dcp") is eager
+    with pytest.raises(RuntimeError, match="stream-affine"):
+        pool.for_stream(8, channel_id="eager:dcp")
+
+
+def test_pool_capture_requires_stable_semantic_id(monkeypatch):
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="stable semantic channel_id"),
+        pool.capture(7),
+    ):
+        pass
+
+
+def test_pool_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
+    target = _make_runtime()
+    draft = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        requested, catalog = local_state
+        assert requested == "graph:target"
+        return [local_state, ("graph:draft", catalog)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with pool.capture(7, channel_id="graph:target") as channel:
+        assert channel is target
+
+    assert pool._captured_channel_ids == {"graph:target"}
+
+
+def test_pool_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
+    target = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["graph:target"] = target
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        return [local_state, ("graph:target", ())]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
+        pool.capture(7, channel_id="graph:target"),
+    ):
+        pass
+
+
+def test_pool_capture_rejects_differing_unprepared_ids(monkeypatch):
+    target = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["graph:target"] = target
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        _, catalog = local_state
+        return [local_state, ("graph:unknown", catalog)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="unprepared logical channels"),
+        pool.capture(7, channel_id="graph:target"),
+    ):
+        pass
+
+
+def test_pool_capture_preserves_same_id_convenience_allocation(monkeypatch):
+    created = []
+    channel = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: created.append(stream_key) or channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+
+    with pool.capture(7, channel_id="graph:target") as captured:
+        assert captured is channel
+
+    assert created == [None]
+    assert pool._logical_channels == {"graph:target": channel}
+
+
+def test_pool_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
+    eager = _make_runtime()
+    target = _make_runtime()
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels.update({"eager:dcp": eager, "graph:target": target})
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: 7 if stream is None else int(stream),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+
+    with pool.capture(7, channel_id="graph:target") as captured:
+        assert captured is target
+        assert pool.for_stream(7, channel_id="eager:dcp") is target
+        with pytest.raises(RuntimeError, match="stream-affine"):
+            pool.for_stream(8, channel_id="eager:dcp")
+
+    assert pool.for_stream(7, channel_id="eager:dcp") is eager
 
 
 def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
@@ -317,8 +716,7 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
         capturing[0] = False
 
     assert target_channel is not draft_channel
-    assert pool._channels[7] is draft_channel
-    assert pool._channels[70] is draft_channel
+    assert pool._channels == {}
     assert target_channel in pool._all_channels
     assert draft_channel in pool._all_channels
     assert [entry[0] for entry in created] == [7, 7]
@@ -326,6 +724,92 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
     pool.close()
     assert target_channel._ext.dispose_calls == [1234]
     assert draft_channel._ext.dispose_calls == [1234]
+
+
+def test_pool_restores_eager_mapping_after_capture(monkeypatch):
+    current_stream = [7]
+    capturing = [False]
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    eager_channel = pool.for_stream()
+    with pool.capture(7) as graph_channel:
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is graph_channel
+        capturing[0] = False
+
+    assert graph_channel is not eager_channel
+    assert pool._channels == {7: eager_channel}
+    assert graph_channel in pool._all_channels
+
+
+def test_pool_restores_nested_capture_mappings(monkeypatch):
+    current_stream = [7]
+    capturing = [False]
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: _make_runtime(),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    eager_channel = pool.for_stream()
+    with pool.capture(7) as outer_channel:
+        assert pool._channels == {7: outer_channel}
+
+        current_stream[0] = 8
+        with pool.capture() as inner_channel:
+            capturing[0] = True
+            current_stream[0] = 80
+            assert pool.for_stream() is inner_channel
+            assert pool._channels == {
+                7: outer_channel,
+                8: inner_channel,
+                80: inner_channel,
+            }
+            capturing[0] = False
+
+        assert pool._channels == {7: outer_channel}
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is outer_channel
+        capturing[0] = False
+
+    assert eager_channel is not outer_channel
+    assert outer_channel is not inner_channel
+    assert pool._channels == {7: eager_channel}
+    assert pool._capture_channel_stack == []
 
 
 def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):

--- a/tests/comm/test_pcie_dcp_a2a_gpu.py
+++ b/tests/comm/test_pcie_dcp_a2a_gpu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import socket
 
@@ -8,9 +9,13 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+import sparkinfer.comm.pcie.pcie_dcp_a2a as pcie_dcp_a2a
+from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
 from sparkinfer.comm.pcie.pcie_dcp_a2a import (
+    PCIeDCPA2A,
     PCIeDCPA2APool,
     _load_extension,
+    _staging_layout,
     lse_reduce_scatter_reference,
 )
 
@@ -99,6 +104,34 @@ def _reference(
     )
 
 
+def _local_staging_words(channel, stream: torch.cuda.Stream) -> tuple[int, int]:
+    assert channel._ipc is not None
+    assert len(channel._owned_buffers) == 1
+    layout = _staging_layout(
+        signal_bytes=int(channel._ext.meta_size()),
+        world_size=channel.world_size,
+        max_batch_size=channel.max_batch_size,
+        total_heads=channel.total_heads,
+        head_dim=channel.head_dim,
+        query_head_dim=channel.query_head_dim,
+    )
+    words = (ctypes.c_uint16(), ctypes.c_uint16())
+    local_ptr = channel._owned_buffers[0].local_ptr
+    for word, offset in zip(
+        words,
+        (layout.staging0_offset, layout.staging1_offset),
+        strict=True,
+    ):
+        channel._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            local_ptr + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
 def _check_eager(
     pool: PCIeDCPA2APool,
     rank: int,
@@ -115,7 +148,7 @@ def _check_eager(
                 dtype,
                 device,
             )
-            gathered_q = pool.all_gather_heads(local_q)
+            gathered_q = pool.all_gather_heads(local_q, channel_id="eager:dcp")
             expected_q = torch.cat(
                 [
                     _rank_query(
@@ -133,7 +166,9 @@ def _check_eager(
             torch.testing.assert_close(gathered_q, expected_q, rtol=0, atol=0)
 
             partial_output, partial_lse = _rank_inputs(step, rank, batch, dtype, device)
-            out = pool.lse_reduce_scatter(partial_output, partial_lse)
+            out = pool.lse_reduce_scatter(
+                partial_output, partial_lse, channel_id="eager:dcp"
+            )
             torch.cuda.synchronize(device)
             expected = _reference(
                 step,
@@ -166,11 +201,69 @@ def _check_eager(
                 head_major_input,
                 partial_lse,
                 out=head_major_output,
+                channel_id="eager:dcp",
             )
             torch.cuda.synchronize(device)
             assert actual is head_major_output
             assert actual.movedim(0, 1).stride(0) == MAX_BATCH * HEAD_DIM
             torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def _check_eager_adjacency(
+    pool: PCIeDCPA2APool,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> None:
+    channel = pool.for_stream(channel_id="eager:dcp")
+    first_query = _rank_query(700, rank, world_size, MAX_BATCH, torch.bfloat16, device)
+    second_query = _rank_query(701, rank, world_size, MAX_BATCH, torch.bfloat16, device)
+    partial_output, partial_lse = _rank_inputs(702, rank, 1, torch.bfloat16, device)
+    first_gather = torch.empty(
+        MAX_BATCH,
+        TOTAL_HEADS,
+        QUERY_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    second_gather = torch.empty_like(first_gather)
+    reduced = torch.empty(
+        1,
+        TOTAL_HEADS // world_size,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    # Issue large-grid AG -> small-grid RS -> large-grid AG without a host
+    # synchronization so adjacent eager executions exercise slot advancement.
+    channel.all_gather_heads(first_query, first_gather)
+    channel.lse_reduce_scatter(partial_output, partial_lse, reduced)
+    channel.all_gather_heads(second_query, second_gather)
+    torch.cuda.synchronize(device)
+
+    expected_first = torch.cat(
+        [
+            _rank_query(700, source, world_size, MAX_BATCH, torch.bfloat16, device)
+            for source in range(world_size)
+        ],
+        dim=1,
+    )
+    expected_second = torch.cat(
+        [
+            _rank_query(701, source, world_size, MAX_BATCH, torch.bfloat16, device)
+            for source in range(world_size)
+        ],
+        dim=1,
+    )
+    torch.testing.assert_close(first_gather, expected_first, rtol=0, atol=0)
+    torch.testing.assert_close(second_gather, expected_second, rtol=0, atol=0)
+    torch.testing.assert_close(
+        reduced,
+        _reference(702, rank, world_size, 1, torch.bfloat16, device),
+        rtol=2e-2,
+        atol=2e-2,
+    )
 
 
 def _check_graph(
@@ -180,7 +273,8 @@ def _check_graph(
     device: torch.device,
 ) -> None:
     stream = torch.cuda.Stream(device=device)
-    channel = pool.for_stream(stream)
+    pool.prepare_channels(("graph",))
+    channel = pool.for_stream(stream, channel_id="graph")
     layers = 7
     input_storages = [
         torch.empty(
@@ -244,7 +338,10 @@ def _check_graph(
             channel.lse_reduce_scatter(inputs[layer], lses[layer], outputs[layer])
     stream.synchronize()
 
-    for replay in range(8):
+    replay_count = int(os.getenv("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS", "8"))
+    if replay_count <= 0:
+        raise ValueError("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS must be positive")
+    for replay in range(replay_count):
         expected = []
         expected_queries = []
         for layer in range(layers):
@@ -302,6 +399,165 @@ def _check_graph(
         for out, reference in zip(gathered_queries, expected_queries, strict=True):
             torch.testing.assert_close(out, reference, rtol=0, atol=0)
 
+    # One captured operation has odd capture-time parity. Adjacent A -> A
+    # replays must advance the device-owned slot at execution time.
+    odd_input = torch.empty(
+        1,
+        TOTAL_HEADS // world_size,
+        QUERY_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    odd_output = torch.empty(
+        1,
+        TOTAL_HEADS,
+        QUERY_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    with torch.cuda.stream(stream):
+        channel.all_gather_heads(odd_input, odd_output)
+    stream.synchronize()
+    dist.barrier()
+
+    odd_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(odd_graph, stream=stream):
+        channel.all_gather_heads(odd_input, odd_output)
+    stream.synchronize()
+
+    # Prime both slots after capture, then observe them read-only. A graph with
+    # a host-baked slot changes the same word on both replays; execution-owned
+    # parity changes alternate words.
+    with torch.cuda.stream(stream):
+        for value in (11.0, 12.0):
+            odd_input.fill_(value)
+            channel.all_gather_heads(odd_input, odd_output)
+    snapshots = [_local_staging_words(channel, stream)]
+    for value in (1.0, 2.0):
+        with torch.cuda.stream(stream):
+            odd_input.fill_(value)
+            odd_graph.replay()
+        snapshots.append(_local_staging_words(channel, stream))
+        torch.testing.assert_close(
+            odd_output, torch.full_like(odd_output, value), rtol=0, atol=0
+        )
+
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(2)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert changed_slots[0] != changed_slots[1]
+
+
+def _check_semantic_capture_warmup(
+    pool: PCIeDCPA2APool,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> None:
+    """Match vLLM's eager DCP warmup inside a graph-owner scope."""
+    stream = torch.cuda.Stream(device=device)
+    local_query = _rank_query(
+        900,
+        rank,
+        world_size,
+        1,
+        torch.bfloat16,
+        device,
+    )
+    gathered = torch.empty(
+        1,
+        TOTAL_HEADS,
+        QUERY_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    expected = torch.cat(
+        [
+            _rank_query(
+                900,
+                source,
+                world_size,
+                1,
+                torch.bfloat16,
+                device,
+            )
+            for source in range(world_size)
+        ],
+        dim=1,
+    )
+    pool.prepare_channels(("graph:warmup",))
+
+    graph = torch.cuda.CUDAGraph()
+    with (
+        torch.cuda.stream(stream),
+        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
+    ):
+        warmup_channel = pool.for_stream(stream, channel_id="eager:dcp")
+        assert warmup_channel is graph_channel
+        warmup_channel.all_gather_heads(local_query, gathered)
+        stream.synchronize()
+        torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
+
+        with torch.cuda.graph(graph, stream=stream):
+            graph_channel.all_gather_heads(local_query, gathered)
+
+    # The eager DCP channel was already bound to vLLM's default stream. Its
+    # original mapping must be usable again after the graph-owner scope exits.
+    eager_channel = pool.for_stream(channel_id="eager:dcp")
+    assert eager_channel is not graph_channel
+    with torch.cuda.stream(stream):
+        graph.replay()
+    stream.synchronize()
+    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
+
+
+def _check_teardown_retry(
+    pool: PCIeDCPA2APool,
+    rank: int,
+    device: torch.device,
+) -> None:
+    """Inject one local unmap failure and prove every rank retries coherently."""
+
+    assert pool._all_channels
+    channel = pool._all_channels[0]
+    assert channel._ipc is not None
+    original_close = channel._ipc.cudaIpcCloseMemHandle
+    injected = False
+
+    if rank == 0:
+
+        def fail_once(ptr):
+            nonlocal injected
+            if not injected:
+                injected = True
+                raise RuntimeError("injected DCP IPC unmap failure")
+            return original_close(ptr)
+
+        channel._ipc.cudaIpcCloseMemHandle = fail_once
+
+    failed = False
+    try:
+        pool.close()
+    except RuntimeError as exc:
+        failed = "IPC unmap" in str(exc)
+    verdict = torch.tensor(int(failed), device=device, dtype=torch.int32)
+    dist.all_reduce(verdict, op=dist.ReduceOp.MIN)
+    assert int(verdict.item()) == 1
+    assert not pool._closed
+
+    if rank == 0:
+        channel._ipc.cudaIpcCloseMemHandle = original_close
+    pool.close()
+    assert pool._closed
+
 
 def _worker(rank: int, world_size: int, port: int) -> None:
     torch.cuda.set_device(rank)
@@ -319,18 +575,117 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         total_heads=TOTAL_HEADS,
         head_dim=HEAD_DIM,
         query_head_dim=QUERY_HEAD_DIM,
+        max_concurrent_channels=2,
     )
+    closed = False
     try:
+        pool.prepare_channels(("eager:dcp", "graph"))
         _check_eager(pool, rank, world_size, device)
+        dist.barrier()
+        _check_eager_adjacency(pool, rank, world_size, device)
+        dist.barrier()
+        _check_semantic_capture_warmup(pool, rank, world_size, device)
         dist.barrier()
         _check_graph(pool, rank, world_size, device)
         torch.cuda.synchronize(device)
+        if os.getenv("SPARKINFER_PCIE_DCP_TEST_TEARDOWN_RETRY", "0") == "1":
+            _check_teardown_retry(pool, rank, device)
+            closed = True
     finally:
-        pool.close()
+        if not closed:
+            pool.close()
+        dist.destroy_process_group()
+
+
+def _residency_rejection_worker(rank: int, world_size: int, port: int) -> None:
+    if rank != 0:
+        # Simulate one constrained/MIG-like rank in an otherwise full device
+        # group; every peer must reject before any IPC allocation.
+        os.environ.pop("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", None)
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
+
+    def unexpected_cuda_rt():
+        raise AssertionError("CUDA IPC allocation started before residency rejection")
+
+    pcie_dcp_a2a.CudaRTLibrary = unexpected_cuda_rt
+    try:
+        with pytest.raises(RuntimeError, match="requires at least 64 visible SMs"):
+            PCIeDCPA2A.from_process_group(
+                process_group=dist.group.WORLD,
+                device=device,
+                max_batch_size=MAX_BATCH,
+                total_heads=TOTAL_HEADS,
+                head_dim=HEAD_DIM,
+                query_head_dim=QUERY_HEAD_DIM,
+            )
+        dist.barrier()
+    finally:
+        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
+        dist.destroy_process_group()
+
+
+def _preflight_rejection_worker(rank: int, world_size: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
+    original_allocate = PCIeOneshotAllReduce._allocate_shared_buffer
+
+    class FakeExt:
+        @staticmethod
+        def meta_size():
+            return 256
+
+    def fail_cuda_rt():
+        raise RuntimeError("injected rank-zero pre-allocation failure")
+
+    def unexpected_allocate(*args, **kwargs):
+        raise AssertionError(
+            "CUDA IPC allocation started after a peer preflight failure"
+        )
+
+    if rank == 0:
+        pcie_dcp_a2a.CudaRTLibrary = fail_cuda_rt
+    PCIeOneshotAllReduce._allocate_shared_buffer = staticmethod(unexpected_allocate)
+    try:
+        with pytest.raises(RuntimeError, match="pre-allocation setup"):
+            PCIeDCPA2A.from_process_group(
+                process_group=dist.group.WORLD,
+                device=device,
+                max_batch_size=MAX_BATCH,
+                total_heads=TOTAL_HEADS,
+                head_dim=HEAD_DIM,
+                query_head_dim=QUERY_HEAD_DIM,
+                ext_module=FakeExt(),
+            )
+        dist.barrier()
+    finally:
+        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
+        PCIeOneshotAllReduce._allocate_shared_buffer = original_allocate
         dist.destroy_process_group()
 
 
 def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
+    if (
+        os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") == "1"
+        or os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") == "1"
+    ):
+        pytest.skip("running the reduced-SM residency rejection gate")
     if not torch.cuda.is_available():
         pytest.skip("CUDA is unavailable")
     world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
@@ -342,3 +697,48 @@ def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
         )
     _load_extension()
     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
+
+
+def test_pcie_dcp_a2a_rejects_reduced_sm_slice_before_ipc_allocation():
+    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") != "1":
+        pytest.skip("set the reduced-SM residency rejection gate to run this test")
+    visible_sms = int(os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
+    assert 0 < visible_sms < pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS, (
+        "set SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT below "
+        f"{pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS} to exercise the residency gate"
+    )
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
+    if world_size not in (2, 4, 8):
+        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(
+            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
+        )
+    mp.spawn(
+        _residency_rejection_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+def test_pcie_dcp_a2a_coordinates_one_rank_preflight_failure_before_ipc():
+    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") != "1":
+        pytest.skip("set the one-rank preflight rejection gate to run this test")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
+    if world_size not in (2, 4, 8):
+        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(
+            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
+        )
+    mp.spawn(
+        _preflight_rejection_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/comm/test_pcie_ipc_lifecycle.py
+++ b/tests/comm/test_pcie_ipc_lifecycle.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pytest
+import torch
+
+from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A, PCIeDCPA2APool
+from sparkinfer.comm.pcie.pcie_oneshot import (
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    PCIeOneshotAllReduce,
+    PCIeOneshotAllReducePool,
+)
+from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
+
+
+class _FakeChannel:
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+
+    def _close_ipc_imports(self) -> None:
+        self.events.append(f"imports:{self.name}")
+
+    def _free_ipc_exports(self) -> None:
+        self.events.append(f"exports:{self.name}")
+
+
+def test_pool_explicit_close_coordinates_imports_before_exports(monkeypatch) -> None:
+    events = []
+    group = object()
+    channel_a = _FakeChannel("a", events)
+    channel_b = _FakeChannel("b", events)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        exchange_group=group,
+        channel_factory=lambda stream_key: channel_a,
+    )
+    pool._all_channels = [channel_a, channel_b]
+    pool._channels = {1: channel_a, 2: channel_b}
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
+        lambda device: events.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    pool.close()
+    pool.close()
+
+    assert events == [
+        "synchronize",
+        "barrier",
+        "imports:a",
+        "imports:b",
+        "barrier",
+        "exports:a",
+        "exports:b",
+        "barrier",
+    ]
+    assert pool._closed
+    assert pool._all_channels == []
+    assert pool._channels == {}
+
+
+def test_pool_destructor_is_nonblocking_and_does_not_touch_cuda_ownership(
+    monkeypatch,
+) -> None:
+    events = []
+    channel = _FakeChannel("a", events)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        exchange_group=object(),
+        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
+    )
+    pool._all_channels = [channel]
+    pool._channels = {1: channel}
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    pool.__del__()
+
+    assert events == []
+
+
+class _FakeExt:
+    def __init__(self, events: list[object], *, dispose_failures: int = 0) -> None:
+        self.events = events
+        self.dispose_failures = dispose_failures
+
+    def dispose(self, ptr: int) -> None:
+        self.events.append(("dispose", ptr))
+        if self.dispose_failures:
+            self.dispose_failures -= 1
+            raise RuntimeError("dispose failed")
+
+    def dispose_best_effort(self, ptr: int) -> None:
+        self.events.append(("dispose_best_effort", ptr))
+
+
+class _FakeIPC:
+    def __init__(
+        self,
+        events: list[object],
+        *,
+        close_failures: dict[int, int] | None = None,
+        free_failures: dict[int, int] | None = None,
+    ) -> None:
+        self.events = events
+        self.close_failures = dict(close_failures or {})
+        self.free_failures = dict(free_failures or {})
+
+    def cudaIpcCloseMemHandle(self, ptr: int) -> None:
+        self.events.append(("close", ptr))
+        if self.close_failures.get(ptr, 0):
+            self.close_failures[ptr] -= 1
+            raise RuntimeError(f"close {ptr} failed")
+
+    def cudaFree(self, ptr: int) -> None:
+        self.events.append(("free", ptr))
+        if self.free_failures.get(ptr, 0):
+            self.free_failures[ptr] -= 1
+            raise RuntimeError(f"free {ptr} failed")
+
+
+class _Shared:
+    def __init__(self, local_ptr: int, remote_ptrs: tuple[int, ...]) -> None:
+        self.local_ptr = local_ptr
+        self.remote_ptrs = remote_ptrs
+
+
+def _fake_twoshot(events: list[object]) -> PCIeTwoShotSP:
+    runtime = object.__new__(PCIeTwoShotSP)
+    runtime.rank = 0
+    runtime.world_size = 2
+    runtime.device = torch.device("cpu")
+    runtime.exchange_group = object()
+    runtime._ext = _FakeExt(events)
+    runtime._fptr = 123
+    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
+    runtime._ipc = _FakeIPC(events)
+    runtime.max_rows = 8
+    runtime.row_elems = 16
+    runtime._closed = False
+    runtime._ipc_imports_closed = False
+    runtime._ipc_exports_freed = False
+    return runtime
+
+
+def _fake_oneshot(events: list[object]) -> PCIeOneshotAllReduce:
+    runtime = object.__new__(PCIeOneshotAllReduce)
+    runtime.rank = 0
+    runtime.world_size = 2
+    runtime.device = torch.device("cpu")
+    runtime.exchange_group = None
+    runtime._ext = _FakeExt(events)
+    runtime._ptr = 123
+    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
+    runtime._ipc = _FakeIPC(events)
+    runtime._registered_input_ptrs = {10: (20,)}
+    runtime._closed = False
+    runtime._ipc_imports_closed = False
+    runtime._ipc_exports_freed = False
+    return runtime
+
+
+def _fake_dcp(events: list[object]) -> PCIeDCPA2A:
+    runtime = object.__new__(PCIeDCPA2A)
+    runtime.rank = 0
+    runtime.world_size = 2
+    runtime.device = torch.device("cpu")
+    runtime.exchange_group = None
+    runtime._ext = _FakeExt(events)
+    runtime._ptr = 123
+    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
+    runtime._ipc = _FakeIPC(events)
+    runtime._closed = False
+    runtime._ipc_imports_closed = False
+    runtime._ipc_exports_freed = False
+    runtime._coordinated_close_complete = False
+    runtime._closed_ipc_import_indices = set()
+    return runtime
+
+
+def test_dcp_explicit_close_retries_failed_unmap_before_export_free() -> None:
+    events: list[object] = []
+    runtime = _fake_dcp(events)
+    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
+
+    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
+        runtime.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+    ]
+    assert runtime._ptr == 0
+    assert not runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+
+    runtime.close()
+    assert events[-2:] == [("close", 2000), ("free", 1000)]
+    assert runtime._ipc_imports_closed
+    assert runtime._ipc_exports_freed
+
+
+def test_dcp_pool_failed_rollback_retains_transient_channel() -> None:
+    retained = _fake_dcp([])
+    transient_events: list[object] = []
+    transient = _fake_dcp(transient_events)
+    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: retained,
+    )
+    pool._all_channels = [retained, transient]
+    pool._channels = {1: retained, 2: transient}
+
+    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
+        pool.rollback_channels((1, {1: retained}))
+
+    assert pool._all_channels == [retained, transient]
+    assert pool._channels == {1: retained, 2: transient}
+    assert ("free", 1000) not in transient_events
+
+
+def test_twoshot_explicit_close_coordinates_unmap_then_free(monkeypatch) -> None:
+    events: list[object] = []
+    runtime = _fake_twoshot(events)
+    runtime.device = torch.device("cuda:0")
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
+        lambda device: events.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    runtime.close()
+    runtime.close()
+
+    assert events == [
+        "synchronize",
+        "barrier",
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        "barrier",
+        ("free", 1000),
+        "barrier",
+    ]
+    assert runtime._fptr == 0
+    assert runtime._owned_buffers == []
+    assert runtime._ipc_imports_closed
+    assert runtime._ipc_exports_freed
+
+
+def test_twoshot_destructor_retains_imports_and_exports_without_cuda_calls(
+    monkeypatch,
+) -> None:
+    events: list[object] = []
+    runtime = _fake_twoshot(events)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+
+    runtime.__del__()
+
+    assert events == []
+    assert runtime._fptr == 123
+    assert runtime._owned_buffers != []
+    assert not runtime._ipc_exports_freed
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
+def test_real_gc_quarantines_dcp_and_twoshot_ownership(runtime_factory) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime_id = id(runtime)
+    runtime_ref = weakref.ref(runtime)
+
+    del runtime
+    gc.collect()
+
+    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(runtime_id)
+    assert runtime_ref() is retained
+    assert events == []
+    pointer_attr = "_ptr" if isinstance(retained, PCIeDCPA2A) else "_fptr"
+    assert getattr(retained, pointer_attr) == 123
+    assert retained._owned_buffers
+    assert not retained._ipc_exports_freed
+
+    # Production deliberately keeps this ownership until process teardown.
+    # The fake can be released after marking the coordinated path complete.
+    retained._coordinated_close_complete = True
+    del retained
+    gc.collect()
+    assert runtime_ref() is None
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
+def test_explicitly_closed_dcp_and_twoshot_are_not_quarantined(runtime_factory) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime.exchange_group = None
+    runtime.close()
+    runtime_id = id(runtime)
+    runtime_ref = weakref.ref(runtime)
+
+    del runtime
+    gc.collect()
+
+    assert runtime_ref() is None
+    assert runtime_id not in _ABANDONED_PCIE_RUNTIME_QUARANTINE
+
+
+def test_real_gc_quarantines_dcp_pool_and_its_channel() -> None:
+    channel = _fake_dcp([])
+    pool = PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        max_batch_size=4,
+        total_heads=32,
+        head_dim=64,
+        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
+    )
+    pool._all_channels = [channel]
+    pool._channels = {0: channel}
+    pool_id = id(pool)
+    pool_ref = weakref.ref(pool)
+
+    del pool
+    gc.collect()
+
+    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(pool_id)
+    assert pool_ref() is retained
+    assert retained._all_channels == [channel]
+    assert retained._channels
+
+    retained._closed = True
+    channel._coordinated_close_complete = True
+    del retained
+    del channel
+    gc.collect()
+    assert pool_ref() is None
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
+def test_strict_close_reports_unmap_failure_retains_exports_and_retries_only_failure(
+    runtime_factory,
+) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime.exchange_group = None
+    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"coordinated PCIe close failed during IPC unmap.*not freed",
+    ):
+        runtime.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+    ]
+    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
+    assert getattr(runtime, pointer_attr) == 0
+    assert runtime._closed
+    assert not runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
+
+    runtime.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("close", 2000),
+        ("free", 1000),
+    ]
+    assert runtime._ipc_imports_closed
+    assert runtime._ipc_exports_freed
+    assert runtime._owned_buffers == []
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
+def test_strict_close_reports_native_dispose_failure_without_losing_pointer(
+    runtime_factory,
+) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime.exchange_group = None
+    runtime._ext = _FakeExt(events, dispose_failures=1)
+
+    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
+        runtime.close()
+
+    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
+    assert getattr(runtime, pointer_attr) == 123
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+    ]
+    assert not runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+
+    runtime.close()
+
+    assert getattr(runtime, pointer_attr) == 0
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("dispose", 123),
+        ("free", 1000),
+    ]
+    assert runtime._ipc_imports_closed
+    assert runtime._ipc_exports_freed
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
+def test_strict_close_reports_free_failure_and_retains_only_failed_export(
+    runtime_factory,
+) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime.exchange_group = None
+    runtime._owned_buffers.append(_Shared(4000, (5000,)))
+    runtime._ipc = _FakeIPC(events, free_failures={1000: 1})
+
+    with pytest.raises(RuntimeError, match="failed during IPC export free"):
+        runtime.close()
+
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("close", 5000),
+        ("free", 1000),
+        ("free", 4000),
+    ]
+    assert runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
+
+    runtime.close()
+
+    assert events[-1] == ("free", 1000)
+    assert runtime._ipc_exports_freed
+    assert runtime._owned_buffers == []
+
+
+def test_peer_unmap_failure_is_exchanged_before_any_local_export_free(
+    monkeypatch,
+) -> None:
+    events: list[object] = []
+    runtime = _fake_oneshot(events)
+    runtime.device = torch.device("cuda:0")
+    runtime.exchange_group = object()
+    peer_statuses = iter(
+        [
+            lambda local: [local, ("peer close failed",)],
+            lambda local: [local, ()],
+            lambda local: [local, ()],
+        ]
+    )
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
+        lambda device: events.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: next(peer_statuses)(local_status),
+    )
+
+    with pytest.raises(RuntimeError, match="group rank 1: peer close failed"):
+        runtime.close()
+
+    assert ("free", 1000) not in events
+    assert runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+
+    runtime.close()
+
+    assert events == [
+        "synchronize",
+        "barrier",
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        "synchronize",
+        "barrier",
+        "barrier",
+        ("free", 1000),
+        "barrier",
+    ]
+    assert runtime._ipc_exports_freed
+
+
+def test_status_exchange_failure_retains_local_exports(monkeypatch) -> None:
+    events: list[object] = []
+    runtime = _fake_oneshot(events)
+    runtime.exchange_group = object()
+
+    def fail_status_exchange(local_status, group):
+        raise RuntimeError("status exchange failed")
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        fail_status_exchange,
+    )
+
+    with pytest.raises(RuntimeError, match="failed to exchange peer IPC unmap"):
+        runtime.close()
+
+    assert events == [
+        "barrier",
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+    ]
+    assert runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+    assert runtime._owned_buffers
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
+def test_rank_that_freed_locally_retries_until_peer_free_succeeds(
+    monkeypatch,
+    runtime_factory,
+) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime.device = torch.device("cuda:0")
+    runtime.exchange_group = object()
+    peer_statuses = iter(
+        [
+            lambda local: [local, ()],
+            lambda local: [local, ("peer export free failed",)],
+            lambda local: [local, ()],
+            lambda local: [local, ()],
+        ]
+    )
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
+        lambda *, group: events.append("barrier"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
+        lambda device: events.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: next(peer_statuses)(local_status),
+    )
+
+    with pytest.raises(RuntimeError, match="group rank 1: peer export free failed"):
+        runtime.close()
+
+    assert runtime._ipc_exports_freed
+    assert not getattr(runtime, "_coordinated_close_complete", False)
+
+    runtime.close()
+    events_after_success = list(events)
+    runtime.close()
+
+    assert events == events_after_success
+    assert events == [
+        "synchronize",
+        "barrier",
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        "barrier",
+        ("free", 1000),
+        "synchronize",
+        "barrier",
+        "barrier",
+        "barrier",
+    ]
+    assert runtime._coordinated_close_complete
+
+
+@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
+def test_gc_never_attempts_native_dispose_or_ipc_unmap(
+    runtime_factory,
+) -> None:
+    events: list[object] = []
+    runtime = runtime_factory(events)
+    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
+
+    runtime.__del__()
+
+    assert events == []
+    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
+    assert getattr(runtime, pointer_attr) == 123
+    assert not runtime._ipc_imports_closed
+    assert not runtime._ipc_exports_freed
+    assert runtime._owned_buffers
+
+
+def test_gc_retention_preserves_explicit_close_retry_path() -> None:
+    events: list[object] = []
+    runtime = _fake_oneshot(events)
+
+    runtime.__del__()
+
+    assert events == []
+    assert runtime._ptr == 123
+    assert not runtime._ipc_imports_closed
+    runtime.close()
+    assert events == [
+        ("dispose", 123),
+        ("close", 2000),
+        ("close", 3000),
+        ("free", 1000),
+    ]
+    assert runtime._ipc_exports_freed
+
+
+def test_failed_rollback_keeps_transient_channel_owned_for_retry() -> None:
+    retained_events: list[object] = []
+    transient_events: list[object] = []
+    retained = _fake_oneshot(retained_events)
+    transient = _fake_oneshot(transient_events)
+    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: retained,
+    )
+    pool._all_channels = [retained, transient]
+    pool._channels = {1: retained, 2: transient}
+    checkpoint = (1, {1: retained})
+
+    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
+        pool.rollback_channels(checkpoint)
+
+    assert pool._all_channels == [retained, transient]
+    assert pool._channels == {1: retained, 2: transient}
+    assert not pool._closed
+    assert ("free", 1000) not in transient_events

--- a/tests/comm/test_pcie_native_teardown.py
+++ b/tests/comm/test_pcie_native_teardown.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PCIE_ONESHOT = ROOT / "sparkinfer" / "comm" / "pcie" / "pcie_oneshot.cu"
+
+
+def test_oneshot_native_dispose_has_strict_and_best_effort_paths() -> None:
+    source = PCIE_ONESHOT.read_text(encoding="utf-8")
+
+    assert "IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>" in source
+    assert "IPCHandles ipc_handles_;" in source
+    assert "~PCIeAllreduce() noexcept = default;" in source
+    assert "cudaError_t close_ipc_handles_noexcept() noexcept" in source
+    assert "void close_ipc_handles_strict()" in source
+    assert "&dispose," in source
+    assert '"dispose_best_effort"' in source
+
+    dispose = source[source.index("static void dispose(fptr_t _fa)") :]
+    dispose = dispose[: dispose.index("static int64_t meta_size()")]
+    assert dispose.index("fa->close_ipc_handles_strict();") < dispose.index(
+        "delete fa;"
+    )
+    assert "static bool dispose_best_effort(fptr_t _fa) noexcept" in dispose
+
+
+def test_native_ipc_registry_destructor_survives_injected_close_failure(
+    tmp_path: Path,
+) -> None:
+    """Compile the production RAII helper and fail a close inside destruction.
+
+    Throwing for this injected status from an implicitly-noexcept destructor,
+    as the old PCIeAllreduce destructor did, would invoke the terminate handler
+    and make the subprocess exit 86.
+    """
+
+    compiler = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
+    if compiler is None:
+        pytest.skip("no C++ compiler available for native teardown regression")
+
+    source = tmp_path / "ipc_registry_failure_injection.cpp"
+    binary = tmp_path / "ipc_registry_failure_injection"
+    source.write_text(
+        textwrap.dedent(
+            r"""
+            #include "sparkinfer/comm/pcie/ipc_handle_registry.h"
+
+            #include <cstdlib>
+            #include <exception>
+            #include <type_traits>
+
+            namespace {
+
+            constexpr int kSuccess = 0;
+            constexpr int kInjectedFailure = 7;
+            int close_calls = 0;
+            int failed_handle = 0;
+            int failures_remaining = 0;
+
+            int injected_close(int handle) noexcept {
+              ++close_calls;
+              if (handle == failed_handle && failures_remaining > 0) {
+                --failures_remaining;
+                return kInjectedFailure;
+              }
+              return kSuccess;
+            }
+
+            using Registry =
+                sparkinfer::pcie::IpcHandleRegistry<int, int, int, kSuccess>;
+
+            struct Owner {
+              Registry handles{&injected_close};
+              ~Owner() noexcept = default;
+            };
+
+            static_assert(std::is_nothrow_destructible_v<Registry>);
+            static_assert(std::is_nothrow_destructible_v<Owner>);
+
+            }  // namespace
+
+            int main() {
+              std::set_terminate([] { std::_Exit(86); });
+
+              failed_handle = 22;
+              failures_remaining = 1;
+              {
+                Owner owner;
+                owner.handles.emplace(1, 11);
+                owner.handles.emplace(2, 22);
+                owner.handles.emplace(3, 33);
+              }
+              if (close_calls != 3 || failures_remaining != 0) {
+                return 10;
+              }
+
+              close_calls = 0;
+              failures_remaining = 1;
+              {
+                Owner owner;
+                owner.handles.emplace(1, 11);
+                owner.handles.emplace(2, 22);
+                owner.handles.emplace(3, 33);
+                if (owner.handles.close_all_noexcept() != kInjectedFailure) {
+                  return 11;
+                }
+                if (close_calls != 3) {
+                  return 12;
+                }
+                if (owner.handles.close_all_noexcept() != kSuccess) {
+                  return 13;
+                }
+                if (close_calls != 4) {
+                  return 14;
+                }
+                if (owner.handles.close_all_noexcept() != kSuccess ||
+                    close_calls != 4) {
+                  return 15;
+                }
+              }
+              return close_calls == 4 ? 0 : 16;
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    compile_result = subprocess.run(
+        [
+            compiler,
+            "-std=c++17",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(ROOT),
+            str(source),
+            "-o",
+            str(binary),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert compile_result.returncode == 0, (
+        "native teardown regression failed to compile\n"
+        f"stdout:\n{compile_result.stdout}\n"
+        f"stderr:\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run(
+        [str(binary)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert run_result.returncode == 0, (
+        "injected native close failure terminated or violated idempotency\n"
+        f"returncode: {run_result.returncode}\n"
+        f"stdout:\n{run_result.stdout}\n"
+        f"stderr:\n{run_result.stderr}"
+    )

--- a/tests/comm/test_pcie_native_teardown.py
+++ b/tests/comm/test_pcie_native_teardown.py
@@ -114,11 +114,19 @@ def test_native_ipc_registry_destructor_survives_injected_close_failure(
                 if (close_calls != 3) {
                   return 12;
                 }
+                if (owner.handles.find(1) != owner.handles.end() ||
+                    owner.handles.find(2) == owner.handles.end() ||
+                    owner.handles.find(3) != owner.handles.end()) {
+                  return 17;
+                }
                 if (owner.handles.close_all_noexcept() != kSuccess) {
                   return 13;
                 }
                 if (close_calls != 4) {
                   return 14;
+                }
+                if (owner.handles.find(2) != owner.handles.end()) {
+                  return 18;
                 }
                 if (owner.handles.close_all_noexcept() != kSuccess ||
                     close_calls != 4) {

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -24,6 +24,15 @@ from sparkinfer.comm.pcie.pcie_oneshot import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_pcie_global_registries():
+    _RETAINED_FAILED_IPC_EXPORTS.clear()
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
+    yield
+    _RETAINED_FAILED_IPC_EXPORTS.clear()
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
+
+
 class _FakeExt:
     def __init__(self):
         self.init_calls = []
@@ -2056,6 +2065,7 @@ def test_channel_destructor_retains_all_cuda_ownership_without_side_effects():
     assert [shared.local_ptr for shared in channel._owned_buffers] == [1000, 4000]
     assert channel._registered_input_ptrs == {1: (2,)}
     assert _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(id(channel)) is channel
+    channel._coordinated_close_complete = True
 
 
 def test_channel_gc_quarantines_rank_data_tensor_and_native_pointer():

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import gc
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -7,7 +10,16 @@ from sparkinfer.comm.pcie.pcie_oneshot import (
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
     PCIeOneshotAllReducePool,
+    _abort_collective_ipc_setup,
+    _broadcast_gather_object,
     _compute_crossover_size,
+    _finish_collective_runtime_setup,
+    _group_ranks,
+    _OwnedSharedBuffer,
+    _require_no_retained_ipc_setup,
+    _require_full_grid_residency,
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    _RETAINED_FAILED_IPC_EXPORTS,
     parse_pcie_oneshot_max_size,
 )
 
@@ -106,6 +118,7 @@ def _make_runtime(
     if eager:
         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
+        kwargs["eager_buffer_bytes"] = max_size
     return PCIeOneshotAllReduce(
         rank=rank,
         world_size=world_size,
@@ -125,6 +138,63 @@ def test_parse_pcie_oneshot_max_size_accepts_auto_and_suffixes():
     assert parse_pcie_oneshot_max_size("64KB") == 64 * 1024
     assert parse_pcie_oneshot_max_size("2m") == 2 * 1024 * 1024
     assert parse_pcie_oneshot_max_size(4096) == 4096
+
+
+def test_full_grid_residency_accepts_device_with_enough_visible_sms(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(multi_processor_count=84),
+    )
+
+    _require_full_grid_residency(
+        owner="test collective",
+        required_sms=64,
+        device=torch.device("cuda:0"),
+        exchange_group=None,
+    )
+
+
+def test_full_grid_residency_rejects_mig_like_capacity_collectively(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(multi_processor_count=84),
+    )
+    monkeypatch.setenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "32")
+    exchanged = []
+
+    def exchange(
+        local_error,
+        *,
+        exchange_group,
+        phase,
+        exports_retained_on_exchange_failure,
+    ):
+        assert not exports_retained_on_exchange_failure
+        exchanged.append((local_error, exchange_group, phase))
+        return ((f"RuntimeError: {local_error}",), ())
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._exchange_setup_failures", exchange
+    )
+
+    group = object()
+    with pytest.raises(RuntimeError, match="requires at least 64 visible SMs") as exc:
+        _require_full_grid_residency(
+            owner="test collective",
+            required_sms=64,
+            device=torch.device("cuda:0"),
+            exchange_group=group,
+        )
+
+    assert exchanged
+    assert exchanged[0][1:] == (group, "test collective resident-grid capability")
+    assert "exports were retained" not in str(exc.value)
 
 
 def test_compute_crossover_size_runs_fine_sweep():
@@ -347,6 +417,76 @@ def test_should_allreduce_checks_device_dtype_size_alignment_and_contiguity():
     )
 
 
+def test_eager_runtime_rejects_threshold_above_buffer_capacity():
+    with pytest.raises(ValueError, match="exceeds eager buffer capacity"):
+        PCIeOneshotAllReduce(
+            rank=0,
+            world_size=2,
+            device=torch.device("cpu"),
+            signal_ptrs=(100, 200),
+            eager_buffer_ptrs0=(300, 400),
+            eager_buffer_ptrs1=(500, 600),
+            eager_buffer_bytes=16,
+            max_size=32,
+            ext_module=_FakeExt(),
+        )
+
+
+def test_cuda_direct_runtime_requires_collective_factory():
+    with pytest.raises(ValueError, match="exchange_group is required"):
+        PCIeOneshotAllReduce(
+            rank=0,
+            world_size=2,
+            device=torch.device("cuda:0"),
+            signal_ptrs=(100, 200),
+            ext_module=_FakeExt(),
+        )
+
+
+@pytest.mark.parametrize(
+    "runtime_class", (PCIeOneshotAllReduce, PCIeOneshotAllReducePool)
+)
+def test_process_group_max_input_sets_threshold_and_capacity(
+    monkeypatch, runtime_class
+):
+    captured = {}
+
+    def fake_from_exchange_group(cls, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        runtime_class, "from_exchange_group", classmethod(fake_from_exchange_group)
+    )
+
+    runtime_class.from_process_group(
+        process_group=object(),
+        device=torch.device("cuda:0"),
+        max_input_bytes=1 << 20,
+    )
+
+    assert captured["eager_buffer_bytes"] == 1 << 20
+    assert captured["max_size"] == 1 << 20
+
+
+def test_autotune_never_benchmarks_past_eager_capacity(monkeypatch):
+    runtime = _make_runtime(eager=True, max_size=4096)
+    runtime.device = torch.device("cuda:0")
+    observed = {}
+
+    def fake_compute(benchmark, *, ceiling_bytes, fine_step_bytes):
+        observed["ceiling_bytes"] = ceiling_bytes
+        return ceiling_bytes, []
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._compute_crossover_size", fake_compute
+    )
+    monkeypatch.setattr(torch.cuda, "Stream", lambda *, device: object())
+
+    assert runtime.find_crossover_size(object(), ceiling_bytes=1 << 20) == 4096
+    assert observed["ceiling_bytes"] == 4096
+
+
 def test_graph_buffer_api_exposes_explicit_registration_hooks():
     runtime = _make_runtime()
     ext = runtime._ext
@@ -395,16 +535,604 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
         "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
+        lambda local_object, group: (
+            [local_object, (), ()]
+            if isinstance(local_object, tuple)
+            else [local_object, b"remote0", b"remote1"]
+        ),
     )
 
-    with pytest.raises(RuntimeError, match="peer rank 2"):
+    with pytest.raises(RuntimeError, match="peer group rank 2"):
         PCIeOneshotAllReduce._allocate_shared_buffer(
             object(), 256, zero_fill=True, ipc=ipc
         )
 
     assert ipc.closed == [2000]
     assert ipc.freed == [1000]
+
+
+def test_failed_setup_export_free_is_retained_and_retryable(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.free_attempts = 0
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            raise RuntimeError("injected setup failure")
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaFree(self, ptr):
+            self.free_attempts += 1
+            if self.free_attempts == 1:
+                raise RuntimeError("transient free failure")
+
+    ipc = FakeIPC()
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_object, group: [local_object, ()],
+    )
+
+    with pytest.raises(RuntimeError, match="exports were retained") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            object(), 256, zero_fill=True, ipc=ipc
+        )
+
+    retained = exc.value.retryable_export
+    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
+    retained.retry()
+    assert ipc.free_attempts == 2
+    assert retained.local_ptr == 0
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_failed_peer_setup_export_free_is_retained_and_retryable(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.closed = []
+            self.free_attempts = 0
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            pass
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaIpcOpenMemHandleBytes(self, handle):
+            return 2000
+
+        def cudaIpcCloseMemHandle(self, ptr):
+            self.closed.append(ptr)
+
+        def cudaFree(self, ptr):
+            self.free_attempts += 1
+            if self.free_attempts == 1:
+                raise RuntimeError("transient free failure")
+
+    ipc = FakeIPC()
+    status_round = 0
+
+    def exchange(local_object, group):
+        nonlocal status_round
+        if not isinstance(local_object, tuple):
+            return [local_object, b"remote"]
+        status_round += 1
+        if status_round == 1:  # retained-setup gate
+            return [local_object, ()]
+        if status_round == 2:  # export preparation
+            return [local_object, ()]
+        if status_round == 3:  # import-open verdict
+            return [local_object, ("peer open failed",)]
+        if status_round == 4:  # rollback-unmap verdict
+            return [local_object, ()]
+        if status_round == 5:  # rollback-export-free verdict
+            return [local_object, ()]
+        if status_round == 6:  # retry export-free verdict
+            return [local_object, ()]
+        raise AssertionError(f"unexpected status round {status_round}")
+
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="exports were retained") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            object(), 256, zero_fill=True, ipc=ipc
+        )
+
+    retained = exc.value.retryable_export
+    assert ipc.closed == [2000]
+    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
+    retained.retry()
+    assert ipc.free_attempts == 2
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_peer_setup_and_unmap_failure_retains_export_and_closes_each_import_once(
+    monkeypatch,
+):
+    class FakeIPC:
+        def __init__(self):
+            self.closed = []
+            self.freed = []
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            pass
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaIpcOpenMemHandleBytes(self, handle):
+            return {b"remote0": 2000, b"remote1": 3000}[handle]
+
+        def cudaIpcCloseMemHandle(self, ptr):
+            self.closed.append(ptr)
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    status_round = 0
+
+    def exchange(local_object, group):
+        nonlocal status_round
+        if not isinstance(local_object, tuple):
+            return [local_object, b"remote0", b"remote1"]
+        status_round += 1
+        if status_round == 1:  # retained-setup gate
+            return [local_object, (), ()]
+        if status_round == 2:  # export preparation
+            return [local_object, (), ()]
+        if status_round == 3:  # import-open verdict
+            return [local_object, ("peer open failed",), ()]
+        if status_round == 4:  # rollback-unmap verdict
+            return [local_object, ("peer unmap failed",), ()]
+        if status_round in (5, 6):  # retry unmap / retry export free
+            return [local_object, (), ()]
+        raise AssertionError(f"unexpected status round {status_round}")
+
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match=r"retained.*peer unmap failed") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            object(), 256, zero_fill=True, ipc=ipc
+        )
+
+    assert ipc.closed == [2000, 3000]
+    assert ipc.freed == []
+    exc.value.retryable_setup.retry()
+    assert ipc.closed == [2000, 3000]
+    assert ipc.freed == [1000]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_handle_exchange_failure_retains_export_until_collective_retry(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.freed = []
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            pass
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    status_round = 0
+    fail_handle_exchange = True
+
+    def exchange(local_object, group):
+        nonlocal status_round, fail_handle_exchange
+        if not isinstance(local_object, tuple):
+            if fail_handle_exchange:
+                fail_handle_exchange = False
+                raise RuntimeError("injected handle exchange failure")
+            return [local_object, b"remote"]
+        status_round += 1
+        return [local_object, ()]
+
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="handle exchange failed") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            object(), 256, zero_fill=True, ipc=ipc
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.local_ptr == 1000
+    assert ipc.freed == []
+    retained.retry()
+    assert ipc.freed == [1000]
+    assert status_round == 4  # gate, export verdict, retry unmap, retry free
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_import_status_exchange_failure_retains_imports_for_retry(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.closed = []
+            self.freed = []
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            pass
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaIpcOpenMemHandleBytes(self, handle):
+            return 2000
+
+        def cudaIpcCloseMemHandle(self, ptr):
+            self.closed.append(ptr)
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    status_round = 0
+
+    def exchange(local_object, group):
+        nonlocal status_round
+        if not isinstance(local_object, tuple):
+            return [local_object, b"remote"]
+        status_round += 1
+        if status_round == 3:
+            raise RuntimeError("injected import verdict exchange failure")
+        return [local_object, ()]
+
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="import-open status") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            object(), 256, zero_fill=True, ipc=ipc
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.remote_ptrs == [2000]
+    assert ipc.closed == []
+    retained.retry()
+    assert ipc.closed == [2000]
+    assert ipc.freed == [1000]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_failed_native_cleanup_is_owned_and_retried_before_export_free(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.closed = []
+            self.freed = []
+
+        def cudaIpcCloseMemHandle(self, ptr):
+            self.closed.append(ptr)
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    cleanup_calls = 0
+
+    def cleanup():
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if cleanup_calls == 1:
+            raise RuntimeError("transient native dispose failure")
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
+        _abort_collective_ipc_setup(
+            owner="test runtime",
+            setup_phase="native initialization",
+            setup_statuses=(("peer init failed",), ()),
+            exchange_group=object(),
+            ipc=ipc,
+            local_ptr=1000,
+            remote_ptrs=(2000,),
+            local_error=RuntimeError("peer init failed"),
+            local_cleanup=cleanup,
+        )
+
+    retained = exc.value.retryable_setup
+    assert cleanup_calls == 1
+    assert retained.state == "native"
+    assert ipc.closed == []
+    assert ipc.freed == []
+    retained.retry()
+    assert cleanup_calls == 2
+    assert ipc.closed == [2000]
+    assert ipc.freed == [1000]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_peer_native_cleanup_failure_blocks_every_rank_from_unmapping(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.closed = []
+            self.freed = []
+
+        def cudaIpcCloseMemHandle(self, ptr):
+            self.closed.append(ptr)
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    cleanup_calls = 0
+    status_round = 0
+
+    def cleanup():
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+
+    def exchange(local_status, group):
+        nonlocal status_round
+        status_round += 1
+        if status_round == 1:
+            return [local_status, ("peer native dispose failed",)]
+        return [local_status, ()]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
+        _abort_collective_ipc_setup(
+            owner="test runtime",
+            setup_phase="native initialization",
+            setup_statuses=(("peer init failed",), ()),
+            exchange_group=object(),
+            ipc=ipc,
+            local_ptr=1000,
+            remote_ptrs=(2000,),
+            local_error=RuntimeError("peer init failed"),
+            local_cleanup=cleanup,
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.state == "native"
+    assert retained.local_cleanup is None
+    assert cleanup_calls == 1
+    assert ipc.closed == []
+    assert ipc.freed == []
+
+    retained.retry()
+    assert cleanup_calls == 1
+    assert ipc.closed == [2000]
+    assert ipc.freed == [1000]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_native_cleanup_verdict_exchange_failure_retains_imports(monkeypatch):
+    events = []
+
+    class FakeIPC:
+        def cudaIpcCloseMemHandle(self, ptr):
+            events.append(("close", ptr))
+
+        def cudaFree(self, ptr):
+            events.append(("free", ptr))
+
+    ipc = FakeIPC()
+    status_round = 0
+
+    def exchange(local_status, group):
+        nonlocal status_round
+        status_round += 1
+        if status_round == 1:
+            raise RuntimeError("injected native cleanup verdict exchange failure")
+        return [local_status, ()]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="cleanup status exchange") as exc:
+        _abort_collective_ipc_setup(
+            owner="test runtime",
+            setup_phase="native initialization",
+            setup_statuses=(("peer init failed",), ()),
+            exchange_group=object(),
+            ipc=ipc,
+            local_ptr=1000,
+            remote_ptrs=(2000,),
+            local_error=RuntimeError("peer init failed"),
+            local_cleanup=lambda: events.append(("dispose", 3000)),
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.state == "native"
+    assert retained.local_cleanup is None
+    assert events == [("dispose", 3000)]
+
+    retained.retry()
+    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_initial_native_verdict_exchange_retains_complete_setup_until_retry(
+    monkeypatch,
+):
+    events = []
+
+    class FakeIPC:
+        def cudaIpcCloseMemHandle(self, ptr):
+            events.append(("close", ptr))
+
+        def cudaFree(self, ptr):
+            events.append(("free", ptr))
+
+    ipc = FakeIPC()
+    group = object()
+    status_round = 0
+
+    def exchange(local_status, exchange_group):
+        nonlocal status_round
+        assert exchange_group is group
+        status_round += 1
+        if status_round == 1:
+            raise RuntimeError("injected first native verdict exchange failure")
+        return [local_status, ()]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
+        _finish_collective_runtime_setup(
+            owner="PCIe twoshot proof",
+            exchange_group=group,
+            ipc=ipc,
+            shared=_OwnedSharedBuffer(
+                local_ptr=1000,
+                peer_ptrs=(1000, 2000),
+                remote_ptrs=(2000,),
+            ),
+            local_error=None,
+            local_cleanup=lambda: events.append(("dispose", 3000)),
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.local_ptr == 1000
+    assert retained.remote_ptrs == [2000]
+    assert retained.local_cleanup is not None
+    assert events == []
+    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
+
+    # The retained generation gate rejects another setup on this process group
+    # before CUDA allocation.  A caller may only retry after arranging the same
+    # retry call on every rank that participated in the failed exchange.
+    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
+        _require_no_retained_ipc_setup(group)
+    assert events == []
+
+    retained.retry()
+    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_free_status_exchange_failure_keeps_coordination_ticket_without_double_free(
+    monkeypatch,
+):
+    class FakeIPC:
+        def __init__(self):
+            self.freed = []
+
+        def cudaFree(self, ptr):
+            self.freed.append(ptr)
+
+    ipc = FakeIPC()
+    status_round = 0
+
+    def exchange(local_status, group):
+        nonlocal status_round
+        status_round += 1
+        if status_round == 2:
+            raise RuntimeError("injected free verdict exchange failure")
+        return [local_status, ()]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="free status exchange") as exc:
+        _abort_collective_ipc_setup(
+            owner="test runtime",
+            setup_phase="native initialization",
+            setup_statuses=(("peer init failed",), ()),
+            exchange_group=object(),
+            ipc=ipc,
+            local_ptr=1000,
+            remote_ptrs=(),
+            local_error=RuntimeError("peer init failed"),
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.local_ptr == 0
+    assert ipc.freed == [1000]
+    retained.retry()
+    assert ipc.freed == [1000]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def test_retained_generation_blocks_second_setup_before_cuda_allocation(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.malloc_calls = 0
+
+        def cudaMalloc(self, size):
+            self.malloc_calls += 1
+            raise RuntimeError("injected no-local-export allocation failure")
+
+    ipc = FakeIPC()
+    group = object()
+    status_round = 0
+
+    def exchange(local_status, exchange_group):
+        nonlocal status_round
+        status_round += 1
+        if status_round == 2:
+            raise RuntimeError("injected preparation verdict exchange failure")
+        return [local_status, ()]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+    )
+
+    with pytest.raises(RuntimeError, match="preparation status") as exc:
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            group, 256, zero_fill=True, ipc=ipc
+        )
+    retained = exc.value.retryable_setup
+    first_key = retained.key
+    assert retained.local_ptr == 0
+    assert ipc.malloc_calls == 1
+
+    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
+        PCIeOneshotAllReduce._allocate_shared_buffer(
+            group, 256, zero_fill=True, ipc=ipc
+        )
+    assert ipc.malloc_calls == 1
+    assert tuple(_RETAINED_FAILED_IPC_EXPORTS) == (first_key,)
+
+    retained.retry()
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
 
 
 def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
@@ -446,7 +1174,11 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
         "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
+        lambda local_object, group: (
+            [local_object, (), ()]
+            if isinstance(local_object, tuple)
+            else [local_object, b"remote0", b"remote1"]
+        ),
     )
 
     buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
@@ -504,7 +1236,11 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
         "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
+        lambda local_object, group: (
+            [local_object, (), ()]
+            if isinstance(local_object, tuple)
+            else [local_object, b"remote0", b"remote1"]
+        ),
     )
 
     with pytest.raises(RuntimeError, match="memset failed"):
@@ -540,13 +1276,46 @@ def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
 
     monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
 
-    runtime = _make_runtime(exchange_group=object())
+    runtime = _make_runtime()
+    runtime.exchange_group = object()
     ext = runtime._ext
     runtime.register_graph_buffers()
 
     assert ext.register_graph_buffers_calls == [
         (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
     ]
+
+
+def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(
+    monkeypatch,
+):
+    group = object()
+    sources: list[int] = []
+    nonmonotonic_ranks = [7, 2, 9]
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 1)
+    monkeypatch.setattr(
+        "torch.distributed.get_process_group_ranks",
+        lambda group=None: list(nonmonotonic_ranks),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+        lambda group: "cpu",
+    )
+
+    def fake_broadcast(object_list, src, group=None, device=None):
+        sources.append(src)
+        object_list[0] = f"from-{src}"
+
+    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
+
+    assert _group_ranks(group) == nonmonotonic_ranks
+    assert _broadcast_gather_object("local", group) == [
+        "from-7",
+        "from-2",
+        "from-9",
+    ]
+    assert sources == nonmonotonic_ranks
 
 
 def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
@@ -566,7 +1335,8 @@ def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatc
         ),
     )
 
-    runtime = _make_runtime(exchange_group=object())
+    runtime = _make_runtime()
+    runtime.exchange_group = object()
     ext = runtime._ext
     ext.handle_bytes = []
     ext.offsets = []
@@ -577,7 +1347,8 @@ def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatc
 
 
 def test_capture_registers_graph_buffers_after_context(monkeypatch):
-    runtime = _make_runtime(exchange_group=object())
+    runtime = _make_runtime()
+    runtime.exchange_group = object()
     calls = []
 
     monkeypatch.setattr(
@@ -591,7 +1362,8 @@ def test_capture_registers_graph_buffers_after_context(monkeypatch):
 
 
 def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
-    runtime = _make_runtime(eager=True, exchange_group=object())
+    runtime = _make_runtime(eager=True)
+    runtime.exchange_group = object()
     calls = []
 
     monkeypatch.setattr(
@@ -631,6 +1403,337 @@ def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
     assert pool.for_stream(8) is ch8
     assert ch7 is not ch8
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_collective_logical_channel_preparation_is_canonical(monkeypatch):
+    created = []
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: created.append(stream_key) or object(),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+
+    pool.prepare_channels(("draft", "target"))
+    pool.prepare_channels(("target", "draft"))
+
+    assert list(pool._logical_channels) == ["draft", "target"]
+    assert created == [None, None]
+
+
+def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypatch):
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if not local_state or isinstance(local_state[0], str):
+            return [local_state, ()]
+        _requested, existing = local_state
+        return [local_state, (("other",), existing)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with pytest.raises(RuntimeError, match="differs across ranks"):
+        pool.prepare_channels(("target",))
+
+
+def test_invalid_logical_channel_id_is_rejected_collectively_before_allocation(
+    monkeypatch,
+):
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    with pytest.raises(RuntimeError, match="must not be empty"):
+        pool.prepare_channels(("  ",))
+
+
+def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch):
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+
+    def gather(local_state, group):
+        if not local_state or isinstance(local_state[0], str):
+            return [local_state, ()]
+        _, existing = local_state
+        return [local_state, (("peer-channel",), existing)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with pytest.raises(RuntimeError, match="differs across ranks"):
+        pool.prepare_channels(())
+
+
+def test_collective_capture_requires_stable_semantic_id(monkeypatch):
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_status, group: [local_status, ()],
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="stable semantic channel_id"),
+        pool.capture(7),
+    ):
+        pass
+
+
+def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
+    target = _make_runtime(eager=True)
+    draft = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        requested, catalog = local_state
+        assert requested == "graph:target"
+        return [local_state, ("graph:draft", catalog)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with pool.capture(7, channel_id="graph:target") as channel:
+        assert channel is target
+
+    assert pool._captured_channel_ids == {"graph:target"}
+
+
+def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
+    target = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["graph:target"] = target
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        return [local_state, ("graph:target", ())]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
+        pool.capture(7, channel_id="graph:target"),
+    ):
+        pass
+
+
+def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
+    target = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["graph:target"] = target
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+
+    def gather(local_state, group):
+        if local_state == ():
+            return [(), ()]
+        _, catalog = local_state
+        return [local_state, ("graph:unknown", catalog)]
+
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="unprepared logical channels"),
+        pool.capture(7, channel_id="graph:target"),
+    ):
+        pass
+
+
+def test_collective_capture_preserves_same_id_convenience_allocation(monkeypatch):
+    created = []
+    channel = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: created.append(stream_key) or channel,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+
+    with pool.capture(7, channel_id="graph:target") as captured:
+        assert captured is channel
+
+    assert created == [None]
+    assert pool._logical_channels == {"graph:target": channel}
+
+
+def test_collective_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
+    eager = _make_runtime(eager=True)
+    target = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels.update({"eager:model": eager, "graph:target": target})
+    monkeypatch.setattr(
+        pool,
+        "_new_channel",
+        lambda stream_key: pytest.fail("channel allocation must not start"),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: 7 if stream is None else int(stream),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_state, group: [local_state, local_state],
+    )
+
+    with pool.capture(7, channel_id="graph:target") as captured:
+        assert captured is target
+        assert pool.for_stream(7, channel_id="eager:model") is target
+        with pytest.raises(RuntimeError, match="stream-affine"):
+            pool.for_stream(8, channel_id="eager:model")
+
+    assert pool.for_stream(7, channel_id="eager:model") is eager
+
+
+def test_collective_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
+    monkeypatch,
+):
+    eager = _make_runtime(eager=True)
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: eager,
+    )
+    pool._channel_factory = None
+    pool.exchange_group = object()
+    pool._logical_channels["eager:model"] = eager
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: int(stream),
+    )
+
+    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
+        pool.for_stream(7)
+
+    assert pool.for_stream(7, channel_id="eager:model") is eager
+    with pytest.raises(RuntimeError, match="stream-affine"):
+        pool.for_stream(8, channel_id="eager:model")
 
 
 def test_pool_reuses_single_channel_across_stream_keys(monkeypatch):
@@ -726,9 +1829,58 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
         capturing[0] = False
 
     assert target_channel is not draft_channel
-    assert pool._channels[70] is target_channel
-    assert pool._channels[80] is draft_channel
+    assert pool._channels == {}
+    assert target_channel in pool._all_channels
+    assert draft_channel in pool._all_channels
     assert [entry[0] for entry in created] == [7, 8]
+
+
+def test_pool_restores_nested_capture_mappings_in_lifo_order(monkeypatch):
+    current_stream = [7]
+    capturing = [False]
+    pool = PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cpu"),
+        channel_factory=lambda stream_key: _make_runtime(eager=True),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+        lambda device, stream=None: (
+            current_stream[0] if stream is None else int(stream)
+        ),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing",
+        lambda device: capturing[0],
+    )
+
+    eager_channel = pool.for_stream()
+    with pool.capture(7) as outer_channel:
+        assert pool._channels == {7: outer_channel}
+
+        current_stream[0] = 8
+        with pool.capture() as inner_channel:
+            capturing[0] = True
+            current_stream[0] = 80
+            assert pool.for_stream() is inner_channel
+            assert pool._channels == {
+                7: outer_channel,
+                8: inner_channel,
+                80: inner_channel,
+            }
+            capturing[0] = False
+
+        assert pool._channels == {7: outer_channel}
+        capturing[0] = True
+        current_stream[0] = 70
+        assert pool.for_stream() is outer_channel
+        capturing[0] = False
+
+    assert eager_channel is not outer_channel
+    assert outer_channel is not inner_channel
+    assert pool._channels == {7: eager_channel}
+    assert pool._capture_channel_stack == []
 
 
 def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
@@ -773,8 +1925,7 @@ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
         capturing[0] = False
 
     assert target_channel is not draft_channel
-    assert pool._channels[7] is draft_channel
-    assert pool._channels[70] is draft_channel
+    assert pool._channels == {}
     assert target_channel in pool._all_channels
     assert draft_channel in pool._all_channels
     assert [entry[0] for entry in created] == [7, 7]
@@ -859,13 +2010,12 @@ def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
     assert pool._channels == {3: retained}
 
 
-def test_channel_teardown_completes_when_ipc_cleanup_raises():
+def test_channel_destructor_retains_all_cuda_ownership_without_side_effects():
     events = []
 
     class FailingExt:
-        def dispose(self, ptr):
-            events.append(("dispose", ptr))
-            raise RuntimeError("dispose failed")
+        def dispose_best_effort(self, ptr):
+            events.append(("dispose_best_effort", ptr))
 
     class FailingIPC:
         def cudaIpcCloseMemHandle(self, ptr):
@@ -873,8 +2023,7 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
             raise RuntimeError("close failed")
 
         def cudaFree(self, ptr):
-            events.append(("free", ptr))
-            raise RuntimeError("free failed")
+            raise AssertionError("GC must not free exported IPC allocations")
 
     class SharedBuffer:
         def __init__(self, local_ptr, remote_ptrs):
@@ -885,6 +2034,8 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
     channel._closed = False
     channel._ipc_imports_closed = False
     channel._ipc_exports_freed = False
+    channel.exchange_group = None
+    channel.device = torch.device("cpu")
     channel._ptr = 123
     channel._ext = FailingExt()
     channel._ipc = FailingIPC()
@@ -893,24 +2044,47 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
         SharedBuffer(4000, (5000,)),
     ]
     channel._registered_input_ptrs = {1: (2,)}
+    channel._coordinated_close_complete = False
 
-    channel.close()
-    channel.close()
+    channel.__del__()
 
-    assert events == [
-        ("dispose", 123),
-        ("close", 2000),
-        ("close", 3000),
-        ("close", 5000),
-        ("free", 1000),
-        ("free", 4000),
-    ]
-    assert channel._ptr == 0
-    assert channel._closed
-    assert channel._ipc_imports_closed
-    assert channel._ipc_exports_freed
-    assert channel._owned_buffers == []
-    assert channel._registered_input_ptrs == {}
+    assert events == []
+    assert channel._ptr == 123
+    assert not channel._closed
+    assert not channel._ipc_imports_closed
+    assert not channel._ipc_exports_freed
+    assert [shared.local_ptr for shared in channel._owned_buffers] == [1000, 4000]
+    assert channel._registered_input_ptrs == {1: (2,)}
+    assert _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(id(channel)) is channel
+
+
+def test_channel_gc_quarantines_rank_data_tensor_and_native_pointer():
+    events = []
+
+    class RankData:
+        def __del__(self):
+            events.append("rank_data_freed")
+
+    channel = object.__new__(PCIeOneshotAllReduce)
+    channel._ptr = 123
+    channel._owned_buffers = []
+    channel._coordinated_close_complete = False
+    channel.rank_data = RankData()
+    channel_id = id(channel)
+
+    del channel
+    gc.collect()
+
+    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(channel_id)
+    assert retained._ptr == 123
+    assert events == []
+
+    # The production quarantine is process-lifetime. Tests may release this
+    # fake only after proving the owned allocation survived object GC.
+    retained._coordinated_close_complete = True
+    del retained
+    gc.collect()
+    assert events == ["rank_data_freed"]
 
 
 def test_pool_rejects_channel_rollback_during_capture():

--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import socket
+import time
+from datetime import timedelta
 
 import pytest
 import torch
@@ -18,6 +21,9 @@ pytestmark = pytest.mark.skipif(
         "set SPARKINFER_RUN_PCIE_ONESHOT_RMS_TEST=1 to run PCIe oneshot fused "
         "RMSNorm GPU tests"
     ),
+)
+TEST_TIMEOUT_SECONDS = float(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
 )
 
 
@@ -71,7 +77,33 @@ def _assert_close(
         torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
 
-def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
+def _local_eager_words(
+    channel, stream: torch.cuda.Stream, *, offset: int = 0
+) -> tuple[int, int]:
+    assert channel._ipc is not None
+    assert channel._eager_ptrs is not None
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
+        channel._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            slot_ptrs[channel.rank] + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
+def _dim3_tuple(value) -> tuple[int, int, int]:
+    return int(value.x), int(value.y), int(value.z)
+
+
+def _cuda_graph_kernel_chain(
+    graph: torch.cuda.CUDAGraph,
+) -> tuple[
+    tuple[tuple[int, int, int], tuple[int, int, int]],
+    tuple[tuple[int, int, int], tuple[int, int, int]],
+]:
     graph_handle = graph.raw_cuda_graph()
     result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
     assert result == cudart.cudaError_t.cudaSuccess
@@ -82,12 +114,62 @@ def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
     assert result == cudart.cudaError_t.cudaSuccess
     assert returned_nodes == num_nodes
     kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
-    kernel_count = 0
+    kernel_nodes = []
     for node in nodes[:num_nodes]:
         result, node_type = cudart.cudaGraphNodeGetType(node)
         assert result == cudart.cudaError_t.cudaSuccess
-        kernel_count += node_type == kernel_type
-    return kernel_count
+        if node_type == kernel_type:
+            kernel_nodes.append(node)
+    assert len(kernel_nodes) == 2, (
+        "staged fused capture must contain one slot-control node followed by "
+        f"one worker node, found {len(kernel_nodes)} kernel nodes"
+    )
+
+    edge_query = cudart.cudaGraphGetEdges(graph_handle)
+    assert edge_query[0] == cudart.cudaError_t.cudaSuccess
+    num_edges = int(edge_query[-1])
+    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
+    result, from_nodes, to_nodes, returned_edges = (
+        edges[0],
+        edges[1],
+        edges[2],
+        edges[-1],
+    )
+    assert result == cudart.cudaError_t.cudaSuccess
+    assert returned_edges == num_edges
+    kernel_edges = []
+    for source, destination in zip(
+        from_nodes[:num_edges],
+        to_nodes[:num_edges],
+        strict=True,
+    ):
+        result, source_type = cudart.cudaGraphNodeGetType(source)
+        assert result == cudart.cudaError_t.cudaSuccess
+        result, destination_type = cudart.cudaGraphNodeGetType(destination)
+        assert result == cudart.cudaError_t.cudaSuccess
+        if source_type == kernel_type and destination_type == kernel_type:
+            kernel_edges.append((source, destination))
+    assert len(kernel_edges) == 1, (
+        "staged fused capture must directly order its control node before its "
+        f"worker node, found {len(kernel_edges)} kernel-to-kernel edges"
+    )
+
+    def geometry(node) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+        result, params = cudart.cudaGraphKernelNodeGetParams(node)
+        if result != cudart.cudaError_t.cudaSuccess and hasattr(
+            cudart, "cudaGraphNodeGetParams"
+        ):
+            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
+            assert fallback_result == cudart.cudaError_t.cudaSuccess
+            result, params = fallback_result, node_params.kernel
+        assert result == cudart.cudaError_t.cudaSuccess
+        return _dim3_tuple(params.gridDim), _dim3_tuple(params.blockDim)
+
+    control, worker = map(geometry, kernel_edges[0])
+    assert control == ((1, 1, 1), (1, 1, 1))
+    assert worker[0][0] > 1
+    assert worker[1][0] >= 64
+    return control, worker
 
 
 def _run_eager(
@@ -129,6 +211,7 @@ def _run_eager(
                 residual,
                 weight,
                 epsilon,
+                channel_id="eager:fused-rmsnorm",
             )
             torch.cuda.synchronize(device)
             _assert_close(out, expected_out, dtype)
@@ -152,10 +235,11 @@ def _run_graph(
         rank,
     )
     out = torch.empty_like(inp)
-    pool.for_stream()
-
     graph = torch.cuda.CUDAGraph(keep_graph=True)
-    with pool.capture(), torch.cuda.graph(graph):
+    with (
+        pool.capture(channel_id="graph:fused-rmsnorm") as channel,
+        torch.cuda.graph(graph),
+    ):
         pool.all_reduce_fused_add_rms_norm(
             inp,
             residual,
@@ -163,8 +247,19 @@ def _run_graph(
             epsilon,
             out=out,
             residual_out=residual,
+            channel_id="graph:fused-rmsnorm",
         )
-    assert _cuda_graph_kernel_count(graph) == 1
+    # Staged capture is now control + worker, in that order. The registered
+    # path still launches only its worker, but public graph capture deliberately
+    # requires stable eager staging buffers and therefore exercises this
+    # two-node contract.
+    _cuda_graph_kernel_chain(graph)
+    stream = torch.cuda.current_stream(device)
+    offset = 0
+    if os.getenv("SPARKINFER_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
+        remote_source = (rank + 1) % dist.get_world_size()
+        offset = remote_source * inp.numel() * inp.element_size()
+    snapshots = [_local_eager_words(channel, stream, offset=offset)]
 
     for iteration in range(3):
         next_inp, next_residual, _ = _make_inputs(
@@ -187,6 +282,23 @@ def _run_graph(
         torch.cuda.synchronize(device)
         _assert_close(out, expected_out, dtype)
         _assert_close(residual, expected_residual, dtype)
+        snapshots.append(_local_eager_words(channel, stream, offset=offset))
+
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(3)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert all(
+        changed_slots[index] != changed_slots[index + 1]
+        for index in range(len(changed_slots) - 1)
+    )
 
 
 def _worker(rank: int, world_size: int, port: int) -> None:
@@ -197,14 +309,18 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         init_method=f"tcp://127.0.0.1:{port}",
         rank=rank,
         world_size=world_size,
+        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
     )
     pool = PCIeOneshotAllReducePool.from_process_group(
         process_group=dist.group.WORLD,
         device=device,
         max_input_bytes=128 * 1024,
         max_size=128 * 1024,
+        max_concurrent_channels=2,
     )
     try:
+        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
+        pool.for_stream(channel_id="eager:fused-rmsnorm")
         _run_eager(pool, device, rank)
         dist.barrier()
         _run_graph(pool, device, rank)
@@ -224,4 +340,27 @@ def test_pcie_oneshot_fused_add_rms_norm_eager_and_graph() -> None:
         pytest.skip(
             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
         )
-    mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
+    context = mp.spawn(
+        _worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=False,
+    )
+    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if context.join(timeout=min(1.0, remaining), grace_period=5):
+            return
+    for process in context.processes:
+        if process.is_alive():
+            process.terminate()
+    for process in context.processes:
+        process.join(timeout=5)
+    for process in context.processes:
+        if process.is_alive():
+            process.kill()
+        process.join()
+    pytest.fail(
+        "PCIe oneshot fused RMSNorm test exceeded "
+        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
+    )

--- a/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
+++ b/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import os
+import socket
+import time
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER") != "1",
+    reason=(
+        "set SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER=1 to run the "
+        "four-rank opposite-order PCIe oneshot GPU test"
+    ),
+)
+
+WORLD_SIZE = 4
+EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_EAGER_ITERS", "64"))
+GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_GRAPH_REPLAYS", "64"))
+TEST_TIMEOUT_SECONDS = float(
+    os.getenv("SPARKINFER_PCIE_OPPOSITE_TIMEOUT_SECONDS", "180")
+)
+NUMEL = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_NUMEL", "32768"))
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _expected(base: float, world_size: int, device: torch.device) -> torch.Tensor:
+    rank_sum = world_size * (world_size - 1) // 2
+    return torch.tensor(
+        world_size * base + rank_sum,
+        dtype=torch.float32,
+        device=device,
+    )
+
+
+def _assert_reduced(
+    out: torch.Tensor,
+    base: float,
+    world_size: int,
+    device: torch.device,
+) -> None:
+    torch.testing.assert_close(
+        out,
+        _expected(base, world_size, device).expand_as(out),
+        rtol=0,
+        atol=0,
+    )
+
+
+def _rank_order(rank: int) -> tuple[str, str]:
+    # Every rank executes the same ordered sequence within each channel. Only
+    # the cross-channel enqueue order differs, which is valid because each
+    # stream owns a distinct signal/staging pair.
+    return ("a", "b") if rank % 2 == 0 else ("b", "a")
+
+
+def _run_eager_opposite_order(
+    pool: PCIeOneshotAllReducePool,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+) -> None:
+    stream_a = torch.cuda.Stream(device=device)
+    stream_b = torch.cuda.Stream(device=device)
+
+    # Each rank supplies the same logical set in opposite local order. The pool
+    # must canonicalize allocation by id rather than pairing local stream keys.
+    logical_ids = ("eager:a", "eager:b")
+    if rank % 2:
+        logical_ids = tuple(reversed(logical_ids))
+    pool.prepare_channels(logical_ids)
+    channel_a = pool.for_stream(stream_a, channel_id="eager:a")
+    channel_b = pool.for_stream(stream_b, channel_id="eager:b")
+    dist.barrier()
+    assert channel_a is not channel_b
+    assert channel_a._signal_ptrs != channel_b._signal_ptrs
+
+    inputs = {
+        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
+        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
+    }
+    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
+    streams = {"a": stream_a, "b": stream_b}
+    channels = {"a": channel_a, "b": channel_b}
+
+    for iteration in range(EAGER_ITERS):
+        bases = {
+            "a": float(4 * (iteration % 32)),
+            "b": float(1024 + 8 * (iteration % 32)),
+        }
+        for name in _rank_order(rank):
+            with torch.cuda.stream(streams[name]):
+                inputs[name].fill_(bases[name] + rank)
+                channels[name].all_reduce(inputs[name], out=outputs[name])
+
+        # Both valid channel collectives are now enqueued on every rank. A
+        # device-wide wait makes a deadlock visible to the parent timeout.
+        torch.cuda.synchronize(device)
+        for name in ("a", "b"):
+            _assert_reduced(outputs[name], bases[name], world_size, device)
+
+
+def _capture_channel(
+    pool: PCIeOneshotAllReducePool,
+    stream: torch.cuda.Stream,
+    inp: torch.Tensor,
+    out: torch.Tensor,
+    channel_id: str,
+) -> tuple[object, torch.cuda.CUDAGraph]:
+    graph = torch.cuda.CUDAGraph()
+    with (
+        pool.capture(stream, channel_id=channel_id) as channel,
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        channel.all_reduce(inp, out=out)
+    return channel, graph
+
+
+def _run_capture_warmup_scope(
+    pool: PCIeOneshotAllReducePool,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+) -> None:
+    """Match vLLM's eager warmup inside its semantic graph-owner scope."""
+    stream = torch.cuda.Stream(device=device)
+    inp = torch.full(
+        (NUMEL,),
+        float(4096 + rank),
+        dtype=torch.float32,
+        device=device,
+    )
+    out = torch.empty_like(inp)
+    pool.prepare_channels(("eager:warmup", "graph:warmup"))
+
+    graph = torch.cuda.CUDAGraph()
+    with (
+        torch.cuda.stream(stream),
+        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
+    ):
+        # CUDA capture has not begun. The active semantic scope must still
+        # override the call site's static eager id on this same owner stream.
+        warmup_channel = pool.for_stream(stream, channel_id="eager:warmup")
+        assert warmup_channel is graph_channel
+        warmup_channel.all_reduce(inp, out=out)
+        stream.synchronize()
+        _assert_reduced(out, 4096.0, world_size, device)
+
+        with torch.cuda.graph(graph, stream=stream):
+            graph_channel.all_reduce(inp, out=out)
+
+    # Leaving the semantic scope restores normal eager routing even though
+    # the graph-owned channel remains alive for replay on the same stream.
+    eager_channel = pool.for_stream(stream, channel_id="eager:warmup")
+    assert eager_channel is not graph_channel
+    with torch.cuda.stream(stream):
+        inp.fill_(8192.0 + rank)
+        graph.replay()
+    stream.synchronize()
+    _assert_reduced(out, 8192.0, world_size, device)
+
+
+def _run_graph_opposite_order(
+    pool: PCIeOneshotAllReducePool,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+) -> None:
+    stream_a = torch.cuda.Stream(device=device)
+    stream_b = torch.cuda.Stream(device=device)
+    inputs = {
+        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
+        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
+    }
+    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
+
+    logical_ids = ("graph:a", "graph:b")
+    if rank % 2:
+        logical_ids = tuple(reversed(logical_ids))
+    pool.prepare_channels(logical_ids)
+    captured = {}
+    for name in _rank_order(rank):
+        captured[name] = _capture_channel(
+            pool,
+            {"a": stream_a, "b": stream_b}[name],
+            inputs[name],
+            outputs[name],
+            f"graph:{name}",
+        )
+        {"a": stream_a, "b": stream_b}[name].synchronize()
+    dist.barrier()
+    channel_a, graph_a = captured["a"]
+    channel_b, graph_b = captured["b"]
+    assert channel_a is not channel_b
+    assert channel_a._signal_ptrs != channel_b._signal_ptrs
+
+    streams = {"a": stream_a, "b": stream_b}
+    graphs = {"a": graph_a, "b": graph_b}
+    for iteration in range(GRAPH_REPLAYS):
+        bases = {
+            "a": float(256 + 4 * (iteration % 32)),
+            "b": float(2048 + 8 * (iteration % 32)),
+        }
+        for name in _rank_order(rank):
+            with torch.cuda.stream(streams[name]):
+                inputs[name].fill_(bases[name] + rank)
+                graphs[name].replay()
+
+        torch.cuda.synchronize(device)
+        for name in ("a", "b"):
+            _assert_reduced(outputs[name], bases[name], world_size, device)
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
+    )
+    pool = PCIeOneshotAllReducePool.from_process_group(
+        process_group=dist.group.WORLD,
+        device=device,
+        max_input_bytes=NUMEL * torch.float32.itemsize,
+        max_size=NUMEL * torch.float32.itemsize,
+        # Two independent streams intentionally enqueue peer-waiting grids at
+        # once; gate residency for the complete overlap, not one grid.
+        max_concurrent_channels=2,
+    )
+    try:
+        _run_capture_warmup_scope(pool, device, rank, world_size)
+        dist.barrier()
+        _run_eager_opposite_order(pool, device, rank, world_size)
+        dist.barrier()
+        _run_graph_opposite_order(pool, device, rank, world_size)
+        torch.cuda.synchronize(device)
+        dist.barrier()
+    finally:
+        try:
+            pool.close()
+        finally:
+            dist.destroy_process_group()
+
+
+def _spawn_with_timeout(port: int) -> None:
+    context = mp.spawn(
+        _worker,
+        args=(WORLD_SIZE, port),
+        nprocs=WORLD_SIZE,
+        join=False,
+    )
+    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if context.join(timeout=min(1.0, remaining), grace_period=5):
+            return
+
+    for process in context.processes:
+        if process.is_alive():
+            process.terminate()
+    for process in context.processes:
+        process.join(timeout=5)
+    for process in context.processes:
+        if process.is_alive():
+            process.kill()
+        process.join()
+    pytest.fail(
+        "four-rank opposite-order eager/graph PCIe oneshot test exceeded "
+        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
+    )
+
+
+def test_pcie_oneshot_four_rank_opposite_channel_order() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if torch.cuda.device_count() < WORLD_SIZE:
+        pytest.skip(
+            f"need {WORLD_SIZE} CUDA devices, found {torch.cuda.device_count()}"
+        )
+    _spawn_with_timeout(_free_port())

--- a/tests/comm/test_pcie_oneshot_torture.py
+++ b/tests/comm/test_pcie_oneshot_torture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import os
 import socket
 
@@ -16,9 +17,15 @@ pytestmark = pytest.mark.skipif(
     reason="set SPARKINFER_RUN_PCIE_ONESHOT_TORTURE=1 to run PCIe oneshot CUDA torture tests",
 )
 
-TORTURE_EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256"))
-TORTURE_GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256"))
-TORTURE_MULTISTREAM_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256"))
+TORTURE_EAGER_ITERS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256")
+)
+TORTURE_GRAPH_REPLAYS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256")
+)
+TORTURE_MULTISTREAM_ITERS = int(
+    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256")
+)
 
 
 def _free_port() -> int:
@@ -36,7 +43,26 @@ def _rank_sum(world_size: int) -> int:
     return world_size * (world_size - 1) // 2
 
 
-def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int) -> None:
+def _local_eager_words(
+    channel, stream: torch.cuda.Stream, *, offset: int = 0
+) -> tuple[int, int]:
+    assert channel._ipc is not None
+    assert channel._eager_ptrs is not None
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
+        channel._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            slot_ptrs[channel.rank] + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
+def _run_eager(
+    pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int
+) -> None:
     dtypes = (torch.float16, torch.bfloat16, torch.float32)
     numels = (8, 256, 4096, 32768)
     rank_sum = _rank_sum(world_size)
@@ -48,7 +74,7 @@ def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, 
             for iteration in range(TORTURE_EAGER_ITERS):
                 base = float((iteration % 64) * 3)
                 inp.fill_(base + rank)
-                pool.all_reduce(inp, out=out)
+                pool.all_reduce(inp, out=out, channel_id="eager:default")
                 torch.cuda.synchronize(device)
                 _assert_constant(out, world_size * base + rank_sum)
 
@@ -60,7 +86,6 @@ def _run_graph_scratch_reuse(
     world_size: int,
 ) -> None:
     stream = torch.cuda.Stream(device=device)
-    channel = pool.for_stream(stream)
     rank_sum = _rank_sum(world_size)
     layers = 17
     numel = 4096
@@ -77,19 +102,56 @@ def _run_graph_scratch_reuse(
     torch.cuda.synchronize(device)
 
     graph = torch.cuda.CUDAGraph()
-    with pool.capture(stream), torch.cuda.graph(graph, stream=stream):
+    with (
+        pool.capture(stream, channel_id="graph:torture") as channel,
+        torch.cuda.graph(graph, stream=stream),
+    ):
         for layer in range(layers):
             scratch.copy_(sources[layer])
             channel.all_reduce(scratch, out=outs[layer])
     stream.synchronize()
 
     for iteration in range(TORTURE_GRAPH_REPLAYS):
-        fill_sources(iteration)
-        graph.replay()
+        with torch.cuda.stream(stream):
+            fill_sources(iteration)
+            graph.replay()
         stream.synchronize()
         for layer, out in enumerate(outs):
             base = float((iteration % 32) * 5 + layer)
             _assert_constant(out, world_size * base + rank_sum)
+
+    # A graph with an odd number of collectives must swap which slot receives
+    # the final layer on every replay. Both slots are overwritten by this
+    # 17-layer graph, so merely counting changed slots cannot identify the
+    # selected parity: the final two layer markers must exchange positions.
+    snapshots = [_local_eager_words(channel, stream)]
+    expected_words = [
+        tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
+    ]
+    for iteration in (101, 102):
+        with torch.cuda.stream(stream):
+            fill_sources(iteration)
+            graph.replay()
+        stream.synchronize()
+        snapshots.append(_local_eager_words(channel, stream))
+        expected_words.append(
+            tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
+        )
+        for layer, out in enumerate(outs):
+            base = float((iteration % 32) * 5 + layer)
+            _assert_constant(out, world_size * base + rank_sum)
+
+    final_slots = []
+    for snapshot, expected in zip(snapshots, expected_words, strict=True):
+        assert set(snapshot) == set(expected), (
+            f"staging slots {snapshot} do not contain the final layer markers "
+            f"{expected}"
+        )
+        final_slots.append(snapshot.index(expected[-1]))
+    assert all(
+        final_slots[index] != final_slots[index + 1]
+        for index in range(len(final_slots) - 1)
+    ), f"odd-collective graph did not alternate final staging slots: {final_slots}"
 
 
 def _run_multistream(
@@ -100,8 +162,8 @@ def _run_multistream(
 ) -> None:
     stream_a = torch.cuda.Stream(device=device)
     stream_b = torch.cuda.Stream(device=device)
-    pool.for_stream(stream_a)
-    pool.for_stream(stream_b)
+    pool.for_stream(stream_a, channel_id="eager:a")
+    pool.for_stream(stream_b, channel_id="eager:b")
     rank_sum = _rank_sum(world_size)
 
     inp_a = torch.empty(2048, device=device, dtype=torch.float16)
@@ -114,10 +176,10 @@ def _run_multistream(
         base_b = float(100 + (iteration % 64) * 2)
         with torch.cuda.stream(stream_a):
             inp_a.fill_(base_a + rank)
-            pool.all_reduce(inp_a, out=out_a)
+            pool.all_reduce(inp_a, out=out_a, channel_id="eager:a")
         with torch.cuda.stream(stream_b):
             inp_b.fill_(base_b + rank)
-            pool.all_reduce(inp_b, out=out_b)
+            pool.all_reduce(inp_b, out=out_b, channel_id="eager:b")
         stream_a.synchronize()
         stream_b.synchronize()
         _assert_constant(out_a, world_size * base_a + rank_sum)
@@ -137,8 +199,10 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         process_group=dist.group.WORLD,
         device=device,
         max_input_bytes=1 << 20,
+        max_concurrent_channels=2,
     )
     try:
+        pool.prepare_channels(("eager:default", "eager:a", "eager:b", "graph:torture"))
         _run_eager(pool, device, rank, world_size)
         dist.barrier()
         _run_graph_scratch_reuse(pool, device, rank, world_size)

--- a/tests/comm/test_pcie_preallocation_setup.py
+++ b/tests/comm/test_pcie_preallocation_setup.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import sparkinfer.comm.pcie.pcie_dcp_a2a as dcp
+import sparkinfer.comm.pcie.pcie_oneshot as oneshot
+import sparkinfer.comm.pcie.pcie_twoshot as twoshot
+
+
+def _mock_collective_failure(monkeypatch) -> None:
+    def exchange(
+        local_error,
+        *,
+        exchange_group,
+        phase,
+        exports_retained_on_exchange_failure=True,
+    ):
+        assert not exports_retained_on_exchange_failure
+        if local_error is None:
+            return ((), ())
+        return ((f"RuntimeError: {local_error}",), ())
+
+    monkeypatch.setattr(oneshot, "_exchange_setup_failures", exchange)
+
+
+def _fail_cuda_runtime():
+    raise RuntimeError("injected one-rank CUDA runtime load failure")
+
+
+def test_oneshot_factory_coordinates_preallocation_failure_before_ipc(
+    monkeypatch,
+) -> None:
+    _mock_collective_failure(monkeypatch)
+    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
+    monkeypatch.setattr(oneshot, "CudaRTLibrary", _fail_cuda_runtime)
+    monkeypatch.setattr(
+        oneshot.PCIeOneshotAllReduce,
+        "_allocate_eager_channel_buffers",
+        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
+    )
+
+    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
+        oneshot.PCIeOneshotAllReduce.from_exchange_group(
+            exchange_group=object(),
+            device=torch.device("cuda:0"),
+        )
+
+    assert "exports were retained" not in str(exc.value)
+
+
+def test_dcp_factory_coordinates_preallocation_failure_before_ipc(monkeypatch) -> None:
+    _mock_collective_failure(monkeypatch)
+    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(dcp, "_require_full_grid_residency", lambda **kwargs: None)
+    monkeypatch.setattr(dcp, "CudaRTLibrary", _fail_cuda_runtime)
+    monkeypatch.setattr(
+        oneshot.PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
+    )
+
+    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
+        dcp.PCIeDCPA2A.from_exchange_group(
+            exchange_group=object(),
+            device=torch.device("cuda:0"),
+            max_batch_size=8,
+            total_heads=16,
+            head_dim=64,
+        )
+
+    assert "exports were retained" not in str(exc.value)
+
+
+def test_twoshot_factory_coordinates_preallocation_failure_before_ipc(
+    monkeypatch,
+) -> None:
+    _mock_collective_failure(monkeypatch)
+    monkeypatch.setattr(twoshot.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(twoshot.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(twoshot, "_require_full_grid_residency", lambda **kwargs: None)
+    monkeypatch.setattr(twoshot, "CudaRTLibrary", _fail_cuda_runtime)
+    monkeypatch.setattr(
+        oneshot.PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
+    )
+
+    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
+        twoshot.PCIeTwoShotSP.from_exchange_group(
+            exchange_group=object(),
+            device=torch.device("cuda:0"),
+            max_rows=8,
+            row_elems=16,
+        )
+
+    assert "exports were retained" not in str(exc.value)
+
+
+@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
+def test_direct_constructor_coordinates_argument_failure_before_residency(
+    monkeypatch,
+    module_name: str,
+) -> None:
+    _mock_collective_failure(monkeypatch)
+    if module_name == "oneshot":
+        monkeypatch.setattr(
+            oneshot,
+            "_require_full_grid_residency",
+            lambda **kwargs: pytest.fail("residency gate must not start"),
+        )
+
+        def constructor():
+            return oneshot.PCIeOneshotAllReduce(
+                rank=0,
+                world_size=2,
+                device=torch.device("cuda:0"),
+                signal_ptrs=(100,),
+                exchange_group=object(),
+                ext_module=object(),
+            )
+    else:
+        monkeypatch.setattr(
+            dcp,
+            "_require_full_grid_residency",
+            lambda **kwargs: pytest.fail("residency gate must not start"),
+        )
+
+        def constructor():
+            return dcp.PCIeDCPA2A(
+                rank=0,
+                world_size=2,
+                device=torch.device("cuda:0"),
+                signal_ptrs=(100,),
+                staging0_ptrs=(200, 300),
+                staging1_ptrs=(400, 500),
+                max_batch_size=8,
+                total_heads=16,
+                head_dim=64,
+                output_capacity_elems=8 * 16 * 64,
+                lse_offset=8 * 16 * 64 * 2,
+                lse_capacity=8 * 16,
+                exchange_group=object(),
+                ext_module=object(),
+            )
+
+    with pytest.raises(RuntimeError, match="argument validation"):
+        constructor()
+
+
+@pytest.mark.parametrize(
+    ("module", "class_name"),
+    (
+        (oneshot, "PCIeOneshotAllReduce"),
+        (dcp, "PCIeDCPA2A"),
+    ),
+)
+def test_exported_direct_constructor_contains_capability_and_setup_coordination(
+    module,
+    class_name: str,
+) -> None:
+    import inspect
+
+    source = inspect.getsource(getattr(module, class_name).__init__)
+    assert "_require_full_grid_residency(" in source
+    assert "_run_collective_preallocation_setup(" in source
+    assert "_finish_collective_unowned_runtime_setup(" in source
+    assert "_factory_managed_setup" not in source
+
+
+def test_twoshot_direct_construction_cannot_bypass_factory_gates() -> None:
+    with pytest.raises(RuntimeError, match="from_exchange_group"):
+        twoshot.PCIeTwoShotSP()
+
+
+def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    class FakeIPC:
+        def cudaSetDevice(self, device):
+            events.append(("device", device))
+
+    class FakeOneshotExt:
+        @staticmethod
+        def meta_size():
+            return 256
+
+    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        oneshot,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_require_full_grid_residency",
+        lambda **kwargs: events.append(("oneshot_sms", kwargs["required_sms"])),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_require_collective_contract",
+        lambda **kwargs: events.append(("oneshot_contract", kwargs["contract"])),
+    )
+
+    oneshot_pool = oneshot.PCIeOneshotAllReducePool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        exchange_group=object(),
+        ipc=FakeIPC(),
+        ext_module=FakeOneshotExt(),
+        max_concurrent_channels=3,
+    )
+    oneshot_pool._closed = True
+
+    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        dcp,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_require_collective_contract",
+        lambda **kwargs: events.append(("dcp_contract", kwargs["contract"])),
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_require_full_grid_residency",
+        lambda **kwargs: events.append(("dcp_sms", kwargs["required_sms"])),
+    )
+
+    dcp_pool = dcp.PCIeDCPA2APool(
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        max_batch_size=8,
+        total_heads=16,
+        head_dim=64,
+        exchange_group=object(),
+        max_concurrent_channels=2,
+    )
+    dcp_pool._closed = True
+
+    assert ("oneshot_sms", oneshot.ONESHOT_REQUIRED_SMS * 3) in events
+    oneshot_contract = next(
+        contract for name, contract in events if name == "oneshot_contract"
+    )
+    assert oneshot_contract[-2] == 3
+    assert ("dcp_contract", 2) in events
+    assert ("dcp_sms", dcp.DCP_A2A_REQUIRED_SMS * 2) in events
+
+
+@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
+def test_pool_rejects_nonpositive_overlap_before_allocation(
+    monkeypatch, module_name: str
+) -> None:
+    if module_name == "oneshot":
+        with pytest.raises(ValueError, match="max_concurrent_channels"):
+            oneshot.PCIeOneshotAllReducePool(
+                rank=0,
+                world_size=2,
+                device=torch.device("cpu"),
+                max_concurrent_channels=0,
+                channel_factory=lambda stream_key: object(),
+            )
+    else:
+        with pytest.raises(ValueError, match="max_concurrent_channels"):
+            dcp.PCIeDCPA2APool(
+                rank=0,
+                world_size=2,
+                device=torch.device("cpu"),
+                max_batch_size=8,
+                total_heads=16,
+                head_dim=64,
+                max_concurrent_channels=0,
+                channel_factory=lambda stream_key: object(),
+            )
+
+
+def test_oneshot_overlap_contract_mismatch_fails_before_channel_allocation(
+    monkeypatch,
+) -> None:
+    class FakeIPC:
+        def cudaSetDevice(self, device):
+            pass
+
+    class FakeExt:
+        @staticmethod
+        def meta_size():
+            return 256
+
+    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        oneshot,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
+    monkeypatch.setattr(
+        oneshot,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, (*contract[:-2], 2, contract[-1])],
+    )
+    monkeypatch.setattr(
+        oneshot.PCIeOneshotAllReduce,
+        "_allocate_eager_channel_buffers",
+        lambda *args, **kwargs: pytest.fail("channel allocation must not start"),
+    )
+
+    with pytest.raises(RuntimeError, match="contract differs across ranks"):
+        oneshot.PCIeOneshotAllReducePool(
+            rank=0,
+            world_size=2,
+            device=torch.device("cuda:0"),
+            exchange_group=object(),
+            ipc=FakeIPC(),
+            ext_module=FakeExt(),
+            max_concurrent_channels=3,
+        )
+
+
+def test_dcp_overlap_contract_mismatch_fails_before_channel_allocation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        dcp,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, 1],
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_require_full_grid_residency",
+        lambda **kwargs: pytest.fail("residency/allocation must not start"),
+    )
+
+    with pytest.raises(RuntimeError, match="contract differs across ranks"):
+        dcp.PCIeDCPA2APool(
+            rank=0,
+            world_size=2,
+            device=torch.device("cuda:0"),
+            max_batch_size=8,
+            total_heads=16,
+            head_dim=64,
+            exchange_group=object(),
+            max_concurrent_channels=2,
+        )
+
+
+def test_oneshot_direct_cuda_constructor_executes_all_collective_gates(
+    monkeypatch,
+) -> None:
+    events = []
+
+    class FakeTensor:
+        pass
+
+    class FakeExt:
+        def init_custom_ar(self, signal_ptrs, rank_data, rank):
+            events.append("native-init")
+            return 123
+
+    class FakeIPC:
+        def cudaSetDevice(self, device):
+            events.append(("set-device", device))
+
+    monkeypatch.setattr(
+        oneshot,
+        "_require_full_grid_residency",
+        lambda **kwargs: events.append("residency"),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_require_collective_contract",
+        lambda **kwargs: events.append("contract"),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_finish_collective_unowned_runtime_setup",
+        lambda **kwargs: events.append("native-verdict"),
+    )
+    monkeypatch.setattr(oneshot.torch, "empty", lambda *args, **kwargs: FakeTensor())
+    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
+
+    runtime = oneshot.PCIeOneshotAllReduce(
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        signal_ptrs=(100, 200),
+        exchange_group=object(),
+        ipc=FakeIPC(),
+        ext_module=FakeExt(),
+    )
+
+    assert runtime._ptr == 123
+    assert events == [
+        "preflight",
+        "residency",
+        "preflight",
+        ("set-device", 0),
+        "contract",
+        "native-init",
+        "native-verdict",
+    ]
+    runtime._coordinated_close_complete = True
+
+
+def test_dcp_direct_cuda_constructor_executes_all_collective_gates(
+    monkeypatch,
+) -> None:
+    events = []
+
+    class FakeExt:
+        def init_dcp_a2a(self, *args):
+            events.append("native-init")
+            return 456
+
+    monkeypatch.setattr(
+        dcp,
+        "_require_full_grid_residency",
+        lambda **kwargs: events.append("residency"),
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_require_collective_contract",
+        lambda **kwargs: events.append("contract"),
+    )
+    monkeypatch.setattr(
+        dcp,
+        "_finish_collective_unowned_runtime_setup",
+        lambda **kwargs: events.append("native-verdict"),
+    )
+    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
+
+    runtime = dcp.PCIeDCPA2A(
+        rank=0,
+        world_size=2,
+        device=torch.device("cuda:0"),
+        signal_ptrs=(100, 200),
+        staging0_ptrs=(300, 400),
+        staging1_ptrs=(500, 600),
+        max_batch_size=8,
+        total_heads=16,
+        head_dim=64,
+        output_capacity_elems=8 * 16 * 64,
+        lse_offset=8 * 16 * 64 * 2,
+        lse_capacity=8 * 16,
+        exchange_group=object(),
+        ext_module=FakeExt(),
+    )
+
+    assert runtime._ptr == 456
+    assert events == [
+        "preflight",
+        "residency",
+        "preflight",
+        "contract",
+        "native-init",
+        "native-verdict",
+    ]
+    runtime._coordinated_close_complete = True

--- a/tests/comm/test_pcie_staging_control.py
+++ b/tests/comm/test_pcie_staging_control.py
@@ -265,27 +265,15 @@ def test_control_and_worker_launches_have_immediate_error_checks(
         assert suffix.lstrip().startswith("CHECK_CUDA_SUCCESS(cudaGetLastError());")
 
 
-def test_control_node_graph_topology_contract() -> None:
-    # This is a node-topology contract, not a performance claim. Public-head
-    # A/B results compare net algorithms; only the staged plain one-shot 64 KiB
-    # path is covered by the dedicated timing harness.
-    control_nodes = {
-        "oneshot_registered": 0,
-        "oneshot_staged_pull": 1,
-        "fused_registered": 0,
-        "fused_staged_pull": 1,
-        "fused_staged_push": 1,
-        "twoshot_reduce_scatter": 1,
-        "twoshot_all_gather": 1,
-        "dcp_lse_reduce_scatter": 1,
-        "dcp_all_gather_heads": 1,
-    }
-    total_nodes = {name: 1 + extra for name, extra in control_nodes.items()}
+@pytest.mark.parametrize(
+    "source_name",
+    ("pcie_oneshot.cu", "pcie_twoshot.cu", "pcie_dcp_a2a.cu"),
+)
+def test_each_staged_collective_has_one_control_launch(source_name: str) -> None:
+    source = (PCIE / source_name).read_text(encoding="utf-8")
+    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>"
 
-    assert total_nodes["oneshot_registered"] == 1
-    assert total_nodes["fused_registered"] == 1
-    assert {
-        total_nodes[name]
-        for name in total_nodes
-        if name not in {"oneshot_registered", "fused_registered"}
-    } == {2}
+    # Each source implements exactly two staged collectives. Registered
+    # one-shot paths remain control-free; their conditional gating is covered
+    # by the neighboring source and GPU graph tests.
+    assert source.count(control_launch) == 2

--- a/tests/comm/test_pcie_staging_control.py
+++ b/tests/comm/test_pcie_staging_control.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PCIE = ROOT / "sparkinfer" / "comm" / "pcie"
+UINT32_MASK = (1 << 32) - 1
+
+
+def _advance(generation: int) -> tuple[int, int]:
+    """Model the device control kernel's unsigned generation update."""
+    return generation & 1, (generation + 1) & UINT32_MASK
+
+
+def _section(source: str, start: str, end: str) -> str:
+    return source[source.index(start) : source.index(end, source.index(start))]
+
+
+def test_slot_control_alternates_across_replays_and_wraps() -> None:
+    generation = 0
+    slots = []
+    for _ in range(7):
+        slot, generation = _advance(generation)
+        slots.append(slot)
+
+    assert slots == [0, 1, 0, 1, 0, 1, 0]
+    assert _advance(UINT32_MASK) == (1, 0)
+    assert _advance(0) == (0, 1)
+
+
+def test_same_stream_capture_replay_handles_variable_worker_grids() -> None:
+    generation = 0
+    replay_slots = []
+    worker_slots = []
+
+    for worker_blocks in (1, 64, 3, 36, 8):
+        slot, generation = _advance(generation)
+        replay_slots.append(slot)
+        worker_slots.append([slot] * worker_blocks)
+
+    assert replay_slots == [0, 1, 0, 1, 0]
+    assert all(len(set(cta_slots)) == 1 for cta_slots in worker_slots)
+
+
+def test_multistream_separate_channels_match_across_rank_interleavings() -> None:
+    schedules = {
+        0: ("decode", "prefill", "decode", "prefill"),
+        1: ("prefill", "decode", "prefill", "decode"),
+    }
+    rank_observations = {}
+
+    for rank, schedule in schedules.items():
+        generations = {"decode": 0, "prefill": 0}
+        observed = {"decode": [], "prefill": []}
+        for channel in schedule:
+            slot, generations[channel] = _advance(generations[channel])
+            observed[channel].append(slot)
+        rank_observations[rank] = observed
+
+    assert rank_observations[0] == rank_observations[1]
+    assert rank_observations[0] == {
+        "decode": [0, 1],
+        "prefill": [0, 1],
+    }
+
+
+@pytest.mark.parametrize("source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu"))
+def test_worker_slot_selection_has_no_grid_rendezvous(source_name: str) -> None:
+    source = (PCIE / source_name).read_text(encoding="utf-8")
+
+    assert "active_staging_slot" in source
+    assert "advance_staging_slot_kernel" in source
+    assert "staging_arrive" not in source
+    assert "cudaLaunchCooperativeKernel" not in source
+    assert "launch_cooperative" not in source
+
+    selector_name = (
+        "DINLINE void select_rank_data"
+        if source_name == "pcie_oneshot.cu"
+        else "DINLINE void select_rank_ptrs"
+    )
+    selector = _section(source, selector_name, "template <")
+    assert "active_staging_slot" in selector
+    assert "atomicAdd" not in selector
+    assert "while (" not in selector
+
+
+def test_fused_rms_residency_is_runtime_derived_and_capture_cached() -> None:
+    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
+
+    assert "cudaOccupancyMaxActiveBlocksPerMultiprocessor" in source
+    assert "cudaDevAttrMultiProcessorCount" in source
+    assert "fused_resident_capacity_" in source
+    assert "cap_fused_ctas_per_row" in source
+    assert "SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY" in source
+    assert "kMaxBlocks <= SM count" not in source
+
+    # Model the native clamp for reduced/MIG-like capacities. A capacity below
+    # the requested multi-CTA grid must select the barrier-free single-CTA path.
+    def cap(requested: int, rows: int, resident: int) -> int:
+        return max(1, min(requested, max(1, resident // rows)))
+
+    assert cap(3, 1, 1) == 1
+    assert cap(3, 1, 2) == 2
+    assert cap(3, 2, 2) == 1
+    assert cap(3, 2, 8) == 3
+
+
+@pytest.mark.parametrize(
+    ("source_name", "python_name", "constant_name", "required_sms"),
+    (
+        ("pcie_oneshot.cu", "pcie_oneshot.py", "ONESHOT_REQUIRED_SMS", 36),
+        ("pcie_twoshot.cu", "pcie_twoshot.py", "TWOSHOT_REQUIRED_SMS", 64),
+        ("pcie_dcp_a2a.cu", "pcie_dcp_a2a.py", "DCP_A2A_REQUIRED_SMS", 64),
+    ),
+)
+def test_peer_waiting_grid_is_fully_resident_or_rejected_before_ipc(
+    source_name: str,
+    python_name: str,
+    constant_name: str,
+    required_sms: int,
+) -> None:
+    source = (PCIE / source_name).read_text(encoding="utf-8")
+    wrapper = (PCIE / python_name).read_text(encoding="utf-8")
+
+    assert f"constexpr int kMaxBlocks = {required_sms};" in source
+    assert source.count("__global__ void __launch_bounds__(512, 1)") == 2
+    assert f"{constant_name} = {required_sms}" in wrapper
+    assert "_require_full_grid_residency(" in wrapper
+
+    # All peer-waiting worker launches use no dynamic shared memory. Combined
+    # with launch_bounds(..., 1), one CTA is resident per visible SM; requiring
+    # kMaxBlocks SMs makes every possible worker CTA simultaneously resident.
+    worker_launches = [
+        line
+        for line in source.splitlines()
+        if "<<<blocks, threads, 0, stream>>>" in line
+    ]
+    assert worker_launches
+    assert all(", 0, stream>>>" in line for line in worker_launches)
+
+
+def test_oneshot_control_is_staged_only_and_precedes_each_worker() -> None:
+    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
+    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
+    assert source.count(control_launch) == 2
+
+    regular = _section(
+        source,
+        "void allreduce(cudaStream_t stream",
+        "void allreduce_fused_add_rms_norm",
+    )
+    assert f"if (stage_input) {{\n      {control_launch}" in regular
+    assert regular.index(control_launch) < regular.index("#define KL(ngpus)")
+
+    fused = _section(
+        source,
+        "void allreduce_fused_add_rms_norm",
+        "~PCIeAllreduce",
+    )
+    assert f"if (use_eager_staging) {{\n      {control_launch}" in fused
+    assert fused.index(control_launch) < fused.index("#define KL(ngpus, SINGLE, MODE)")
+
+    # Registered one-shot and fused registered paths retain their original
+    # direct buffer route; only the double-buffered staged route advances.
+    assert "if (stage_input)" in regular
+    assert "pcie_allreduce_kernel<T, ngpus, true>" in regular
+    assert "pcie_allreduce_kernel<T, ngpus, false>" in regular
+    assert "if (mode == kModeStagePush)" in fused
+    assert "KL(ngpus, SINGLE, kModeStagePush)" in fused
+    assert "KL(ngpus, SINGLE, kModeStagePull)" in fused
+    assert "kModeRegistered" in fused
+
+
+def test_twoshot_control_precedes_reduce_scatter_and_all_gather_workers() -> None:
+    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
+    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
+    assert source.count(control_launch) == 2
+
+    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
+    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
+        "rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
+    )
+
+    all_gather = _section(source, "void all_gather(", "\n};")
+    assert all_gather.index(control_launch) < all_gather.index(
+        "ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
+    )
+
+
+def test_twoshot_validates_launch_geometry_before_grid_division() -> None:
+    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
+    validator = _section(source, "void check_launch_config(", "void reduce_scatter(")
+
+    assert "threads < world_size_" in validator
+    assert "threads > 1024" in validator
+    assert "threads % 32 != 0" in validator
+    assert "block_limit <= 0" in validator
+    assert "block_limit > kMaxBlocks" in validator
+
+    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
+    all_gather = _section(source, "void all_gather(", "\n};")
+    for operation in (reduce_scatter, all_gather):
+        assert operation.index("check_launch_config(threads, block_limit);") < (
+            operation.index("(shard_packs + threads - 1) / threads")
+        )
+
+
+def test_dcp_control_selects_one_slot_per_operation_before_workers() -> None:
+    source = (PCIE / "pcie_dcp_a2a.cu").read_text(encoding="utf-8")
+    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);"
+    assert source.count(control_launch) == 2
+
+    selector = _section(source, "DINLINE void select_staging", "// pre_sync")
+    assert "active_staging_slot" in selector
+    assert "self_counter[blockIdx.x]" not in selector
+    assert "atomicAdd" not in selector
+    assert "while (" not in selector
+
+    reduce_scatter = _section(
+        source, "void run(cudaStream_t stream", "void all_gather_heads("
+    )
+    gather = _section(source, "void all_gather_heads(", "\n};")
+    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
+        "#define LAUNCH(world)"
+    )
+    assert gather.index(control_launch) < gather.index("#define LAUNCH(world)")
+    assert "SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES" in source
+    assert "test_post_barrier_delay(rank, delayed_rank, delay_cycles);" in source
+
+
+@pytest.mark.parametrize(
+    "source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu", "pcie_dcp_a2a.cu")
+)
+def test_control_kernel_is_graph_replay_dynamic(source_name: str) -> None:
+    source = (PCIE / source_name).read_text(encoding="utf-8")
+    control = _section(
+        source,
+        "__global__ void advance_staging_slot_kernel",
+        "template <",
+    )
+
+    # The generation update runs in a CUDA kernel—not on the host—so capture
+    # records it as a graph node and every replay advances the channel slot.
+    assert "staging_generation" in control
+    assert "active_staging_slot = generation & FlagType{1}" in control
+    assert "staging_generation = generation + FlagType{1}" in control
+
+
+@pytest.mark.parametrize(
+    ("source_name", "expected_checks"),
+    (("pcie_oneshot.cu", 4), ("pcie_twoshot.cu", 4)),
+)
+def test_control_and_worker_launches_have_immediate_error_checks(
+    source_name: str, expected_checks: int
+) -> None:
+    source = (PCIE / source_name).read_text(encoding="utf-8")
+    assert source.count("CHECK_CUDA_SUCCESS(cudaGetLastError());") >= expected_checks
+
+    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
+    for suffix in source.split(control_launch)[1:]:
+        assert suffix.lstrip().startswith("CHECK_CUDA_SUCCESS(cudaGetLastError());")
+
+
+def test_control_node_graph_topology_contract() -> None:
+    # This is a node-topology contract, not a performance claim. Public-head
+    # A/B results compare net algorithms; only the staged plain one-shot 64 KiB
+    # path is covered by the dedicated timing harness.
+    control_nodes = {
+        "oneshot_registered": 0,
+        "oneshot_staged_pull": 1,
+        "fused_registered": 0,
+        "fused_staged_pull": 1,
+        "fused_staged_push": 1,
+        "twoshot_reduce_scatter": 1,
+        "twoshot_all_gather": 1,
+        "dcp_lse_reduce_scatter": 1,
+        "dcp_all_gather_heads": 1,
+    }
+    total_nodes = {name: 1 + extra for name, extra in control_nodes.items()}
+
+    assert total_nodes["oneshot_registered"] == 1
+    assert total_nodes["fused_registered"] == 1
+    assert {
+        total_nodes[name]
+        for name in total_nodes
+        if name not in {"oneshot_registered", "fused_registered"}
+    } == {2}

--- a/tests/comm/test_pcie_twoshot.py
+++ b/tests/comm/test_pcie_twoshot.py
@@ -6,12 +6,19 @@ Run with torchrun on 2, 4 or 8 GPUs:
         --nproc-per-node=8 tests/distributed/test_pcie_twoshot.py
 """
 
+import ctypes
 import os
 import time
 
+import pytest
 import torch
 import torch.distributed as dist
 
+from sparkinfer.comm.pcie.pcie_oneshot import (
+    PCIeOneshotAllReduce,
+    _OwnedSharedBuffer,
+    _RETAINED_FAILED_IPC_EXPORTS,
+)
 from sparkinfer.comm.pcie.pcie_twoshot import (
     PCIeTwoShotSP,
     quantize_per_row,
@@ -19,6 +26,159 @@ from sparkinfer.comm.pcie.pcie_twoshot import (
 
 ROWS = 4096
 ROW_ELEMS = 6144
+
+
+def test_factory_retains_twoshot_native_and_ipc_ownership_when_verdict_fails(
+    monkeypatch,
+) -> None:
+    events: list[tuple[str, int]] = []
+
+    class FakeIPC:
+        def cudaIpcCloseMemHandle(self, ptr):
+            events.append(("close", ptr))
+
+        def cudaFree(self, ptr):
+            events.append(("free", ptr))
+
+    class FakeExt:
+        @staticmethod
+        def init_twoshot(*args):
+            return 3000
+
+        @staticmethod
+        def dispose(ptr):
+            events.append(("dispose", ptr))
+
+    ipc = FakeIPC()
+    ext = FakeExt()
+    group = object()
+    shared = _OwnedSharedBuffer(
+        local_ptr=1000,
+        peer_ptrs=(1000, 2000),
+        remote_ptrs=(2000,),
+    )
+    preallocation_round = 0
+
+    def fake_preallocation(*, owner, exchange_group, setup):
+        nonlocal preallocation_round
+        assert exchange_group is group
+        preallocation_round += 1
+        if preallocation_round == 1:
+            return torch.device("cuda:0"), 8, 16
+        assert preallocation_round == 2
+        return ipc, ext, 1, 256, 64, 256, 512, 1280
+
+    verdict_round = 0
+
+    def exchange(local_status, exchange_group):
+        nonlocal verdict_round
+        assert exchange_group is group
+        verdict_round += 1
+        if verdict_round == 1:
+            raise RuntimeError("injected twoshot native verdict exchange failure")
+        return [local_status, ()]
+
+    monkeypatch.setattr(dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_twoshot._run_collective_preallocation_setup",
+        fake_preallocation,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_twoshot._require_full_grid_residency",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_twoshot._require_collective_contract",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        classmethod(lambda cls, *args, **kwargs: shared),
+    )
+    monkeypatch.setattr(
+        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        exchange,
+    )
+
+    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
+        PCIeTwoShotSP.from_exchange_group(
+            exchange_group=group,
+            device="cuda:0",
+            max_rows=8,
+            row_elems=16,
+            ext_module=ext,
+        )
+
+    retained = exc.value.retryable_setup
+    assert retained.local_ptr == 1000
+    assert retained.remote_ptrs == [2000]
+    assert retained.local_cleanup is not None
+    assert events == []
+    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
+
+    retained.retry()
+    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
+    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _local_staging_words(
+    pool: PCIeTwoShotSP, stream: torch.cuda.Stream
+) -> tuple[int, int]:
+    assert len(pool._owned_buffers) == 1
+    max_rows_per_rank = pool.max_rows // pool.world_size
+    pack_stride = _align_up(max_rows_per_rank * (pool.row_elems // 16), 16)
+    payload_bytes = pool.world_size * pack_stride * 16
+    scale_offset = _align_up(payload_bytes, 256)
+    scale_stride = _align_up(max_rows_per_rank, 64)
+    slot_bytes = _align_up(
+        scale_offset + pool.world_size * scale_stride * 4,
+        256,
+    )
+    signal_bytes = _align_up(int(pool._ext.meta_size()), 256)
+    remote_source = (pool.rank + 1) % pool.world_size
+    source_offset = remote_source * pack_stride * 16
+    words = (ctypes.c_uint64(), ctypes.c_uint64())
+    local_ptr = pool._owned_buffers[0].local_ptr
+    for word, offset in zip(
+        words,
+        (
+            signal_bytes + source_offset,
+            signal_bytes + slot_bytes + source_offset,
+        ),
+        strict=True,
+    ):
+        pool._ipc.cudaMemcpyAsync(
+            ctypes.addressof(word),
+            local_ptr + offset,
+            ctypes.sizeof(word),
+            int(stream.cuda_stream),
+        )
+    stream.synchronize()
+    return words[0].value, words[1].value
+
+
+def _assert_alternating_slots(snapshots: list[tuple[int, int]]) -> None:
+    changed_slots = [
+        {
+            slot
+            for slot, (before, after) in enumerate(
+                zip(snapshots[index], snapshots[index + 1], strict=True)
+            )
+            if before != after
+        }
+        for index in range(len(snapshots) - 1)
+    ]
+    assert all(len(changed) == 1 for changed in changed_slots)
+    assert all(
+        changed_slots[index] != changed_slots[index + 1]
+        for index in range(len(changed_slots) - 1)
+    )
 
 
 def _partial(seed: int, rows: int, device: torch.device) -> torch.Tensor:
@@ -126,6 +286,56 @@ def _check_graph_capture(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
             ]
         )
         assert torch.equal(ag_out, ag_ref)
+
+    # Capture a single collective so adjacent replays must alternate the
+    # device-selected staging slot. The two-op graph above has even parity.
+    odd_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(odd_graph):
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+
+    for value in (11, 12):
+        ag_q.fill_(float(value + rank))
+        ag_s.fill_(1.0)
+        pool.all_gather_fp8(ag_q, ag_s, ag_out)
+    torch.cuda.synchronize()
+    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
+
+    for value in (1, 2):
+        ag_q.fill_(float(value + rank))
+        ag_s.fill_(1.0)
+        dist.barrier()
+        odd_graph.replay()
+        torch.cuda.synchronize()
+        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
+        for source_rank in range(world):
+            lo = source_rank * rows_per_rank
+            hi = lo + rows_per_rank
+            assert torch.all(ag_out[lo:hi] == float(value + source_rank))
+
+    _assert_alternating_slots(snapshots)
+
+    rs_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(rs_graph):
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+
+    for value in (21, 22):
+        q_in.fill_(float(value + rank))
+        s_in.fill_(1.0)
+        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
+    torch.cuda.synchronize()
+    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
+
+    rank_sum = world * (world - 1) // 2
+    for value in (3, 4):
+        q_in.fill_(float(value + rank))
+        s_in.fill_(1.0)
+        dist.barrier()
+        rs_graph.replay()
+        torch.cuda.synchronize()
+        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
+        assert torch.all(rs_out == float(world * value + rank_sum))
+
+    _assert_alternating_slots(snapshots)
 
 
 def _bench(pool: PCIeTwoShotSP, rank: int, world: int) -> None:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 try:
@@ -10,6 +11,8 @@ except ModuleNotFoundError:  # Python 3.10
 
 ROOT = Path(__file__).parents[1]
 PCIE_PACKAGE = "sparkinfer.comm.pcie"
+PCIE_SOURCE_DIR = ROOT / "sparkinfer" / "comm" / "pcie"
+PCIE_PACKAGE_PATTERNS = {"*.cu", "*.h"}
 RUNTIME_CUDA_SOURCES = {
     "pcie_dcp_a2a.cu",
     "pcie_dcp_topk.cu",
@@ -17,13 +20,27 @@ RUNTIME_CUDA_SOURCES = {
     "pcie_oneshot.cu",
     "pcie_twoshot.cu",
 }
+LOCAL_INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"', re.MULTILINE)
 
 
 def test_runtime_cuda_sources_are_in_package_data() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text())
     package_data = config["tool"]["setuptools"]["package-data"]
 
-    assert package_data[PCIE_PACKAGE] == ["*.cu"]
+    assert set(package_data[PCIE_PACKAGE]) == PCIE_PACKAGE_PATTERNS
     assert {
-        path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
-    } == RUNTIME_CUDA_SOURCES
+        path.name for path in PCIE_SOURCE_DIR.glob("*.cu")
+    } >= RUNTIME_CUDA_SOURCES
+
+
+def test_runtime_cuda_local_includes_are_packaged() -> None:
+    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    package_patterns = config["tool"]["setuptools"]["package-data"][PCIE_PACKAGE]
+
+    for source in PCIE_SOURCE_DIR.glob("*.cu"):
+        for include in LOCAL_INCLUDE_RE.findall(source.read_text(encoding="utf-8")):
+            dependency = source.parent / include
+            assert dependency.is_file(), f"{source.name} includes missing {include}"
+            assert any(dependency.match(pattern) for pattern in package_patterns), (
+                f"{source.name} includes {include}, but {include} is not package data"
+            )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -23,6 +23,14 @@ RUNTIME_CUDA_SOURCES = {
 LOCAL_INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"', re.MULTILINE)
 
 
+def _packaged_paths(root: Path, patterns: list[str]) -> set[Path]:
+    return {
+        candidate.resolve()
+        for pattern in patterns
+        for candidate in root.glob(pattern)
+    }
+
+
 def test_runtime_cuda_sources_are_in_package_data() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text())
     package_data = config["tool"]["setuptools"]["package-data"]
@@ -36,11 +44,24 @@ def test_runtime_cuda_sources_are_in_package_data() -> None:
 def test_runtime_cuda_local_includes_are_packaged() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text())
     package_patterns = config["tool"]["setuptools"]["package-data"][PCIE_PACKAGE]
+    packaged_paths = _packaged_paths(PCIE_SOURCE_DIR, package_patterns)
 
     for source in PCIE_SOURCE_DIR.glob("*.cu"):
         for include in LOCAL_INCLUDE_RE.findall(source.read_text(encoding="utf-8")):
             dependency = source.parent / include
             assert dependency.is_file(), f"{source.name} includes missing {include}"
-            assert any(dependency.match(pattern) for pattern in package_patterns), (
+            assert dependency.resolve() in packaged_paths, (
                 f"{source.name} includes {include}, but {include} is not package data"
             )
+
+
+def test_package_root_glob_does_not_hide_nested_header_omissions(
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "pcie"
+    nested_header = package_root / "nested" / "runtime.h"
+    nested_header.parent.mkdir(parents=True)
+    nested_header.write_text("#pragma once\n", encoding="utf-8")
+
+    assert nested_header.resolve() not in _packaged_paths(package_root, ["*.h"])
+    assert nested_header.resolve() in _packaged_paths(package_root, ["**/*.h"])


### PR DESCRIPTION
## Summary

Rebase the replay and CUDA IPC lifecycle hardening from #105 directly onto the
current SparkInfer `master`, then close the lifecycle and benchmark-contract
gaps found during review.

## What changes

- Makes named eager and CUDA-graph channels deterministic across ranks,
  including opposite local capture order and single-channel DCP pools.
- Preallocates staged buffers and advances their generation on device so graph
  replay cannot reuse stale staging state.
- Makes IPC teardown coordinated and retryable; successful registry entries are
  erased while failed closes remain owned for a later retry.
- Removes dead best-effort teardown paths that could bypass the coordinated
  ownership protocol.
- Tightens residency/preflight validation, package-data validation, and the
  immutable A/B benchmark contract.
- Requires an explicit passing correctness verdict before benchmark timing is
  accepted or aggregated.

## Why a successor

#105 is hosted on an external fork and its packaging invariant predates current
`master`. This PR has `master` as its direct parent and supersedes #105 without
requiring a conflict-resolution overlay.

## Validation

- `ruff check`: pass.
- `python -m compileall`: pass.
- `git diff --check`: pass.
- Focused CPU suite: **143 passed**.
- Four-GPU eager/CUDA-graph DCP correctness: pass.
- Four-GPU opposite channel-order replay: pass.
- Two-GPU asymmetric collective validation: pass.
- Reduced-SM residency rejection: pass.
- One-rank preflight-failure coordination: pass.
- DCP teardown failure/retry path: pass.

GPU validation used four isolated RTX PRO 6000 Blackwell GPUs and the exact PR
tree. Nothing is merged into `master` by this PR update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named, independently routable channels for PCIe collective operations, including eager and CUDA graph workflows.
  * Added configurable concurrent-channel support and safer capture, checkpoint, and rollback behavior.
  * Added device-controlled staging for more consistent repeated and graph-replayed operations.
  * Added standalone benchmarking and comparison reports for PCIe collective performance.

* **Bug Fixes**
  * Improved validation of distributed setup, device compatibility, residency, and launch configuration.
  * Made resource cleanup retryable and safer after partial failures or interrupted shutdowns.

* **Packaging**
  * Ensured required PCIe CUDA header files are included in distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->