### PR TITLE
feat(mla): Enable native GLM H8 decode path for NVFP4 MLA KV cache

### DIFF
--- a/sparkinfer/attention/_shared/mla/decode_math.py
+++ b/sparkinfer/attention/_shared/mla/decode_math.py
@@ -1127,6 +1127,84 @@ def s2_qk_rope_bf16_glm_h8_swap_ab(
     return qk
 
 
+@cute.jit
+def s2_qk_rope_bf16_nvfp4_h8_swap_ab(
+    qk,
+    q_rope_base_addr: Int32,
+    kv_rope_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    *,
+    d_rope: cutlass.Constexpr,
+    q_rope_stride: cutlass.Constexpr,
+    kv_rope_stride_bytes: cutlass.Constexpr,
+    fp8_rope: cutlass.Constexpr = False,
+):
+    """NVFP4 GLM TP4 RoPE dot product in the swapped H8 fragment layout.
+
+    Handles both BF16 rope (432B record, ``fp8_rope=False``) and E4M3
+    fp8-rope (368B record, ``fp8_rope=True``).  The A operand (K-rope
+    candidates) is loaded via ldmatrix when BF16, or dequanted from E4M3
+    in registers when fp8_rope.  The B operand (Q-rope heads) is always
+    scalar BF16 loads from smem.
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    q_head = gid
+
+    for ks in cutlass.range_constexpr(d_rope // 16):
+        ko = Int32(ks) * Int32(16)
+        if cutlass.const_expr(fp8_rope):
+            # A: K-rope (candidates) -- dequant E4M3 to BF16 in registers.
+            # MMA A-fragment layout: row = gid (M-rows {gid, gid+8}),
+            # col-pair = 2*tid (K-cols {2*tid, 2*tid+8}).
+            col_offset = ko + Int32(2) * tid
+            cand0 = warp_first_cand + gid
+            cand1 = cand0 + Int32(8)
+            a0 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr, cand0, col_offset, d_rope=d_rope,
+            )
+            a1 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr, cand0, col_offset + Int32(8), d_rope=d_rope,
+            )
+            a2 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr, cand1, col_offset, d_rope=d_rope,
+            )
+            a3 = _fp8_rope_pair_bfloat2(
+                kv_rope_base_addr, cand1, col_offset + Int32(8), d_rope=d_rope,
+            )
+        else:
+            # A: K-rope (candidates) -- BF16, ldmatrix from smem.
+            a_byte = (warp_first_cand + a_row) * Int32(kv_rope_stride_bytes) + (
+                ko + a_col
+            ) * Int32(2)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(
+                _smem_byte(kv_rope_base_addr, a_byte)
+            )
+        # B: Q-rope (heads) -- BF16 scalar loads from smem.
+        row_byte = q_head * Int32(q_rope_stride * 2) + ko * Int32(2)
+        b0 = _ld_u32(q_rope_base_addr, row_byte + tid * Int32(2) * Int32(2))
+        b1 = _ld_u32(
+            q_rope_base_addr,
+            row_byte + (tid * Int32(2) + Int32(8)) * Int32(2),
+        )
+        qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+            qk[0],
+            qk[1],
+            qk[2],
+            qk[3],
+            a0,
+            a1,
+            a2,
+            a3,
+            b0,
+            b1,
+        )
+    return qk
+
+
 # =============================================================================
 # S3 -- mask invalid candidates -> -inf, then qk *= sm_scale * LOG2E
 # =============================================================================
@@ -3043,3 +3121,263 @@ def _d2_load_b_fp8(
     t23 = byte_perm(r2, r3, sel)
     b1 = byte_perm(t01, t23, Int32(0x5410))
     return b0, b1
+
+
+
+# =============================================================================
+# NVFP4 H8 swap-AB: BF16 MMA with E2M1 register dequant, 4-warp, full m16n8
+# =============================================================================
+
+
+@cute.jit
+def s1_qk_nope_nvfp4_bf16_h8_swap_ab(
+    qk,
+    q_nope_bf16_base_addr: Int32,
+    kv_fp4_base_addr: Int32,
+    warp_first_cand: Int32,
+    lane: Int32,
+    latent_scale: Float32,
+    *,
+    num_scales: cutlass.Constexpr,
+    quant_tile: cutlass.Constexpr,
+    q_nope_bf16_stride: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    latent_scale_per_token: cutlass.Constexpr = False,
+    kv_sc_base_addr: Int32 = Int32(0),
+):
+    """NVFP4 GLM TP4 QK-NoPE with swapped A/B for full m16n8 occupancy.
+
+    Hardware A = 16-candidate K tile (E2M1 dequanted to BF16 in registers via
+    ``_nvfp4_pair_bfloat2``).  Hardware B = 8-head Q (BF16 scalar loads from
+    smem).  Four warps cover BI=64 candidates (16 per warp).
+
+    Fragment ownership (same as the FP8 H8 swap-AB path)::
+
+        qk[0] = score[cand=base+gid,   head=2*tid]
+        qk[1] = score[cand=base+gid,   head=2*tid+1]
+        qk[2] = score[cand=base+gid+8, head=2*tid]
+        qk[3] = score[cand=base+gid+8, head=2*tid+1]
+    """
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    cand0 = warp_first_cand + gid
+    cand1 = cand0 + Int32(8)
+    col_offset = Int32(2) * tid
+
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
+            # A: K (candidates) -- dequant E2M1 to BF16 in registers.
+            # Each thread holds 4 uint32 (a0..a3) matching the m16n8k16 A
+            # operand layout: row = gid (M-rows {gid, gid+8}), col-pair =
+            # 2*tid (K-cols {2*tid, 2*tid+8}).  This matches the D output
+            # fragment layout (S3 reads cand=base+gid) and the B-fragment
+            # layout used by the generic non-swap NVFP4 S1.
+            a0 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                cand0,
+                ko + col_offset,
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+                latent_scale_per_token=latent_scale_per_token,
+                kv_sc_base_addr=kv_sc_base_addr,
+            )
+            a1 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                cand0,
+                ko + col_offset + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+                latent_scale_per_token=latent_scale_per_token,
+                kv_sc_base_addr=kv_sc_base_addr,
+            )
+            a2 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                cand1,
+                ko + col_offset,
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+                latent_scale_per_token=latent_scale_per_token,
+                kv_sc_base_addr=kv_sc_base_addr,
+            )
+            a3 = _nvfp4_pair_bfloat2(
+                kv_fp4_base_addr,
+                cand1,
+                ko + col_offset + Int32(8),
+                latent_scale,
+                kv_smem_stride=kv_smem_stride,
+                latent_scale_per_token=latent_scale_per_token,
+                kv_sc_base_addr=kv_sc_base_addr,
+            )
+
+            # B: Q (heads) -- BF16 scalar loads from smem.
+            # Q is stored as (heads x kdim) with stride q_nope_bf16_stride.
+            # Each thread loads 2 uint32 (b0, b1) covering 4 kdim values for
+            # its head (gid), matching the m16n8k16 B operand layout.
+            q_byte = gid * Int32(q_nope_bf16_stride * 2) + (ko + tid * Int32(2)) * Int32(2)
+            b0 = _ld_u32(q_nope_bf16_base_addr, q_byte)
+            b1 = _ld_u32(
+                q_nope_bf16_base_addr,
+                q_byte + Int32(8 * 2),
+            )
+
+            qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(
+                qk[0],
+                qk[1],
+                qk[2],
+                qk[3],
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+            )
+    return qk
+
+
+@cute.jit
+def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
+    w_pre,
+    acc_nope,
+    kv_fp4_base_addr: Int32,
+    sm_p_full_addr: Int32,
+    warp_id: Int32,
+    lane: Int32,
+    tid_flat: Int32,
+    latent_scale: Float32,
+    *,
+    n_v_chunks: cutlass.Constexpr,
+    v_chunk: cutlass.Constexpr,
+    hpb: cutlass.Constexpr,
+    bi: cutlass.Constexpr,
+    kv_smem_stride: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr,
+    nt_per_warp_xv: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    latent_scale_per_token: cutlass.Constexpr = False,
+    kv_sc_base_addr: Int32 = Int32(0),
+):
+    """NVFP4 GLM TP4 XV-NoPE with H8 swap-AB fragment layout.
+
+    P (probabilities) from S4 are in registers as ``w_pre`` in the swapped
+    (candidate x head) layout.  This function transposes them to (head x
+    candidate) by storing to the ``sm_p_full`` smem buffer, then loads via
+    ldmatrix as the A operand.  V is dequanted from E2M1 to BF16 in registers
+    as the B operand.  A single BF16 m16n8k16 MMA per (vc, nt) replaces the
+    FP8 path's 2-pass HIGH/LOW residual cycle.
+
+    The output accumulator ``acc_nope`` uses the ordinary m16n8 output-row
+    mapping (lane gid owns head gid), matching the existing H8 FP8 S6 and
+    the S7 epilogue.
+    """
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    head0 = tid * Int32(2)
+    head1 = head0 + Int32(1)
+    cand0 = warp_id * Int32(16) + gid
+    cand1 = cand0 + Int32(8)
+
+    # --- Store P to sm_p_full in (head x candidate) layout for ldmatrix A. ---
+    # w_pre[0],[1] = P[cand0, head0], P[cand0, head1]
+    # w_pre[2],[3] = P[cand1, head0], P[cand1, head1]
+    # sm_p_full is indexed as (head, candidate) with stride sm_p_stride.
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head0 * Int32(sm_p_stride) + cand0) * Int32(2),
+        w_pre[0],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head1 * Int32(sm_p_stride) + cand0) * Int32(2),
+        w_pre[1],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head0 * Int32(sm_p_stride) + cand1) * Int32(2),
+        w_pre[2],
+    )
+    st_shared_bf16_from_f32(
+        sm_p_full_addr + (head1 * Int32(sm_p_stride) + cand1) * Int32(2),
+        w_pre[3],
+    )
+    cute.arch.barrier(**bar_kw)
+
+    # --- PV MMA loop: A = P (head x cand) from smem, B = V (cand x d_v) regs. ---
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            dim_base = Int32(vc) * Int32(v_chunk) + (
+                Int32(nt) * Int32(n_warps) + warp_id
+            ) * Int32(8)
+            col = dim_base + gid
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for ks in cutlass.range_constexpr(bi // 16):
+                k_base = Int32(ks) * Int32(16)
+                # A: P (head x candidate) from smem via ldmatrix.
+                a_byte = (a_row * Int32(sm_p_stride) + (k_base + a_col)) * Int32(2)
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+
+                # B: V (candidate x d_v) dequanted from E2M1 in registers.
+                ent0 = k_base + tid * Int32(2)
+                v0 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0,
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                    latent_scale_per_token=latent_scale_per_token,
+                    kv_sc_base_addr=kv_sc_base_addr,
+                )
+                v1 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(1),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                    latent_scale_per_token=latent_scale_per_token,
+                    kv_sc_base_addr=kv_sc_base_addr,
+                )
+                v8 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(8),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                    latent_scale_per_token=latent_scale_per_token,
+                    kv_sc_base_addr=kv_sc_base_addr,
+                )
+                v9 = _nvfp4_scalar_bf16_u16(
+                    kv_fp4_base_addr,
+                    ent0 + Int32(9),
+                    col,
+                    latent_scale,
+                    kv_smem_stride=kv_smem_stride,
+                    latent_scale_per_token=latent_scale_per_token,
+                    kv_sc_base_addr=kv_sc_base_addr,
+                )
+                b0 = v0 | (v1 << Uint32(16))
+                b1 = v8 | (v9 << Uint32(16))
+                xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(
+                    xv0,
+                    xv1,
+                    xv2,
+                    xv3,
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    b0,
+                    b1,
+                )
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] = acc_nope[at][0] + xv0
+            acc_nope[at][1] = acc_nope[at][1] + xv1
+            acc_nope[at][2] = acc_nope[at][2] + xv2
+            acc_nope[at][3] = acc_nope[at][3] + xv3
+    return acc_nope

--- a/sparkinfer/attention/_shared/mla/decode_math.py
+++ b/sparkinfer/attention/_shared/mla/decode_math.py
@@ -3271,6 +3271,11 @@ def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
     transposed through warp shuffles into the established head-major
     ``acc_nope`` ABI, so online-softmax rescaling and S7 remain unchanged.
     """
+    # The transposed MMA pairs exactly two eight-dimension epilogue tiles per
+    # warp.  Keep that implicit launch contract fail-closed if a future trait
+    # changes the GLM NVFP4 tile geometry.
+    assert cutlass.const_expr(nt_per_warp_xv == 2)
+    assert cutlass.const_expr(v_chunk == n_warps * 16)
     bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
     gid = lane >> Int32(2)
     tid = lane & Int32(3)

--- a/sparkinfer/attention/_shared/mla/decode_math.py
+++ b/sparkinfer/attention/_shared/mla/decode_math.py
@@ -3257,18 +3257,19 @@ def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
     latent_scale_per_token: cutlass.Constexpr = False,
     kv_sc_base_addr: Int32 = Int32(0),
 ):
