### PR TITLE
Make mixed Trellis expert counts runtime-dynamic

### DIFF
--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -11,7 +11,7 @@ belong to the serving framework; SparkInfer owns only the prepared kernel path.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from typing import Protocol, Sequence
 
@@ -97,6 +97,7 @@ class MixedTrellisBuffers:
 class MixedTrellisTier(Protocol):
     """Prepared Trellis tier fields consumed by the mixed launch."""
 
+    num_experts: int
     intermediate_rotations: torch.Tensor
     gate_suh: torch.Tensor
     up_suh: torch.Tensor
@@ -112,7 +113,7 @@ class MixedTrellisTier(Protocol):
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
-    ABI_VERSION = 4
+    ABI_VERSION = 5
 
     def __init__(
         self,
@@ -185,7 +186,6 @@ class W4A16MixedTrellisKernel:
         self.driver = driver
         self.tier0 = tier0
         self.tier1 = tier1
-        self.total_experts = driver.num_experts
         self.size_m = driver.size_m
         self.hidden_size = driver.hidden_size
         self.intermediate_size = driver.intermediate_size
@@ -207,6 +207,8 @@ class W4A16MixedTrellisKernel:
             self.driver.__cache_key__,
             self.tier0.__cache_key__,
             self.tier1.__cache_key__,
+            # Expert counts are runtime artifact data. All E-sized views and
+            # dispatch bounds are reconstructed from the launch scalars.
             self.blocks_per_sm,
             self.shared_words,
         )
@@ -312,6 +314,8 @@ class W4A16MixedTrellisKernel:
         smem_base: Int32,
         tid: Int32,
         active_size_m: Int32,
+        tier0_num_experts: Int32,
+        tier1_num_experts: Int32,
         route_block_idx: Int32,
         output_n_tile: Int32,
         reduce_k_tile: Int32,
@@ -330,12 +334,13 @@ class W4A16MixedTrellisKernel:
                 )
             )
         combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
-        if combined_expert >= Int32(0) and combined_expert < Int32(self.total_experts):
+        total_experts = tier0_num_experts + tier1_num_experts
+        if combined_expert >= Int32(0) and combined_expert < total_experts:
             descriptor = descriptor_map[combined_expert].to(Int32)
             if descriptor >= Int32(0):
                 tier = descriptor >> Int32(8)
                 local_expert = descriptor & Int32(0xFF)
-                if tier == Int32(0) and local_expert < Int32(self.tier0.num_experts):
+                if tier == Int32(0) and local_expert < tier0_num_experts:
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier0.fc1
                     else:
@@ -364,7 +369,7 @@ class W4A16MixedTrellisKernel:
                         lock_slot,
                         active_size_m,
                     )
-                elif tier == Int32(1) and local_expert < Int32(self.tier1.num_experts):
+                elif tier == Int32(1) and local_expert < tier1_num_experts:
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier1.fc1
                     else:
@@ -400,36 +405,173 @@ class W4A16MixedTrellisKernel:
         rotation_input_ptr: cute.Pointer,
         rotation_gate: cute.Tensor,
         rotation_up: cute.Tensor,
-        t0_w13: cute.Tensor,
-        t0_w2: cute.Tensor,
-        t0_w13_scales: cute.Tensor,
-        t0_w2_scales: cute.Tensor,
-        t0_w13_global: cute.Tensor,
-        t0_w2_global: cute.Tensor,
-        t1_w13: cute.Tensor,
-        t1_w2: cute.Tensor,
-        t1_w13_scales: cute.Tensor,
-        t1_w2_scales: cute.Tensor,
-        t1_w13_global: cute.Tensor,
-        t1_w2_global: cute.Tensor,
+        t0_w13_ptr: cute.Pointer,
+        t0_w2_ptr: cute.Pointer,
+        t0_w13_scales_ptr: cute.Pointer,
+        t0_w2_scales_ptr: cute.Pointer,
+        t0_w13_global_ptr: cute.Pointer,
+        t0_w2_global_ptr: cute.Pointer,
+        t1_w13_ptr: cute.Pointer,
+        t1_w2_ptr: cute.Pointer,
+        t1_w13_scales_ptr: cute.Pointer,
+        t1_w2_scales_ptr: cute.Pointer,
+        t1_w13_global_ptr: cute.Pointer,
+        t1_w2_global_ptr: cute.Pointer,
         fc1: cute.Tensor,
         activated: cute.Tensor,
         fc2: cute.Tensor,
         packed_route_indices: cute.Tensor,
         block_expert_ids: cute.Tensor,
         packed_route_count: cute.Tensor,
-        descriptor_map: cute.Tensor,
+        descriptor_map_ptr: cute.Pointer,
         topk_weights_ptr: cute.Pointer,
         fc1_scratch: cute.Tensor,
         fc2_scratch: cute.Tensor,
         workspace: cute.Tensor,
