### PR TITLE
[HH] Fix Kimi K3 DCP and native E8M0 graph safety

### DIFF
--- a/benchmarks/benchmark_kimi_k3_dense_mla_splits.py
+++ b/benchmarks/benchmark_kimi_k3_dense_mla_splits.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Benchmark capture-static Kimi-K3 dense-MLA split plans on one GPU.
+
+This isolates the exact TP16/DCP8 per-rank production shape without loading
+the model.  Global context length is eight times ``cache_seqlens`` because a
+DCP8 rank owns one eighth of the KV cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+
+import torch
+
+from sparkinfer.attention import dense_mla
+
+
+FP8 = torch.float8_e4m3fn
+HEADS = 48
+HEAD_DIM = 576
+VALUE_DIM = 512
+
+
+def _csv_ints(value: str) -> tuple[int, ...]:
+    parsed = tuple(int(item) for item in value.split(",") if item)
+    if not parsed or any(item <= 0 for item in parsed):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--page-size", type=int, default=768)
+    parser.add_argument("--max-cache-tokens", type=int, default=131_072)
+    parser.add_argument(
+        "--splits",
+        type=_csv_ints,
+        default=_csv_ints("1,8,16,32,64,94"),
+    )
+    parser.add_argument(
+        "--sequence-lengths",
+        type=_csv_ints,
+        default=_csv_ints("18,256,2048,8192,32768,65536,131072"),
+        help="Per-rank DCP cache lengths, not global context lengths.",
+    )
+    parser.add_argument("--warmups", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    return parser.parse_args()
+
+
+@torch.inference_mode()
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    torch.cuda.set_device(device)
+    if max(args.sequence_lengths) > args.max_cache_tokens:
+        raise ValueError("sequence length exceeds --max-cache-tokens")
+
+    page_width = (args.max_cache_tokens + args.page_size - 1) // args.page_size
+    cache = torch.full(
+        (page_width, args.page_size, HEAD_DIM),
+        0.25,
+        dtype=FP8,
+        device=device,
+    )
+    q = torch.full((1, HEADS, HEAD_DIM), 0.125, dtype=FP8, device=device)
+    q_scale = torch.ones(1, dtype=torch.float32, device=device)
+    kv_scale = torch.ones(1, dtype=torch.float32, device=device)
+    page_table = torch.arange(page_width, dtype=torch.int32, device=device).view(1, -1)
+    cache_seqlens = torch.ones(1, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    reference_outputs: dict[int, torch.Tensor] = {}
+    all_results: list[dict[str, float | int]] = []
+
+    for requested_splits in args.splits:
+        plan = dense_mla.plan(
+            dense_mla.Caps(
+                device=device,
+                mode="decode",
+                kv_dtype=FP8,
+                num_q_heads=HEADS,
+                page_size=args.page_size,
+                max_total_q=1,
+                max_batch=1,
+                max_cache_tokens=args.max_cache_tokens,
+                max_page_table_width=page_width,
+                num_cache_pages=page_width,
+                use_cuda_graph=True,
+                budget=dense_mla.Budget(max_splits=requested_splits),
+            )
+        )
+        (scratch_spec,) = plan.scratch_specs()
+        scratch = torch.empty(
+            scratch_spec.shape,
+            dtype=scratch_spec.dtype,
+            device=scratch_spec.device,
+        )
+        output = torch.empty(
+            (1, HEADS, VALUE_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        binding = dense_mla.bind(
+            plan,
+            scratch=scratch,
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
+        )
+        dense_mla.compile(binding=binding)
+        dense_mla.run(binding=binding)
+        torch.cuda.synchronize(device)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured_output, _ = dense_mla.run(binding=binding)
+        torch.cuda.synchronize(device)
+
+        for local_length in args.sequence_lengths:
+            cache_seqlens.fill_(local_length)
+            for _ in range(args.warmups):
+                graph.replay()
+            torch.cuda.synchronize(device)
+
+            samples: list[float] = []
+            for _ in range(5):
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                for _ in range(args.iterations):
+                    graph.replay()
+                end.record()
+                end.synchronize()
+                samples.append(start.elapsed_time(end) / args.iterations)
+
+            actual = captured_output.float().cpu()
+            reference = reference_outputs.setdefault(local_length, actual.clone())
+            max_abs = float((actual - reference).abs().max().item())
+            cosine = float(
+                torch.nn.functional.cosine_similarity(
+                    actual.reshape(1, -1), reference.reshape(1, -1), dim=1
+                ).item()
+            )
+            result: dict[str, float | int] = {
+                "requested_max_splits": requested_splits,
+                "actual_splits": plan.num_splits,
+                "chunks_per_split": plan.chunks_per_split,
+                "local_cache_tokens": local_length,
+                "global_dcp8_context_tokens": local_length * 8,
+                "median_ms": statistics.median(samples),
+                "min_ms": min(samples),
+                "max_ms": max(samples),
+                "cosine_vs_first_plan": cosine,
+                "max_abs_vs_first_plan": max_abs,
+            }
+            all_results.append(result)
+            print(json.dumps(result), flush=True)
+
+        del graph, binding, output, scratch, plan
+        torch.cuda.empty_cache()
+
+    print(json.dumps({"results": all_results}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_pcie_hierarchical_tp12.py
+++ b/benchmarks/benchmark_pcie_hierarchical_tp12.py
@@ -1,4 +1,4 @@
-"""Exact Kimi-K3 TP12 decode all-reduce benchmark.
+"""Exact Kimi-K3 TP12/TP16 decode all-reduce benchmark.
 
 Measures CUDA-graph replay for the two BF16 collective shapes used by each K3
 MoE layer:
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import socket
+import argparse
 from statistics import median
 
 os.environ.setdefault("NCCL_IB_DISABLE", "1")
@@ -204,7 +205,10 @@ def _worker(rank: int, world_size: int, port: int) -> None:
 
 
 def main() -> None:
-    world_size = 12
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--world-size", type=int, choices=(12, 16), default=16)
+    args = parser.parse_args()
+    world_size = args.world_size
     if torch.cuda.device_count() < world_size:
         raise RuntimeError(
             f"TP12 benchmark needs 12 CUDA devices, found {torch.cuda.device_count()}"

--- a/benchmarks/reproduce_kimi_k3_tp16_direct_lifecycle.py
+++ b/benchmarks/reproduce_kimi_k3_tp16_direct_lifecycle.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Reproduce the Kimi-K3 TP16 native-MXFP4 small-M MoE lifecycle.
+
+The vLLM startup sequence first warms M=1, captures an M=1 CUDA graph, and
+then executes an eager M=2 sampler warmup while the graph remains alive.  This
+script exercises that sequence on one GPU without loading the full model.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+import torch
+
+from sparkinfer.moe._shared.kernels.w4a16.kernel import run_w4a16_moe
+from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+    make_w4a16_packed_buffers,
+    prepare_w4a16_e8m0_native_weights,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--experts", type=int, default=896)
+    parser.add_argument(
+        "--post-m",
+        type=int,
+        default=2,
+        help="Eager token count launched after the M=1 graph capture.",
+    )
+    parser.add_argument(
+        "--routes",
+        choices=("low", "high", "random"),
+        default="low",
+    )
+    parser.add_argument("--route-seed", type=int, default=1)
+    parser.add_argument(
+        "--route-ids",
+        help="Comma-separated expert IDs; overrides --routes and --route-seed.",
+    )
+    parser.add_argument(
+        "--sort-routes",
+        action="store_true",
+        help="Sort each generated random top-k row by expert ID.",
+    )
+    parser.add_argument("--random-input", action="store_true")
+    parser.add_argument(
+        "--weight-byte",
+        type=int,
+        default=0,
+        help="Packed FP4 byte used to initialize both expert weight tensors.",
+    )
+    parser.add_argument("--scan-start", type=int, default=0)
+    parser.add_argument("--scan-stop", type=int)
+    parser.add_argument("--scan-step", type=int, default=1)
+    parser.add_argument(
+        "--mode",
+        choices=(
+            "eager-m2",
+            "capture-m1",
+            "capture-m1-then-eager-m2",
+            "scan-experts",
+        ),
+        default="capture-m1-then-eager-m2",
+    )
+    return parser.parse_args()
+
+
+def _make_runner(
+    *,
+    prepared: object,
+    m: int,
+    device: torch.device,
+    experts: int,
+    routes: str,
+    route_seed: int,
+    route_ids: tuple[int, ...] | None,
+    sort_routes: bool,
+    random_input: bool,
+) -> tuple[Callable[[], torch.Tensor], torch.Tensor, torch.Tensor]:
+    hidden_size = 3_584
+    topk = 16
+    buffers = make_w4a16_packed_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    fc2_chunks = ((192 // 2) + 127) // 128
+    required_inter_u32 = m * fc2_chunks * 128 * topk
+    intermediate_cache2 = buffers.intermediate_cache2
+    if intermediate_cache2.view(torch.uint32).numel() < required_inter_u32:
+        intermediate_cache2 = torch.empty(
+            required_inter_u32 * 2,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+    if random_input:
+        generator = torch.Generator(device=device).manual_seed(route_seed)
+        inputs = torch.randn(
+            (m, hidden_size),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+    else:
+        inputs = torch.zeros((m, hidden_size), dtype=torch.bfloat16, device=device)
+    if route_ids is not None:
+        if len(route_ids) != topk:
+            raise ValueError(f"--route-ids must contain exactly {topk} IDs")
+        topk_ids = (
+            torch.tensor(route_ids, dtype=torch.int32, device=device)
+            .unsqueeze(0)
+            .expand(m, -1)
+            .contiguous()
+        )
+    elif routes == "random":
+        generator = torch.Generator(device=device).manual_seed(route_seed)
+        topk_ids = torch.stack(
+            [
+                torch.randperm(experts, device=device, generator=generator)[:topk]
+                for _ in range(m)
+            ]
+        ).to(torch.int32)
+        if sort_routes:
+            topk_ids = topk_ids.sort(dim=-1).values
+    else:
+        route_start = 0 if routes == "low" else experts - topk
+        topk_ids = (
+            torch.arange(
+                route_start,
+                route_start + topk,
+                dtype=torch.int32,
+                device=device,
+            )
+            .unsqueeze(0)
+            .expand(m, -1)
+            .contiguous()
+        )
+    topk_weights = torch.full(
+        (m, topk),
+        1.0 / topk,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    def run() -> torch.Tensor:
+        return run_w4a16_moe(
+            inputs,
+            prepared,
+            topk_weights,
+            topk_ids,
+            activation="situ",
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=intermediate_cache2,
+            output=buffers.output,
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            expert_offsets=buffers.expert_offsets,
+            expert_counts=buffers.expert_counts,
+        )
+
+    return run, buffers.output, topk_ids
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    torch.cuda.set_device(device)
+    hidden_size = 3_584
+    intermediate_size = 192
+    rows = 2 * intermediate_size
+    e8m0_dtype = torch.float8_e8m0fnu
+    route_ids = None
+    if args.route_ids:
+        route_ids = tuple(int(value) for value in args.route_ids.split(","))
+
+    if not 0 <= args.weight_byte <= 255:
+        raise ValueError("--weight-byte must be in [0, 255]")
+    w13 = torch.full(
+        (args.experts, rows, hidden_size // 2),
+        args.weight_byte,
+        dtype=torch.uint8,
+        device=device,
+    )
+    w2 = torch.full(
+        (args.experts, hidden_size, intermediate_size // 2),
+        args.weight_byte,
+        dtype=torch.uint8,
+        device=device,
+    )
+    w13_scale = torch.full(
+        (args.experts, rows, hidden_size // 32),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    ).view(e8m0_dtype)
+    w2_scale = torch.full(
+        (args.experts, hidden_size, intermediate_size // 32),
+        127,
+        dtype=torch.uint8,
+        device=device,
+    ).view(e8m0_dtype)
+    scales = torch.ones(args.experts, dtype=torch.float32, device=device)
+    prepared = prepare_w4a16_e8m0_native_weights(
+        w13,
+        w13_scale,
+        scales,
+        w2,
+        w2_scale,
+        scales,
+        activation="situ",
+        params_dtype=torch.bfloat16,
+        w13_layout="w31",
+    )
+
+    if args.mode == "scan-experts":
+        scan_stop = args.experts if args.scan_stop is None else args.scan_stop
+        for expert_id in range(args.scan_start, scan_stop, args.scan_step):
+            run_scan, output_scan, _ = _make_runner(
+                prepared=prepared,
+                m=args.post_m,
+                device=device,
+                experts=args.experts,
+                routes=args.routes,
+                route_seed=args.route_seed,
+                route_ids=(expert_id,) * 16,
+                sort_routes=args.sort_routes,
+                random_input=args.random_input,
+            )
+            print(f"launching expert {expert_id}", flush=True)
+            run_scan()
+            torch.cuda.synchronize(device)
+            print(
+                f"expert {expert_id} passed; "
+                f"finite={bool(torch.isfinite(output_scan).all())}",
+                flush=True,
+            )
+        return
+
+    run_m1, output_m1, topk_ids_m1 = _make_runner(
+        prepared=prepared,
+        m=1,
+        device=device,
+        experts=args.experts,
+        routes=args.routes,
+        route_seed=args.route_seed,
+        route_ids=route_ids,
+        sort_routes=args.sort_routes,
+        random_input=args.random_input,
+    )
+    run_post, output_post, topk_ids_post = _make_runner(
+        prepared=prepared,
+        m=args.post_m,
+        device=device,
+        experts=args.experts,
+        routes=args.routes,
+        route_seed=args.route_seed,
+        route_ids=route_ids,
+        sort_routes=args.sort_routes,
+        random_input=args.random_input,
+    )
+    print(f"M=1 routes: {topk_ids_m1.cpu().tolist()}")
+    if args.post_m != 1:
+        print(f"M={args.post_m} routes: {topk_ids_post.cpu().tolist()}")
+
+    if args.mode == "eager-m2":
+        run_post()
+        torch.cuda.synchronize(device)
+        print(
+            f"eager M={args.post_m} passed; "
+            f"finite={bool(torch.isfinite(output_post).all())}"
+        )
+        return
+
+    run_m1()
+    torch.cuda.synchronize(device)
+    eager_m1 = output_m1.clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_m1()
+    torch.cuda.synchronize(device)
+    print(f"M=1 capture passed; finite={bool(torch.isfinite(output_m1).all())}")
+
+    if args.mode == "capture-m1":
+        output_m1.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize(device)
+        exact = bool(torch.equal(output_m1, eager_m1))
+        max_abs = float((output_m1.float() - eager_m1.float()).abs().max())
+        print(f"M=1 replay passed; exact={exact}; max_abs={max_abs}")
+        return
+
+    run_post()
+    torch.cuda.synchronize(device)
+    print(
+        f"post-capture eager M={args.post_m} passed; "
+        f"finite={bool(torch.isfinite(output_post).all())}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reproduce_kimi_k3_tp16_direct_lifecycle.py
+++ b/benchmarks/reproduce_kimi_k3_tp16_direct_lifecycle.py
@@ -55,6 +55,8 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--scan-start", type=int, default=0)
     parser.add_argument("--scan-stop", type=int)
     parser.add_argument("--scan-step", type=int, default=1)
+    parser.add_argument("--benchmark-warmups", type=int, default=0)
+    parser.add_argument("--benchmark-iterations", type=int, default=0)
     parser.add_argument(
         "--mode",
         choices=(
@@ -287,6 +289,24 @@ def main() -> None:
         run_m1()
     torch.cuda.synchronize(device)
     print(f"M=1 capture passed; finite={bool(torch.isfinite(output_m1).all())}")
+
+    if args.benchmark_iterations:
+        for _ in range(args.benchmark_warmups):
+            graph.replay()
+        torch.cuda.synchronize(device)
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(args.benchmark_iterations):
+            graph.replay()
+        end.record()
+        end.synchronize()
+        elapsed_ms = start.elapsed_time(end)
+        print(
+            f"M=1 graph benchmark: iterations={args.benchmark_iterations}; "
+            f"total_ms={elapsed_ms:.6f}; "
+            f"per_layer_ms={elapsed_ms / args.benchmark_iterations:.6f}"
+        )
 
     if args.mode == "capture-m1":
         output_m1.fill_(float("nan"))

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
@@ -97,7 +97,9 @@ struct DoubleStaging {
 };
 
 template <typename T> struct __align__(16) Pack {
-  T values[8];
+  // Every transaction is exactly 16 bytes. Half/BF16 therefore carry eight
+  // elements while the raw E4M3 query-gather path carries sixteen bytes.
+  T values[16 / sizeof(T)];
 };
 
 #define DINLINE __device__ __forceinline__
@@ -329,6 +331,12 @@ __global__ void __launch_bounds__(512, 1)
         const int64_t source_base = src == rank ? local_base : staging_base;
         const Pack<T> values = rot_packs[i][source_base + pack];
         const float weight = weights[i] * inv_weight_sum;
+        // Empty DCP shards legitimately return LSE=-inf and leave their
+        // partial output undefined. IEEE 0*NaN is NaN, so do not read or
+        // accumulate an invalid contributor merely because its weight is 0.
+        if (weight == 0.0f) {
+          continue;
+        }
 #pragma unroll
         for (int element = 0; element < kPackElems; ++element) {
           accum[element] += weight * to_float(values.values[element]);
@@ -357,7 +365,7 @@ __global__ void __launch_bounds__(512, 1)
                             Signal *self, T *__restrict__ output, int rank,
                             int batch, int local_heads, int head_dim,
                             int delayed_rank, uint64_t delay_cycles) {
-  constexpr int kPackElems = 8;
+  constexpr int kPackElems = 16 / sizeof(T);
   const int packs_per_head = head_dim / kPackElems;
   const int total_heads = local_heads * world_size;
   const int rows = batch * total_heads;
@@ -506,13 +514,15 @@ public:
   void all_gather_heads(cudaStream_t stream, const T *local_input, T *output,
                         int batch, int local_heads, int head_dim, int threads,
                         int block_limit) {
+    constexpr int kPackElems = 16 / sizeof(T);
     const int total_heads = local_heads * world_size_;
     const int64_t output_elems = int64_t(batch) * total_heads * head_dim;
     if (output_elems > output_capacity_elems_) {
       throw std::runtime_error("PCIe DCP all-gather staging capacity exceeded");
     }
-    if (head_dim % 8 != 0) {
-      throw std::runtime_error("head_dim must be a multiple of 8");
+    if (head_dim % kPackElems != 0) {
+      throw std::runtime_error(
+          "head_dim must align to a 16-byte gather transaction");
     }
     if (threads < world_size_ || threads > 1024) {
       throw std::runtime_error("invalid thread count");
@@ -709,8 +719,17 @@ static void all_gather_heads(fptr_t pointer, torch::Tensor &local_input,
         reinterpret_cast<nv_bfloat16 *>(output.data_ptr()), int(batch),
         int(local_heads), int(head_dim), int(threads), int(block_limit));
     break;
+  case at::ScalarType::Float8_e4m3fn:
+    // The gather is a bitwise exchange. Treat E4M3 records as bytes; no
+    // arithmetic or conversion occurs in this path.
+    runtime->all_gather_heads(
+        stream, reinterpret_cast<const uint8_t *>(local_input.data_ptr()),
+        reinterpret_cast<uint8_t *>(output.data_ptr()), int(batch),
+        int(local_heads), int(head_dim), int(threads), int(block_limit));
+    break;
   default:
-    TORCH_CHECK(false, "local_input must be float16 or bfloat16");
+    TORCH_CHECK(false,
+                "local_input must be float16, bfloat16, or float8_e4m3fn");
   }
 }
 

--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
@@ -41,6 +41,7 @@ from .pcie_oneshot import (
 
 SUPPORTED_WORLD_SIZES = (2, 4, 8)
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+SUPPORTED_GATHER_DTYPES = (*SUPPORTED_DTYPES, torch.float8_e4m3fn)
 DCP_A2A_REQUIRED_SMS = 64
 
 
@@ -165,6 +166,7 @@ def lse_reduce_scatter_reference(
     outputs = partial_outputs[:, :, head_slice, :].float()
     lses = partial_lses[:, :, head_slice].float()
     valid = torch.isfinite(lses)
+    outputs = torch.where(valid.unsqueeze(-1), outputs, torch.zeros_like(outputs))
     sanitized = torch.where(valid, lses, torch.full_like(lses, -torch.inf))
     max_lse = sanitized.amax(dim=0)
     max_lse = torch.where(torch.isfinite(max_lse), max_lse, 0.0)
@@ -737,7 +739,7 @@ class PCIeDCPA2A:
             raise RuntimeError("PCIeDCPA2A is closed")
         if local_input.device != self.device:
             raise ValueError("input must be on the runtime device")
-        if local_input.dtype not in SUPPORTED_DTYPES:
+        if local_input.dtype not in SUPPORTED_GATHER_DTYPES:
             raise ValueError(f"unsupported input dtype {local_input.dtype}")
         if local_input.ndim != 3:
             raise ValueError("input must have shape [batch, local_heads, head_dim]")

--- a/sparkinfer/moe/_shared/kernels/micro.py
+++ b/sparkinfer/moe/_shared/kernels/micro.py
@@ -4381,7 +4381,16 @@ class MoEMicroKernelBackend:
                             gw1 = ld_global_nc_u32(
                                 gate_byte_addr + seg_byte_off + Int64(4)
                             )
-                            if cutlass.const_expr(self.w4a16_mode):
+                            if cutlass.const_expr(self.scale_format_e8m0_k32):
+                                sf_g = self._ld_e8m0_scale(
+                                    w1s_base_addr,
+                                    ebase_sf_packed,
+                                    scale_col >> Int32(1),
+                                    row_g,
+                                    Int32(e8m0_w1_n_cols),
+                                    Int32(cfg.k_dim // 32),
+                                )
+                            elif cutlass.const_expr(self.w4a16_mode):
                                 sf_g = self._ld_e4m3_packed_scale_col(
                                     w1s_base_addr,
                                     ebase_sf_packed_e4m3,
@@ -4402,7 +4411,16 @@ class MoEMicroKernelBackend:
                                 uw1 = ld_global_nc_u32(
                                     up_byte_addr + seg_byte_off + Int64(4)
                                 )
-                                if cutlass.const_expr(self.w4a16_mode):
+                                if cutlass.const_expr(self.scale_format_e8m0_k32):
+                                    sf_u = self._ld_e8m0_scale(
+                                        w1s_base_addr,
+                                        ebase_sf_packed,
+                                        scale_col >> Int32(1),
+                                        row_u,
+                                        Int32(e8m0_w1_n_cols),
+                                        Int32(cfg.k_dim // 32),
+                                    )
+                                elif cutlass.const_expr(self.w4a16_mode):
                                     sf_u = self._ld_e4m3_packed_scale_col(
                                         w1s_base_addr,
                                         ebase_sf_packed_e4m3,

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -26,6 +26,24 @@ def _scratch(plan: dense_mla.Plan) -> torch.Tensor:
     )
 
 
+def _guarded_scratch(
+    plan: dense_mla.Plan,
+    *,
+    guard_bytes: int = 16 * 1024 * 1024,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return exact planned scratch surrounded by initialized canaries."""
+    (spec,) = plan.scratch_specs()
+    assert spec.dtype == torch.uint8
+    storage = torch.full(
+        (spec.nbytes + 2 * guard_bytes,),
+        0xA5,
+        dtype=torch.uint8,
+        device=spec.device,
+    )
+    scratch = storage.narrow(0, guard_bytes, spec.nbytes)
+    return storage, scratch
+
+
 def _assert_matches(
     output: torch.Tensor,
     lse: torch.Tensor,
@@ -533,6 +551,93 @@ def test_cuda_graph_replay_is_allocation_stable_and_reads_live_inputs() -> None:
 
 
 @torch.inference_mode()
+def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
+    """The 1M K3 plan must not touch inactive split storage or cache pages."""
+    device = require_sparkinfer()
+    torch.manual_seed(20260803)
+    page_size = 768
+    page_width = (131_072 + page_size - 1) // page_size
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=FP8,
+            num_q_heads=48,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=131_072,
+            max_page_table_width=page_width,
+            num_cache_pages=1,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits == 94
+
+    q_float = torch.randn(1, 48, QK_DIM, device=device) * 0.1
+    cache_float = torch.randn(1, page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([257], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(
+        1,
+        48,
+        VALUE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    guarded_storage, scratch = _guarded_scratch(plan)
+    binding = dense_mla.bind(
+        plan,
+        scratch=scratch,
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+    guard_bytes = scratch.storage_offset()
+    expected_guard = torch.full(
+        (guard_bytes,),
+        0xA5,
+        dtype=torch.uint8,
+        device=device,
+    )
+    torch.testing.assert_close(guarded_storage[:guard_bytes], expected_guard)
+    torch.testing.assert_close(guarded_storage[-guard_bytes:], expected_guard)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    _assert_matches(
+        captured_output,
+        captured_lse,
+        expected_output,
+        expected_lse,
+    )
+
+
+@torch.inference_mode()
 def test_page_ids_past_int32_scaled_offset_match_reference() -> None:
     device = require_sparkinfer()
     torch.manual_seed(20260803)
@@ -616,6 +721,104 @@ def test_page_ids_past_int32_scaled_offset_match_reference() -> None:
         page_table,
         cache_seqlens,
         cu_seqlens_q,
+    )
+    _assert_matches(
+        actual_output,
+        actual_lse,
+        expected_output,
+        expected_lse,
+    )
+
+
+@torch.inference_mode()
+def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
+    device = require_sparkinfer()
+    torch.manual_seed(20260803)
+    page_size = 768
+    record_bytes = QK_DIM
+    page_stride_bytes = page_size * record_bytes
+    high_page = torch.iinfo(torch.int32).max // page_stride_bytes + 2
+    live_pages = 2
+    pages = high_page + live_pages
+    assert high_page * page_stride_bytes > torch.iinfo(torch.int32).max
+
+    cache = torch.empty(
+        pages,
+        page_size,
+        QK_DIM,
+        dtype=FP8,
+        device=device,
+    )
+    cache_float = torch.randn(
+        live_pages,
+        page_size,
+        QK_DIM,
+        device=device,
+    ) * 0.1
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    cache[high_page:] = (cache_float / kv_scale).to(FP8)
+    page_table = torch.arange(
+        high_page,
+        pages,
+        dtype=torch.int32,
+        device=device,
+    ).reshape(1, live_pages)
+    assert (
+        int(page_table.min().item()) * cache.stride(0) * cache.element_size()
+        > torch.iinfo(torch.int32).max
+    )
+
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=FP8,
+            num_q_heads=HEADS,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=page_size * live_pages,
+            max_page_table_width=live_pages,
+            num_cache_pages=pages,
+        )
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache_seqlens = torch.tensor(
+        [page_size + 9],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(
+        1,
+        HEADS,
+        VALUE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
     )
     _assert_matches(
         actual_output,

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -148,6 +148,21 @@ def test_reference_selects_destination_heads_and_combines_lse_weights():
     torch.testing.assert_close(rank1, torch.tensor([[[20.0], [0.0]]]))
 
 
+def test_reference_ignores_nan_output_from_empty_shard():
+    outputs = torch.tensor(
+        [
+            [[[[torch.nan], [2.0]]]],
+            [[[[4.0], [6.0]]]],
+        ],
+        dtype=torch.float32,
+    ).reshape(2, 1, 2, 1)
+    lses = torch.tensor([[[-torch.inf, 0.0]], [[0.0, 0.0]]])
+
+    actual = lse_reduce_scatter_reference(outputs, lses, 0)
+
+    torch.testing.assert_close(actual, torch.tensor([[[4.0]]]))
+
+
 def test_runtime_validates_and_dispatches_to_extension():
     ext = _FakeExt()
     runtime = _make_runtime(ext)
@@ -181,6 +196,13 @@ def test_runtime_validates_and_dispatches_to_extension():
         16,
         (2, 16, 64),
     )
+
+    fp8_input = torch.arange(16 * 64, dtype=torch.float32).reshape(1, 16, 64)
+    fp8_input = fp8_input.to(torch.float8_e4m3fn)
+    fp8_gathered = runtime.all_gather_heads(fp8_input)
+    assert fp8_gathered.dtype == torch.float8_e4m3fn
+    expected_fp8 = torch.cat((fp8_input, fp8_input), dim=1)
+    assert torch.equal(fp8_gathered.view(torch.uint8), expected_fp8.view(torch.uint8))
     runtime.close()
     assert ext.dispose_calls == [1234]
 

--- a/tests/comm/test_pcie_dcp_a2a_gpu.py
+++ b/tests/comm/test_pcie_dcp_a2a_gpu.py
@@ -208,6 +208,37 @@ def _check_eager(
             assert actual.movedim(0, 1).stride(0) == MAX_BATCH * HEAD_DIM
             torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
+    for step, batch in enumerate(TEST_BATCHES, start=100):
+        local_q = _rank_query(
+            step,
+            rank,
+            world_size,
+            batch,
+            torch.float8_e4m3fn,
+            device,
+        )
+        gathered_q = pool.all_gather_heads(local_q, channel_id="eager:dcp")
+        expected_q = torch.cat(
+            [
+                _rank_query(
+                    step,
+                    source,
+                    world_size,
+                    batch,
+                    torch.float8_e4m3fn,
+                    device,
+                )
+                for source in range(world_size)
+            ],
+            dim=1,
+        )
+        torch.testing.assert_close(
+            gathered_q.view(torch.uint8),
+            expected_q.view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+
 
 def _check_eager_adjacency(
     pool: PCIeDCPA2APool,
@@ -309,7 +340,7 @@ def _check_graph(
             1,
             TOTAL_HEADS // world_size,
             QUERY_HEAD_DIM,
-            dtype=torch.bfloat16,
+            dtype=torch.float8_e4m3fn,
             device=device,
         )
         for _ in range(layers)
@@ -319,7 +350,7 @@ def _check_graph(
             1,
             TOTAL_HEADS,
             QUERY_HEAD_DIM,
-            dtype=torch.bfloat16,
+            dtype=torch.float8_e4m3fn,
             device=device,
         )
         for _ in range(layers)
@@ -361,7 +392,7 @@ def _check_graph(
                     rank,
                     world_size,
                     1,
-                    torch.bfloat16,
+                    torch.float8_e4m3fn,
                     device,
                 )
             )
@@ -373,7 +404,7 @@ def _check_graph(
                             source,
                             world_size,
                             1,
-                            torch.bfloat16,
+                            torch.float8_e4m3fn,
                             device,
                         )
                         for source in range(world_size)
@@ -397,7 +428,12 @@ def _check_graph(
         for out, reference in zip(outputs, expected, strict=True):
             torch.testing.assert_close(out, reference, rtol=2e-2, atol=2e-2)
         for out, reference in zip(gathered_queries, expected_queries, strict=True):
-            torch.testing.assert_close(out, reference, rtol=0, atol=0)
+            torch.testing.assert_close(
+                out.view(torch.uint8),
+                reference.view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
 
     # One captured operation has odd capture-time parity. Adjacent A -> A
     # replays must advance the device-owned slot at execution time.

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -960,6 +960,95 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_w4a16_e8m0_native_aligned_generic_fc1_uses_k32_scale_stride() -> None:
+    """K/32 scales keep their native expert stride in aligned generic FC1."""
+    experts, hidden_size, intermediate_size = 8, 512, 128
+    rows = 2 * intermediate_size
+    torch.manual_seed(20260803)
+    w13 = torch.randint(
+        0,
+        256,
+        (experts, rows, hidden_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (experts, hidden_size, intermediate_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w13_scale = _pattern_e8m0((experts, rows, hidden_size // 32))
+    w2_scale = _pattern_e8m0(
+        (experts, hidden_size, intermediate_size // 32), offset=1
+    )
+    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    prepared = prepare_w4a16_e8m0_native_weights(
+        w13,
+        w13_scale,
+        w13_global_scale,
+        w2,
+        w2_scale,
+        w2_global_scale,
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        w13_layout="w31",
+    )
+    buffers = make_w4a16_buffers(
+        prepared,
+        m=1,
+        topk=2,
+        dtype=torch.bfloat16,
+        device=torch.device("cuda"),
+    )
+    intermediate_cache2 = torch.zeros(
+        2 * 128 * 2, dtype=torch.bfloat16, device="cuda"
+    )
+    x = torch.randn(1, hidden_size, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.tensor([[6, 7]], dtype=torch.int32, device="cuda")
+    topk_weights = torch.tensor([[0.4, 0.6]], dtype=torch.float32, device="cuda")
+
+    actual = run_w4a16_moe(
+        x,
+        prepared,
+        topk_weights,
+        topk_ids,
+        activation="silu",
+        intermediate_cache13=buffers.intermediate_cache13,
+        intermediate_cache2=intermediate_cache2,
+        output=buffers.output,
+        fc1_c_tmp=buffers.fc1_c_tmp,
+        fc2_c_tmp=buffers.fc2_c_tmp,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        expert_offsets=buffers.expert_offsets,
+    )
+    expected = moe_reference_w4a16_fp4_e8m0_k32(
+        x,
+        w13,
+        w13_scale,
+        w13_global_scale,
+        w2,
+        w2_scale,
+        w2_global_scale,
+        topk_ids,
+        topk_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation="silu",
+        w13_layout="w31",
+    )
+    torch.cuda.synchronize()
+
+    assert bool((actual != 0).any().item())
+    _assert_matches_oracle(actual, expected, activation="silu")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("w13_layout", ["w13", "w31"])
 @pytest.mark.parametrize("activation", ["relu2", "silu"])
 def test_w4a16_e8m0_native_large_m_uses_main_gemm(
@@ -1070,6 +1159,7 @@ def test_w4a16_e8m0_native_large_m_uses_main_gemm(
         # same logical-tail path must engage (2048/TP6 = 352, 3072/TP16 = 192).
         ("silu", 352),
         ("relu2", 192),
+        ("situ", 192),
     ],
 )
 def test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid(
@@ -1078,7 +1168,7 @@ def test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid(
 ) -> None:
     """Native E8M0 supports compact FC2 K tails without padding I to 32."""
     experts, hidden_size = 4, 128
-    rows = intermediate_size * (2 if activation == "silu" else 1)
+    rows = intermediate_size * (2 if activation in {"silu", "situ"} else 1)
     topk, m = 2, 24
     assert intermediate_size % 8 == 0
     assert intermediate_size % 128 != 0


### PR DESCRIPTION
## Summary

- make the PCIe DCP head gather accept FP8 E4M3 with the correct 16-byte transaction width
- skip invalid empty-shard partial outputs when their LSE weight is zero, avoiding IEEE `0 * NaN`
- select the native E8M0 K/32 scale loader before the W4A16 packed-E4M3 path for aligned Kimi K3 FC1 segments
- add DCP graph/replay coverage, native-MXFP4 oracle coverage, and model-free dense-MLA/TP16 decode probes

Paired HH vLLM integration: local-inference-lab/vllm#232.

## Root cause

Kimi K3 uses `K=3584`, split into seven aligned FC1 segments. The generic aligned path checked W4A16 first and interpreted native E8M0 K/32 scales as packed E4M3 K/16 scales. That doubled the expert scale stride and could read outside the allocation for high expert IDs. The DCP path also treated FP8 gathers as eight-byte packs and could accumulate undefined empty-shard output even when its softmax weight was zero.

## Validation

- SparkInfer selected suite: 37 passed, 3 skipped
- arbitrary-route lifecycle, CUDA graph replay, and targeted native-E8M0 oracle checks pass
- full original Kimi K3 MXFP4 checkpoint: TP16/DCP8, SparkInfer dense MLA, FP8 KV, physical 1M cache
- three idle 1,024-token decode runs: 40.949 / 41.401 / 41.167 tok/s; 41.167 tok/s median
- coherent output with no CUDA, nonfinite, assertion, or repeated-`!` failure

Full reproduction and profiling notes: https://github.com/local-inference-lab/rtx6kpro/blob/docs/kimi-k3-hh-dense-mla-dcp8-20260803/models/kimi-k3/hh-dense-mla-full-mxfp4-dcp8-2026-08-03.md