-    """NVFP4 GLM TP4 XV-NoPE with H8 swap-AB fragment layout.
+    """Full-occupancy NVFP4 GLM TP4 XV-NoPE for the native H8 path.
 
-    P (probabilities) from S4 are in registers as ``w_pre`` in the swapped
-    (candidate x head) layout.  This function transposes them to (head x
-    candidate) by storing to the ``sm_p_full`` smem buffer, then loads via
-    ldmatrix as the A operand.  V is dequanted from E2M1 to BF16 in registers
-    as the B operand.  A single BF16 m16n8k16 MMA per (vc, nt) replaces the
-    FP8 path's 2-pass HIGH/LOW residual cycle.
+    The four math warps own disjoint 16-candidate probability fragments, so a
+    minimal 8x64 BF16 shared-memory rendezvous remains necessary before any
+    one warp can reduce all candidates.  After that rendezvous the MMA is
+    transposed: A is ``V.T`` (sixteen output dimensions by candidates) and B
+    is P (candidates by eight heads).  All rows of the m16n8 tile are useful,
+    halving the BF16 PV MMA count relative to the padded H8 implementation.
 
-    The output accumulator ``acc_nope`` uses the ordinary m16n8 output-row
-    mapping (lane gid owns head gid), matching the existing H8 FP8 S6 and
-    the S7 epilogue.
+    Each warp pairs its ordinary eight-dimension epilogue tile with the tile
+    32 dimensions above it.  The resulting dimension-major MMA fragment is
+    transposed through warp shuffles into the established head-major
+    ``acc_nope`` ABI, so online-softmax rescaling and S7 remain unchanged.
     """
     bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
     gid = lane >> Int32(2)
@@ -3278,7 +3279,8 @@ def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
     cand0 = warp_id * Int32(16) + gid
     cand1 = cand0 + Int32(8)
 
-    # --- Store P to sm_p_full in (head x candidate) layout for ldmatrix A. ---
+    # Store each warp's register-owned P into the shared 8x64 matrix. This is
+    # the only cross-warp exchange; rows 8..15 are never read by this path.
     # w_pre[0],[1] = P[cand0, head0], P[cand0, head1]
     # w_pre[2],[3] = P[cand1, head0], P[cand1, head1]
     # sm_p_full is indexed as (head, candidate) with stride sm_p_stride.
@@ -3299,95 +3301,152 @@ def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
         w_pre[3],
     )
 
-    # ldmatrix.x4 reads a full 16-row A tile even though native GLM H8 only
-    # owns rows 0..7. Keep the architecturally-unused rows deterministic so
-    # their discarded accumulator fragments cannot depend on stale shared
-    # memory or turn into NaNs under sanitizers and graph replay.
-    upper_row_elem = tid_flat
-    while upper_row_elem < Int32(8 * sm_p_stride):
-        st_shared_bf16_from_f32(
-            sm_p_full_addr
-            + (Int32(8 * sm_p_stride) + upper_row_elem) * Int32(2),
-            Float32(0.0),
-        )
-        upper_row_elem += Int32(num_threads)
     cute.arch.barrier(**bar_kw)
 
-    # --- PV MMA loop: A = P (head x cand) from smem, B = V (cand x d_v) regs. ---
-    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
-    a_col = (lane >> Int32(4)) * Int32(8)
-
+    # A = V.T uses two non-contiguous eight-row dimension tiles so one MMA
+    # fills the two existing nt slots owned by this warp. B = P is loaded as
+    # the ordinary K-major candidate x head operand from shared memory.
     for vc in cutlass.range_constexpr(n_v_chunks):
-        for nt in cutlass.range_constexpr(nt_per_warp_xv):
-            dim_base = Int32(vc) * Int32(v_chunk) + (
-                Int32(nt) * Int32(n_warps) + warp_id
-            ) * Int32(8)
-            col = dim_base + gid
-            xv0 = Float32(0.0)
-            xv1 = Float32(0.0)
-            xv2 = Float32(0.0)
-            xv3 = Float32(0.0)
-            for ks in cutlass.range_constexpr(bi // 16):
-                k_base = Int32(ks) * Int32(16)
-                # A: P (head x candidate) from smem via ldmatrix.
-                a_byte = (a_row * Int32(sm_p_stride) + (k_base + a_col)) * Int32(2)
-                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_full_addr + a_byte)
+        dim_lo = Int32(vc) * Int32(v_chunk) + warp_id * Int32(8) + gid
+        dim_hi = dim_lo + Int32(n_warps * 8)
+        xv0 = Float32(0.0)
+        xv1 = Float32(0.0)
+        xv2 = Float32(0.0)
+        xv3 = Float32(0.0)
+        for ks in cutlass.range_constexpr(bi // 16):
+            k_base = Int32(ks) * Int32(16)
+            ent0 = k_base + tid * Int32(2)
+            ent1 = ent0 + Int32(1)
+            ent8 = ent0 + Int32(8)
+            ent9 = ent0 + Int32(9)
 
-                # B: V (candidate x d_v) dequanted from E2M1 in registers.
-                ent0 = k_base + tid * Int32(2)
-                v0 = _nvfp4_scalar_bf16_u16(
-                    kv_fp4_base_addr,
-                    ent0,
-                    col,
-                    latent_scale,
-                    kv_smem_stride=kv_smem_stride,
-                    latent_scale_per_token=latent_scale_per_token,
-                    kv_sc_base_addr=kv_sc_base_addr,
-                )
-                v1 = _nvfp4_scalar_bf16_u16(
-                    kv_fp4_base_addr,
-                    ent0 + Int32(1),
-                    col,
-                    latent_scale,
-                    kv_smem_stride=kv_smem_stride,
-                    latent_scale_per_token=latent_scale_per_token,
-                    kv_sc_base_addr=kv_sc_base_addr,
-                )
-                v8 = _nvfp4_scalar_bf16_u16(
-                    kv_fp4_base_addr,
-                    ent0 + Int32(8),
-                    col,
-                    latent_scale,
-                    kv_smem_stride=kv_smem_stride,
-                    latent_scale_per_token=latent_scale_per_token,
-                    kv_sc_base_addr=kv_sc_base_addr,
-                )
-                v9 = _nvfp4_scalar_bf16_u16(
-                    kv_fp4_base_addr,
-                    ent0 + Int32(9),
-                    col,
-                    latent_scale,
-                    kv_smem_stride=kv_smem_stride,
-                    latent_scale_per_token=latent_scale_per_token,
-                    kv_sc_base_addr=kv_sc_base_addr,
-                )
-                b0 = v0 | (v1 << Uint32(16))
-                b1 = v8 | (v9 << Uint32(16))
-                xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(
-                    xv0,
-                    xv1,
-                    xv2,
-                    xv3,
-                    a0,
-                    a1,
-                    a2,
-                    a3,
-                    b0,
-                    b1,
-                )
-            at = vc * nt_per_warp_xv + nt
-            acc_nope[at][0] = acc_nope[at][0] + xv0
-            acc_nope[at][1] = acc_nope[at][1] + xv1
-            acc_nope[at][2] = acc_nope[at][2] + xv2
-            acc_nope[at][3] = acc_nope[at][3] + xv3
+            outer0 = latent_scale
+            outer1 = latent_scale
+            outer8 = latent_scale
+            outer9 = latent_scale
+            if cutlass.const_expr(latent_scale_per_token):
+                outer0 = ld_shared_f32(kv_sc_base_addr + ent0 * Int32(4))
+                outer1 = ld_shared_f32(kv_sc_base_addr + ent1 * Int32(4))
+                outer8 = ld_shared_f32(kv_sc_base_addr + ent8 * Int32(4))
+                outer9 = ld_shared_f32(kv_sc_base_addr + ent9 * Int32(4))
+
+            # A rows 0..7 are the lower output-dimension tile; rows 8..15
+            # are the tile 32 dimensions above it. K is the candidate axis.
+            a00 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent0,
+                dim_lo,
+                outer0,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a01 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent1,
+                dim_lo,
+                outer1,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a08 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent8,
+                dim_lo,
+                outer8,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a09 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent9,
+                dim_lo,
+                outer9,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a10 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent0,
+                dim_hi,
+                outer0,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a11 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent1,
+                dim_hi,
+                outer1,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a18 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent8,
+                dim_hi,
+                outer8,
+                kv_smem_stride=kv_smem_stride,
+            )
+            a19 = _nvfp4_scalar_bf16_u16(
+                kv_fp4_base_addr,
+                ent9,
+                dim_hi,
+                outer9,
+                kv_smem_stride=kv_smem_stride,
+            )
+            # PTX m16n8k16 BF16 A-fragment order is
+            #   {row gid, K+0:1}, {row gid+8, K+0:1},
+            #   {row gid, K+8:9}, {row gid+8, K+8:9}.
+            # Keep this explicit: swapping the middle registers is a legal
+            # instruction stream that silently cross-wires dimensions.
+            a0 = a00 | (a01 << Uint32(16))
+            a1 = a10 | (a11 << Uint32(16))
+            a2 = a08 | (a09 << Uint32(16))
+            a3 = a18 | (a19 << Uint32(16))
+
+            p_row_byte = gid * Int32(sm_p_stride * 2) + k_base * Int32(2)
+            b0 = _ld_u32(
+                sm_p_full_addr,
+                p_row_byte + tid * Int32(2 * 2),
+            )
+            b1 = _ld_u32(
+                sm_p_full_addr,
+                p_row_byte + (tid * Int32(2) + Int32(8)) * Int32(2),
+            )
+            xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(
+                xv0,
+                xv1,
+                xv2,
+                xv3,
+                a0,
+                a1,
+                a2,
+                a3,
+                b0,
+                b1,
+            )
+
+        # MMA D owns (dimension-row gid/gid+8, head columns 2*tid/+1).
+        # Transpose it to the established epilogue ownership
+        # (head row gid, dimension columns 2*tid/+1).
+        src_even_dim = tid * Int32(8) + (gid >> Int32(1))
+        src_odd_dim = src_even_dim + Int32(4)
+        lo0_even = cute.arch.shuffle_sync(xv0, src_even_dim)
+        lo0_odd = cute.arch.shuffle_sync(xv1, src_even_dim)
+        lo1_even = cute.arch.shuffle_sync(xv0, src_odd_dim)
+        lo1_odd = cute.arch.shuffle_sync(xv1, src_odd_dim)
+        hi0_even = cute.arch.shuffle_sync(xv2, src_even_dim)
+        hi0_odd = cute.arch.shuffle_sync(xv3, src_even_dim)
+        hi1_even = cute.arch.shuffle_sync(xv2, src_odd_dim)
+        hi1_odd = cute.arch.shuffle_sync(xv3, src_odd_dim)
+        lo0 = lo0_even
+        lo1 = lo1_even
+        hi0 = hi0_even
+        hi1 = hi1_even
+        if (gid & Int32(1)) != Int32(0):
+            lo0 = lo0_odd
+            lo1 = lo1_odd
+            hi0 = hi0_odd
+            hi1 = hi1_odd
+
+        at_lo = vc * nt_per_warp_xv
+        at_hi = at_lo + 1
+        acc_nope[at_lo][0] = acc_nope[at_lo][0] + lo0
+        acc_nope[at_lo][1] = acc_nope[at_lo][1] + lo1
+        acc_nope[at_hi][0] = acc_nope[at_hi][0] + hi0
+        acc_nope[at_hi][1] = acc_nope[at_hi][1] + hi1
     return acc_nope

--- a/sparkinfer/attention/_shared/mla/decode_math.py
+++ b/sparkinfer/attention/_shared/mla/decode_math.py
@@ -1158,8 +1158,9 @@ def s2_qk_rope_bf16_nvfp4_h8_swap_ab(
         ko = Int32(ks) * Int32(16)
         if cutlass.const_expr(fp8_rope):
             # A: K-rope (candidates) -- dequant E4M3 to BF16 in registers.
-            # MMA A-fragment layout: row = gid (M-rows {gid, gid+8}),
-            # col-pair = 2*tid (K-cols {2*tid, 2*tid+8}).
+            # PTX A-fragment order is {row gid, K+0:1},
+            # {row gid+8, K+0:1}, {row gid, K+8:9},
+            # {row gid+8, K+8:9}; mirror the BF16 ldmatrix path exactly.
             col_offset = ko + Int32(2) * tid
             cand0 = warp_first_cand + gid
             cand1 = cand0 + Int32(8)
@@ -1167,10 +1168,10 @@ def s2_qk_rope_bf16_nvfp4_h8_swap_ab(
                 kv_rope_base_addr, cand0, col_offset, d_rope=d_rope,
             )
             a1 = _fp8_rope_pair_bfloat2(
-                kv_rope_base_addr, cand0, col_offset + Int32(8), d_rope=d_rope,
+                kv_rope_base_addr, cand1, col_offset, d_rope=d_rope,
             )
             a2 = _fp8_rope_pair_bfloat2(
-                kv_rope_base_addr, cand1, col_offset, d_rope=d_rope,
+                kv_rope_base_addr, cand0, col_offset + Int32(8), d_rope=d_rope,
             )
             a3 = _fp8_rope_pair_bfloat2(
                 kv_rope_base_addr, cand1, col_offset + Int32(8), d_rope=d_rope,
@@ -3173,11 +3174,11 @@ def s1_qk_nope_nvfp4_bf16_h8_swap_ab(
         for ks in cutlass.range_constexpr(quant_tile // 16):
             ko = Int32(blk) * Int32(quant_tile) + Int32(ks) * Int32(16)
             # A: K (candidates) -- dequant E2M1 to BF16 in registers.
-            # Each thread holds 4 uint32 (a0..a3) matching the m16n8k16 A
-            # operand layout: row = gid (M-rows {gid, gid+8}), col-pair =
-            # 2*tid (K-cols {2*tid, 2*tid+8}).  This matches the D output
-            # fragment layout (S3 reads cand=base+gid) and the B-fragment
-            # layout used by the generic non-swap NVFP4 S1.
+            # Each thread holds 4 uint32 (a0..a3) in PTX m16n8k16 A-fragment
+            # order: {row gid, K+0:1}, {row gid+8, K+0:1},
+            # {row gid, K+8:9}, {row gid+8, K+8:9}.  Keeping the candidate
+            # row transition in a1 (not a2) is important: the opposite order
+            # compiles but cross-wires candidate scores on real hardware.
             a0 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
                 cand0,
@@ -3187,16 +3188,16 @@ def s1_qk_nope_nvfp4_bf16_h8_swap_ab(
             )
             a1 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
-                cand0,
-                ko + col_offset + Int32(8),
-                latent_scale0,
+                cand1,
+                ko + col_offset,
+                latent_scale1,
                 kv_smem_stride=kv_smem_stride,
             )
             a2 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
-                cand1,
-                ko + col_offset,
-                latent_scale1,
+                cand0,
+                ko + col_offset + Int32(8),
+                latent_scale0,
                 kv_smem_stride=kv_smem_stride,
             )
             a3 = _nvfp4_pair_bfloat2(

--- a/sparkinfer/attention/_shared/mla/decode_math.py
+++ b/sparkinfer/attention/_shared/mla/decode_math.py
@@ -3163,6 +3163,11 @@ def s1_qk_nope_nvfp4_bf16_h8_swap_ab(
     cand0 = warp_first_cand + gid
     cand1 = cand0 + Int32(8)
     col_offset = Int32(2) * tid
+    latent_scale0 = latent_scale
+    latent_scale1 = latent_scale
+    if cutlass.const_expr(latent_scale_per_token):
+        latent_scale0 = ld_shared_f32(kv_sc_base_addr + cand0 * Int32(4))
+        latent_scale1 = ld_shared_f32(kv_sc_base_addr + cand1 * Int32(4))
 
     for blk in cutlass.range_constexpr(num_scales):
         for ks in cutlass.range_constexpr(quant_tile // 16):
@@ -3177,37 +3182,29 @@ def s1_qk_nope_nvfp4_bf16_h8_swap_ab(
                 kv_fp4_base_addr,
                 cand0,
                 ko + col_offset,
-                latent_scale,
+                latent_scale0,
                 kv_smem_stride=kv_smem_stride,
-                latent_scale_per_token=latent_scale_per_token,
-                kv_sc_base_addr=kv_sc_base_addr,
             )
             a1 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
                 cand0,
                 ko + col_offset + Int32(8),
-                latent_scale,
+                latent_scale0,
                 kv_smem_stride=kv_smem_stride,
-                latent_scale_per_token=latent_scale_per_token,
-                kv_sc_base_addr=kv_sc_base_addr,
             )
             a2 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
                 cand1,
                 ko + col_offset,
-                latent_scale,
+                latent_scale1,
                 kv_smem_stride=kv_smem_stride,
-                latent_scale_per_token=latent_scale_per_token,
-                kv_sc_base_addr=kv_sc_base_addr,
             )
             a3 = _nvfp4_pair_bfloat2(
                 kv_fp4_base_addr,
                 cand1,
                 ko + col_offset + Int32(8),
-                latent_scale,
+                latent_scale1,
                 kv_smem_stride=kv_smem_stride,
-                latent_scale_per_token=latent_scale_per_token,
-                kv_sc_base_addr=kv_sc_base_addr,
             )
 
             # B: Q (heads) -- BF16 scalar loads from smem.
@@ -3301,6 +3298,19 @@ def s6_xv_nope_nvfp4_bf16_h8_swap_ab(
         sm_p_full_addr + (head1 * Int32(sm_p_stride) + cand1) * Int32(2),
         w_pre[3],
     )
+
+    # ldmatrix.x4 reads a full 16-row A tile even though native GLM H8 only
+    # owns rows 0..7. Keep the architecturally-unused rows deterministic so
+    # their discarded accumulator fragments cannot depend on stale shared
+    # memory or turn into NaNs under sanitizers and graph replay.
+    upper_row_elem = tid_flat
+    while upper_row_elem < Int32(8 * sm_p_stride):
+        st_shared_bf16_from_f32(
+            sm_p_full_addr
+            + (Int32(8 * sm_p_stride) + upper_row_elem) * Int32(2),
+            Float32(0.0),
+        )
+        upper_row_elem += Int32(num_threads)
     cute.arch.barrier(**bar_kw)
 
     # --- PV MMA loop: A = P (head x cand) from smem, B = V (cand x d_v) regs. ---

--- a/sparkinfer/attention/_shared/mla/kernel.py
+++ b/sparkinfer/attention/_shared/mla/kernel.py
@@ -154,8 +154,16 @@ def _env_num_splits_override() -> int:
 
 
 def _env_glm_h8_native_enabled() -> bool:
+    """Return whether the experimental native GLM H8 NVFP4 path is enabled.
+
+    Keep the generic path as the default until a supported serving image shows
+    a repeatable end-to-end win.  The native implementation remains available
+    for qualification with ``SPARKINFER_MLA_SM120_GLM_H8_NATIVE=1``.
+    """
     raw = os.environ.get(_MLA_SM120_GLM_H8_NATIVE_ENV)
-    return raw is None or raw.strip().lower() not in {"0", "false", "off", "no"}
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "on", "yes"}
 
 
 def _env_dsv4_h16_native_mode() -> bool | None:

--- a/sparkinfer/attention/_shared/mla/kernel.py
+++ b/sparkinfer/attention/_shared/mla/kernel.py
@@ -40,7 +40,6 @@ from .decode_math import (
     s1_qk_nope_block_scaled,
     s1_qk_nope_block_scaled_dsv4_h8_swap_ab,
     s1_qk_nope_block_scaled_glm_h8_swap_ab,
-    s1_qk_nope_nvfp4_bf16,
     s1_qk_nope_nvfp4_bf16_h8_swap_ab,
     s2_qk_rope_bf16,
     s2_qk_rope_bf16_glm_h8_swap_ab,
@@ -2105,11 +2104,11 @@ class UnifiedDecodeKernel:
                                 w_pre,
                                 acc_nope,
                                 kv_fp8_b,
-                                w_head_sc_view,
-                                w_fp8_addr,
-                                warp_id,
+                                w_head_sc_stage_view,
+                                w_fp8_stage,
+                                warp_sel,
                                 lane,
-                                tid,
+                                tid_sel,
                                 n_v_chunks=t.n_v_chunks,
                                 v_chunk=t.quant_tile,
                                 hpb=t.hpb,
@@ -2118,7 +2117,7 @@ class UnifiedDecodeKernel:
                                 w_fp8_stride=t.bi + 16,
                                 n_warps=4,
                                 nt_per_warp_xv=t.nt_per_warp_xv,
-                                num_threads=self.math_threads,
+                                num_threads=nt_stage,
                                 barrier_id=3,
                             )
                     else:
@@ -3167,7 +3166,14 @@ def run_unified_decode(
             else (320 if native_dsv4_h16 else int(traits.block_threads))
         ),
         io_warps=(2 if native_dsv4_h16 else 1),
-        kv_stage_packed=native_h8 or native_dsv4_h16,
+        kv_stage_packed=(
+            (
+                native_glm_h8
+                and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3)
+            )
+            or native_dsv4_h8
+            or native_dsv4_h16
+        ),
         kv_smem_stride=(
             _GLM_KV_GMEM_STRIDE
             if (native_glm_h8 and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3))

--- a/sparkinfer/attention/_shared/mla/kernel.py
+++ b/sparkinfer/attention/_shared/mla/kernel.py
@@ -40,8 +40,11 @@ from .decode_math import (
     s1_qk_nope_block_scaled,
     s1_qk_nope_block_scaled_dsv4_h8_swap_ab,
     s1_qk_nope_block_scaled_glm_h8_swap_ab,
+    s1_qk_nope_nvfp4_bf16,
+    s1_qk_nope_nvfp4_bf16_h8_swap_ab,
     s2_qk_rope_bf16,
     s2_qk_rope_bf16_glm_h8_swap_ab,
+    s2_qk_rope_bf16_nvfp4_h8_swap_ab,
     s3_mask_and_scale,
     s3_mask_and_scale_glm_h8_swap_ab,
     s4_online_softmax,
@@ -50,6 +53,7 @@ from .decode_math import (
     s6_xv_nope,
     s6_xv_nope_dsv4_h8_swap_ab,
     s6_xv_nope_glm_h8_swap_ab,
+    s6_xv_nope_nvfp4_bf16_h8_swap_ab,
     s6b_xv_rope,
     s6b_xv_rope_h8_swap_ab,
     s7_epilogue,
@@ -723,14 +727,16 @@ class UnifiedDecodeKernel:
         # Math warps are consumers; the final warp is the IO producer.
         is_io = warp_id >= Int32(self.math_threads // 32)
 
-        # Native H8 stages one contiguous data record per candidate. GLM keeps
-        # its 656-byte source layout; DSV4 pads its 576-byte source record to a
+        # Native H8 stages one contiguous data record per candidate. GLM FP8
+        # keeps its 656-byte source layout; NVFP4 uses the 432/368-byte record
+        # stride from traits. DSV4 pads its 576-byte source record to a
         # bank-friendly 592-byte shared row and puts the two 512-byte scale
         # footers immediately after the data buffers. Both alias the existing
         # kv_fp8/kv_sc/kv_rope allocation, so graph-time workspace is unchanged.
         staged_kv_stride = t.kv_smem_stride
         if cutlass.const_expr(self.native_glm_h8):
-            staged_kv_stride = _GLM_KV_GMEM_STRIDE
+            if cutlass.const_expr(t.scale_format != ScaleFormat.NVFP4_E4M3):
+                staged_kv_stride = _GLM_KV_GMEM_STRIDE
         if cutlass.const_expr(self.native_dsv4_h8):
             staged_kv_stride = _DSV4_PACKED_SMEM_STRIDE
         kv_fp8_buf = Int32(t.bi * staged_kv_stride)
@@ -814,7 +820,7 @@ class UnifiedDecodeKernel:
                     io_threads=self.io_threads,
                     split_mbar_arrival=self.native_dsv4_h16,
                     fp8_rope=t.fp8_rope,
-                    packed_glm=self.native_glm_h8,
+                    packed_glm=self.native_glm_h8 and t.scale_format != ScaleFormat.NVFP4_E4M3,
                     packed_dsv4=self.native_dsv4_h8,
                     per_token_latent_scale=t.latent_scale_per_token,
                 )
@@ -926,20 +932,40 @@ class UnifiedDecodeKernel:
                     split_cand_end = section_len
                 if cutlass.const_expr(self.native_h8):
                     if cutlass.const_expr(self.native_glm_h8):
-                        qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
-                            qk,
-                            q_fp8_addr,
-                            kv_fp8_b,
-                            q_sc_view,
-                            warp_first_cand,
-                            lane,
-                            num_scales=t.num_scales,
-                            quant_tile=t.quant_tile,
-                            q_nope_stride=t.q_nope_stride,
-                            kv_smem_stride=staged_kv_stride,
-                        )
-                        h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
-                        h8_rope_stride = staged_kv_stride
+                        if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                            qk = s1_qk_nope_nvfp4_bf16_h8_swap_ab(
+                                qk,
+                                q_fp8_addr,
+                                kv_fp8_b,
+                                warp_first_cand,
+                                lane,
+                                latent_scale,
+                                num_scales=t.num_scales,
+                                quant_tile=t.quant_tile,
+                                q_nope_bf16_stride=t.q_nope_stride,
+                                kv_smem_stride=t.kv_smem_stride,
+                                latent_scale_per_token=t.latent_scale_per_token,
+                                kv_sc_base_addr=kv_sc_b,
+                            )
+                            # NVFP4 stages rope in a separate kv_rope smem
+                            # buffer (not packed with the NoPE record).
+                            h8_rope_addr = kv_rope_b
+                            h8_rope_stride = L.kv_rope_stride * 2
+                        else:
+                            qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
+                                qk,
+                                q_fp8_addr,
+                                kv_fp8_b,
+                                q_sc_view,
+                                warp_first_cand,
+                                lane,
+                                num_scales=t.num_scales,
+                                quant_tile=t.quant_tile,
+                                q_nope_stride=t.q_nope_stride,
+                                kv_smem_stride=staged_kv_stride,
+                            )
+                            h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
+                            h8_rope_stride = staged_kv_stride
                     else:
                         qk = s1_qk_nope_block_scaled_dsv4_h8_swap_ab(
                             qk,
@@ -959,16 +985,32 @@ class UnifiedDecodeKernel:
                         )
                         h8_rope_addr = kv_rope_b
                         h8_rope_stride = staged_kv_stride
-                    qk = s2_qk_rope_bf16_glm_h8_swap_ab(
-                        qk,
-                        q_rope_addr,
-                        h8_rope_addr,
-                        warp_first_cand,
-                        lane,
-                        d_rope=t.d_rope,
-                        q_rope_stride=L.q_rope_stride,
-                        kv_rope_stride_bytes=h8_rope_stride,
-                    )
+                    if cutlass.const_expr(
+                        self.native_glm_h8
+                        and t.scale_format == ScaleFormat.NVFP4_E4M3
+                    ):
+                        qk = s2_qk_rope_bf16_nvfp4_h8_swap_ab(
+                            qk,
+                            q_rope_addr,
+                            h8_rope_addr,
+                            warp_first_cand,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            kv_rope_stride_bytes=h8_rope_stride,
+                            fp8_rope=t.fp8_rope,
+                        )
+                    else:
+                        qk = s2_qk_rope_bf16_glm_h8_swap_ab(
+                            qk,
+                            q_rope_addr,
+                            h8_rope_addr,
+                            warp_first_cand,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            kv_rope_stride_bytes=h8_rope_stride,
+                        )
                     qk = s3_mask_and_scale_glm_h8_swap_ab(
                         qk,
                         tok_buf_view,
@@ -1006,26 +1048,50 @@ class UnifiedDecodeKernel:
                         p[3] * wr1,
                     ]
                     if cutlass.const_expr(self.native_glm_h8):
-                        acc_nope = s6_xv_nope_glm_h8_swap_ab(
-                            w_pre,
-                            acc_nope,
-                            kv_fp8_b,
-                            w_head_sc_view,
-                            w_fp8_addr,
-                            warp_id,
-                            lane,
-                            tid,
-                            n_v_chunks=t.n_v_chunks,
-                            v_chunk=t.quant_tile,
-                            hpb=t.hpb,
-                            bi=t.bi,
-                            kv_smem_stride=staged_kv_stride,
-                            w_fp8_stride=t.bi + 16,
-                            n_warps=4,
-                            nt_per_warp_xv=t.nt_per_warp_xv,
-                            num_threads=self.math_threads,
-                            barrier_id=3,
-                        )
+                        if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                            acc_nope = s6_xv_nope_nvfp4_bf16_h8_swap_ab(
+                                w_pre,
+                                acc_nope,
+                                kv_fp8_b,
+                                sm_p_full_addr,
+                                warp_id,
+                                lane,
+                                tid,
+                                latent_scale,
+                                n_v_chunks=t.n_v_chunks,
+                                v_chunk=t.quant_tile,
+                                hpb=t.hpb,
+                                bi=t.bi,
+                                kv_smem_stride=t.kv_smem_stride,
+                                n_warps=4,
+                                nt_per_warp_xv=t.nt_per_warp_xv,
+                                num_threads=self.math_threads,
+                                sm_p_stride=L.sm_p_full_stride,
+                                barrier_id=3,
+                                latent_scale_per_token=t.latent_scale_per_token,
+                                kv_sc_base_addr=kv_sc_b,
+                            )
+                        else:
+                            acc_nope = s6_xv_nope_glm_h8_swap_ab(
+                                w_pre,
+                                acc_nope,
+                                kv_fp8_b,
+                                w_head_sc_view,
+                                w_fp8_addr,
+                                warp_id,
+                                lane,
+                                tid,
+                                n_v_chunks=t.n_v_chunks,
+                                v_chunk=t.quant_tile,
+                                hpb=t.hpb,
+                                bi=t.bi,
+                                kv_smem_stride=staged_kv_stride,
+                                w_fp8_stride=t.bi + 16,
+                                n_warps=4,
+                                nt_per_warp_xv=t.nt_per_warp_xv,
+                                num_threads=self.math_threads,
+                                barrier_id=3,
+                            )
                     else:
                         acc_nope = s6_xv_nope_dsv4_h8_swap_ab(
                             w_pre,
@@ -1543,7 +1609,8 @@ class UnifiedDecodeKernel:
         # Match the single-cache body's allocation-preserving packed H8 layout.
         staged_kv_stride = t.kv_smem_stride
         if cutlass.const_expr(self.native_glm_h8):
-            staged_kv_stride = _GLM_KV_GMEM_STRIDE
+            if cutlass.const_expr(t.scale_format != ScaleFormat.NVFP4_E4M3):
+                staged_kv_stride = _GLM_KV_GMEM_STRIDE
         if cutlass.const_expr(self.native_dsv4_h8 or self.native_dsv4_h16):
             staged_kv_stride = _DSV4_PACKED_SMEM_STRIDE
         kv_fp8_buf = Int32(t.bi * staged_kv_stride)
@@ -1655,7 +1722,7 @@ class UnifiedDecodeKernel:
                     io_threads=self.io_threads,
                     split_mbar_arrival=self.native_dsv4_h16,
                     fp8_rope=t.fp8_rope,
-                    packed_glm=self.native_glm_h8,
+                    packed_glm=self.native_glm_h8 and t.scale_format != ScaleFormat.NVFP4_E4M3,
                     packed_dsv4=self.native_dsv4_h8 or self.native_dsv4_h16,
                     overlap_footer_gather=self.native_dsv4_h16,
                     per_token_latent_scale=t.latent_scale_per_token,
@@ -1884,20 +1951,38 @@ class UnifiedDecodeKernel:
                 qk = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
                 if cutlass.const_expr(self.native_h8 or self.native_dsv4_h16):
                     if cutlass.const_expr(self.native_glm_h8):
-                        qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
-                            qk,
-                            q_fp8_stage,
-                            kv_fp8_b,
-                            q_sc_stage_view,
-                            warp_first_cand,
-                            lane,
-                            num_scales=t.num_scales,
-                            quant_tile=t.quant_tile,
-                            q_nope_stride=t.q_nope_stride,
-                            kv_smem_stride=staged_kv_stride,
-                        )
-                        h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
-                        h8_rope_stride = staged_kv_stride
+                        if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                            qk = s1_qk_nope_nvfp4_bf16_h8_swap_ab(
+                                qk,
+                                q_fp8_stage,
+                                kv_fp8_b,
+                                warp_first_cand,
+                                lane,
+                                latent_scale,
+                                num_scales=t.num_scales,
+                                quant_tile=t.quant_tile,
+                                q_nope_bf16_stride=t.q_nope_stride,
+                                kv_smem_stride=t.kv_smem_stride,
+                                latent_scale_per_token=t.latent_scale_per_token,
+                                kv_sc_base_addr=kv_sc_b,
+                            )
+                            h8_rope_addr = kv_rope_b
+                            h8_rope_stride = L.kv_rope_stride * 2
+                        else:
+                            qk = s1_qk_nope_block_scaled_glm_h8_swap_ab(
+                                qk,
+                                q_fp8_stage,
+                                kv_fp8_b,
+                                q_sc_stage_view,
+                                warp_first_cand,
+                                lane,
+                                num_scales=t.num_scales,
+                                quant_tile=t.quant_tile,
+                                q_nope_stride=t.q_nope_stride,
+                                kv_smem_stride=staged_kv_stride,
+                            )
+                            h8_rope_addr = kv_fp8_b + Int32(t.kv_smem_stride)
+                            h8_rope_stride = staged_kv_stride
                     else:
                         qk = s1_qk_nope_block_scaled_dsv4_h8_swap_ab(
                             qk,
@@ -1917,16 +2002,32 @@ class UnifiedDecodeKernel:
                         )
                         h8_rope_addr = kv_rope_b
                         h8_rope_stride = staged_kv_stride
-                    qk = s2_qk_rope_bf16_glm_h8_swap_ab(
-                        qk,
-                        q_rope_stage,
-                        h8_rope_addr,
-                        warp_first_cand,
-                        lane,
-                        d_rope=t.d_rope,
-                        q_rope_stride=L.q_rope_stride,
-                        kv_rope_stride_bytes=h8_rope_stride,
-                    )
+                    if cutlass.const_expr(
+                        self.native_glm_h8
+                        and t.scale_format == ScaleFormat.NVFP4_E4M3
+                    ):
+                        qk = s2_qk_rope_bf16_nvfp4_h8_swap_ab(
+                            qk,
+                            q_rope_stage,
+                            h8_rope_addr,
+                            warp_first_cand,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            kv_rope_stride_bytes=h8_rope_stride,
+                            fp8_rope=t.fp8_rope,
+                        )
+                    else:
+                        qk = s2_qk_rope_bf16_glm_h8_swap_ab(
+                            qk,
+                            q_rope_stage,
+                            h8_rope_addr,
+                            warp_first_cand,
+                            lane,
+                            d_rope=t.d_rope,
+                            q_rope_stride=L.q_rope_stride,
+                            kv_rope_stride_bytes=h8_rope_stride,
+                        )
                     sc_start = split_cand_start
                     sec_len = section_len
                     if cutlass.const_expr(has_extra):
@@ -1976,26 +2077,50 @@ class UnifiedDecodeKernel:
                         p[3] * wr1,
                     ]
                     if cutlass.const_expr(self.native_glm_h8):
-                        acc_nope = s6_xv_nope_glm_h8_swap_ab(
-                            w_pre,
-                            acc_nope,
-                            kv_fp8_b,
-                            w_head_sc_view,
-                            w_fp8_addr,
-                            warp_id,
-                            lane,
-                            tid,
-                            n_v_chunks=t.n_v_chunks,
-                            v_chunk=t.quant_tile,
-                            hpb=t.hpb,
-                            bi=t.bi,
-                            kv_smem_stride=staged_kv_stride,
-                            w_fp8_stride=t.bi + 16,
-                            n_warps=4,
-                            nt_per_warp_xv=t.nt_per_warp_xv,
-                            num_threads=self.math_threads,
-                            barrier_id=3,
-                        )
+                        if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+                            acc_nope = s6_xv_nope_nvfp4_bf16_h8_swap_ab(
+                                w_pre,
+                                acc_nope,
+                                kv_fp8_b,
+                                sm_p_stage,
+                                warp_sel,
+                                lane,
+                                tid_sel,
+                                latent_scale,
+                                n_v_chunks=t.n_v_chunks,
+                                v_chunk=t.quant_tile,
+                                hpb=t.hpb,
+                                bi=t.bi,
+                                kv_smem_stride=t.kv_smem_stride,
+                                n_warps=4,
+                                nt_per_warp_xv=t.nt_per_warp_xv,
+                                num_threads=nt_stage,
+                                sm_p_stride=L.sm_p_full_stride,
+                                barrier_id=3,
+                                latent_scale_per_token=t.latent_scale_per_token,
+                                kv_sc_base_addr=kv_sc_b,
+                            )
+                        else:
+                            acc_nope = s6_xv_nope_glm_h8_swap_ab(
+                                w_pre,
+                                acc_nope,
+                                kv_fp8_b,
+                                w_head_sc_view,
+                                w_fp8_addr,
+                                warp_id,
+                                lane,
+                                tid,
+                                n_v_chunks=t.n_v_chunks,
+                                v_chunk=t.quant_tile,
+                                hpb=t.hpb,
+                                bi=t.bi,
+                                kv_smem_stride=staged_kv_stride,
+                                w_fp8_stride=t.bi + 16,
+                                n_warps=4,
+                                nt_per_warp_xv=t.nt_per_warp_xv,
+                                num_threads=self.math_threads,
+                                barrier_id=3,
+                            )
                     else:
                         acc_nope = s6_xv_nope_dsv4_h8_swap_ab(
                             w_pre,
@@ -2392,8 +2517,6 @@ def _sparse_mla_decode_grid_flat_launch(
         and int(grid_h_blocks) == 1
         and int(head_block_offset) == 0
         and not bool(has_extra)
-        # NVFP4 records are validated on the generic HPB=16 arm only.
-        and int(scale_format) != int(ScaleFormat.NVFP4_E4M3)
         and _env_glm_h8_native_enabled()
     )
     native_dsv4_h8 = bool(
@@ -3027,9 +3150,6 @@ def run_unified_decode(
         int(model_type) == int(ModelType.GLM_NSA)
         and int(heads) == 8
         and not has_extra
-        # NVFP4 records (432B, packed E2M1+E4M3) are validated on the generic
-        # HPB=16 arm only; the packed-656B H8 staging would misread them.
-        and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3)
         and _env_glm_h8_native_enabled()
     )
     native_h8 = native_glm_h8 or native_dsv4_h8
@@ -3050,7 +3170,7 @@ def run_unified_decode(
         kv_stage_packed=native_h8 or native_dsv4_h16,
         kv_smem_stride=(
             _GLM_KV_GMEM_STRIDE
-            if native_glm_h8
+            if (native_glm_h8 and int(traits.scale_format) != int(ScaleFormat.NVFP4_E4M3))
             else (
                 _DSV4_PACKED_SMEM_STRIDE
                 if (native_dsv4_h8 or native_dsv4_h16)

--- a/tests/attention/test_attention_mla_kv_cache.py
+++ b/tests/attention/test_attention_mla_kv_cache.py
@@ -471,6 +471,7 @@ def test_writer_records_feed_native_glm_h8_decode_graph(
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         run()
+    output.zero_()
     graph.replay()
     torch.cuda.synchronize(device)
 
@@ -482,6 +483,115 @@ def test_writer_records_feed_native_glm_h8_decode_graph(
         sm_scale=sm_scale,
         per_token_scale=per_token_scale,
     )
+    _assert_reader_matches_dequantized_records(output, expected)
+    assert launch.LAST_DECODE_PLAN["native_glm_h8"] is True
+    assert launch.LAST_DECODE_PLAN["kv_stage_packed"] is False
+    assert launch.LAST_DECODE_PLAN["kv_smem_stride"] == 288
+    assert launch.LAST_DECODE_PLAN["fp8_rope"] is True
+
+
+@torch.inference_mode()
+def test_native_glm_h8_fp8_rope_decode_graph_handles_high_pool_page_id() -> None:
+    """Replay the 368-byte reader from a live page beyond a 2^31 byte offset."""
+    device = require_sparkinfer()
+    import sparkinfer.attention._shared.mla.kernel as launch
+
+    heads = 8
+    topk = 129
+    q, live_cache, live_indices = _make_written_reader_case(
+        rows=1,
+        topk=topk,
+        seed=8_1368,
+        device=device,
+        per_token_scale=True,
+        heads=heads,
+    )
+    lengths = torch.full((1,), topk, dtype=torch.int32, device=device)
+    sm_scale = _HEAD_DIM**-0.5
+    expected = _reference_attention_from_records(
+        q=q,
+        cache=live_cache,
+        indices=live_indices,
+        lengths=lengths,
+        sm_scale=sm_scale,
+        per_token_scale=True,
+    )
+
+    page_stride_bytes = _PAGE_SIZE * _RECORD_BYTES
+    int32_max = torch.iinfo(torch.int32).max
+    high_page = int32_max // page_stride_bytes + 2
+    live_pages = int(live_cache.shape[0])
+    # Roughly 2 GiB is deliberately left uninitialized. Only the real tail
+    # pages are populated, reproducing a long-lived/recycled paged pool.
+    cache = torch.empty(
+        (high_page + live_pages, _PAGE_SIZE, _RECORD_BYTES),
+        dtype=torch.uint8,
+        device=device,
+    )
+    cache[high_page:].copy_(live_cache)
+    assert cache.stride(0) * cache.element_size() == page_stride_bytes
+    assert high_page * page_stride_bytes > int32_max
+    indices = live_indices + high_page * _PAGE_SIZE
+
+    caps = SPARKINFERSparseMLAScratchCaps(
+        device=device,
+        dtype=torch.bfloat16,
+        kv_dtype=torch.uint8,
+        num_q_heads=heads,
+        max_q_rows=1,
+        max_batch=1,
+        max_width=topk,
+        max_kv_rows=topk,
+        head_dim=_HEAD_DIM,
+        v_head_dim=_V_HEAD_DIM,
+        max_chunks_per_row=8,
+        page_size=_PAGE_SIZE,
+    )
+    plan = plan_sparse_mla_scratch(caps)
+    (scratch_spec,) = plan.scratch_specs()
+    scratch_storage = torch.zeros(
+        scratch_spec.shape,
+        dtype=scratch_spec.dtype,
+        device=scratch_spec.device,
+    )
+    binding = plan.bind(
+        scratch=scratch_storage,
+        q=q,
+        selected_indices=indices,
+        cache_seqlens_int32=lengths,
+        nsa_cache_seqlens_int32=lengths,
+    )
+    output = torch.empty(
+        (1, heads, _V_HEAD_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    def run() -> None:
+        run_unified_decode(
+            q_all=q,
+            swa_k_cache=cache,
+            swa_indices=indices,
+            swa_topk_lengths=lengths,
+            workspace=binding.scratch,
+            sm_scale=sm_scale,
+            swa_page_size=_PAGE_SIZE,
+            forced_num_splits=2,
+            scale_format_override=ScaleFormat.NVFP4_E4M3,
+            fp8_rope_override=True,
+            latent_scale_per_token=True,
+            out=output,
+        )
+
+    run()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    output.zero_()
+    graph.replay()
+    torch.cuda.synchronize(device)
+
     _assert_reader_matches_dequantized_records(output, expected)
     assert launch.LAST_DECODE_PLAN["native_glm_h8"] is True
     assert launch.LAST_DECODE_PLAN["kv_stage_packed"] is False

--- a/tests/attention/test_attention_mla_kv_cache.py
+++ b/tests/attention/test_attention_mla_kv_cache.py
@@ -354,6 +354,7 @@ def _make_written_reader_case(
     seed: int,
     device: torch.device,
     per_token_scale: bool = False,
+    heads: int = _HEADS,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     generator = torch.Generator(device="cpu")
     generator.manual_seed(seed)
@@ -366,7 +367,7 @@ def _make_written_reader_case(
         dtype=torch.float32,
     ).to(device=device, dtype=torch.bfloat16)
     q = torch.randn(
-        (rows, _HEADS, _HEAD_DIM), generator=generator, dtype=torch.float32
+        (rows, heads, _HEAD_DIM), generator=generator, dtype=torch.float32
     ).to(device=device, dtype=torch.bfloat16)
     indices = torch.stack(
         [torch.randperm(topk, generator=generator) for _ in range(rows)]
@@ -388,6 +389,104 @@ def _make_written_reader_case(
         per_token_scale=per_token_scale,
     )
     return q, cache, indices
+
+
+@pytest.mark.parametrize(
+    "per_token_scale",
+    [False, True],
+    ids=["static", "dynamic-token"],
+)
+@torch.inference_mode()
+def test_writer_records_feed_native_glm_h8_decode_graph(
+    per_token_scale: bool,
+) -> None:
+    """The 368-byte FP8-RoPE record uses the native H8 path under replay."""
+    device = require_sparkinfer()
+    import sparkinfer.attention._shared.mla.kernel as launch
+
+    heads = 8
+    topk = 129
+    q, cache, indices = _make_written_reader_case(
+        rows=1,
+        topk=topk,
+        seed=8_1301,
+        device=device,
+        per_token_scale=per_token_scale,
+        heads=heads,
+    )
+    lengths = torch.full((1,), topk, dtype=torch.int32, device=device)
+    sm_scale = _HEAD_DIM**-0.5
+    caps = SPARKINFERSparseMLAScratchCaps(
+        device=device,
+        dtype=torch.bfloat16,
+        kv_dtype=torch.uint8,
+        num_q_heads=heads,
+        max_q_rows=1,
+        max_batch=1,
+        max_width=topk,
+        max_kv_rows=topk,
+        head_dim=_HEAD_DIM,
+        v_head_dim=_V_HEAD_DIM,
+        max_chunks_per_row=8,
+        page_size=_PAGE_SIZE,
+    )
+    plan = plan_sparse_mla_scratch(caps)
+    (scratch_spec,) = plan.scratch_specs()
+    scratch_storage = torch.zeros(
+        scratch_spec.shape,
+        dtype=scratch_spec.dtype,
+        device=scratch_spec.device,
+    )
+    binding = plan.bind(
+        scratch=scratch_storage,
+        q=q,
+        selected_indices=indices,
+        cache_seqlens_int32=lengths,
+        nsa_cache_seqlens_int32=lengths,
+    )
+    output = torch.empty(
+        (1, heads, _V_HEAD_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    def run() -> None:
+        run_unified_decode(
+            q_all=q,
+            swa_k_cache=cache,
+            swa_indices=indices,
+            swa_topk_lengths=lengths,
+            workspace=binding.scratch,
+            sm_scale=sm_scale,
+            swa_page_size=_PAGE_SIZE,
+            forced_num_splits=2,
+            scale_format_override=ScaleFormat.NVFP4_E4M3,
+            fp8_rope_override=True,
+            latent_scale_per_token=per_token_scale,
+            out=output,
+        )
+
+    run()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    expected = _reference_attention_from_records(
+        q=q,
+        cache=cache,
+        indices=indices,
+        lengths=lengths,
+        sm_scale=sm_scale,
+        per_token_scale=per_token_scale,
+    )
+    _assert_reader_matches_dequantized_records(output, expected)
+    assert launch.LAST_DECODE_PLAN["native_glm_h8"] is True
+    assert launch.LAST_DECODE_PLAN["kv_stage_packed"] is False
+    assert launch.LAST_DECODE_PLAN["kv_smem_stride"] == 288
+    assert launch.LAST_DECODE_PLAN["fp8_rope"] is True
 
 
 def _reference_attention_from_records(

--- a/tests/attention/test_attention_mla_kv_cache.py
+++ b/tests/attention/test_attention_mla_kv_cache.py
@@ -399,8 +399,10 @@ def _make_written_reader_case(
 @torch.inference_mode()
 def test_writer_records_feed_native_glm_h8_decode_graph(
     per_token_scale: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The 368-byte FP8-RoPE record uses the native H8 path under replay."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer()
     import sparkinfer.attention._shared.mla.kernel as launch
 
@@ -491,8 +493,11 @@ def test_writer_records_feed_native_glm_h8_decode_graph(
 
 
 @torch.inference_mode()
-def test_native_glm_h8_fp8_rope_decode_graph_handles_high_pool_page_id() -> None:
+def test_native_glm_h8_fp8_rope_decode_graph_handles_high_pool_page_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Replay the 368-byte reader from a live page beyond a 2^31 byte offset."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer()
     import sparkinfer.attention._shared.mla.kernel as launch
 

--- a/tests/attention/test_attention_mla_sm120.py
+++ b/tests/attention/test_attention_mla_sm120.py
@@ -1275,8 +1275,10 @@ def _run_unified_glm(
 @pytest.mark.parametrize("forced_num_splits", [1, 4])
 def test_unified_decode_glm_tp8_native_swap_ab_matches_reference(
     forced_num_splits,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """GLM TP8 uses the native four-warp swapped-QK decode specialization."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer_sparse_mla()
     import sparkinfer.attention._shared.mla.kernel as launch
 
