### PR TITLE
perf(dcp-a2a): block-wide top-16 in the fused Kimi pair gather (320 -> 27.8 us)

### DIFF
--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1253,6 +1253,13 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
+                # Per-thread partial argmax for the block-wide top-16 below.
+                reduce_scores: cute.struct.Align[
+                    cute.struct.MemRange[Float32, 512], 16
+                ]
+                reduce_ids: cute.struct.Align[
+                    cute.struct.MemRange[Int32, 512], 16
+                ]
 
             storage = smem_alloc.allocate(SharedStorage)
             selection_scores = storage.selection_scores.get_tensor(
@@ -1260,6 +1267,12 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
+            )
+            reduce_scores = storage.reduce_scores.get_tensor(
+                cute.make_layout((512,), stride=(1,))
+            )
+            reduce_ids = storage.reduce_ids.get_tensor(
+                cute.make_layout((512,), stride=(1,))
             )
 
             expert = Int32(tidx)
@@ -1306,43 +1319,62 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            if Int32(tidx) == Int32(0):
-                selected_ids = cute.make_rmem_tensor((16,), Int32)
-                selected_weights = cute.make_rmem_tensor((16,), Float32)
-                for selected in cutlass.range_constexpr(16):
-                    selected_ids[selected] = Int32(-1)
-                    selected_weights[selected] = Float32(0.0)
-                weight_sum = Float32(0.0)
-                for selected in cutlass.range_constexpr(16):
-                    best_score = Float32(float("-inf"))
-                    best_expert = Int32(-1)
-                    candidate = Int32(0)
-                    while candidate < Int32(896):
-                        already_selected = False
-                        for prior in cutlass.range_constexpr(selected):
-                            if selected_ids[prior] == candidate:
-                                already_selected = True
-                        score = selection_scores[candidate]
-                        if not already_selected:
-                            if (
-                                score > best_score
-                                or (
-                                    score == best_score
-                                    and (
-                                        best_expert < Int32(0)
-                                        or candidate < best_expert
-                                    )
-                                )
+            # Block-wide top-16 selection. The previous implementation ran
+            # this on thread 0 alone: 16 rounds x 896 candidates x up to 15
+            # prior-selection checks, about 1e5 serial steps per row, which
+            # made this kernel 320 us against 39 us for the C++ original.
+            # Each round now argmaxes across every thread and masks the winner
+            # with -inf, the same scheme the C++ kernel used.
+            selected_ids = cute.make_rmem_tensor((16,), Int32)
+            selected_weights = cute.make_rmem_tensor((16,), Float32)
+            for selected in cutlass.range_constexpr(16):
+                selected_ids[selected] = Int32(-1)
+                selected_weights[selected] = Float32(0.0)
+            weight_sum = Float32(0.0)
+            for selected in cutlass.range_constexpr(16):
+                local_best = Float32(float("-inf"))
+                local_id = Int32(-1)
+                candidate = Int32(tidx)
+                while candidate < Int32(896):
+                    score = selection_scores[candidate]
+                    if score > local_best or (
+                        score == local_best
+                        and (local_id < Int32(0) or candidate < local_id)
+                    ):
+                        local_best = score
+                        local_id = candidate
+                    candidate += Int32(self._threads)
+                reduce_scores[tidx] = local_best
+                reduce_ids[tidx] = local_id
+                cute.arch.sync_threads()
+                stride = Int32(self._threads // 2)
+                while stride > Int32(0):
+                    if Int32(tidx) < stride:
+                        other_score = reduce_scores[tidx + stride]
+                        other_id = reduce_ids[tidx + stride]
+                        this_score = reduce_scores[tidx]
+                        this_id = reduce_ids[tidx]
+                        if other_id >= Int32(0):
+                            if other_score > this_score or (
+                                other_score == this_score
+                                and (this_id < Int32(0) or other_id < this_id)
                             ):
-                                best_score = score
-                                best_expert = candidate
-                        candidate += Int32(1)
-                    selected_ids[selected] = best_expert
-                    weight = Float32(0.0)
+                                reduce_scores[tidx] = other_score
+                                reduce_ids[tidx] = other_id
+                    cute.arch.sync_threads()
+                    stride = stride // Int32(2)
+                best_expert = reduce_ids[0]
+                selected_ids[selected] = best_expert
+                weight = Float32(0.0)
+                if best_expert >= Int32(0):
+                    weight = unbiased_scores[best_expert]
+                selected_weights[selected] = weight
+                weight_sum += weight
+                if Int32(tidx) == Int32(0):
                     if best_expert >= Int32(0):
-                        weight = unbiased_scores[best_expert]
-                    selected_weights[selected] = weight
-                    weight_sum += weight
+                        selection_scores[best_expert] = Float32(float("-inf"))
+                cute.arch.sync_threads()
+            if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):
                     cute.arch.store(


### PR DESCRIPTION
The CuTe DSL rewrite of `all_gather_pair_kimi_topk` runs its top-16 selection on **thread 0 alone**: 16 rounds over 896 candidates, each rescanning up to 15 already-selected ids, roughly 1e5 serial steps per row. Every round now argmaxes across the whole block through a shared scratch reduction and masks the winner with `-inf`, which is the scheme the C++ kernel it replaced used.

### Measurements

Model-free, `benchmarks/benchmark_kimi_k3_pair_topk.py --world-size 16` (batch 8, 16x RTX PRO 6000 Blackwell on PCIe):

| kernel | C++ (pre-migration) | CuTe before | CuTe after |
|---|---|---|---|
| fused pair gather + top-16 | 38.87 us | **320.11 us** | **27.82 us** |
| reference (unfused) path | 41.31 us | 18.35 us | 18.24 us |

Kimi-K3 calls this once per MoE layer, so at 92 layers the old cost was 28.4 ms per decoded token. End to end on the full MXFP4 target at TP16/DCP16, decode without speculation:

| | tok/s |
|---|---|
| pre-migration C++ b12x | 52.616 |
| CuTe b12x before this fix | 20.907 |
| CuTe b12x with this fix | 47.376 |

**This does not close the regression.** The kernel is now faster than the C++ one it replaced, but end to end the CuTe stack is still about 10% behind the pre-migration baseline (47.4 vs 52.6 tok/s), so at least one more cost remains elsewhere in the migrated path. This PR is one step, not the fix.

### Correctness

`benchmark_kimi_k3_pair_topk.py` compares against the HH native reference across its random, near-ties and wide cases. Selected ids and the gathered down projection stay bit-exact, before and after this change. The 7.45e-09 difference in the normalized weights is pre-existing in this CuTe path (float summation order in the normalization) and is unchanged here.

### Note

`_AllGatherPairLaunch` still launches with `grid=(1, 1, 1)` while every other launch in `_dcp_a2a_cute.py` uses `grid=(grid_x, 1, 1)`, and the C++ kernel used `<<<batch, threads>>>`. Parallelizing the batch across CTAs is a further lever this PR does not touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved top-k expert selection with parallel processing for faster and more efficient routing.
  * Added deterministic tie-breaking to ensure consistent expert selection when scores are equal.
  * Enhanced selection handling across multiple rounds while preserving existing weight accumulation and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
