### PR TITLE
feat(kimi-k3): add TP16 dense-MLA bindings and vocabulary argmax

### DIFF
--- a/b12x/attention/dense_mla/_kernel.py
+++ b/b12x/attention/dense_mla/_kernel.py
@@ -93,37 +93,20 @@ def _signature(binding: Binding) -> tuple[object, ...]:
     )
 
 
-@dataclass(frozen=True)
-class _ForwardLaunch:
+@dataclass(frozen=True, slots=True)
+class _ForwardCompileTemplate:
     entry: DenseMlaForwardKernel
-    args: tuple[object, ...]
     spec: KernelCompileSpec
 
 
-@dataclass(frozen=True)
-class _MergeLaunch:
+@dataclass(frozen=True, slots=True)
+class _MergeCompileTemplate:
     entry: DenseMlaMergeKernel
-    args: tuple[object, ...]
     spec: KernelCompileSpec
 
 
-def _forward_launch(binding: Binding) -> _ForwardLaunch:
+def _forward_args(binding: Binding) -> tuple[object, ...]:
     scratch = binding.scratch
-    fp8 = binding.q.dtype == _FP8
-    layout = make_smem_layout(
-        query_tile=scratch.query_tile,
-        fp8=fp8,
-    )
-    entry = DenseMlaForwardKernel(
-        layout=layout,
-        page_size=scratch.page_size,
-        num_heads=scratch.num_q_heads,
-        num_splits=scratch.num_splits,
-        chunks_per_split=scratch.chunks_per_split,
-        query_tile=scratch.query_tile,
-        fp8=fp8,
-    )
-
     q_bytes = _byte_base_pointer(binding.q)
     cache_bytes = _byte_base_pointer(binding.kv_cache)
     page_table = binding.page_table.reshape(-1)
@@ -139,7 +122,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
     )
     q_scale = binding.q_scale if binding.q_scale is not None else unused_scale_storage
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    args = (
+    return (
         _to_cute(
             q_bytes,
             cutlass.Uint8,
@@ -191,6 +174,24 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         Int32(binding.active_splits),
         stream,
     )
+
+
+def _forward_compile_template(binding: Binding) -> _ForwardCompileTemplate:
+    scratch = binding.scratch
+    fp8 = binding.q.dtype == _FP8
+    layout = make_smem_layout(
+        query_tile=scratch.query_tile,
+        fp8=fp8,
+    )
+    entry = DenseMlaForwardKernel(
+        layout=layout,
+        page_size=scratch.page_size,
+        num_heads=scratch.num_q_heads,
+        num_splits=scratch.num_splits,
+        chunks_per_split=scratch.chunks_per_split,
+        query_tile=scratch.query_tile,
+        fp8=fp8,
+    )
     spec = KernelCompileSpec.from_fields(
         "attention.dense_mla.forward",
         3,
@@ -223,7 +224,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         ),
         tensor_key(
             "output",
-            output,
+            binding.output,
             dims=(
                 DimKey.dynamic(),
                 DimKey.exact(scratch.num_q_heads),
@@ -231,18 +232,17 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
             ),
         ),
     )
-    return _ForwardLaunch(entry=entry, args=args, spec=spec)
+    return _ForwardCompileTemplate(entry=entry, spec=spec)
 
 
-def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+def _merge_args(binding: Binding) -> tuple[object, ...] | None:
     scratch = binding.scratch
     if scratch.num_splits == 1:
         return None
     assert scratch.partial_output is not None
     assert scratch.partial_lse is not None
-    entry = DenseMlaMergeKernel(scratch.num_splits)
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    args = (
+    return (
         _to_cute(
             scratch.partial_output,
             cutlass.BFloat16,
@@ -259,6 +259,14 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
         Int32(binding.active_splits),
         stream,
     )
+
+
+def _merge_compile_template(binding: Binding) -> _MergeCompileTemplate | None:
+    scratch = binding.scratch
+    if scratch.num_splits == 1:
+        return None
+    assert scratch.partial_output is not None
+    entry = DenseMlaMergeKernel(scratch.num_splits)
     spec = KernelCompileSpec.from_fields(
         "attention.dense_mla.merge",
         4,
@@ -284,7 +292,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
             ),
         ),
     )
-    return _MergeLaunch(entry=entry, args=args, spec=spec)
+    return _MergeCompileTemplate(entry=entry, spec=spec)
 
 
 def _compile_entries(binding: Binding) -> tuple[object, object | None]:
@@ -293,21 +301,24 @@ def _compile_entries(binding: Binding) -> tuple[object, object | None]:
         compiled_forward = _FORWARD_CACHE.get(signature)
         compiled_merge = _MERGE_CACHE.get(signature)
     if compiled_forward is None:
-        launch = _forward_launch(binding)
+        template = _forward_compile_template(binding)
+        args = _forward_args(binding)
         compiled_forward = compile_cute(
-            launch.entry,
-            *launch.args,
-            compile_spec=launch.spec,
+            template.entry,
+            *args,
+            compile_spec=template.spec,
         )
         with _LOCK:
             _FORWARD_CACHE[signature] = compiled_forward
     if binding.scratch.num_splits > 1 and compiled_merge is None:
-        launch = _merge_launch(binding)
-        assert launch is not None
+        template = _merge_compile_template(binding)
+        args = _merge_args(binding)
+        assert template is not None
+        assert args is not None
         compiled_merge = compile_cute(
-            launch.entry,
-            *launch.args,
-            compile_spec=launch.spec,
+            template.entry,
+            *args,
+            compile_spec=template.spec,
         )
         with _LOCK:
             _MERGE_CACHE[signature] = compiled_merge
@@ -343,13 +354,12 @@ def run_dense_mla(
             )
         compiled_forward, compiled_merge = _compile_entries(binding)
 
-    forward = _forward_launch(binding)
-    run_compiled(compiled_forward, forward.args)
+    run_compiled(compiled_forward, _forward_args(binding))
     if binding.scratch.num_splits > 1 and binding.active_splits > 1:
         assert compiled_merge is not None
-        merge = _merge_launch(binding)
-        assert merge is not None
-        run_compiled(compiled_merge, merge.args)
+        merge_args = _merge_args(binding)
+        assert merge_args is not None
+        run_compiled(compiled_merge, merge_args)
     rows = int(binding.q.shape[0])
     return binding.output, binding.scratch.final_lse[:rows]
 

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -206,7 +206,7 @@ def _dense_mla_scratch_layout(
     )
 
 
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, slots=True)
 class Scratch:
     shared_scratch: torch.Tensor
     device: torch.device
@@ -228,7 +228,7 @@ class Scratch:
     final_lse: torch.Tensor
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, kw_only=True, slots=True)
 class Binding:
     scratch: Scratch
     q: torch.Tensor
@@ -462,6 +462,51 @@ def _validate_binding(
     )
 
 