@@ -1324,8 +1326,11 @@ def test_unified_decode_glm_tp8_native_matches_padded_path(
 
 
 @torch.inference_mode()
-def test_unified_decode_glm_tp8_native_scalar_length_matches_reference() -> None:
+def test_unified_decode_glm_tp8_native_scalar_length_matches_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The uniform scalar-length entry uses the same native TP8 math path."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer_sparse_mla()
     import sparkinfer.attention._shared.mla.kernel as launch
 

--- a/tests/attention/test_attention_mla_unified_corpus.py
+++ b/tests/attention/test_attention_mla_unified_corpus.py
@@ -1062,6 +1062,72 @@ def test_unified_glm_decode_live_graph_oracle(entrypoint: str) -> None:
 
 
 @torch.inference_mode()
+def test_unified_glm_nvfp4_bf16_rope_h8_decode_live_graph_oracle() -> None:
+    """The 432-byte BF16-RoPE NVFP4 record uses native H8 under replay."""
+    device = require_sparkinfer()
+    import sparkinfer.attention._shared.mla.kernel as launch
+
+    rows, heads, width = 2, 8, 128
+    inputs = _make_nvfp4_glm_inputs(
+        rows=rows,
+        heads=heads,
+        width=width,
+        device=device,
+    )
+    workspace = _make_decode_workspace(
+        rows=rows,
+        heads=heads,
+        width=width,
+        device=device,
+    )
+    output = torch.empty(
+        (rows, heads, _GLM_V_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    expected = tuple(
+        _nvfp4_glm_reference(inputs, scenario)[0] for scenario in range(2)
+    )
+    assert not torch.allclose(expected[0], expected[1])
+
+    def launch_decode() -> None:
+        run_unified_decode(
+            q_all=inputs.q,
+            swa_k_cache=inputs.launch_cache,
+            swa_indices=inputs.indices,
+            swa_topk_lengths=inputs.lengths,
+            workspace=workspace,
+            sm_scale=_GLM_SM_SCALE,
+            swa_page_size=_PAGE_SIZE,
+            forced_num_splits=1,
+            scale_format_override=ScaleFormat.NVFP4_E4M3,
+            fp8_rope_override=False,
+            out=output,
+        )
+
+    _install_nvfp4_glm_scenario(inputs, 0)
+    launch_decode()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch_decode()
+    for scenario in range(2):
+        _install_nvfp4_glm_scenario(inputs, scenario)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        _assert_output(
+            output,
+            expected[scenario],
+            label=f"GLM NVFP4 BF16-RoPE H8 replay {scenario}",
+        )
+
+    assert launch.LAST_DECODE_PLAN["native_glm_h8"] is True
+    assert launch.LAST_DECODE_PLAN["kv_stage_packed"] is False
+    assert launch.LAST_DECODE_PLAN["kv_smem_stride"] == 288
+    assert launch.LAST_DECODE_PLAN["fp8_rope"] is False
+
+
+@torch.inference_mode()
 def test_unified_glm_prefill_live_graph_oracle() -> None:
     """Validate GLM MG prefill with live inputs and fixed caller-owned output."""
     device = require_sparkinfer()

--- a/tests/attention/test_attention_mla_unified_corpus.py
+++ b/tests/attention/test_attention_mla_unified_corpus.py
@@ -1062,8 +1062,11 @@ def test_unified_glm_decode_live_graph_oracle(entrypoint: str) -> None:
 
 
 @torch.inference_mode()
-def test_unified_glm_nvfp4_bf16_rope_h8_decode_live_graph_oracle() -> None:
+def test_unified_glm_nvfp4_bf16_rope_h8_decode_live_graph_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The 432-byte BF16-RoPE NVFP4 record uses native H8 under replay."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer()
     import sparkinfer.attention._shared.mla.kernel as launch
 
@@ -1128,8 +1131,11 @@ def test_unified_glm_nvfp4_bf16_rope_h8_decode_live_graph_oracle() -> None:
 
 
 @torch.inference_mode()
-def test_unified_glm_nvfp4_bf16_rope_h8_graph_handles_high_pool_page_id() -> None:
+def test_unified_glm_nvfp4_bf16_rope_h8_graph_handles_high_pool_page_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Replay the 432-byte reader from a live page beyond a 2^31 byte offset."""
+    monkeypatch.setenv("SPARKINFER_MLA_SM120_GLM_H8_NATIVE", "1")
     device = require_sparkinfer()
     import sparkinfer.attention._shared.mla.kernel as launch
 

--- a/tests/attention/test_attention_mla_unified_corpus.py
+++ b/tests/attention/test_attention_mla_unified_corpus.py
@@ -1128,6 +1128,95 @@ def test_unified_glm_nvfp4_bf16_rope_h8_decode_live_graph_oracle() -> None:
 
 
 @torch.inference_mode()
+def test_unified_glm_nvfp4_bf16_rope_h8_graph_handles_high_pool_page_id() -> None:
+    """Replay the 432-byte reader from a live page beyond a 2^31 byte offset."""
+    device = require_sparkinfer()
+    import sparkinfer.attention._shared.mla.kernel as launch
+
+    rows, heads, width = 2, 8, 128
+    inputs = _make_nvfp4_glm_inputs(
+        rows=rows,
+        heads=heads,
+        width=width,
+        device=device,
+    )
+    expected = tuple(
+        _nvfp4_glm_reference(inputs, scenario)[0] for scenario in range(2)
+    )
+    workspace = _make_decode_workspace(
+        rows=rows,
+        heads=heads,
+        width=width,
+        device=device,
+    )
+    output = torch.empty(
+        (rows, heads, _GLM_V_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    record_bytes = int(inputs.launch_cache.shape[2])
+    assert record_bytes == 432
+    page_stride_bytes = _PAGE_SIZE * record_bytes
+    int32_max = torch.iinfo(torch.int32).max
+    high_page = int32_max // page_stride_bytes + 2
+    live_pages = int(inputs.launch_cache.shape[0])
+    # Keep the multi-GiB prefix untouched. The populated tail is a real 432-B
+    # NVFP4 record page and the launched token ids address that tail directly.
+    cache = torch.empty(
+        (high_page + live_pages, _PAGE_SIZE, record_bytes),
+        dtype=torch.uint8,
+        device=device,
+    )
+    cache[high_page:].copy_(inputs.launch_cache)
+    assert cache.stride(0) * cache.element_size() == page_stride_bytes
+    assert high_page * page_stride_bytes > int32_max
+    token_offset = high_page * _PAGE_SIZE
+
+    def install_scenario(scenario: int) -> None:
+        inputs.q.copy_(inputs.q_scenarios[scenario])
+        inputs.indices.copy_(inputs.index_scenarios[scenario] + token_offset)
+        inputs.lengths.copy_(inputs.length_scenarios[scenario])
+
+    def launch_decode() -> None:
+        run_unified_decode(
+            q_all=inputs.q,
+            swa_k_cache=cache,
+            swa_indices=inputs.indices,
+            swa_topk_lengths=inputs.lengths,
+            workspace=workspace,
+            sm_scale=_GLM_SM_SCALE,
+            swa_page_size=_PAGE_SIZE,
+            forced_num_splits=1,
+            scale_format_override=ScaleFormat.NVFP4_E4M3,
+            fp8_rope_override=False,
+            out=output,
+        )
+
+    install_scenario(0)
+    launch_decode()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch_decode()
+    for scenario in range(2):
+        install_scenario(scenario)
+        output.zero_()
+        graph.replay()
+        torch.cuda.synchronize(device)
+        _assert_output(
+            output,
+            expected[scenario],
+            label=f"GLM NVFP4 BF16-RoPE high-pid replay {scenario}",
+        )
+
+    assert launch.LAST_DECODE_PLAN["native_glm_h8"] is True
+    assert launch.LAST_DECODE_PLAN["kv_stage_packed"] is False
+    assert launch.LAST_DECODE_PLAN["kv_smem_stride"] == 288
+    assert launch.LAST_DECODE_PLAN["fp8_rope"] is False
+
+
+@torch.inference_mode()
 def test_unified_glm_prefill_live_graph_oracle() -> None:
     """Validate GLM MG prefill with live inputs and fixed caller-owned output."""
     device = require_sparkinfer()


### PR DESCRIPTION
## Summary

Adds an experimental native four-math-warp GLM H8 decode path for NVFP4 MLA
KV records (368-byte FP8-RoPE and 432-byte BF16-RoPE), extending the existing
FP8 H8 swap-AB structure.

The implementation is **opt-in** with:

```bash
SPARKINFER_MLA_SM120_GLM_H8_NATIVE=1
```

The generic NVFP4 path remains the default because the completed AIBeast A/B
does not show the performance improvement originally estimated in #122.

## Implementation

- Native NVFP4 BF16 QK-NoPE swap-AB math.
- Native BF16/E4M3 QK-RoPE handling for both NVFP4 record layouts.
- Native PV swap-AB path with the probability transpose staged through SMEM.
- Static/dynamic-token latent scales and the existing record writer ABI.
- 160-thread native H8 launch contract (four math warps plus one I/O warp).
- CUDA-graph, high-page, tail-top-k, large-row and exact-profile coverage.

## Correctness repair found during qualification

The first submitted implementation had the wrong PTX `m16n8k16` BF16 A
fragment ordering in NoPE and FP8-RoPE QK. Commit `402a8c2` repairs both. The
corrected path now matches the generic oracle and the record-writer output.

Validated cases include:

- static and dynamic-token 368-byte graph replay;
- 432-byte BF16-RoPE graph replay;
- live page offsets beyond the signed 32-bit byte range for both layouts;
- C1 through C32, plus C64/C128/C256/C512/C1024/C3072;
- top-k tails 1 through 512 around every important tile boundary;
- exact C3072/top-k 2048 profiler shape;
- full GLM-5.2 3.36-bpw TP4/DCP4/MTP3 model startup, all serving CUDA graphs,
  524,288-token KV allocation, and successful C1/C4/C8 requests.

Representative exact-profile error: max abs `0.001953125`, cosine `0.999996`.

## Measured performance

Hardware: 4x RTX PRO 6000 Blackwell (96 GiB, 280 W cap), driver 595.71.05,
CUDA 13.2. Serving A/B used the exact r26 integration tree plus only this PR.

At the real dynamic-token FP8-RoPE top-k 2048 shape, the native graph replay is
slower than the generic path:

| Rows | Hot generic | Hot native | Cold-L2 generic | Cold-L2 native |
|---:|---:|---:|---:|---:|
| 1 | 15.936 us | 20.032 us | 20.512 us | 34.816 us |
| 4 | 15.968 us | 20.032 us | 18.432 us | 33.120 us |
| 8 | 20.064 us | 28.256 us | 22.528 us | 41.280 us |

The S6 full-occupancy follow-up is neutral versus the corrected padded native
variant. End-to-end steady C1 is at parity (`100.689` generic versus `102.011`
native tok/s); C4/C8 variation follows speculative acceptance and is not a
repeatable native-path gain. Prefill is unchanged within 1.1-1.8% noise.

The original 1.5-2x MLA / 15-30% end-to-end estimate is therefore **not
confirmed** on AIBeast. The PR is useful as correct experimental groundwork,
but should not replace the generic default without a further kernel redesign.

## Evidence

Full methodology, tables, and raw JSON:

https://gist.github.com/malaiwah/891f1d7ab3df7a764a030f51c13d8f57

Issue: #122