-        intermediate_rotations: cute.Tensor,
-        gate_suh: cute.Tensor,
-        up_suh: cute.Tensor,
+        intermediate_rotations_ptr: cute.Pointer,
+        gate_suh_ptr: cute.Pointer,
+        up_suh_ptr: cute.Pointer,
+        tier0_num_experts: cutlass.Int32,
+        tier1_num_experts: cutlass.Int32,
         active_m: cutlass.Int32,
         grid_x: cutlass.Int32,
         stream: cuda.CUstream,
     ):
+        tier0_experts = cutlass.Int64(tier0_num_experts)
+        tier1_experts = cutlass.Int64(tier1_num_experts)
+        total_experts = tier0_experts + tier1_experts
+
+        t0_w13 = cute.make_tensor(
+            t0_w13_ptr,
+            layout=cute.make_layout(
+                (
+                    tier0_experts
+                    * cutlass.Int64(self.hidden_size // 16)
+                    * cutlass.Int64(self.driver.fc1_cols // 16)
+                    * cutlass.Int64(8 * self.tier0.trellis_bits),
+                ),
+                stride=(1,),
+            ),
+        )
+        t0_w2 = cute.make_tensor(
+            t0_w2_ptr,
+            layout=cute.make_layout(
+                (
+                    tier0_experts
+                    * cutlass.Int64(self.intermediate_size // 16)
+                    * cutlass.Int64(self.hidden_size // 16)
+                    * cutlass.Int64(8 * self.tier0.trellis_bits),
+                ),
+                stride=(1,),
+            ),
+        )
+        t1_w13 = cute.make_tensor(
+            t1_w13_ptr,
+            layout=cute.make_layout(
+                (
+                    tier1_experts
+                    * cutlass.Int64(self.hidden_size // 16)
+                    * cutlass.Int64(self.driver.fc1_cols // 16)
+                    * cutlass.Int64(8 * self.tier1.trellis_bits),
+                ),
+                stride=(1,),
+            ),
+        )
+        t1_w2 = cute.make_tensor(
+            t1_w2_ptr,
+            layout=cute.make_layout(
+                (
+                    tier1_experts
+                    * cutlass.Int64(self.intermediate_size // 16)
+                    * cutlass.Int64(self.hidden_size // 16)
+                    * cutlass.Int64(8 * self.tier1.trellis_bits),
+                ),
+                stride=(1,),
+            ),
+        )
+        t0_w13_scales = cute.make_tensor(
+            t0_w13_scales_ptr,
+            layout=cute.make_layout(
+                (
+                    tier0_experts
+                    * cutlass.Int64(self.tier0.fc1.scale_k_groups)
+                    * cutlass.Int64(self.tier0.fc1.scale_size_n // 4),
+                ),
+                stride=(1,),
+            ),
+        )
+        t0_w2_scales = cute.make_tensor(
+            t0_w2_scales_ptr,
+            layout=cute.make_layout(
+                (
+                    tier0_experts
+                    * cutlass.Int64(self.tier0.fc2.scale_k_groups)
+                    * cutlass.Int64(self.tier0.fc2.scale_size_n // 4),
+                ),
+                stride=(1,),
+            ),
+        )
+        t1_w13_scales = cute.make_tensor(
+            t1_w13_scales_ptr,
+            layout=cute.make_layout(
+                (
+                    tier1_experts
+                    * cutlass.Int64(self.tier1.fc1.scale_k_groups)
+                    * cutlass.Int64(self.tier1.fc1.scale_size_n // 4),
+                ),
+                stride=(1,),
+            ),
+        )
+        t1_w2_scales = cute.make_tensor(
+            t1_w2_scales_ptr,
+            layout=cute.make_layout(
+                (
+                    tier1_experts
+                    * cutlass.Int64(self.tier1.fc2.scale_k_groups)
+                    * cutlass.Int64(self.tier1.fc2.scale_size_n // 4),
+                ),
+                stride=(1,),
+            ),
+        )
+        t0_w13_global = cute.make_tensor(
+            t0_w13_global_ptr,
+            layout=cute.make_layout((tier0_experts,), stride=(1,)),
+        )
+        t0_w2_global = cute.make_tensor(
+            t0_w2_global_ptr,
+            layout=cute.make_layout((tier0_experts,), stride=(1,)),
+        )
+        t1_w13_global = cute.make_tensor(
+            t1_w13_global_ptr,
+            layout=cute.make_layout((tier1_experts,), stride=(1,)),
+        )
+        t1_w2_global = cute.make_tensor(
+            t1_w2_global_ptr,
+            layout=cute.make_layout((tier1_experts,), stride=(1,)),
+        )
+        descriptor_map = cute.make_tensor(
+            descriptor_map_ptr,
+            layout=cute.make_layout((total_experts,), stride=(1,)),
+        )
+        intermediate_rotations = cute.make_tensor(
+            intermediate_rotations_ptr,
+            layout=cute.make_layout(
+                (total_experts * cutlass.Int64(3 * self.intermediate_size),),
+                stride=(1,),
+            ),
+        )
+        gate_suh = cute.make_tensor(
+            gate_suh_ptr,
+            layout=cute.make_layout(
+                (total_experts * cutlass.Int64(self.hidden_size),), stride=(1,)
+            ),
+        )
+        up_suh = cute.make_tensor(
+            up_suh_ptr,
+            layout=cute.make_layout(
+                (total_experts * cutlass.Int64(self.hidden_size),), stride=(1,)
+            ),
+        )
         rotation_input = cute.make_tensor(
             rotation_input_ptr,
             layout=cute.make_layout(
@@ -474,6 +616,8 @@ class W4A16MixedTrellisKernel:
             intermediate_rotations,
             gate_suh,
             up_suh,
+            tier0_num_experts,
+            tier1_num_experts,
             active_m,
         ).launch(
             grid=(grid_x, 1, 1),
@@ -515,6 +659,8 @@ class W4A16MixedTrellisKernel:
         intermediate_rotations: cute.Tensor,
         gate_suh: cute.Tensor,
         up_suh: cute.Tensor,
+        tier0_num_experts: cutlass.Int32,
+        tier1_num_experts: cutlass.Int32,
         active_m: cutlass.Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -555,6 +701,8 @@ class W4A16MixedTrellisKernel:
             smem_base,
             tid,
             active_m,
+            tier0_num_experts,
+            tier1_num_experts,
         )
         fc2_emit = partial(
             self._emit_tier_tile,
@@ -577,7 +725,10 @@ class W4A16MixedTrellisKernel:
             smem_base,
             tid,
             active_m * Int32(self.top_k),
+            tier0_num_experts,
+            tier1_num_experts,
         )
+        total_experts = tier0_num_experts + tier1_num_experts
         self.driver._moe_body(
             rotation_gate,
             rotation_up,
@@ -604,8 +755,8 @@ class W4A16MixedTrellisKernel:
             gate_suh,
             up_suh,
             descriptor_map,
-            Int32(self.total_experts),
-            Int32(self.total_experts),
+            total_experts,
+            total_experts,
             smem_base,
             tid,
             cta,
@@ -617,16 +768,6 @@ class W4A16MixedTrellisKernel:
 
 
 _CACHE: dict[tuple[object, ...], MixedTrellisCompileResult] = {}
-
-
-def _trellis_weight_fake(
-    *, num_experts: int, size_k: int, size_n: int, bits: int
-) -> cute.Tensor:
-    return cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32,
-        (num_experts * (size_k // 16) * (size_n // 16) * (8 * bits),),
-        assumed_align=16,
-    )
 
 
 def compile_mixed_trellis(
@@ -715,9 +856,29 @@ def compile_mixed_trellis(
         int(size_m),
         int(max_m_blocks),
     )
+    topk_sum = compile_w4a16_topk_sum(
+        m=size_m,
+        topk=top_k,
+        hidden_size=hidden_size,
+        element_dtype="fp16",
+        full_rotation=True,
+        num_experts=total_experts,
+        route_num_experts=total_experts,
+        route_ids_dtype=route_ids_dtype,
+        use_expert_map=True,
+    )
     cached = _CACHE.get(cache_key)
     if cached is not None:
-        return cached
+        # The compiled object is intentionally independent of the artifact's
+        # K3/K4 partition. Keep the current plan metadata and top-k launch,
+        # rather than leaking the first split that populated the cache.
+        return replace(
+            cached,
+            topk_sum=topk_sum,
+            tier0_num_experts=int(tier0_num_experts),
+            tier1_num_experts=int(tier1_num_experts),
+            sms=int(sms),
+        )
 
     compile_m = _fake_m_for_specialization(size_m)
     compile_rows = compile_m * top_k
@@ -730,24 +891,14 @@ def compile_mixed_trellis(
             dtype, (max(int(elements), 1),), assumed_align=align
         )
 
-    def tier_args(experts: int, bits: int):
+    def tier_args():
         return (
-            _trellis_weight_fake(
-                num_experts=experts,
-                size_k=hidden_size,
-                size_n=fc1_cols,
-                bits=bits,
-            ),
-            _trellis_weight_fake(
-                num_experts=experts,
-                size_k=intermediate_size,
-                size_n=hidden_size,
-                bits=bits,
-            ),
-            tensor(cutlass.Int32, 1),
-            tensor(cutlass.Int32, 1),
-            tensor(cutlass.Float32, experts),
-            tensor(cutlass.Float32, experts),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=16),
         )
 
     scratch_elements = max(
@@ -759,22 +910,24 @@ def compile_mixed_trellis(
         make_ptr(rotation_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
         tensor(cutlass_dtype, compile_rows * hidden_size),
         tensor(cutlass_dtype, compile_rows * hidden_size),
-        *tier_args(int(tier0_num_experts), int(tier0_bits)),
-        *tier_args(int(tier1_num_experts), int(tier1_bits)),
+        *tier_args(),
+        *tier_args(),
         tensor(cutlass_dtype, compile_rows * fc1_cols),
         tensor(cutlass_dtype, compile_rows * intermediate_size),
         tensor(cutlass_dtype, compile_rows * hidden_size),
         tensor(cutlass.Int32, moe_block_size),
         tensor(cutlass.Int32, 1),
         tensor(cutlass.Int32, 1, align=4),
-        tensor(cutlass.Int32, total_experts),
+        make_ptr(cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4),
         make_ptr(cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4),
         tensor(cutlass.Float32, scratch_elements),
         tensor(cutlass.Float32, scratch_elements),
         tensor(cutlass.Int32, 4 * 256 + 2),
-        tensor(cutlass.Float16, total_experts * 3 * intermediate_size),
-        tensor(cutlass.Float16, total_experts * hidden_size),
-        tensor(cutlass.Float16, total_experts * hidden_size),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        Int32(tier0_num_experts),
+        Int32(tier1_num_experts),
         1,
         1,
         current_cuda_stream(),
@@ -800,17 +953,6 @@ def compile_mixed_trellis(
                 "mixed Trellis codegen spills to local memory "
                 f"({local_bytes} bytes/thread)"
             )
-    topk_sum = compile_w4a16_topk_sum(
-        m=size_m,
-        topk=top_k,
-        hidden_size=hidden_size,
-        element_dtype="fp16",
-        full_rotation=True,
-        num_experts=total_experts,
-        route_num_experts=total_experts,
-        route_ids_dtype=route_ids_dtype,
-        use_expert_map=True,
-    )
     result = MixedTrellisCompileResult(
         compiled=compiled,
         topk_sum=topk_sum,
@@ -980,6 +1122,69 @@ def combine_trellis_rotations(
     )
 
 
+def _validate_mixed_trellis_tier_storage(
+    *,
+    name: str,
+    tier: MixedTrellisTier,
+    expected_experts: int,
+    bits: int,
+    hidden_size: int,
+    intermediate_size: int,
+    device: torch.device,
+) -> None:
+    """Fail closed before binding expert-sized storage as raw CuTe pointers."""
+    expected_experts = int(expected_experts)
+    bits = int(bits)
+    fc1_cols = 2 * int(intermediate_size)
+    expected = (
+        (
+            "w13",
+            tier.w13,
+            torch.int32,
+            expected_experts * (int(hidden_size) // 16) * (fc1_cols // 16) * (8 * bits),
+        ),
+        (
+            "w2",
+            tier.w2,
+            torch.int32,
+            expected_experts
+            * (int(intermediate_size) // 16)
+            * (int(hidden_size) // 16)
+            * (8 * bits),
+        ),
+        # Native Trellis decodes its codebook tiles directly. These scale
+        # pointers retain the prepared four-byte dummy ABI and are not the
+        # per-expert K/32 scale grids used by packed/NF3 weights.
+        ("w13_scale", tier.w13_scale, torch.uint8, 4),
+        ("w2_scale", tier.w2_scale, torch.uint8, 4),
+        (
+            "w13_global_scale",
+            tier.w13_global_scale,
+            torch.float32,
+            expected_experts,
+        ),
+        (
+            "w2_global_scale",
+            tier.w2_global_scale,
+            torch.float32,
+            expected_experts,
+        ),
+    )
+    for field, tensor, expected_dtype, expected_elements in expected:
+        if (
+            tensor.dtype != expected_dtype
+            or tensor.device != device
+            or not tensor.is_contiguous()
+            or int(tensor.numel()) != int(expected_elements)
+            or int(tensor.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                f"mixed Trellis {name}.{field} must be contiguous "
+                f"{expected_dtype} on {device} with {int(expected_elements)} "
+                "elements and at least 16-byte alignment"
+            )
+
+
 def run_mixed_trellis(
     x: torch.Tensor,
     tier0: MixedTrellisTier,
@@ -1011,11 +1216,70 @@ def run_mixed_trellis(
             )
         if not tensor.is_contiguous():
             raise ValueError(f"mixed Trellis {name} must be contiguous")
+    for name, tier, expected_experts in (
+        ("tier0", tier0, launch.tier0_num_experts),
+        ("tier1", tier1, launch.tier1_num_experts),
+    ):
+        actual_experts = int(tier.num_experts)
+        if actual_experts != int(expected_experts):
+            raise ValueError(
+                f"mixed Trellis {name} has {actual_experts} experts, but the "
+                f"launch plan describes {int(expected_experts)}"
+            )
+    _validate_mixed_trellis_tier_storage(
+        name="tier0",
+        tier=tier0,
+        expected_experts=launch.tier0_num_experts,
+        bits=launch.tier0_bits,
+        hidden_size=launch.hidden_size,
+        intermediate_size=launch.intermediate_size,
+        device=x.device,
+    )
+    _validate_mixed_trellis_tier_storage(
+        name="tier1",
+        tier=tier1,
+        expected_experts=launch.tier1_num_experts,
+        bits=launch.tier1_bits,
+        hidden_size=launch.hidden_size,
+        intermediate_size=launch.intermediate_size,
+        device=x.device,
+    )
     total_experts = launch.tier0_num_experts + launch.tier1_num_experts
-    if int(global_to_combined.numel()) != total_experts:
-        raise ValueError("global_to_combined must cover every routed expert")
-    if int(descriptor_map.numel()) != total_experts:
-        raise ValueError("descriptor_map must cover the combined namespace")
+    for name, mapping in (
+        ("global_to_combined", global_to_combined),
+        ("descriptor_map", descriptor_map),
+    ):
+        if (
+            mapping.dtype != torch.int32
+            or mapping.device != x.device
+            or not mapping.is_contiguous()
+            or int(mapping.numel()) != total_experts
+        ):
+            raise ValueError(
+                f"mixed Trellis {name} must be contiguous int32 on {x.device} "
+                f"with {total_experts} elements"
+            )
+    for name, table, expected_elements in (
+        (
+            "intermediate rotations",
+            rotations.intermediate,
+            total_experts * 3 * launch.intermediate_size,
+        ),
+        ("gate SUH", rotations.gate_suh, total_experts * launch.hidden_size),
+        ("up SUH", rotations.up_suh, total_experts * launch.hidden_size),
+        ("down SVH", rotations.down_svh, total_experts * launch.hidden_size),
+    ):
+        if (
+            table.dtype != torch.float16
+            or table.device != x.device
+            or not table.is_contiguous()
+            or int(table.numel()) != expected_elements
+            or int(table.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                f"mixed Trellis {name} must be contiguous fp16 on {x.device} "
+                f"with {expected_elements} elements and at least 16-byte alignment"
+            )
     required_route_slots = max_packed_route_slots(
         m * launch.top_k, launch.moe_block_size, total_experts
     )
@@ -1057,25 +1321,90 @@ def run_mixed_trellis(
         ),
         buffers.rotation_gate.view(-1),
         buffers.rotation_up.view(-1),
-        tier0.w13.view(torch.int32).view(-1),
-        tier0.w2.view(torch.int32).view(-1),
-        tier0.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
-        tier0.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
-        tier0.w13_global_scale,
-        tier0.w2_global_scale,
-        tier1.w13.view(torch.int32).view(-1),
-        tier1.w2.view(torch.int32).view(-1),
-        tier1.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
-        tier1.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
-        tier1.w13_global_scale,
-        tier1.w2_global_scale,
+        make_ptr(
+            cutlass.Int32,
+            tier0.w13.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier0.w2.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier0.w13_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier0.w2_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            tier0.w13_global_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            tier0.w2_global_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier1.w13.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier1.w2.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier1.w13_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            tier1.w2_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            tier1.w13_global_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            tier1.w2_global_scale.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
         buffers.fc1.view(-1),
         buffers.activated.view(-1),
         buffers.fc2.view(-1),
         packed,
         block_experts,
         packed_count,
-        descriptor_map,
+        make_ptr(
+            cutlass.Int32,
+            descriptor_map.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
         make_ptr(
             cutlass.Float32,
             topk_weights.data_ptr(),
@@ -1085,9 +1414,26 @@ def run_mixed_trellis(
         buffers.fc1_scratch,
         buffers.fc2_scratch,
         buffers.workspace,
-        rotations.intermediate.view(-1),
-        rotations.gate_suh.view(-1),
-        rotations.up_suh.view(-1),
+        make_ptr(
+            cutlass.Float16,
+            rotations.intermediate.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            rotations.gate_suh.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            rotations.up_suh.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        Int32(launch.tier0_num_experts),
+        Int32(launch.tier1_num_experts),
         m,
         max(int(launch.blocks_per_sm) * int(launch.sms), 1),
         stream,

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -20,6 +21,8 @@ from sparkinfer.moe._shared.kernels.w4a16.kernel import (
 )
 from sparkinfer.moe._shared.kernels.w4a16.mixed_trellis import (
     W4A16MixedTrellisKernel,
+    _validate_mixed_trellis_tier_storage,
+    build_ordered_maps,
     build_tiered_maps,
     combine_trellis_rotations,
     compile_mixed_trellis,
@@ -29,6 +32,94 @@ from sparkinfer.moe._shared.kernels.w4a16.mixed_trellis import (
 from sparkinfer.moe._shared.kernels.w4a16.prepare import (
     prepare_trellis256_moe_weights,
 )
+
+
+def _mixed_cache_key(tier0_experts: int, tier1_experts: int) -> tuple[object, ...]:
+    """Build the key without constructing CUDA-backed kernels.
+
+    The tier subkeys are stubbed, so this proves only that the outer mixed key
+    does not read expert counts directly. The GPU ABBA test covers real child
+    keys and verifies that they resolve to one compiled object.
+    """
+
+    kernel = object.__new__(W4A16MixedTrellisKernel)
+    kernel.driver = SimpleNamespace(__cache_key__=("driver",))
+    kernel.tier0 = SimpleNamespace(
+        __cache_key__=("dynamic-k3",), num_experts=tier0_experts
+    )
+    kernel.tier1 = SimpleNamespace(
+        __cache_key__=("dynamic-k4",), num_experts=tier1_experts
+    )
+    kernel.blocks_per_sm = 1
+    kernel.shared_words = 1
+    return kernel.__cache_key__
+
+
+def test_mixed_kernel_cache_key_is_tier_partition_agnostic() -> None:
+    # The exact K3/K4 partition is checkpoint data, not launch geometry. One
+    # compiled object must serve every 256-expert GLM-5.2 mixed layout.
+    assert _mixed_cache_key(206, 50) == _mixed_cache_key(160, 96)
+    assert _mixed_cache_key(192, 64) == _mixed_cache_key(206, 50)
+    assert _mixed_cache_key(96, 32) == _mixed_cache_key(80, 16)
+
+
+def test_mixed_kernel_uses_runtime_expert_bounds() -> None:
+    emit_source = textwrap.dedent(
+        inspect.getsource(W4A16MixedTrellisKernel._emit_tier_tile)
+    )
+    kernel_source = textwrap.dedent(inspect.getsource(W4A16MixedTrellisKernel.kernel))
+    call_parameters = inspect.signature(W4A16MixedTrellisKernel.__call__).parameters
+
+    assert "tier0_num_experts" in call_parameters
+    assert "tier1_num_experts" in call_parameters
+    assert "self.tier0.num_experts" not in emit_source
+    assert "self.tier1.num_experts" not in emit_source
+    assert "self.total_experts" not in emit_source
+    assert "self.total_experts" not in kernel_source
+    assert "local_expert < tier0_num_experts" in emit_source
+    assert "local_expert < tier1_num_experts" in emit_source
+
+
+def test_mixed_runtime_rejects_invalid_raw_tier_storage() -> None:
+    device = torch.device("cpu")
+    experts, hidden, intermediate, bits = 2, 128, 128, 3
+    tier = SimpleNamespace(
+        num_experts=experts,
+        w13=torch.empty(
+            experts * (hidden // 16) * ((2 * intermediate) // 16) * (8 * bits),
+            dtype=torch.int32,
+        ),
+        w2=torch.empty(
+            experts * (intermediate // 16) * (hidden // 16) * (8 * bits),
+            dtype=torch.int32,
+        ),
+        w13_scale=torch.empty(4, dtype=torch.uint8),
+        w2_scale=torch.empty(4, dtype=torch.uint8),
+        w13_global_scale=torch.empty(experts, dtype=torch.float32),
+        w2_global_scale=torch.empty(experts, dtype=torch.float32),
+    )
+
+    def validate(candidate) -> None:
+        _validate_mixed_trellis_tier_storage(
+            name="tier0",
+            tier=candidate,
+            expected_experts=experts,
+            bits=bits,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            device=device,
+        )
+
+    validate(tier)
+    for field, replacement in (
+        ("w13", tier.w13[:-1]),
+        ("w2", tier.w2.to(torch.int16)),
+        ("w13_scale", tier.w13_scale[:3]),
+        ("w2_global_scale", tier.w2_global_scale[:1]),
+    ):
+        candidate = SimpleNamespace(**{**vars(tier), field: replacement})
+        with pytest.raises(ValueError, match=rf"tier0\.{field}"):
+            validate(candidate)
 
 
 def _sm12x_available() -> bool:
@@ -55,8 +146,8 @@ def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
     assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
     assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
         "descriptor_map",
-        "Int32(self.total_experts)",
-        "Int32(self.total_experts)",
+        "total_experts",
+        "total_experts",
         "smem_base",
         "tid",
         "cta",
@@ -238,6 +329,31 @@ def test_mixed_k3_k4_matches_serial_and_captures(
     )
     assert buffers.fc2.data_ptr() == buffers.rotation_gate.data_ptr()
 
+    misaligned_intermediate = torch.empty(
+        rotations.intermediate.numel() + 1, dtype=torch.float16, device=device
+    )[1:]
+    assert misaligned_intermediate.is_contiguous()
+    assert misaligned_intermediate.data_ptr() % 16 != 0
+    misaligned_rotations = type(rotations)(
+        intermediate=misaligned_intermediate,
+        gate_suh=rotations.gate_suh,
+        up_suh=rotations.up_suh,
+        down_svh=rotations.down_svh,
+    )
+    with pytest.raises(ValueError, match="intermediate rotations.*16-byte alignment"):
+        run_mixed_trellis(
+            x,
+            tier0,
+            tier1,
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            misaligned_rotations,
+            launch,
+            buffers,
+        )
+
     eager = run_mixed_trellis(
         x,
         tier0,
@@ -315,6 +431,195 @@ def test_mixed_k3_k4_matches_serial_and_captures(
         skipped - skipped_serial
     ).norm() / skipped_serial.norm().clamp_min(1.0e-12)
     assert float(skipped_relative) < 4.0e-3
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize(
+    ("layouts", "max_m_blocks"),
+    (
+        (((206, 50), (160, 96)), 8),
+        (((160, 96), (206, 50)), 9),
+        (((80, 16), (96, 32)), 10),
+    ),
+    ids=("206-50_then_160-96", "160-96_then_206-50", "total-96_then_total-128"),
+)
+def test_mixed_runtime_partition_reuses_one_compiled_object_abba(
+    layouts: tuple[tuple[int, int], tuple[int, int]], max_m_blocks: int
+) -> None:
+    """One compiled kernel must safely serve both production split families."""
+
+    torch.manual_seed(20260803)
+    device = torch.device("cuda", torch.cuda.current_device())
+    m, hidden, intermediate, topk = 2, 256, 128, 2
+    props = torch.cuda.get_device_properties(device)
+
+    def prepare_partition(
+        tier0_experts: int, tier1_experts: int, seed: int
+    ) -> tuple[object, object]:
+        return (
+            _prepared(
+                experts=tier0_experts,
+                hidden=hidden,
+                intermediate=intermediate,
+                bits=3,
+                seed=seed,
+                device=device,
+            ),
+            _prepared(
+                experts=tier1_experts,
+                hidden=hidden,
+                intermediate=intermediate,
+                bits=4,
+                seed=seed + 100,
+                device=device,
+            ),
+        )
+
+    def serial_partition(
+        x: torch.Tensor,
+        tiers: tuple[object, object],
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        tier0_experts = int(tiers[0].num_experts)
+        tier1_experts = int(tiers[1].num_experts)
+        map0 = torch.cat(
+            (
+                torch.arange(tier0_experts, dtype=torch.int32, device=device),
+                torch.full((tier1_experts,), -1, dtype=torch.int32, device=device),
+            )
+        )
+        map1 = torch.cat(
+            (
+                torch.full((tier0_experts,), -1, dtype=torch.int32, device=device),
+                torch.arange(tier1_experts, dtype=torch.int32, device=device),
+            )
+        )
+        return _serial_tier(x, tiers[0], topk_weights, topk_ids, map0) + _serial_tier(
+            x, tiers[1], topk_weights, topk_ids, map1
+        )
+
+    tiers_a = prepare_partition(*layouts[0], seed=301)
+    tiers_b = prepare_partition(*layouts[1], seed=501)
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_weights = torch.tensor(
+        [[0.65, 0.35], [0.2, 0.8]], dtype=torch.float32, device=device
+    )
+
+    # Exercise the highest local id in both tiers. Stale compile-time bounds
+    # would either skip these routes or read beyond the compact tier tensor.
+    def boundary_routes(layout: tuple[int, int]) -> torch.Tensor:
+        tier0_experts, tier1_experts = layout
+        total_experts = tier0_experts + tier1_experts
+        return torch.tensor(
+            [[tier0_experts - 1, total_experts - 1], [0, tier0_experts]],
+            dtype=torch.int32,
+            device=device,
+        )
+
+    topk_ids_a = boundary_routes(layouts[0])
+    topk_ids_b = boundary_routes(layouts[1])
+
+    def compile_partition(
+        tier0_experts: int, tier1_experts: int, *, sms: int | None = None
+    ):
+        return compile_mixed_trellis(
+            size_m=m,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            tier0_num_experts=tier0_experts,
+            tier1_num_experts=tier1_experts,
+            top_k=topk,
+            max_m_blocks=max_m_blocks,
+            sms=int(props.multi_processor_count if sms is None else sms),
+            max_shared_mem=int(props.shared_memory_per_block_optin),
+            force_tile_config=(128, 128, 128, 128),
+        )
+
+    launch_a = compile_partition(*layouts[0])
+    launch_b = compile_partition(*layouts[1])
+    assert launch_a.compiled is launch_b.compiled
+    assert (launch_a.tier0_num_experts, launch_a.tier1_num_experts) == layouts[0]
+    assert (launch_b.tier0_num_experts, launch_b.tier1_num_experts) == layouts[1]
+    alternate_sms = max(int(props.multi_processor_count) - 1, 1)
+    launch_alt_sms = compile_partition(*layouts[1], sms=alternate_sms)
+    launch_restored_sms = compile_partition(
+        *layouts[0], sms=int(props.multi_processor_count)
+    )
+    assert launch_alt_sms.compiled is launch_a.compiled
+    assert launch_restored_sms.compiled is launch_a.compiled
+    assert launch_alt_sms.sms == alternate_sms
+    assert launch_restored_sms.sms == int(props.multi_processor_count)
+
+    def run_partition(
+        tiers: tuple[object, object],
+        topk_ids: torch.Tensor,
+        launch,
+        buffers,
+        global_to_combined: torch.Tensor,
+        descriptor: torch.Tensor,
+        rotations,
+    ) -> torch.Tensor:
+        return run_mixed_trellis(
+            x,
+            tiers[0],
+            tiers[1],
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            rotations,
+            launch,
+            buffers,
+        )
+
+    maps_a = build_ordered_maps(*layouts[0], device=device)
+    maps_b = build_ordered_maps(*layouts[1], device=device)
+    rotations_a = combine_trellis_rotations(*tiers_a)
+    rotations_b = combine_trellis_rotations(*tiers_b)
+    buffers_a = make_mixed_trellis_buffers(
+        launch_a, device=device, sms=int(props.multi_processor_count)
+    )
+    buffers_b = make_mixed_trellis_buffers(
+        launch_b, device=device, sms=int(props.multi_processor_count)
+    )
+    serial_a = serial_partition(x, tiers_a, topk_weights, topk_ids_a)
+    serial_b = serial_partition(x, tiers_b, topk_weights, topk_ids_b)
+
+    output_a1 = run_partition(
+        tiers_a, topk_ids_a, launch_a, buffers_a, *maps_a, rotations_a
+    ).clone()
+    output_b1 = run_partition(
+        tiers_b, topk_ids_b, launch_b, buffers_b, *maps_b, rotations_b
+    ).clone()
+    output_b2 = run_partition(
+        tiers_b, topk_ids_b, launch_b, buffers_b, *maps_b, rotations_b
+    ).clone()
+    output_a2 = run_partition(
+        tiers_a, topk_ids_a, launch_a, buffers_a, *maps_a, rotations_a
+    ).clone()
+    torch.cuda.synchronize(device)
+
+    for actual, expected in (
+        (output_a1, serial_a),
+        (output_b1, serial_b),
+        (output_b2, serial_b),
+        (output_a2, serial_a),
+    ):
+        assert not torch.isnan(actual).any()
+        relative = (actual - expected).norm() / expected.norm().clamp_min(1.0e-12)
+        assert float(relative) < 4.0e-3
+    assert torch.equal(output_a1, output_a2)
+    assert torch.equal(output_b1, output_b2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_b = run_partition(
+            tiers_b, topk_ids_b, launch_b, buffers_b, *maps_b, rotations_b
+        )
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured_b, output_b1)
 
 
 def test_build_tiered_maps_rejects_invalid_partitions() -> None:


### PR DESCRIPTION
## What changed

- make the mixed EXL3 Trellis launch ABI accept the K3 and K4 expert counts at runtime;
- pass every expert-sized weight, scale, descriptor, and rotation table as a pointer, then reconstruct its `Int64` view from those runtime counts;
- use runtime tier bounds in both FC1 and FC2 dispatch and pass the runtime total to the shared MoE body;
- keep the compiled-kernel cache key independent of both the split and total expert count;
- rebind cached launch metadata and the top-k sum plan for every checkpoint layer, so a cache hit cannot leak the first layer's partition;
- fail closed on mismatched tier metadata, maps, or rotation-table storage before a raw-pointer launch;
- bump the mixed-kernel ABI from 4 to 5.

## Why

PR #112 correctly made compact EXL3 tier counts runtime data in each child kernel. The outer mixed dispatcher still baked `self.tier0.num_experts`, `self.tier1.num_experts`, and `self.total_experts` into device code while omitting them from its key.

That collision is observable in `willfalco/GLM-5.2-EXL3-TR3-3.36bpw@8d9aa923`: layer 3 is `206/50`, while layers 4-77 are `160/96`. The original version of this PR specialized the outer key on those counts. Per Luke's review, this revision instead completes the intended runtime-E architecture: one compiled mixed kernel can serve changing expert partitions.

## Regression coverage

The focused GPU test uses high boundary expert IDs, a serial two-tier oracle, repeated launch ordering, and CUDA graph capture/replay. Its isolated cache arms are:

- `206/50 -> 160/96 -> 160/96 -> 206/50`;
- `160/96 -> 206/50 -> 206/50 -> 160/96`;
- total-E growth `80/16 -> 96/32 -> 96/32 -> 80/16` (96 to 128 experts).

Each arm asserts that both launch plans reference the same compiled object while retaining their own tier metadata.

## Validation

- independent peer review: approved after two rounds; no remaining blocker;
- `ruff check`, `ruff format --check`, `py_compile`, and `git diff --check`: pass;
- SM120 exact-image focused matrix: pass on one RTX 5090 (driver 610.43.03, CUDA 13.2, PyTorch 2.12.0+cu132, CUTLASS DSL 4.6.0) in `voipmonitor/vllm:gilded-gnosis-v20-vllm72c35f1-si2b9bf2a-fi801d57a-cu132-20260802-r20`;
- all 14 tests in `tests/moe/test_w4a16_mixed_trellis.py`: pass, including both production warm orders, total-E growth, high boundary IDs, serial-oracle parity, repeat determinism, CUDA graph capture/replay, 32/64-block prefill, the GLM-5.2-sized 3,072-row case, stale-SM metadata rebinding, and fail-closed raw-storage validation;
- initial cold compile subsets for the new runtime ABI: 5/5 core GPU cases pass in 64.21 s and 3/3 large-shape cases pass in 59.57 s; after review hardening, a fresh-cache whole-file run passes 14/14 in 48.82 s and the warm-cache repeat passes 14/14 in 5.36 s; after adding rotation-pointer alignment parity, its focused graph/oracle test passes 2/2 and the complete file passes 14/14 again;
- exact-image static contract subset: 5/5 pass;
- no CUDA error, launch failure, mismatch, or nondeterministic output was observed. The rental does not permit reading the host kernel ring buffer, so this does not claim a host-side Xid audit.

The previous split-specialized field patch completed full 4x RTX PRO 6000 Blackwell KLD, C8, graph-captured MTP3, deterministic warm-cache, and 521K retrieval qualification. Those results establish the original collision and rollback path, but they are not presented as qualification of this rewritten runtime-E ABI. Full-checkpoint successor gates remain a separate maintenance-window follow-up after the focused SM120 kernel gate.