+def _bind_prevalidated(
+    *,
+    scratch: Scratch,
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    output: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    kv_scale: torch.Tensor | None,
+    q_scale: torch.Tensor | None,
+    sm_scale: float,
+    active_splits: int,
+) -> Binding:
+    """Build fresh views for a caller that already proved the tensor contract.
+
+    Framework integrations validate and capacity-plan these capture-static
+    tensors while constructing their attention metadata. Repeating storage
+    bounds, shape, stride, device, and dtype checks in every layer of every
+    decode step adds Python latency but no additional safety. This path still
+    creates a new caller-scratch-owned ``Scratch`` and ``Binding`` per call;
+    it never caches a binding or workspace.
+    """
+    active_splits = int(active_splits)
+    if not 1 <= active_splits <= scratch.num_splits:
+        raise ValueError(
+            "active_splits must be in the planned range "
+            f"[1, {scratch.num_splits}], got {active_splits}"
+        )
+    cache = kv_cache[:, :, 0, :] if kv_cache.ndim == 4 else kv_cache
+    return Binding(
+        scratch=scratch,
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        kv_scale=kv_scale,
+        q_scale=q_scale,
+        sm_scale=float(sm_scale),
+        active_splits=active_splits,
+    )
+
+
 def _materialize(
     caps: Caps,
     scratch_storage: torch.Tensor,
@@ -518,6 +563,75 @@ def _materialize(
     )
 
 
+def _materialize_prevalidated(
+    caps: Caps,
+    scratch_storage: torch.Tensor,
+    layout: _ScratchLayout,
+) -> Scratch:
+    """Map fresh typed views without repeating the generic layout checks.
+
+    ``Plan.bind(validate=False)`` is used only after the framework has proved
+    that the capture-static byte tensor matches the plan.  Keep the ownership
+    contract explicit by constructing new tensor views and a new ``Scratch``
+    container for every bind, while avoiding per-layer scalar-tensor dtype
+    queries and generic alignment work.
+    """
+    partial_output = None
+    partial_lse = None
+    if layout.num_splits > 1:
+        assert layout.partial_output_offset_bytes is not None
+        assert layout.partial_lse_offset_bytes is not None
+        bf16_storage = scratch_storage.view(torch.bfloat16)
+        partial_output = bf16_storage.as_strided(
+            (
+                caps.max_total_q,
+                caps.num_q_heads,
+                layout.num_splits,
+                K3_VALUE_DIM,
+            ),
+            (
+                caps.num_q_heads * layout.num_splits * K3_VALUE_DIM,
+                layout.num_splits * K3_VALUE_DIM,
+                K3_VALUE_DIM,
+                1,
+            ),
+            bf16_storage.storage_offset() + layout.partial_output_offset_bytes // 2,
+        )
+        fp32_storage = scratch_storage.view(torch.float32)
+        partial_lse = fp32_storage.as_strided(
+            (caps.max_total_q, caps.num_q_heads, layout.num_splits),
+            (caps.num_q_heads * layout.num_splits, layout.num_splits, 1),
+            fp32_storage.storage_offset() + layout.partial_lse_offset_bytes // 4,
+        )
+    else:
+        fp32_storage = scratch_storage.view(torch.float32)
+    final_lse = fp32_storage.as_strided(
+        (caps.max_total_q, caps.num_q_heads),
+        (caps.num_q_heads, 1),
+        fp32_storage.storage_offset() + layout.final_lse_offset_bytes // 4,
+    )
+    return Scratch(
+        shared_scratch=scratch_storage,
+        device=caps.device,
+        mode=caps.mode,
+        kv_dtype=caps.kv_dtype,
+        num_q_heads=caps.num_q_heads,
+        page_size=caps.page_size,
+        max_total_q=caps.max_total_q,
+        max_batch=caps.max_batch,
+        max_cache_tokens=caps.max_cache_tokens,
+        max_page_table_width=caps.max_page_table_width,
+        num_cache_pages=caps.num_cache_pages,
+        num_splits=layout.num_splits,
+        chunks_per_split=layout.chunks_per_split,
+        query_tile=_query_tile(caps),
+        use_cuda_graph=caps.use_cuda_graph,
+        partial_output=partial_output,
+        partial_lse=partial_lse,
+        final_lse=final_lse,
+    )
+
+
 @dataclass(frozen=True)
 class Plan:
     caps: Caps
@@ -556,14 +670,28 @@ class Plan:
         q_scale: torch.Tensor | None = None,
         sm_scale: float = K3_SM_SCALE,
         active_splits: int | None = None,
+        validate: bool = True,
     ) -> Binding:
-        storage = scratch_tensor(
-            scratch,
-            self._scratch_specs,
-            owner="dense MLA",
-        )
-        scratch_views = _materialize(self.caps, storage, self.layout)
-        return _validate_binding(
+        if not validate and isinstance(scratch, torch.Tensor):
+            # Framework integrations hand us the exact planned 1-D uint8
+            # tensor.  They validated it when constructing attention metadata;
+            # mapping it directly is the hot decode path.  Non-tensor adapters
+            # and the checked public path retain the generic validator below.
+            storage = scratch
+            scratch_views = _materialize_prevalidated(
+                self.caps,
+                storage,
+                self.layout,
+            )
+        else:
+            storage = scratch_tensor(
+                scratch,
+                self._scratch_specs,
+                owner="dense MLA",
+            )
+            scratch_views = _materialize(self.caps, storage, self.layout)
+        bind_impl = _validate_binding if validate else _bind_prevalidated
+        return bind_impl(
             scratch=scratch_views,
             q=q,
             kv_cache=kv_cache,

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -673,10 +673,17 @@ class Plan:
         validate: bool = True,
     ) -> Binding:
         if not validate and isinstance(scratch, torch.Tensor):
-            # Framework integrations hand us the exact planned 1-D uint8
-            # tensor.  They validated it when constructing attention metadata;
-            # mapping it directly is the hot decode path.  Non-tensor adapters
-            # and the checked public path retain the generic validator below.
+            # The unchecked binding path omits dtype, layout, and device
+            # queries after the framework validates capture-static metadata.
+            # Capacity remains a memory-safety invariant because as_strided
+            # does not reject a view that extends beyond the allocation.
+            required_bytes = int(self.layout.nbytes)
+            available_bytes = int(scratch.numel()) * scratch.element_size()
+            if available_bytes < required_bytes:
+                raise ValueError(
+                    "prevalidated dense MLA scratch is smaller than required: "
+                    f"need {required_bytes} bytes, got {available_bytes}"
+                )
             storage = scratch
             scratch_views = _materialize_prevalidated(
                 self.caps,

--- a/b12x/comm/pcie/__init__.py
+++ b/b12x/comm/pcie/__init__.py
@@ -17,9 +17,9 @@ pools via ``<Class>Pool``.
 - ``DcpTopKOwnerExchange``: exact DCP candidate owner staging.
 - ``VocabParallelArgmax``: TP16 fused BF16 add and exact global greedy argmax.
 
-Every device kernel is authored in Python with CuTe DSL.  Host-side CUDA
-Runtime/Driver calls are also made from Python; this package contains no
-repo-authored C++ or CUDA source and never invokes a native extension build.
+Most device kernels are authored in Python with CuTe DSL. Vocabulary-parallel
+argmax JIT-builds the bundled ``pcie_vocab_argmax.cu`` extension on first use.
+Host-side CUDA Runtime and Driver calls are made from Python.
 """
 
 from __future__ import annotations

--- a/b12x/comm/pcie/__init__.py
+++ b/b12x/comm/pcie/__init__.py
@@ -15,6 +15,7 @@ pools via ``<Class>Pool``.
   per-token FP8-e4m3 transport.
 - ``DcpAllToAll``: DCP attention exchange with fused LSE reduce-scatter.
 - ``DcpTopKOwnerExchange``: exact DCP candidate owner staging.
+- ``VocabParallelArgmax``: TP16 fused BF16 add and exact global greedy argmax.
 
 Every device kernel is authored in Python with CuTe DSL.  Host-side CUDA
 Runtime/Driver calls are also made from Python; this package contains no
@@ -40,13 +41,14 @@ META = OpMeta(
         "DcpAllToAll",
         "DcpAllToAllPool",
         "DcpTopKOwnerExchange",
+        "VocabParallelArgmax",
         "autotune_dma_crossovers",
         "parse_oneshot_max_size",
         "lse_reduce_scatter_reference",
         "owner_stage_reference",
         "is_supported",
     ),
-    dtypes=("bf16", "fp32", "fp8_e4m3", "int32"),
+    dtypes=("bf16", "fp32", "fp8_e4m3", "int32", "int64"),
     requires=("multi_gpu",),
     provenance=Provenance(
         repo="https://github.com/lukealonso/b12x",
@@ -68,6 +70,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
         OneshotAllReduce,
         OneshotAllReducePool,
         TwoShotReduceScatter,
+        VocabParallelArgmax,
         autotune_dma_crossovers,
         is_supported,
         lse_reduce_scatter_reference,

--- a/b12x/comm/pcie/api.py
+++ b/b12x/comm/pcie/api.py
@@ -45,8 +45,8 @@ from .pcie_vocab_argmax import (
 def is_supported(device=None) -> bool:
     """True on SM120/SM121 with >= 2 visible CUDA devices.
 
-    Device kernels are compiled from the Python CuTe DSL sources on first use;
-    no repo-authored C++/CUDA extension or runtime nvcc build is involved.
+    CuTe device kernels compile from Python sources. ``VocabParallelArgmax``
+    JIT-builds its bundled CUDA extension on first use.
     """
     import torch
 

--- a/b12x/comm/pcie/api.py
+++ b/b12x/comm/pcie/api.py
@@ -37,6 +37,9 @@ from .pcie_oneshot import (
 from .pcie_twoshot import (
     PCIeTwoShotSP as TwoShotReduceScatter,
 )
+from .pcie_vocab_argmax import (
+    PCIeVocabParallelArgmax as VocabParallelArgmax,
+)
 
 
 def is_supported(device=None) -> bool:
@@ -59,6 +62,7 @@ __all__ = [
     "DcpAllToAll",
     "DcpAllToAllPool",
     "DcpTopKOwnerExchange",
+    "VocabParallelArgmax",
     "autotune_dma_crossovers",
     "parse_oneshot_max_size",
     "lse_reduce_scatter_reference",

--- a/b12x/comm/pcie/pcie_vocab_argmax.cu
+++ b/b12x/comm/pcie/pcie_vocab_argmax.cu
@@ -1,0 +1,346 @@
+// Bounded-degree TP16 fused BF16 add + global greedy argmax.
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <math_constants.h>
+#include <torch/extension.h>
+
+#include <climits>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+#ifndef B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES
+#define B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES 24
+#endif
+
+static_assert(B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES >= 0);
+
+namespace pcie_vocab_argmax {
+
+constexpr int kWorldSize = 16;
+constexpr int kIslandSize = 4;
+constexpr int kNumIslands = 4;
+constexpr int kSlots = 2;
+constexpr int kMaxBatch = 8;
+constexpr int kThreads = 512;
+
+struct Pair {
+  float value;
+  int32_t index;
+};
+
+struct alignas(128) Flag {
+  uint32_t value;
+  uint32_t padding[31];
+};
+
+struct alignas(256) Header {
+  uint32_t generation[kMaxBatch];
+  uint32_t generation_padding[64 - kMaxBatch];
+  Flag local_ready[kSlots][kMaxBatch][kIslandSize];
+  Flag island_ready[kSlots][kMaxBatch][kNumIslands];
+  Pair local_pair[kSlots][kMaxBatch];
+  Pair island_pair[kSlots][kMaxBatch];
+};
+
+static_assert(sizeof(Flag) == 128);
+static_assert(sizeof(Header) % 256 == 0);
+
+struct Runtime {
+  Header* slabs[kWorldSize] = {};
+  int rank;
+  int64_t local_elements;
+  int max_batch;
+};
+
+__device__ __forceinline__ uint32_t load_acquire(const uint32_t* ptr) {
+  uint32_t value;
+  asm volatile("ld.acquire.sys.global.u32 %0, [%1];"
+               : "=r"(value)
+               : "l"(ptr));
+  return value;
+}
+
+__device__ __forceinline__ void store_release(
+    uint32_t* ptr, uint32_t value) {
+  asm volatile("st.release.sys.global.u32 [%0], %1;"
+               :
+               : "l"(ptr), "r"(value)
+               : "memory");
+}
+
+__device__ __forceinline__ void wait_for(
+    const uint32_t* ptr, uint32_t generation) {
+  while (load_acquire(ptr) < generation) {
+#if __CUDA_ARCH__ >= 700 && \
+    B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES > 0
+    __nanosleep(B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES);
+#endif
+  }
+}
+
+__device__ __forceinline__ Pair better(Pair lhs, Pair rhs) {
+  const bool lhs_nan = isnan(lhs.value);
+  const bool rhs_nan = isnan(rhs.value);
+  if (lhs_nan != rhs_nan) {
+    return rhs_nan ? rhs : lhs;
+  }
+  if (rhs.value > lhs.value ||
+      (rhs.value == lhs.value && rhs.index < lhs.index)) {
+    return rhs;
+  }
+  return lhs;
+}
+
+__device__ __forceinline__ Pair warp_reduce(Pair value) {
+  constexpr unsigned mask = 0xffffffffU;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    Pair other{
+        __shfl_down_sync(mask, value.value, offset),
+        __shfl_down_sync(mask, value.index, offset),
+    };
+    if ((threadIdx.x & 31) + offset < 32) {
+      value = better(value, other);
+    }
+  }
+  return value;
+}
+
+__global__ void fused_add_argmax_tp16(
+    Runtime runtime,
+    const nv_bfloat16* base,
+    const nv_bfloat16* bias,
+    int64_t base_row_stride,
+    int64_t bias_row_stride,
+    int64_t* output) {
+  __shared__ Pair warp_pairs[32];
+  __shared__ Pair block_pair;
+  __shared__ uint32_t generation;
+
+  const int tid = threadIdx.x;
+  const int row = blockIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+  const int warps = blockDim.x >> 5;
+  const int64_t base_row_offset =
+      static_cast<int64_t>(row) * base_row_stride;
+  const int64_t bias_row_offset =
+      static_cast<int64_t>(row) * bias_row_stride;
+
+  Pair best{-CUDART_INF_F, INT_MAX};
+  for (int64_t index = tid; index < runtime.local_elements;
+       index += blockDim.x) {
+    const float sum = __bfloat162float(base[base_row_offset + index]) +
+                      __bfloat162float(bias[bias_row_offset + index]);
+    const nv_bfloat16 rounded = __float2bfloat16_rn(sum);
+    const Pair candidate{
+        __bfloat162float(rounded),
+        static_cast<int32_t>(runtime.rank * runtime.local_elements + index),
+    };
+    best = better(best, candidate);
+  }
+  best = warp_reduce(best);
+  if (lane == 0) {
+    warp_pairs[warp] = best;
+  }
+  __syncthreads();
+
+  if (warp == 0) {
+    Pair warp_best = lane < warps
+                         ? warp_pairs[lane]
+                         : Pair{-CUDART_INF_F, INT_MAX};
+    warp_best = warp_reduce(warp_best);
+    if (lane == 0) {
+      block_pair = warp_best;
+    }
+  }
+  __syncthreads();
+  if (tid != 0) {
+    return;
+  }
+
+  Header* self = runtime.slabs[runtime.rank];
+  generation = atomicAdd(&self->generation[row], 1U) + 1U;
+  const int slot = static_cast<int>(generation & 1U);
+  const int island = runtime.rank / kIslandSize;
+  const int local_rank = runtime.rank % kIslandSize;
+  const int island_base = island * kIslandSize;
+
+  self->local_pair[slot][row] = block_pair;
+  __threadfence_system();
+#pragma unroll
+  for (int peer_local = 0; peer_local < kIslandSize; ++peer_local) {
+    if (peer_local == local_rank) {
+      continue;
+    }
+    Header* peer = runtime.slabs[island_base + peer_local];
+    store_release(
+        &peer->local_ready[slot][row][local_rank].value,
+        generation);
+  }
+#pragma unroll
+  for (int peer_local = 0; peer_local < kIslandSize; ++peer_local) {
+    if (peer_local == local_rank) {
+      continue;
+    }
+    wait_for(
+        &self->local_ready[slot][row][peer_local].value,
+        generation);
+  }
+
+  Pair island_best{-CUDART_INF_F, INT_MAX};
+#pragma unroll
+  for (int peer_local = 0; peer_local < kIslandSize; ++peer_local) {
+    island_best = better(
+        island_best,
+        runtime.slabs[island_base + peer_local]->local_pair[slot][row]);
+  }
+  self->island_pair[slot][row] = island_best;
+  __threadfence_system();
+
+#pragma unroll
+  for (int peer_island = 0; peer_island < kNumIslands; ++peer_island) {
+    if (peer_island == island) {
+      continue;
+    }
+    Header* peer =
+        runtime.slabs[peer_island * kIslandSize + local_rank];
+    store_release(
+        &peer->island_ready[slot][row][island].value,
+        generation);
+  }
+#pragma unroll
+  for (int peer_island = 0; peer_island < kNumIslands; ++peer_island) {
+    if (peer_island == island) {
+      continue;
+    }
+    wait_for(
+        &self->island_ready[slot][row][peer_island].value,
+        generation);
+  }
+
+  Pair global_best{-CUDART_INF_F, INT_MAX};
+#pragma unroll
+  for (int peer_island = 0; peer_island < kNumIslands; ++peer_island) {
+    global_best = better(
+        global_best,
+        runtime.slabs[peer_island * kIslandSize + local_rank]
+            ->island_pair[slot][row]);
+  }
+  output[row] = static_cast<int64_t>(global_best.index);
+}
+
+}  // namespace pcie_vocab_argmax
+
+using Runtime = pcie_vocab_argmax::Runtime;
+
+static int64_t slab_bytes() {
+  return static_cast<int64_t>(sizeof(pcie_vocab_argmax::Header));
+}
+
+static int64_t init_runtime(
+    const std::vector<int64_t>& slab_ptrs,
+    int64_t rank,
+    int64_t local_elements,
+    int64_t max_batch) {
+  if (slab_ptrs.size() != pcie_vocab_argmax::kWorldSize) {
+    throw std::invalid_argument("vocabulary argmax requires TP16");
+  }
+  if (rank < 0 || rank >= pcie_vocab_argmax::kWorldSize ||
+      local_elements <= 0 ||
+      local_elements * pcie_vocab_argmax::kWorldSize >= (int64_t(1) << 31) ||
+      max_batch <= 0 || max_batch > pcie_vocab_argmax::kMaxBatch) {
+    throw std::invalid_argument("invalid vocabulary argmax geometry");
+  }
+  auto runtime = std::make_unique<Runtime>();
+  runtime->rank = static_cast<int>(rank);
+  runtime->local_elements = local_elements;
+  runtime->max_batch = static_cast<int>(max_batch);
+  for (int index = 0; index < pcie_vocab_argmax::kWorldSize; ++index) {
+    runtime->slabs[index] =
+        reinterpret_cast<pcie_vocab_argmax::Header*>(slab_ptrs[index]);
+  }
+
+  const int island = runtime->rank / pcie_vocab_argmax::kIslandSize;
+  const int local_rank = runtime->rank % pcie_vocab_argmax::kIslandSize;
+  for (int peer_local = 0; peer_local < pcie_vocab_argmax::kIslandSize;
+       ++peer_local) {
+    const int peer_rank = island * pcie_vocab_argmax::kIslandSize + peer_local;
+    if (runtime->slabs[peer_rank] == nullptr) {
+      throw std::invalid_argument("missing local-island slab");
+    }
+  }
+  for (int peer_island = 0; peer_island < pcie_vocab_argmax::kNumIslands;
+       ++peer_island) {
+    const int peer_rank =
+        peer_island * pcie_vocab_argmax::kIslandSize + local_rank;
+    if (runtime->slabs[peer_rank] == nullptr) {
+      throw std::invalid_argument("missing cross-island lane slab");
+    }
+  }
+  return reinterpret_cast<int64_t>(runtime.release());
+}
+
+static void fused_add_argmax(
+    int64_t runtime_handle,
+    torch::Tensor base,
+    torch::Tensor bias,
+    torch::Tensor output) {
+  auto* runtime = reinterpret_cast<Runtime*>(runtime_handle);
+  TORCH_CHECK(runtime != nullptr, "vocabulary argmax runtime is closed");
+  TORCH_CHECK(base.is_cuda() && bias.is_cuda() && output.is_cuda(),
+              "tensors must be CUDA");
+  TORCH_CHECK(base.scalar_type() == torch::kBFloat16 &&
+                  bias.scalar_type() == torch::kBFloat16,
+              "base and bias must be BF16");
+  TORCH_CHECK(output.scalar_type() == torch::kInt64,
+              "output must be int64");
+  TORCH_CHECK(base.device() == bias.device() &&
+                  base.device() == output.device(),
+              "tensors must be on the same CUDA device");
+  TORCH_CHECK(base.dim() == 2 && bias.dim() == 2,
+              "base and bias must be two-dimensional");
+  TORCH_CHECK(base.stride(1) == 1 && bias.stride(1) == 1,
+              "input last dimensions must be contiguous");
+  TORCH_CHECK(base.stride(0) > 0 && bias.stride(0) > 0,
+              "input row strides must be positive");
+  TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
+  TORCH_CHECK(base.sizes() == bias.sizes(),
+              "base and bias shapes must match");
+  TORCH_CHECK(base.dim() == 2 && base.size(1) == runtime->local_elements,
+              "inputs must be [batch, local_vocab]");
+  TORCH_CHECK(base.size(0) > 0 && base.size(0) <= runtime->max_batch,
+              "batch exceeds vocabulary argmax capacity");
+  TORCH_CHECK(output.dim() == 1 && output.size(0) == base.size(0),
+              "output must be [batch]");
+
+  const c10::cuda::CUDAGuard guard(base.device());
+  const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  pcie_vocab_argmax::fused_add_argmax_tp16
+      <<<static_cast<int>(base.size(0)), pcie_vocab_argmax::kThreads, 0, stream>>>(
+          *runtime,
+          reinterpret_cast<const nv_bfloat16*>(base.data_ptr()),
+          reinterpret_cast<const nv_bfloat16*>(bias.data_ptr()),
+          base.stride(0),
+          bias.stride(0),
+          reinterpret_cast<int64_t*>(output.data_ptr()));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+static void destroy_runtime(int64_t runtime_handle) {
+  delete reinterpret_cast<Runtime*>(runtime_handle);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  module.def("slab_bytes", &slab_bytes);
+  module.def("init_runtime", &init_runtime);
+  module.def("fused_add_argmax", &fused_add_argmax);
+  module.def("destroy_runtime", &destroy_runtime);
+}

--- a/b12x/comm/pcie/pcie_vocab_argmax.py
+++ b/b12x/comm/pcie/pcie_vocab_argmax.py
@@ -39,12 +39,11 @@ def _exchange_ipc_handles(
         )
 
     world_size = dist.get_world_size(group=group)
-    rank = dist.get_rank(group=group)
-    all_objects: list[list[object | None]] = [[None] for _ in range(world_size)]
-    all_objects[rank][0] = local_handle
-    for index, src_rank in enumerate(dist.get_process_group_ranks(group)):
-        dist.broadcast_object_list(all_objects[index], src=src_rank, group=group)
-    return [entry[0] for entry in all_objects]
+    handles: list[object | None] = [None] * world_size
+    dist.all_gather_object(handles, local_handle, group=group)
+    if any(handle is None for handle in handles):
+        raise RuntimeError("vocabulary argmax IPC exchange returned an empty handle")
+    return list(handles)
 
 
 def _wait_nanosleep_cycles_from_env() -> int:

--- a/b12x/comm/pcie/pcie_vocab_argmax.py
+++ b/b12x/comm/pcie/pcie_vocab_argmax.py
@@ -1,0 +1,290 @@
+"""Bounded-degree TP16 vocabulary argmax runtime."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, suppress
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.utils.cpp_extension import load
+
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import _broadcast_gather_object
+
+
+WORLD_SIZE = 16
+ISLAND_SIZE = 4
+MAX_BATCH_SIZE = 8
+
+
+def _exchange_ipc_handles(
+    local_handle: object,
+    group: ProcessGroup,
+) -> list[object]:
+    """Exchange CUDA IPC handles over NCCL or a metadata-only Gloo group."""
+
+    backend = str(dist.get_backend(group=group)).lower()
+    if "nccl" in backend:
+        return _broadcast_gather_object(local_handle, group)
+    if "gloo" not in backend:
+        raise ValueError(
+            "vocabulary argmax IPC exchange requires an NCCL or Gloo group, "
+            f"got {backend}"
+        )
+
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    all_objects: list[list[object | None]] = [[None] for _ in range(world_size)]
+    all_objects[rank][0] = local_handle
+    for index, src_rank in enumerate(dist.get_process_group_ranks(group)):
+        dist.broadcast_object_list(all_objects[index], src=src_rank, group=group)
+    return [entry[0] for entry in all_objects]
+
+
+def _wait_nanosleep_cycles_from_env() -> int:
+    raw = os.getenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", "24")
+    try:
+        cycles = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be an integer"
+        ) from exc
+    if not 0 <= cycles <= 1024:
+        raise ValueError(
+            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]"
+        )
+    return cycles
+
+
+@lru_cache(maxsize=1)
+def _load_extension():
+    source = Path(__file__).with_name("pcie_vocab_argmax.cu")
+    wait_cycles = _wait_nanosleep_cycles_from_env()
+    return load(
+        name=f"b12x_pcie_vocab_argmax_ext_ns{wait_cycles}",
+        sources=[str(source)],
+        extra_cuda_cflags=[
+            "-O3",
+            f"-DB12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES={wait_cycles}",
+        ],
+        extra_ldflags=["-lcuda"],
+        verbose=(os.getenv("B12X_PCIE_VOCAB_ARGMAX_VERBOSE_BUILD", "0") == "1"),
+    )
+
+
+def _selected_peers(rank: int, world_size: int = WORLD_SIZE) -> tuple[int, ...]:
+    """Return three island peers plus the same lane in other islands."""
+
+    if world_size != WORLD_SIZE or not 0 <= rank < world_size:
+        raise ValueError(
+            f"vocabulary argmax requires TP{WORLD_SIZE}, got rank={rank}, "
+            f"TP={world_size}"
+        )
+    island = rank // ISLAND_SIZE
+    lane = rank % ISLAND_SIZE
+    local = set(range(island * ISLAND_SIZE, (island + 1) * ISLAND_SIZE))
+    cross_island = set(range(lane, world_size, ISLAND_SIZE))
+    return tuple(sorted((local | cross_island) - {rank}))
+
+
+class PCIeVocabParallelArgmax:
+    """Fuse BF16 add and exact global greedy sampling across TP16 shards."""
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+        ext_module=None,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = (
+            device
+            if isinstance(device, torch.device)
+            else torch.device(f"cuda:{device}" if isinstance(device, int) else device)
+        )
+        if self.world_size != WORLD_SIZE:
+            raise ValueError(
+                f"vocabulary argmax requires TP{WORLD_SIZE}, got TP{self.world_size}"
+            )
+        if self.device.type != "cuda":
+            raise ValueError("vocabulary argmax requires a CUDA device")
+        if local_vocab_size <= 0 or local_vocab_size * self.world_size >= 1 << 31:
+            raise ValueError("global vocabulary must fit a positive int32 index")
+        if not 0 < max_batch_size <= MAX_BATCH_SIZE:
+            raise ValueError(f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]")
+
+        self.local_vocab_size = int(local_vocab_size)
+        self.max_batch_size = int(max_batch_size)
+        self._ext = ext_module or _load_extension()
+        self._ipc = CudaRTLibrary()
+        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._runtime = 0
+        self._local_ptr = 0
+        self._remote_ptrs: list[int] = []
+        self._closed = False
+
+        slab_bytes = int(self._ext.slab_bytes())
+        peer_ptrs = [0] * self.world_size
+        try:
+            self._local_ptr = self._ipc.cudaMalloc(slab_bytes)
+            self._ipc.cudaMemset(self._local_ptr, 0, slab_bytes)
+            local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
+            handles = _exchange_ipc_handles(local_handle, exchange_group)
+            peer_ptrs[self.rank] = self._local_ptr
+            for peer in _selected_peers(self.rank, self.world_size):
+                remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
+                peer_ptrs[peer] = remote_ptr
+                self._remote_ptrs.append(remote_ptr)
+            self._runtime = int(
+                self._ext.init_runtime(
+                    peer_ptrs,
+                    self.rank,
+                    self.local_vocab_size,
+                    self.max_batch_size,
+                )
+            )
+        except Exception:
+            for ptr in self._remote_ptrs:
+                with suppress(Exception):
+                    self._ipc.cudaIpcCloseMemHandle(ptr)
+            self._remote_ptrs.clear()
+            if self._local_ptr:
+                with suppress(Exception):
+                    self._ipc.cudaFree(self._local_ptr)
+                self._local_ptr = 0
+            raise
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+        ext_module=None,
+    ) -> "PCIeVocabParallelArgmax":
+        return cls(
+            exchange_group=exchange_group,
+            device=device,
+            local_vocab_size=local_vocab_size,
+            max_batch_size=max_batch_size,
+            ext_module=ext_module,
+        )
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+        ext_module=None,
+    ) -> "PCIeVocabParallelArgmax":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            local_vocab_size=local_vocab_size,
+            max_batch_size=max_batch_size,
+            ext_module=ext_module,
+        )
+
+    @property
+    def mapped_peer_count(self) -> int:
+        return len(self._remote_ptrs)
+
+    def fused_add_argmax(
+        self,
+        base: torch.Tensor,
+        bias: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Return exact global argmax of the BF16-rounded local sum."""
+
+        if self._closed:
+            raise RuntimeError("vocabulary argmax runtime is closed")
+        if base.device != self.device or bias.device != self.device:
+            raise ValueError("inputs must be on the runtime device")
+        if base.dtype != torch.bfloat16 or bias.dtype != torch.bfloat16:
+            raise ValueError("inputs must be BF16")
+        if base.ndim != 2 or base.shape != bias.shape:
+            raise ValueError("inputs must have matching [batch, local_vocab] shapes")
+        batch, local_vocab = (int(value) for value in base.shape)
+        if not 0 < batch <= self.max_batch_size:
+            raise ValueError(
+                f"batch size {batch} exceeds capacity {self.max_batch_size}"
+            )
+        if local_vocab != self.local_vocab_size:
+            raise ValueError(
+                f"local vocabulary must be {self.local_vocab_size}, got {local_vocab}"
+            )
+        if base.stride(1) != 1 or bias.stride(1) != 1:
+            raise ValueError("input last dimensions must be contiguous")
+        if base.stride(0) <= 0 or bias.stride(0) <= 0:
+            raise ValueError("input row strides must be positive")
+        if out is None:
+            out = torch.empty(batch, dtype=torch.int64, device=self.device)
+        if (
+            out.device != self.device
+            or out.dtype != torch.int64
+            or out.shape != (batch,)
+            or not out.is_contiguous()
+        ):
+            raise ValueError("output must be contiguous int64 [batch] on the device")
+        self._ext.fused_add_argmax(self._runtime, base, bias, out)
+        return out
+
+    def for_stream(self, stream: object = None) -> "PCIeVocabParallelArgmax":
+        del stream
+        return self
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        del stream
+        yield self
+
+    def register_graph_buffers(self) -> None:
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        torch.cuda.synchronize(self.device)
+        dist.barrier(group=self.group)
+        if self._runtime:
+            self._ext.destroy_runtime(self._runtime)
+            self._runtime = 0
+        for ptr in self._remote_ptrs:
+            self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._remote_ptrs.clear()
+        dist.barrier(group=self.group)
+        if self._local_ptr:
+            self._ipc.cudaFree(self._local_ptr)
+            self._local_ptr = 0
+        dist.barrier(group=self.group)
+
+    def __enter__(self) -> "PCIeVocabParallelArgmax":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        if not getattr(self, "_closed", True):
+            with suppress(Exception):
+                self.close()
+
+
+__all__ = ["PCIeVocabParallelArgmax"]

--- a/b12x/comm/pcie/pcie_vocab_argmax.py
+++ b/b12x/comm/pcie/pcie_vocab_argmax.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager, suppress
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
+from warnings import warn
 
 import torch
 import torch.distributed as dist
@@ -55,9 +56,7 @@ def _wait_nanosleep_cycles_from_env() -> int:
             "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be an integer"
         ) from exc
     if not 0 <= cycles <= 1024:
-        raise ValueError(
-            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]"
-        )
+        raise ValueError("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]")
     return cycles
 
 
@@ -118,6 +117,10 @@ class PCIeVocabParallelArgmax:
             )
         if self.device.type != "cuda":
             raise ValueError("vocabulary argmax requires a CUDA device")
+        device_index = self.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+            self.device = torch.device("cuda", device_index)
         if local_vocab_size <= 0 or local_vocab_size * self.world_size >= 1 << 31:
             raise ValueError("global vocabulary must fit a positive int32 index")
         if not 0 < max_batch_size <= MAX_BATCH_SIZE:
@@ -127,7 +130,7 @@ class PCIeVocabParallelArgmax:
         self.max_batch_size = int(max_batch_size)
         self._ext = ext_module or _load_extension()
         self._ipc = CudaRTLibrary()
-        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._ipc.cudaSetDevice(device_index)
         self._runtime = 0
         self._local_ptr = 0
         self._remote_ptrs: list[int] = []
@@ -154,6 +157,9 @@ class PCIeVocabParallelArgmax:
                 )
             )
         except Exception:
+            # Construction cleanup is rank-local. Mark the object closed so
+            # garbage collection cannot enter the collective close protocol.
+            self._closed = True
             for ptr in self._remote_ptrs:
                 with suppress(Exception):
                     self._ipc.cudaIpcCloseMemHandle(ptr)
@@ -282,9 +288,39 @@ class PCIeVocabParallelArgmax:
         self.close()
 
     def __del__(self) -> None:
-        if not getattr(self, "_closed", True):
+        if getattr(self, "_closed", True):
+            return
+
+        # Python garbage collection is not ordered across distributed ranks.
+        # Calling close() here could deadlock on its collective barriers, so
+        # finalization releases only resources owned by this rank. Callers
+        # must use close() or the context manager for coordinated teardown.
+        self._closed = True
+        with suppress(Exception):
+            warn(
+                "PCIeVocabParallelArgmax was garbage-collected without close(); "
+                "releasing rank-local CUDA resources without collective teardown",
+                ResourceWarning,
+                stacklevel=2,
+            )
+
+        runtime = getattr(self, "_runtime", 0)
+        self._runtime = 0
+        if runtime:
             with suppress(Exception):
-                self.close()
+                self._ext.destroy_runtime(runtime)
+
+        remote_ptrs = list(getattr(self, "_remote_ptrs", ()))
+        self._remote_ptrs = []
+        for ptr in remote_ptrs:
+            with suppress(Exception):
+                self._ipc.cudaIpcCloseMemHandle(ptr)
+
+        local_ptr = getattr(self, "_local_ptr", 0)
+        self._local_ptr = 0
+        if local_ptr:
+            with suppress(Exception):
+                self._ipc.cudaFree(local_ptr)
 
 
 __all__ = ["PCIeVocabParallelArgmax"]

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -148,10 +148,12 @@ def test_prevalidated_bind_is_fresh_and_caller_scratch_owned() -> None:
     assert first.output is kwargs["output"]
     with pytest.raises(ValueError, match="active_splits"):
         dense_mla.bind(plan, **{**kwargs, "active_splits": 0})
+    with pytest.raises(ValueError, match="scratch is smaller"):
+        dense_mla.bind(plan, **{**kwargs, "scratch": scratch[:-1]})
 
 
 def test_runtime_launch_does_not_rebuild_compile_template(monkeypatch) -> None:
-    from sparkinfer.attention.dense_mla import _kernel
+    from b12x.attention.dense_mla import _kernel
 
     signature = ("already-compiled",)
     compiled = object()
@@ -752,7 +754,7 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
 @torch.inference_mode()
 def test_fp8_dcp16_fresh_bind_matches_reference() -> None:
     """Exercise the exact 96-head/65,536-local-token DCP16 decode plan."""
-    device = require_sparkinfer()
+    device = require_b12x()
     torch.manual_seed(20260806)
     page_size = 768
     max_cache_tokens = 65_536

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 import torch
 
 from b12x.attention import dense_mla
@@ -96,6 +98,92 @@ def test_public_types_are_module_scoped_names() -> None:
     assert dense_mla.Binding.__name__ == "Binding"
     assert dense_mla.Scratch.__name__ == "Scratch"
     assert dense_mla.Budget.__name__ == "Budget"
+
+
+def test_prevalidated_bind_is_fresh_and_caller_scratch_owned() -> None:
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device="cpu",
+            mode="verify",
+            kv_dtype=torch.bfloat16,
+            num_q_heads=HEADS,
+            page_size=16,
+            max_total_q=8,
+            max_batch=1,
+            max_cache_tokens=128,
+            max_page_table_width=8,
+            num_cache_pages=8,
+        )
+    )
+    scratch = _scratch(plan)
+    kwargs = {
+        "scratch": scratch,
+        "q": torch.empty(8, HEADS, QK_DIM, dtype=torch.bfloat16),
+        "kv_cache": torch.empty(8, 16, QK_DIM, dtype=torch.bfloat16),
+        "output": torch.empty(8, HEADS, VALUE_DIM, dtype=torch.bfloat16),
+        "page_table": torch.zeros(1, 8, dtype=torch.int32),
+        "cache_seqlens": torch.tensor([128], dtype=torch.int32),
+        "cu_seqlens_q": torch.tensor([0, 8], dtype=torch.int32),
+        "active_splits": plan.num_splits,
+        "validate": False,
+    }
+
+    first = dense_mla.bind(plan, **kwargs)
+    second = dense_mla.bind(plan, **kwargs)
+
+    assert first is not second
+    assert first.scratch is not second.scratch
+    assert first.scratch.shared_scratch.data_ptr() == scratch.data_ptr()
+    assert second.scratch.shared_scratch.data_ptr() == scratch.data_ptr()
+    assert first.scratch.final_lse is not second.scratch.final_lse
+    assert first.scratch.final_lse.data_ptr() == second.scratch.final_lse.data_ptr()
+    if first.scratch.partial_output is not None:
+        assert second.scratch.partial_output is not None
+        assert first.scratch.partial_output is not second.scratch.partial_output
+        assert (
+            first.scratch.partial_output.data_ptr()
+            == second.scratch.partial_output.data_ptr()
+        )
+    assert first.q is kwargs["q"]
+    assert first.output is kwargs["output"]
+    with pytest.raises(ValueError, match="active_splits"):
+        dense_mla.bind(plan, **{**kwargs, "active_splits": 0})
+
+
+def test_runtime_launch_does_not_rebuild_compile_template(monkeypatch) -> None:
+    from sparkinfer.attention.dense_mla import _kernel
+
+    signature = ("already-compiled",)
+    compiled = object()
+    launches: list[tuple[object, tuple[object, ...]]] = []
+    binding = SimpleNamespace(
+        q=SimpleNamespace(is_cuda=True, shape=(1,)),
+        scratch=SimpleNamespace(
+            num_splits=1,
+            final_lse=torch.empty(1, HEADS),
+        ),
+        output=torch.empty(1, HEADS, VALUE_DIM),
+    )
+    monkeypatch.setattr(_kernel, "_signature", lambda _: signature)
+    monkeypatch.setattr(_kernel, "_forward_args", lambda _: ("runtime",))
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        _kernel,
+        "_forward_compile_template",
+        lambda _: pytest.fail("runtime rebuilt immutable compile metadata"),
+    )
+    monkeypatch.setattr(
+        _kernel,
+        "run_compiled",
+        lambda entry, args: launches.append((entry, args)),
+    )
+    monkeypatch.setitem(_kernel._FORWARD_CACHE, signature, compiled)
+
+    output, lse = _kernel.run_dense_mla(binding=binding)
+
+    assert launches == [(compiled, ("runtime",))]
+    assert output is binding.output
+    assert lse.data_ptr() == binding.scratch.final_lse.data_ptr()
 
 
 def test_partial_row_budget_changes_native_split_policy() -> None:
@@ -662,6 +750,76 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
 
 
 @torch.inference_mode()
+def test_fp8_dcp16_fresh_bind_matches_reference() -> None:
+    """Exercise the exact 96-head/65,536-local-token DCP16 decode plan."""
+    device = require_sparkinfer()
+    torch.manual_seed(20260806)
+    page_size = 768
+    max_cache_tokens = 65_536
+    page_width = (max_cache_tokens + page_size - 1) // page_size
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=FP8,
+            num_q_heads=96,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=max_cache_tokens,
+            max_page_table_width=page_width,
+            num_cache_pages=1,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits == 47
+
+    q_float = torch.randn(1, 96, QK_DIM, device=device) * 0.1
+    cache_float = torch.randn(1, page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    output = torch.empty(1, 96, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    scratch = _scratch(plan)
+    kwargs = {
+        "scratch": scratch,
+        "q": q,
+        "kv_cache": cache,
+        "output": output,
+        "page_table": torch.zeros(1, 1, dtype=torch.int32, device=device),
+        "cache_seqlens": torch.tensor([257], dtype=torch.int32, device=device),
+        "cu_seqlens_q": torch.tensor([0, 1], dtype=torch.int32, device=device),
+        "q_scale": q_scale,
+        "kv_scale": kv_scale,
+        "active_splits": 1,
+        "validate": False,
+    }
+    first = dense_mla.bind(plan, **kwargs)
+    binding = dense_mla.bind(plan, **kwargs)
+    assert first is not binding
+    assert first.scratch is not binding.scratch
+    assert first.scratch.partial_output is not binding.scratch.partial_output
+    assert (
+        first.scratch.partial_output.data_ptr()
+        == binding.scratch.partial_output.data_ptr()
+    )
+
+    dense_mla.compile(binding=binding)
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        kwargs["page_table"],
+        kwargs["cache_seqlens"],
+        kwargs["cu_seqlens_q"],
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
 def test_page_ids_past_int32_scaled_offset_match_reference() -> None:
     device = require_b12x()
     torch.manual_seed(20260803)
@@ -773,12 +931,15 @@ def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
         dtype=FP8,
         device=device,
     )
-    cache_float = torch.randn(
-        live_pages,
-        page_size,
-        QK_DIM,
-        device=device,
-    ) * 0.1
+    cache_float = (
+        torch.randn(
+            live_pages,
+            page_size,
+            QK_DIM,
+            device=device,
+        )
+        * 0.1
+    )
     kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
     cache[high_page:] = (cache_float / kv_scale).to(FP8)
     page_table = torch.arange(

--- a/tests/comm/test_pcie_vocab_argmax.py
+++ b/tests/comm/test_pcie_vocab_argmax.py
@@ -58,18 +58,31 @@ def test_vocab_argmax_peer_graph_is_reciprocal_and_connected() -> None:
 def test_vocab_argmax_exchanges_metadata_over_gloo(monkeypatch) -> None:
     group = MagicMock()
     monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
-    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 1)
-    monkeypatch.setattr(torch.distributed, "get_rank", lambda group: 0)
-    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda group: [0])
-    broadcasts = []
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+    exchanges = []
 
-    def fake_broadcast(objects, src, group):
-        broadcasts.append((objects, src, group))
+    def fake_all_gather(objects, local_handle, group):
+        exchanges.append((objects, local_handle, group))
+        objects[:] = [b"rank-0", b"rank-1"]
 
-    monkeypatch.setattr(torch.distributed, "broadcast_object_list", fake_broadcast)
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather)
 
-    assert _exchange_ipc_handles(b"handle", group) == [b"handle"]
-    assert broadcasts == [([b"handle"], 0, group)]
+    assert _exchange_ipc_handles(b"rank-0", group) == [b"rank-0", b"rank-1"]
+    assert exchanges == [([b"rank-0", b"rank-1"], b"rank-0", group)]
+
+
+def test_vocab_argmax_rejects_missing_gloo_handle(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+
+    def fake_all_gather(objects, local_handle, group):
+        objects[:] = [local_handle, None]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather)
+
+    with pytest.raises(RuntimeError, match="empty handle"):
+        _exchange_ipc_handles(b"rank-0", group)
 
 
 @pytest.mark.parametrize("rank", [-1, 16])

--- a/tests/comm/test_pcie_vocab_argmax.py
+++ b/tests/comm/test_pcie_vocab_argmax.py
@@ -5,10 +5,11 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from sparkinfer.comm.pcie.pcie_hierarchical import (
+from b12x.comm.pcie import pcie_vocab_argmax as vocab_argmax_module
+from b12x.comm.pcie.pcie_hierarchical import (
     _selected_peers as _allreduce_peers,
 )
-from sparkinfer.comm.pcie.pcie_vocab_argmax import (
+from b12x.comm.pcie.pcie_vocab_argmax import (
     PCIeVocabParallelArgmax,
     _exchange_ipc_handles,
     _selected_peers,
@@ -88,7 +89,7 @@ def test_vocab_argmax_wait_cycles(
     monkeypatch: pytest.MonkeyPatch,
     value: str,
 ) -> None:
-    monkeypatch.setenv("SPARKINFER_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    monkeypatch.setenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
     assert _wait_nanosleep_cycles_from_env() == int(value)
 
 
@@ -97,7 +98,7 @@ def test_vocab_argmax_rejects_invalid_wait_cycles(
     monkeypatch: pytest.MonkeyPatch,
     value: str,
 ) -> None:
-    monkeypatch.setenv("SPARKINFER_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    monkeypatch.setenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
     with pytest.raises(ValueError):
         _wait_nanosleep_cycles_from_env()
 
@@ -110,7 +111,65 @@ def _fake_runtime() -> PCIeVocabParallelArgmax:
     runtime._closed = False
     runtime._runtime = 123
     runtime._ext = MagicMock()
+    runtime._ipc = MagicMock()
+    runtime._remote_ptrs = [456]
+    runtime._local_ptr = 789
     return runtime
+
+
+def test_vocab_argmax_resolves_implicit_cuda_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = MagicMock()
+    extension = MagicMock()
+    extension.slab_bytes.return_value = 4096
+    extension.init_runtime.return_value = 123
+    ipc = MagicMock()
+    ipc.cudaMalloc.return_value = 1000
+    ipc.cudaIpcGetMemHandleBytes.return_value = b"local"
+    ipc.cudaIpcOpenMemHandleBytes.side_effect = range(2000, 2006)
+
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group: 0)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 16)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 7)
+    monkeypatch.setattr(vocab_argmax_module, "CudaRTLibrary", lambda: ipc)
+    monkeypatch.setattr(
+        vocab_argmax_module,
+        "_exchange_ipc_handles",
+        lambda local_handle, group: [local_handle] * 16,
+    )
+
+    runtime = PCIeVocabParallelArgmax(
+        exchange_group=group,
+        device="cuda",
+        local_vocab_size=16,
+        ext_module=extension,
+    )
+
+    assert runtime.device == torch.device("cuda:7")
+    ipc.cudaSetDevice.assert_called_once_with(7)
+    runtime._closed = True
+
+
+def test_vocab_argmax_destructor_never_enters_collective_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _fake_runtime()
+    runtime.group = MagicMock()
+    barrier = MagicMock()
+    monkeypatch.setattr(torch.distributed, "barrier", barrier)
+
+    with pytest.warns(ResourceWarning, match="without close"):
+        runtime.__del__()
+
+    barrier.assert_not_called()
+    runtime._ext.destroy_runtime.assert_called_once_with(123)
+    runtime._ipc.cudaIpcCloseMemHandle.assert_called_once_with(456)
+    runtime._ipc.cudaFree.assert_called_once_with(789)
+    assert runtime._closed
+    assert runtime._runtime == 0
+    assert runtime._remote_ptrs == []
+    assert runtime._local_ptr == 0
 
 
 def test_vocab_argmax_allocates_int64_output_and_dispatches() -> None:

--- a/tests/comm/test_pcie_vocab_argmax.py
+++ b/tests/comm/test_pcie_vocab_argmax.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from sparkinfer.comm.pcie.pcie_hierarchical import (
+    _selected_peers as _allreduce_peers,
+)
+from sparkinfer.comm.pcie.pcie_vocab_argmax import (
+    PCIeVocabParallelArgmax,
+    _exchange_ipc_handles,
+    _selected_peers,
+    _wait_nanosleep_cycles_from_env,
+)
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (0, (1, 2, 3, 4, 8, 12)),
+        (1, (0, 2, 3, 5, 9, 13)),
+        (6, (2, 4, 5, 7, 10, 14)),
+        (15, (3, 7, 11, 12, 13, 14)),
+    ],
+)
+def test_vocab_argmax_uses_bounded_lane_topology(
+    rank: int,
+    expected: tuple[int, ...],
+) -> None:
+    assert _selected_peers(rank) == expected
+
+
+def test_vocab_argmax_and_tp16_allreduce_union_stays_within_peer_limit() -> None:
+    for rank in range(16):
+        peers = set(_selected_peers(rank)) | set(_allreduce_peers(rank, 16))
+        assert len(peers) <= 6
+
+
+def test_vocab_argmax_peer_graph_is_reciprocal_and_connected() -> None:
+    peer_sets = {rank: set(_selected_peers(rank)) for rank in range(16)}
+    for rank, peers in peer_sets.items():
+        for peer in peers:
+            assert rank in peer_sets[peer]
+
+    reached = {0}
+    frontier = [0]
+    while frontier:
+        rank = frontier.pop()
+        for peer in peer_sets[rank] - reached:
+            reached.add(peer)
+            frontier.append(peer)
+    assert reached == set(range(16))
+
+
+def test_vocab_argmax_exchanges_metadata_over_gloo(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 1)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group: 0)
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", lambda group: [0])
+    broadcasts = []
+
+    def fake_broadcast(objects, src, group):
+        broadcasts.append((objects, src, group))
+
+    monkeypatch.setattr(torch.distributed, "broadcast_object_list", fake_broadcast)
+
+    assert _exchange_ipc_handles(b"handle", group) == [b"handle"]
+    assert broadcasts == [([b"handle"], 0, group)]
+
+
+@pytest.mark.parametrize("rank", [-1, 16])
+def test_vocab_argmax_rejects_invalid_rank(rank: int) -> None:
+    with pytest.raises(ValueError, match="requires TP16"):
+        _selected_peers(rank)
+
+
+@pytest.mark.parametrize("world_size", [1, 8, 12, 32])
+def test_vocab_argmax_rejects_non_tp16_world(world_size: int) -> None:
+    with pytest.raises(ValueError, match="requires TP16"):
+        _selected_peers(0, world_size)
+
+
+@pytest.mark.parametrize("value", ["0", "24", "1024"])
+def test_vocab_argmax_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    assert _wait_nanosleep_cycles_from_env() == int(value)
+
+
+@pytest.mark.parametrize("value", ["-1", "1025", "bad"])
+def test_vocab_argmax_rejects_invalid_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("SPARKINFER_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    with pytest.raises(ValueError):
+        _wait_nanosleep_cycles_from_env()
+
+
+def _fake_runtime() -> PCIeVocabParallelArgmax:
+    runtime = PCIeVocabParallelArgmax.__new__(PCIeVocabParallelArgmax)
+    runtime.device = torch.device("cpu")
+    runtime.local_vocab_size = 16
+    runtime.max_batch_size = 8
+    runtime._closed = False
+    runtime._runtime = 123
+    runtime._ext = MagicMock()
+    return runtime
+
+
+def test_vocab_argmax_allocates_int64_output_and_dispatches() -> None:
+    runtime = _fake_runtime()
+    base = torch.randn(4, 16, dtype=torch.bfloat16)
+    bias = torch.randn_like(base)
+
+    output = runtime.fused_add_argmax(base, bias)
+
+    assert output.shape == (4,)
+    assert output.dtype == torch.int64
+    runtime._ext.fused_add_argmax.assert_called_once_with(
+        123,
+        base,
+        bias,
+        output,
+    )
+
+
+def test_vocab_argmax_accepts_row_strided_inputs() -> None:
+    runtime = _fake_runtime()
+    base_storage = torch.randn(4, 3, 16, dtype=torch.bfloat16)
+    bias_storage = torch.randn(4, 5, 16, dtype=torch.bfloat16)
+    base = base_storage[:, 1]
+    bias = bias_storage[:, 3]
+
+    assert not base.is_contiguous()
+    assert not bias.is_contiguous()
+    output = runtime.fused_add_argmax(base, bias)
+
+    runtime._ext.fused_add_argmax.assert_called_once_with(
+        123,
+        base,
+        bias,
+        output,
+    )
+
+
+def test_vocab_argmax_rejects_noncontiguous_last_dimension() -> None:
+    base = torch.zeros(1, 32, dtype=torch.bfloat16)[:, ::2]
+    bias = torch.zeros_like(base)
+
+    with pytest.raises(ValueError, match="last dimensions"):
+        _fake_runtime().fused_add_argmax(base, bias)
+
+
+@pytest.mark.parametrize(
+    ("base", "bias", "error"),
+    [
+        (
+            torch.zeros(1, 16, dtype=torch.float32),
+            torch.zeros(1, 16, dtype=torch.float32),
+            "BF16",
+        ),
+        (
+            torch.zeros(1, 15, dtype=torch.bfloat16),
+            torch.zeros(1, 15, dtype=torch.bfloat16),
+            "local vocabulary",
+        ),
+        (
+            torch.zeros(9, 16, dtype=torch.bfloat16),
+            torch.zeros(9, 16, dtype=torch.bfloat16),
+            "capacity",
+        ),
+        (
+            torch.zeros(1, 16, dtype=torch.bfloat16),
+            torch.zeros(2, 16, dtype=torch.bfloat16),
+            "matching",
+        ),
+    ],
+)
+def test_vocab_argmax_validates_inputs(
+    base: torch.Tensor,
+    bias: torch.Tensor,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _fake_runtime().fused_add_argmax(base, bias)


### PR DESCRIPTION
## Status

**Qualified** for Kimi-K3 TP16/DCP16 integration when paired with `local-inference-lab/vllm#242`. The implementation provides fresh dense-MLA bindings and exact distributed vocabulary argmax for a 16-GPU PCIe topology.

## Resulting behavior

- `dense_mla.Plan.bind(validate=False)` skips capture-static dtype, layout, and device queries while retaining the scratch-capacity check required before `as_strided`.
- Every dense-MLA execution receives a fresh binding backed by caller-owned scratch. Immutable compile metadata may be cached; ownership-bearing bindings, tensor views, and workspaces are not cached.
- `VocabParallelArgmax` fuses BF16-rounded local base-plus-bias addition with exact global greedy argmax.
- Each TP16 rank maps the three peers in its four-GPU island and the same lane in the other three islands, keeping the union with the island all-reduce topology within six peer mappings.
- NCCL metadata exchange uses the B12X tensor-based object path. Gloo metadata exchange uses one `all_gather_object` collective and rejects an empty returned handle.
- Construction failure and Python finalization release rank-local resources only. `close()` and context-manager exit remain collective operations and must run coherently on every rank.
- The `pcie_vocab_argmax.cu` extension is JIT-built on first use. Dense-MLA execution remains implemented with CuTe DSL.

## Interfaces and limits

- Public API: `b12x.comm.pcie.VocabParallelArgmax`.
- Vocabulary argmax supports TP16 and batch sizes 1 through 8.
- `validate=False` is valid only after the framework has established the capture-static tensor contract.
- Explicit coordinated teardown is required; the destructor performs no distributed barrier.

## Validation

- Vocabulary argmax host-side contract suite: 29 passed.
- Dense-MLA and vocabulary argmax qualification suite at the preceding review commit: 32 passed, 10 CUDA-dependent tests skipped.
- Full Kimi-K3 startup exercised the Gloo handle exchange, dense-MLA bindings, M=8 speculative graph, and M=1 no-draft graph across 16 ranks.
- `ruff check`, `ruff format --check`, and `git diff --check` pass for the modified files.

## Related runtime PRs

- `local-inference-lab/vllm#242`: Kimi-K3 TP16/DCP16 runtime.
- `local-inference-lab/b12x#138`: TP16 pair gather and exact top-16 routing.
- `local-inference-lab/b12x#139`: size-routed TP16 island reduce-scatter.
- `local-inference-lab/b12x#141` is not part of the qualified Docker composition.

## Review disclosure

Implementation and PR text were AI-assisted. Human review is required before merge.
