### PR TITLE
perf(pcie): add topology-scoped fused all-reduce paths

### DIFF
--- a/b12x/comm/pcie/_cute_intrinsics.py
+++ b/b12x/comm/pcie/_cute_intrinsics.py
@@ -18,6 +18,25 @@ from cutlass.cutlass_dsl import T, dsl_user_op
 
 
 @dsl_user_op
+def f32_as_u32(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Bitcast float32 to uint32 without numeric conversion."""
+
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
 def ld_global_u64(addr: Int64, *, loc=None, ip=None) -> Uint64:
     return Uint64(
         llvm.inline_asm(
@@ -195,9 +214,7 @@ def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32
 
 
 @dsl_user_op
-def pack_f32x2_to_f16x2(
-    lo: Float32, hi: Float32, *, loc=None, ip=None
-) -> Uint32:
+def pack_f32x2_to_f16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
     return Uint32(
         llvm.inline_asm(
             T.i32(),
@@ -217,9 +234,7 @@ def pack_f32x2_to_f16x2(
 
 
 @dsl_user_op
-def pack_f32x2_to_bf16x2(
-    lo: Float32, hi: Float32, *, loc=None, ip=None
-) -> Uint32:
+def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
     """Match two scalar ``__float2bfloat16`` conversions without saturation."""
     return Uint32(
         llvm.inline_asm(
@@ -313,9 +328,7 @@ def ld_relaxed_gpu_u32(addr: Int64, *, loc=None, ip=None) -> Uint32:
 
 
 @dsl_user_op
-def atomic_add_global_u32(
-    addr: Int64, value: Uint32, *, loc=None, ip=None
-) -> Uint32:
+def atomic_add_global_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> Uint32:
     return Uint32(
         llvm.inline_asm(
             T.i32(),

--- a/b12x/comm/pcie/_oneshot_cute.py
+++ b/b12x/comm/pcie/_oneshot_cute.py
@@ -30,6 +30,7 @@ from b12x._lib.utils import current_cuda_stream, make_ptr
 
 from ._cute_intrinsics import (
     atomic_add_global_u32,
+    f32_as_u32,
     graph_epoch_arrive,
     ld_global_f32,
     ld_relaxed_gpu_u32,
@@ -108,9 +109,7 @@ class _PackedMath:
                     accumulator[lane + 1] = accumulator[lane + 1] + hi
 
     @cute.jit
-    def _store_accumulator(
-        self, address: Int64, accumulator: cute.Tensor
-    ) -> None:
+    def _store_accumulator(self, address: Int64, accumulator: cute.Tensor) -> None:
         if cutlass.const_expr(self._dtype_name == "float32"):
             st_global_v4_f32(
                 address,
@@ -131,16 +130,12 @@ class _PackedMath:
                     packed[word] = pack_f32x2_to_bf16x2(
                         accumulator[lane], accumulator[lane + 1]
                     )
-            st_global_v4_u32(
-                address, packed[0], packed[1], packed[2], packed[3]
-            )
+            st_global_v4_u32(address, packed[0], packed[1], packed[2], packed[3])
 
     @cute.jit
     def _copy_pack(self, source: Int64, destination: Int64) -> None:
         words = ld_global_v4_u32(source)
-        st_global_v4_u32(
-            destination, words[0], words[1], words[2], words[3]
-        )
+        st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
 
     @cute.jit
     def _warp_reduce_down(self, value: Float32) -> Float32:
@@ -204,14 +199,24 @@ class _OneshotLaunch(_PackedMath):
             self_counter = self_signal + (
                 Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
             ) * Int64(4)
-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
-                + Int64(self._rank * _FLAG_STRIDE)
-            ) * Int64(4)
-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
-                + Int64(tidx) * Int64(_FLAG_STRIDE)
-            ) * Int64(4)
+            peer_slot0 = (
+                peer_signal
+                + Int64(_SELF_COUNTER_BYTES)
+                + (
+                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+                    + Int64(self._rank * _FLAG_STRIDE)
+                )
+                * Int64(4)
+            )
+            wait_slot0 = (
+                self_signal
+                + Int64(_SELF_COUNTER_BYTES)
+                + (
+                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+                    + Int64(tidx) * Int64(_FLAG_STRIDE)
+                )
+                * Int64(4)
+            )
             pcie_arrive_and_wait(
                 self_counter,
                 peer_slot0,
@@ -258,9 +263,7 @@ class _OneshotLaunch(_PackedMath):
         self._multi_gpu_barrier(signal_ptrs)
 
         while index < size_packs:
-            accumulator = cute.make_rmem_tensor(
-                (self._pack_elems,), cutlass.Float32
-            )
+            accumulator = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
             for peer_index in cutlass.range_constexpr(self._world_size):
                 peer_rank = (self._rank + peer_index) % self._world_size
                 peer_base = Int64(peer_ptrs[peer_rank])
@@ -269,9 +272,7 @@ class _OneshotLaunch(_PackedMath):
                     peer_base + Int64(index) * Int64(16),
                     peer_index == 0,
                 )
-            self._store_accumulator(
-                output_base + Int64(index) * Int64(16), accumulator
-            )
+            self._store_accumulator(output_base + Int64(index) * Int64(16), accumulator)
             index += stride
 
         if cutlass.const_expr(self._device_slot_selection):
@@ -298,8 +299,18 @@ class _FusedOneshotLaunch(_PackedMath):
         threads: int,
     ) -> None:
         super().__init__(dtype_name)
-        if mode not in ("registered", "stage_pull", "stage_push"):
+        if mode not in (
+            "registered",
+            "stage_pull",
+            "stage_push",
+            "stage_remote_push",
+            "stage_tp8_owner",
+        ):
             raise ValueError(f"invalid fused oneshot mode {mode!r}")
+        if mode == "stage_remote_push" and world_size not in (2, 4):
+            raise ValueError("fused remote push requires TP2 or TP4")
+        if mode == "stage_tp8_owner" and world_size != 8:
+            raise ValueError("fused owner transport requires TP8")
         self._world_size = int(world_size)
         self._rank = int(rank)
         self._mode = mode
@@ -308,6 +319,10 @@ class _FusedOneshotLaunch(_PackedMath):
         self._device_slot_selection = bool(device_slot_selection)
         self._slot_bias = int(slot_bias) & 1
         self._threads = int(threads)
+        # C1 uses the ordinary staged protocol while C2-C8 use three scoped
+        # phases. Keep their reusable barrier generations in separate rank
+        # slots when one graph-owned channel alternates between those shapes.
+        self._barrier_rank_offset = 8 if mode == "stage_tp8_owner" else 0
 
     @cute.jit
     def __call__(
@@ -348,31 +363,73 @@ class _FusedOneshotLaunch(_PackedMath):
         )
 
     @cute.jit
+    def _pair_arrive_and_wait(
+        self,
+        signal_ptrs: cute.Pointer,
+        peer_rank: Int32,
+    ) -> None:
+        bidx, _, _ = cute.arch.block_idx()
+        barrier_peer = peer_rank + Int32(self._barrier_rank_offset)
+        self_signal = Int64(signal_ptrs[self._rank])
+        peer_signal = Int64(signal_ptrs[peer_rank])
+        self_counter = self_signal + (
+            Int64(bidx) * Int64(_MAX_RANKS) + Int64(barrier_peer)
+        ) * Int64(4)
+        peer_slot0 = (
+            peer_signal
+            + Int64(_SELF_COUNTER_BYTES)
+            + (
+                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+                + Int64((self._rank + self._barrier_rank_offset) * _FLAG_STRIDE)
+            )
+            * Int64(4)
+        )
+        wait_slot0 = (
+            self_signal
+            + Int64(_SELF_COUNTER_BYTES)
+            + (
+                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+                + Int64(barrier_peer) * Int64(_FLAG_STRIDE)
+            )
+            * Int64(4)
+        )
+        pcie_arrive_and_wait(
+            self_counter,
+            peer_slot0,
+            wait_slot0,
+            Int64(_PEER_SLOT_BYTES),
+        )
+
+    @cute.jit
     def _multi_gpu_barrier(self, signal_ptrs: cute.Pointer) -> None:
         tidx, _, _ = cute.arch.thread_idx()
-        bidx, _, _ = cute.arch.block_idx()
         if cutlass.const_expr(self._mode != "registered"):
             cute.arch.sync_threads()
         if tidx < Int32(self._world_size):
-            self_signal = Int64(signal_ptrs[self._rank])
-            peer_signal = Int64(signal_ptrs[tidx])
-            self_counter = self_signal + (
-                Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
-            ) * Int64(4)
-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
-                + Int64(self._rank * _FLAG_STRIDE)
-            ) * Int64(4)
-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
-                + Int64(tidx) * Int64(_FLAG_STRIDE)
-            ) * Int64(4)
-            pcie_arrive_and_wait(
-                self_counter,
-                peer_slot0,
-                wait_slot0,
-                Int64(_PEER_SLOT_BYTES),
-            )
+            self._pair_arrive_and_wait(signal_ptrs, Int32(tidx))
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _tp8_island_barrier(self, signal_ptrs: cute.Pointer) -> None:
+        """Publish and acquire payloads within one four-rank island."""
+
+        tidx, _, _ = cute.arch.thread_idx()
+        island_base = Int32(0 if self._rank < 4 else 4)
+        cute.arch.sync_threads()
+        if tidx < Int32(4):
+            peer_rank = island_base + Int32(tidx)
+            if peer_rank != Int32(self._rank):
+                self._pair_arrive_and_wait(signal_ptrs, peer_rank)
+        cute.arch.sync_threads()
+
+    @cute.jit
+    def _tp8_owner_pair_barrier(self, signal_ptrs: cute.Pointer) -> None:
+        """Publish and acquire one FP32 partial between paired owners."""
+
+        tidx, _, _ = cute.arch.thread_idx()
+        cute.arch.sync_threads()
+        if Int32(tidx) == Int32(0):
+            self._pair_arrive_and_wait(signal_ptrs, Int32(self._rank ^ 4))
         cute.arch.sync_threads()
 
     @cute.jit
@@ -381,6 +438,7 @@ class _FusedOneshotLaunch(_PackedMath):
         peer_ptrs: cute.Pointer,
         input_base: Int64,
         index: Int64,
+        total_packs: Int64,
         shard_packs: Int64,
     ) -> None:
         if cutlass.const_expr(self._mode == "stage_pull"):
@@ -388,7 +446,9 @@ class _FusedOneshotLaunch(_PackedMath):
                 input_base + index * Int64(16),
                 Int64(peer_ptrs[self._rank]) + index * Int64(16),
             )
-        elif cutlass.const_expr(self._mode == "stage_push"):
+        elif cutlass.const_expr(
+            self._mode == "stage_push" or self._mode == "stage_remote_push"
+        ):
             source = input_base + index * Int64(16)
             words = ld_global_v4_u32(source)
             for peer_index in cutlass.range_constexpr(1, self._world_size):
@@ -396,8 +456,135 @@ class _FusedOneshotLaunch(_PackedMath):
                 destination = Int64(peer_ptrs[destination_rank]) + (
                     Int64(self._rank) * shard_packs + index
                 ) * Int64(16)
+                st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
+        elif cutlass.const_expr(self._mode == "stage_tp8_owner"):
+            part = total_packs // Int64(4)
+            chunk = index // part
+            if chunk > Int64(3):
+                chunk = Int64(3)
+            island_base = Int64(0 if self._rank < 4 else 4)
+            owner_rank = island_base + chunk
+            destination = Int64(peer_ptrs[owner_rank]) + (
+                Int64(self._rank) * shard_packs + index
+            ) * Int64(16)
+            words = ld_global_v4_u32(input_base + index * Int64(16))
+            st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
+
+    @cute.jit
+    def _tp8_publish_local_partial(
+        self,
+        peer_ptrs: cute.Pointer,
+        index: Int64,
+        total_packs: Int64,
+        shard_packs: Int64,
+    ) -> None:
+        part = total_packs // Int64(4)
+        chunk = index // part
+        if chunk > Int64(3):
+            chunk = Int64(3)
+        island_base = 0 if self._rank < 4 else 4
+        owner_rank = Int32(island_base) + Int32(chunk)
+        if Int32(self._rank) == owner_rank:
+            local_stage = Int64(peer_ptrs[self._rank])
+            local_sum = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+            for peer_local in cutlass.range_constexpr(4):
+                source_rank = island_base + peer_local
+                self._load_accumulate(
+                    local_sum,
+                    local_stage
+                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
+                    peer_local == 0,
+                )
+
+            low = (
+                f32_as_u32(local_sum[0]),
+                f32_as_u32(local_sum[1]),
+                f32_as_u32(local_sum[2]),
+                f32_as_u32(local_sum[3]),
+            )
+            high = (
+                f32_as_u32(local_sum[4]),
+                f32_as_u32(local_sum[5]),
+                f32_as_u32(local_sum[6]),
+                f32_as_u32(local_sum[7]),
+            )
+            cross_owner = self._rank ^ 4
+            for destination_rank in (self._rank, cross_owner):
+                destination_stage = Int64(peer_ptrs[destination_rank])
                 st_global_v4_u32(
-                    destination, words[0], words[1], words[2], words[3]
+                    destination_stage
+                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
+                    low[0],
+                    low[1],
+                    low[2],
+                    low[3],
+                )
+                st_global_v4_u32(
+                    destination_stage
+                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
+                    high[0],
+                    high[1],
+                    high[2],
+                    high[3],
+                )
+
+    @cute.jit
+    def _tp8_publish_final(
+        self,
+        peer_ptrs: cute.Pointer,
+        index: Int64,
+        total_packs: Int64,
+        shard_packs: Int64,
+    ) -> None:
+        part = total_packs // Int64(4)
+        chunk = index // part
+        if chunk > Int64(3):
+            chunk = Int64(3)
+        island_base = 0 if self._rank < 4 else 4
+        owner_rank = Int32(island_base) + Int32(chunk)
+        if Int32(self._rank) == owner_rank:
+            local_stage = Int64(peer_ptrs[self._rank])
+            cross_owner = self._rank ^ 4
+            local_low = ld_global_v4_u32(
+                local_stage + (Int64(self._rank) * shard_packs + index) * Int64(16)
+            )
+            local_high = ld_global_v4_u32(
+                local_stage + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16)
+            )
+            cross_low = ld_global_v4_u32(
+                local_stage + (Int64(cross_owner) * shard_packs + index) * Int64(16)
+            )
+            cross_high = ld_global_v4_u32(
+                local_stage + (Int64(cross_owner ^ 1) * shard_packs + index) * Int64(16)
+            )
+            final_low = cute.make_rmem_tensor((4,), cutlass.Uint32)
+            final_high = cute.make_rmem_tensor((4,), cutlass.Uint32)
+            for lane in cutlass.range_constexpr(4):
+                final_low[lane] = f32_as_u32(
+                    u32_as_f32(local_low[lane]) + u32_as_f32(cross_low[lane])
+                )
+                final_high[lane] = f32_as_u32(
+                    u32_as_f32(local_high[lane]) + u32_as_f32(cross_high[lane])
+                )
+
+            for peer_local in cutlass.range_constexpr(4):
+                destination_rank = island_base + peer_local
+                destination_stage = Int64(peer_ptrs[destination_rank])
+                st_global_v4_u32(
+                    destination_stage
+                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
+                    final_low[0],
+                    final_low[1],
+                    final_low[2],
+                    final_low[3],
+                )
+                st_global_v4_u32(
+                    destination_stage
+                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
+                    final_high[0],
+                    final_high[1],
+                    final_high[2],
+                    final_high[3],
                 )
 
     @cute.jit
@@ -407,10 +594,44 @@ class _FusedOneshotLaunch(_PackedMath):
         input_base: Int64,
         residual_base: Int64,
         index: Int64,
+        total_packs: Int64,
         shard_packs: Int64,
         accumulator: cute.Tensor,
     ) -> None:
-        if cutlass.const_expr(self._mode == "stage_push"):
+        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
+            part = total_packs // Int64(4)
+            chunk = index // part
+            if chunk > Int64(3):
+                chunk = Int64(3)
+            island_base = Int64(0 if self._rank < 4 else 4)
+            owner_rank = island_base + chunk
+            local_stage = Int64(peer_ptrs[self._rank])
+            low = ld_global_v4_u32(
+                local_stage + (owner_rank * shard_packs + index) * Int64(16)
+            )
+            high = ld_global_v4_u32(
+                local_stage
+                + ((owner_rank ^ Int64(1)) * shard_packs + index) * Int64(16)
+            )
+            for lane in cutlass.range_constexpr(4):
+                accumulator[lane] = u32_as_f32(low[lane])
+                accumulator[lane + 4] = u32_as_f32(high[lane])
+        elif cutlass.const_expr(self._mode == "stage_remote_push"):
+            self._load_accumulate(
+                accumulator,
+                input_base + index * Int64(16),
+                True,
+            )
+            local_stage = Int64(peer_ptrs[self._rank])
+            for peer_index in cutlass.range_constexpr(1, self._world_size):
+                source_rank = (self._rank + peer_index) % self._world_size
+                self._load_accumulate(
+                    accumulator,
+                    local_stage
+                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
+                    False,
+                )
+        elif cutlass.const_expr(self._mode == "stage_push"):
             self._load_accumulate(
                 accumulator,
                 input_base + index * Int64(16),
@@ -423,10 +644,7 @@ class _FusedOneshotLaunch(_PackedMath):
                     self._load_accumulate(
                         accumulator,
                         local_stage
-                        + (
-                            Int64(source_rank) * shard_packs + index
-                        )
-                        * Int64(16),
+                        + (Int64(source_rank) * shard_packs + index) * Int64(16),
                         not initialized,
                     )
                     initialized = True
@@ -480,7 +698,6 @@ class _FusedOneshotLaunch(_PackedMath):
         shard_packs: Int64,
         epsilon: Float32,
     ) -> None:
-        del rows
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
         gdim, _, _ = cute.arch.grid_dim()
@@ -494,6 +711,7 @@ class _FusedOneshotLaunch(_PackedMath):
             col_stride = ctas_per_row * Int32(self._threads)
         col0 = row_cta * Int32(self._threads) + Int32(tidx)
         row_offset = Int64(row) * Int64(hidden_packs)
+        total_packs = Int64(rows) * Int64(hidden_packs)
 
         input_base = Int64(input_ptr.toint())
         residual_base = Int64(residual_ptr.toint())
@@ -502,9 +720,7 @@ class _FusedOneshotLaunch(_PackedMath):
         residual_output_base = Int64(residual_output_ptr.toint())
         self_signal = Int64(signal_ptrs[self._rank])
         if cutlass.const_expr(self._device_slot_selection):
-            generation = ld_relaxed_gpu_u32(
-                self_signal + Int64(_GRAPH_EPOCH_OFFSET)
-            )
+            generation = ld_relaxed_gpu_u32(self_signal + Int64(_GRAPH_EPOCH_OFFSET))
             slot = (generation + Uint32(self._slot_bias)) % Uint32(2)
             peer_ptrs = peer_ptrs + Int64(slot) * Int64(_MAX_RANKS)
 
@@ -535,6 +751,7 @@ class _FusedOneshotLaunch(_PackedMath):
                         peer_ptrs,
                         input_base,
                         row_offset + Int64(col),
+                        total_packs,
                         shard_packs,
                     )
         elif cutlass.const_expr(self._mode != "registered"):
@@ -544,16 +761,39 @@ class _FusedOneshotLaunch(_PackedMath):
                     peer_ptrs,
                     input_base,
                     row_offset + Int64(col),
+                    total_packs,
                     shard_packs,
                 )
                 col += col_stride
 
-        self._multi_gpu_barrier(signal_ptrs)
+        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
+            self._tp8_island_barrier(signal_ptrs)
+            col = col0
+            while col < hidden_packs:
+                self._tp8_publish_local_partial(
+                    peer_ptrs,
+                    row_offset + Int64(col),
+                    total_packs,
+                    shard_packs,
+                )
+                col += col_stride
+            self._tp8_owner_pair_barrier(signal_ptrs)
+
+            col = col0
+            while col < hidden_packs:
+                self._tp8_publish_final(
+                    peer_ptrs,
+                    row_offset + Int64(col),
+                    total_packs,
+                    shard_packs,
+                )
+                col += col_stride
+            self._tp8_island_barrier(signal_ptrs)
+        else:
+            self._multi_gpu_barrier(signal_ptrs)
 
         square_sum = Float32(0.0)
-        values = cute.make_rmem_tensor(
-            (_REG_PACKS, self._pack_elems), cutlass.Float32
-        )
+        values = cute.make_rmem_tensor((_REG_PACKS, self._pack_elems), cutlass.Float32)
         if cutlass.const_expr(self._register_normalize):
             for pack_number in cutlass.range_constexpr(_REG_PACKS):
                 col = col0 + Int32(pack_number) * col_stride
@@ -567,6 +807,7 @@ class _FusedOneshotLaunch(_PackedMath):
                         input_base,
                         residual_base,
                         index,
+                        total_packs,
                         shard_packs,
                         accumulator,
                     )
@@ -589,6 +830,7 @@ class _FusedOneshotLaunch(_PackedMath):
                     input_base,
                     residual_base,
                     index,
+                    total_packs,
                     shard_packs,
                     accumulator,
                 )
@@ -604,38 +846,28 @@ class _FusedOneshotLaunch(_PackedMath):
         hidden_size_f = Float32(hidden_packs * Int32(self._pack_elems))
         if cutlass.const_expr(self._single_cta):
             if Int32(tidx) == Int32(0):
-                inv_rms_smem[0] = rsqrt_approx_f32(
-                    square_sum / hidden_size_f + epsilon
-                )
+                inv_rms_smem[0] = rsqrt_approx_f32(square_sum / hidden_size_f + epsilon)
         else:
             if Int32(tidx) == Int32(0):
                 st_global_f32(
-                    self_signal
-                    + Int64(_RMS_PARTIAL_OFFSET)
-                    + Int64(bidx) * Int64(4),
+                    self_signal + Int64(_RMS_PARTIAL_OFFSET) + Int64(bidx) * Int64(4),
                     square_sum,
                 )
                 threadfence_gpu()
                 arrive_address = (
-                    self_signal
-                    + Int64(_RMS_ARRIVE_OFFSET)
-                    + Int64(row) * Int64(4)
+                    self_signal + Int64(_RMS_ARRIVE_OFFSET) + Int64(row) * Int64(4)
                 )
                 prior = atomic_add_global_u32(arrive_address, Uint32(1))
                 if prior == Uint32(ctas_per_row - Int32(1)):
                     st_global_u32(arrive_address, Uint32(0))
                     threadfence_gpu()
                     atomic_add_global_u32(
-                        self_signal
-                        + Int64(_RMS_GEN_OFFSET)
-                        + Int64(row) * Int64(4),
+                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
                         Uint32(1),
                     )
                 else:
                     spin_until_changed_acquire_gpu(
-                        self_signal
-                        + Int64(_RMS_GEN_OFFSET)
-                        + Int64(row) * Int64(4),
+                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
                         row_generation,
                     )
             cute.arch.sync_threads()
@@ -646,10 +878,7 @@ class _FusedOneshotLaunch(_PackedMath):
                     partial = partial + ld_global_f32(
                         self_signal
                         + Int64(_RMS_PARTIAL_OFFSET)
-                        + (
-                            Int64(row) * Int64(ctas_per_row)
-                            + Int64(partial_index)
-                        )
+                        + (Int64(row) * Int64(ctas_per_row) + Int64(partial_index))
                         * Int64(4)
                     )
                     partial_index += Int32(32)
@@ -665,9 +894,7 @@ class _FusedOneshotLaunch(_PackedMath):
             for pack_number in cutlass.range_constexpr(_REG_PACKS):
                 col = col0 + Int32(pack_number) * col_stride
                 if col < hidden_packs:
-                    scale = cute.make_rmem_tensor(
-                        (self._pack_elems,), cutlass.Float32
-                    )
+                    scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
                     self._load_accumulate(
                         scale, weight_base + Int64(col) * Int64(16), True
                     )
@@ -675,38 +902,28 @@ class _FusedOneshotLaunch(_PackedMath):
                         (self._pack_elems,), cutlass.Float32
                     )
                     for lane in cutlass.range_constexpr(self._pack_elems):
-                        normalized[lane] = (
-                            values[pack_number, lane]
-                            * (inv_rms * scale[lane])
+                        normalized[lane] = values[pack_number, lane] * (
+                            inv_rms * scale[lane]
                         )
                     self._store_accumulator(
-                        output_base
-                        + (row_offset + Int64(col)) * Int64(16),
+                        output_base + (row_offset + Int64(col)) * Int64(16),
                         normalized,
                     )
         else:
             col = col0
             while col < hidden_packs:
                 index = row_offset + Int64(col)
-                value = cute.make_rmem_tensor(
-                    (self._pack_elems,), cutlass.Float32
-                )
-                scale = cute.make_rmem_tensor(
-                    (self._pack_elems,), cutlass.Float32
-                )
+                value = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+                scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
                 self._load_accumulate(
                     value,
                     residual_output_base + index * Int64(16),
                     True,
                 )
-                self._load_accumulate(
-                    scale, weight_base + Int64(col) * Int64(16), True
-                )
+                self._load_accumulate(scale, weight_base + Int64(col) * Int64(16), True)
                 for lane in cutlass.range_constexpr(self._pack_elems):
                     value[lane] = value[lane] * (inv_rms * scale[lane])
-                self._store_accumulator(
-                    output_base + index * Int64(16), value
-                )
+                self._store_accumulator(output_base + index * Int64(16), value)
                 col += col_stride
 
         if cutlass.const_expr(self._device_slot_selection):
@@ -719,9 +936,7 @@ class _FusedOneshotLaunch(_PackedMath):
 
 
 def _dummy(dtype, alignment: int):
-    return make_ptr(
-        dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment
-    )
+    return make_ptr(dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment)
 
 
 def _oneshot_process_key(
@@ -758,16 +973,19 @@ def is_oneshot_launcher_prepared(
 ) -> bool:
     """Return whether this exact process-local launcher is already loaded."""
 
-    return _oneshot_process_key(
-        dtype_name,
-        world_size,
-        rank,
-        stage_input,
-        device_slot_selection,
-        slot_bias,
-        threads,
-        device_index,
-    ) in _PREPARED_ONESHOT_LAUNCHERS
+    return (
+        _oneshot_process_key(
+            dtype_name,
+            world_size,
+            rank,
+            stage_input,
+            device_slot_selection,
+            slot_bias,
+            threads,
+            device_index,
+        )
+        in _PREPARED_ONESHOT_LAUNCHERS
+    )
 
 
 @functools.cache
@@ -823,9 +1041,7 @@ def get_oneshot_launcher(
         1,
         1,
         current_cuda_stream(),
-        compile_spec=KernelCompileSpec.from_key(
-            "comm.pcie.oneshot", 1, cache_key
-        ),
+        compile_spec=KernelCompileSpec.from_key("comm.pcie.oneshot", 1, cache_key),
     )
 
     def run(
@@ -910,18 +1126,21 @@ def is_fused_oneshot_launcher_prepared(
 ) -> bool:
     """Return whether this exact fused graph launcher is already loaded."""
 
-    return _fused_oneshot_process_key(
-        dtype_name,
-        world_size,
-        rank,
-        mode,
-        single_cta,
-        register_normalize,
-        device_slot_selection,
-        slot_bias,
-        threads,
-        device_index,
-    ) in _PREPARED_FUSED_ONESHOT_LAUNCHERS
+    return (
+        _fused_oneshot_process_key(
+            dtype_name,
+            world_size,
+            rank,
+            mode,
+            single_cta,
+            register_normalize,
+            device_slot_selection,
+            slot_bias,
+            threads,
+            device_index,
+        )
+        in _PREPARED_FUSED_ONESHOT_LAUNCHERS
+    )
 
 
 @functools.cache
@@ -1013,13 +1232,39 @@ def get_fused_oneshot_launcher(
         grid_x: int,
     ) -> None:
         raw(
-            make_ptr(cutlass.Uint64, peer_table_address, cute.AddressSpace.gmem, assumed_align=8),
-            make_ptr(cutlass.Uint64, signal_table_address, cute.AddressSpace.gmem, assumed_align=8),
-            make_ptr(cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(cutlass.Uint32, residual_address, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(cutlass.Uint32, residual_output_address, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(
+                cutlass.Uint64,
+                peer_table_address,
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            make_ptr(
+                cutlass.Uint64,
+                signal_table_address,
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            make_ptr(
+                cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16
+            ),
+            make_ptr(
+                cutlass.Uint32,
+                residual_address,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16
+            ),
+            make_ptr(
+                cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16
+            ),
+            make_ptr(
+                cutlass.Uint32,
+                residual_output_address,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
             int(hidden_packs),
             int(rows),
             int(ctas_per_row),

--- a/b12x/comm/pcie/_oneshot_cute.py
+++ b/b12x/comm/pcie/_oneshot_cute.py
@@ -311,6 +311,11 @@ class _FusedOneshotLaunch(_PackedMath):
             raise ValueError("fused remote push requires TP2 or TP4")
         if mode == "stage_tp8_owner" and world_size != 8:
             raise ValueError("fused owner transport requires TP8")
+        if mode == "stage_tp8_owner" and dtype_name not in (
+            "float16",
+            "bfloat16",
+        ):
+            raise ValueError("fused TP8 owner transport requires float16 or bfloat16")
         self._world_size = int(world_size)
         self._rank = int(rank)
         self._mode = mode
@@ -424,7 +429,13 @@ class _FusedOneshotLaunch(_PackedMath):
 
     @cute.jit
     def _tp8_owner_pair_barrier(self, signal_ptrs: cute.Pointer) -> None:
-        """Publish and acquire one FP32 partial between paired owners."""
+        """Publish and acquire one FP32 partial between paired owners.
+
+        This barrier must remain mutual so paired owners can skew by at most
+        one invocation. Eager slots alternate between invocations, making
+        that bounded skew use different storage. Both properties are safety
+        requirements for local-partial publication and final consumption.
+        """
 
         tidx, _, _ = cute.arch.thread_idx()
         cute.arch.sync_threads()

--- a/b12x/comm/pcie/pcie_oneshot.py
+++ b/b12x/comm/pcie/pcie_oneshot.py
@@ -114,6 +114,45 @@ def _push_mode_enabled() -> bool:
     return os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0")
 
 
+def _tp2_remote_push_enabled() -> bool:
+    """Enable the qualified fused TP2 remote-write transport."""
+
+    return os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
+
+
+def _tp4_remote_push_enabled() -> bool:
+    """Enable the qualified fused TP4 remote-write transport."""
+
+    return os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
+
+
+def _tp8_owner_reduce_enabled() -> bool:
+    """Enable the qualified topology-scoped fused TP8 transport by default."""
+
+    return os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
+
+
+def _uses_sharded_eager_storage(world_size: int) -> bool:
+    """Return whether staged fused transport needs one shard per source."""
+
+    return _push_mode_enabled() or (
+        (world_size == 2 and _tp2_remote_push_enabled())
+        or (world_size == 4 and _tp4_remote_push_enabled())
+        or (world_size == 8 and _tp8_owner_reduce_enabled())
+    )
+
+
+def _transport_policy_contract() -> tuple[bool, bool, bool, bool]:
+    """Values that must agree across ranks before IPC storage is allocated."""
+
+    return (
+        _push_mode_enabled(),
+        _tp2_remote_push_enabled(),
+        _tp4_remote_push_enabled(),
+        _tp8_owner_reduce_enabled(),
+    )
+
+
 def _is_weak_contiguous(inp: torch.Tensor) -> bool:
     if inp.is_contiguous():
         return True
@@ -569,9 +608,7 @@ def _require_full_grid_residency(
         visible_sms = int(
             torch.cuda.get_device_properties(device).multi_processor_count
         )
-        test_visible_sms = int(
-            os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
-        )
+        test_visible_sms = int(os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
         if test_visible_sms > 0:
             visible_sms = min(visible_sms, test_visible_sms)
         if visible_sms < required_sms:
@@ -1206,6 +1243,7 @@ class _CuTeOneshotState:
     registered_tables: dict[int, int]
     eager_tables: Optional[tuple[int, int]] = None
     eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
+    eager_buffer_bytes: Optional[int] = None
     eager_slot: int = 0
     device_slot_selection: bool = False
     slot_bias: int = 0
@@ -1315,6 +1353,7 @@ class _CuTeOneshotBackend:
         handle: int,
         pointers0: Sequence[int],
         pointers1: Sequence[int],
+        eager_buffer_bytes: Optional[int] = None,
     ) -> None:
         state = self._state(handle)
         ptrs0 = tuple(int(pointer) for pointer in pointers0)
@@ -1323,6 +1362,9 @@ class _CuTeOneshotBackend:
         table1 = self._write_table(state, ptrs1)
         state.eager_tables = (table0, table1)
         state.eager_ptrs = (ptrs0, ptrs1)
+        state.eager_buffer_bytes = (
+            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+        )
         state.registered_tables[ptrs0[state.rank]] = table0
         state.registered_tables[ptrs1[state.rank]] = table1
         state.eager_slot = 0
@@ -1331,9 +1373,7 @@ class _CuTeOneshotBackend:
     def _launch_geometry(size_packs: int) -> tuple[int, int]:
         threads = int(os.getenv("B12X_PCIE_ONESHOT_THREADS", "256"))
         threads = min(512, max(64, (threads // 32) * 32))
-        block_limit = int(
-            os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8")
-        )
+        block_limit = int(os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8"))
         if block_limit <= 0 or block_limit > _MAX_BLOCKS:
             raise ValueError(
                 f"B12X_PCIE_ONESHOT_BLOCK_LIMIT must be in [1, {_MAX_BLOCKS}]"
@@ -1345,6 +1385,47 @@ class _CuTeOneshotBackend:
     def _fused_threads() -> int:
         threads = int(os.getenv("B12X_PCIE_FUSED_THREADS", "256"))
         return min(512, max(64, (threads // 32) * 32))
+
+    @staticmethod
+    def _fused_topology_mode(
+        state: _CuTeOneshotState,
+        inp: torch.Tensor,
+    ) -> Optional[str]:
+        """Select only topology transports with a qualified shape contract."""
+
+        if (
+            state.eager_tables is None
+            or state.eager_buffer_bytes is None
+            or inp.dtype not in (torch.float16, torch.bfloat16)
+            or inp.ndim == 0
+        ):
+            return None
+        hidden = int(inp.shape[-1])
+        if hidden <= 0 or inp.numel() % hidden != 0:
+            return None
+        rows = inp.numel() // hidden
+        if (
+            state.world_size == 8
+            and _tp8_owner_reduce_enabled()
+            and hidden in (4096, 6144)
+            and 2 <= rows <= 8
+        ):
+            return "stage_tp8_owner"
+        if (
+            state.world_size == 4
+            and _tp4_remote_push_enabled()
+            and hidden in (4096, 6144)
+            and 1 <= rows <= 32
+        ):
+            return "stage_remote_push"
+        if (
+            state.world_size == 2
+            and _tp2_remote_push_enabled()
+            and hidden == 4096
+            and 1 <= rows <= 32
+        ):
+            return "stage_remote_push"
+        return None
 
     @classmethod
     def _fused_launch_config(
@@ -1360,15 +1441,18 @@ class _CuTeOneshotBackend:
         if override > 0:
             ctas_per_row = override
         else:
-            min_ctas = (
-                hidden_packs + threads * _REG_PACKS - 1
-            ) // (threads * _REG_PACKS)
+            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
+                threads * _REG_PACKS
+            )
             ctas_per_row = max(max(1, 3 // rows), min_ctas)
         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
-        register_normalize = (
-            hidden_packs + ctas_per_row * threads - 1
-        ) // (ctas_per_row * threads) <= _REG_PACKS
-        if state.eager_tables is None:
+        register_normalize = (hidden_packs + ctas_per_row * threads - 1) // (
+            ctas_per_row * threads
+        ) <= _REG_PACKS
+        topology_mode = cls._fused_topology_mode(state, inp)
+        if topology_mode is not None:
+            mode = topology_mode
+        elif state.eager_tables is None:
             mode = "registered"
         elif _push_mode_enabled():
             mode = "stage_push"
@@ -1378,11 +1462,7 @@ class _CuTeOneshotBackend:
 
     @staticmethod
     def _device_index(device: torch.device) -> int:
-        return (
-            device.index
-            if device.index is not None
-            else torch.cuda.current_device()
-        )
+        return device.index if device.index is not None else torch.cuda.current_device()
 
     def prepare_all_reduce(self, handle: int, inp: torch.Tensor) -> None:
         """Compile/load every graph slot variant without launching a kernel."""
@@ -1412,7 +1492,10 @@ class _CuTeOneshotBackend:
         """Compile/load fused graph variants without launching a kernel."""
 
         state = self._state(handle)
-        if state.eager_tables is None and int(inp.data_ptr()) not in state.registered_tables:
+        if (
+            state.eager_tables is None
+            and int(inp.data_ptr()) not in state.registered_tables
+        ):
             raise RuntimeError("input buffer is not registered")
         mode, single_cta, register_normalize, threads = self._fused_launch_config(
             state, inp
@@ -1421,9 +1504,7 @@ class _CuTeOneshotBackend:
 
         device_index = self._device_index(inp.device)
         variants = (
-            ((True, 0), (True, 1))
-            if state.eager_tables is not None
-            else ((False, 0),)
+            ((True, 0), (True, 1)) if state.eager_tables is not None else ((False, 0),)
         )
         for device_slot_selection, slot_bias in variants:
             get_fused_oneshot_launcher(
@@ -1440,9 +1521,7 @@ class _CuTeOneshotBackend:
             )
 
     @staticmethod
-    def _select_table(
-        state: _CuTeOneshotState, input_pointer: int
-    ) -> tuple[int, bool]:
+    def _select_table(state: _CuTeOneshotState, input_pointer: int) -> tuple[int, bool]:
         if state.eager_tables is not None:
             if state.device_slot_selection:
                 # The two 16-entry tables are adjacent in rank_data.  A
@@ -1477,9 +1556,7 @@ class _CuTeOneshotBackend:
             capturing and state.eager_tables is not None
         )
         prospective_slot_bias = (
-            state.slot_bias
-            if state.device_slot_selection
-            else state.eager_slot & 1
+            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
         )
         if capturing:
             from ._oneshot_cute import is_oneshot_launcher_prepared
@@ -1498,7 +1575,11 @@ class _CuTeOneshotBackend:
                     "cold PCIe oneshot CUDA graph capture is not allowed; "
                     "call prepare_graph_all_reduce() before capture"
                 )
-        if capturing and state.eager_tables is not None and not state.device_slot_selection:
+        if (
+            capturing
+            and state.eager_tables is not None
+            and not state.device_slot_selection
+        ):
             # The graph epoch begins at zero.  Bias it to the host slot that
             # would have been selected for this invocation, then keep both
             # values fixed in the captured specialization.
@@ -1563,9 +1644,7 @@ class _CuTeOneshotBackend:
             capturing and state.eager_tables is not None
         )
         prospective_slot_bias = (
-            state.slot_bias
-            if state.device_slot_selection
-            else state.eager_slot & 1
+            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
         )
         if capturing:
             from ._oneshot_cute import is_fused_oneshot_launcher_prepared
@@ -1602,9 +1681,9 @@ class _CuTeOneshotBackend:
         if override > 0:
             ctas_per_row = override
         else:
-            min_ctas = (
-                hidden_packs + threads * _REG_PACKS - 1
-            ) // (threads * _REG_PACKS)
+            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
+                threads * _REG_PACKS
+            )
             ctas_per_row = max(max(1, 3 // rows), min_ctas)
         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
         assert single_cta_check == (ctas_per_row == 1)
@@ -1650,7 +1729,7 @@ class _CuTeOneshotBackend:
                 hidden_packs,
                 rows,
                 ctas_per_row,
-                inp.numel() // pack_elems,
+                int(state.eager_buffer_bytes or inp.numel() * inp.element_size()) // 16,
                 float(epsilon),
                 blocks,
             )
@@ -1664,9 +1743,7 @@ class _CuTeOneshotBackend:
     def register_graph_buffers(self, handle: int, handles, offsets) -> None:
         self._state(handle)
         if any(handles) or any(offsets):
-            raise RuntimeError(
-                "CuTe oneshot graph capture requires eager IPC buffers"
-            )
+            raise RuntimeError("CuTe oneshot graph capture requires eager IPC buffers")
 
     def dispose(self, handle: int) -> None:
         with self._lock:
@@ -1993,11 +2070,19 @@ class PCIeOneshotAllReduce:
             )
             if self._pending_eager_ptrs is not None:
                 self._eager_ptrs = self._pending_eager_ptrs
-                self._ext.register_pcie_buffers(
-                    self._ptr,
-                    list(self._eager_ptrs[0]),
-                    list(self._eager_ptrs[1]),
-                )
+                if isinstance(self._ext, _CuTeOneshotBackend):
+                    self._ext.register_pcie_buffers(
+                        self._ptr,
+                        list(self._eager_ptrs[0]),
+                        list(self._eager_ptrs[1]),
+                        self.eager_buffer_bytes,
+                    )
+                else:
+                    self._ext.register_pcie_buffers(
+                        self._ptr,
+                        list(self._eager_ptrs[0]),
+                        list(self._eager_ptrs[1]),
+                    )
         except Exception as exc:
             init_error = exc
         finally:
@@ -2121,7 +2206,7 @@ class PCIeOneshotAllReduce:
                 eager_buffer_bytes,
                 max_size,
                 rank_data_bytes,
-                _push_mode_enabled(),
+                _transport_policy_contract(),
             ),
         )
 
@@ -2407,8 +2492,9 @@ class PCIeOneshotAllReduce:
             raise ValueError("signal_bytes must be positive")
         if eager_buffer_bytes <= 0:
             raise ValueError("eager_buffer_bytes must be positive")
-        if _push_mode_enabled():
-            eager_buffer_bytes *= dist.get_world_size(group=exchange_group)
+        world_size = dist.get_world_size(group=exchange_group)
+        if _uses_sharded_eager_storage(world_size):
+            eager_buffer_bytes *= world_size
 
         signal_offset = 0
         eager0_offset = _align_up(signal_bytes, IPC_SLAB_ALIGNMENT)
@@ -2523,7 +2609,9 @@ class PCIeOneshotAllReduce:
         if not self.should_allreduce(inp) or inp.ndim == 0:
             raise ValueError("input does not satisfy fused PCIe oneshot requirements")
         if inp.shape[-1] * inp.element_size() % 16 != 0:
-            raise ValueError("the last input dimension must occupy a multiple of 16 bytes")
+            raise ValueError(
+                "the last input dimension must occupy a multiple of 16 bytes"
+            )
         self._check_stream()
         self._prepare_input(inp, peer_input_ptrs)
         self._ext.prepare_fused_all_reduce(self._ptr, inp)
@@ -3145,7 +3233,7 @@ class PCIeOneshotAllReducePool:
                     self.rank_data_bytes,
                     self.single_channel,
                     self.max_concurrent_channels,
-                    _push_mode_enabled(),
+                    _transport_policy_contract(),
                 ),
             )
             # A genuine single-channel pool has no independent eager/graph
@@ -3486,9 +3574,7 @@ class PCIeOneshotAllReducePool:
                         inp, peer_input_ptrs=peer_input_ptrs
                     )
             else:
-                channel.prepare_graph_all_reduce(
-                    inp, peer_input_ptrs=peer_input_ptrs
-                )
+                channel.prepare_graph_all_reduce(inp, peer_input_ptrs=peer_input_ptrs)
 
     def prepare_graph_fused_add_rms_norm(
         self,

--- a/b12x/comm/pcie/pcie_oneshot.py
+++ b/b12x/comm/pcie/pcie_oneshot.py
@@ -132,13 +132,19 @@ def _tp8_owner_reduce_enabled() -> bool:
     return os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
 
 
-def _uses_sharded_eager_storage(world_size: int) -> bool:
+def _uses_sharded_eager_storage(
+    world_size: int,
+    transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
+) -> bool:
     """Return whether staged fused transport needs one shard per source."""
 
-    return _push_mode_enabled() or (
-        (world_size == 2 and _tp2_remote_push_enabled())
-        or (world_size == 4 and _tp4_remote_push_enabled())
-        or (world_size == 8 and _tp8_owner_reduce_enabled())
+    push, tp2_remote, tp4_remote, tp8_owner = (
+        _transport_policy_contract() if transport_policy is None else transport_policy
+    )
+    return push or (
+        (world_size == 2 and tp2_remote)
+        or (world_size == 4 and tp4_remote)
+        or (world_size == 8 and tp8_owner)
     )
 
 
@@ -1244,6 +1250,8 @@ class _CuTeOneshotState:
     eager_tables: Optional[tuple[int, int]] = None
     eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
     eager_buffer_bytes: Optional[int] = None
+    transport_policy: tuple[bool, bool, bool, bool] = (False, False, False, False)
+    sharded_eager_storage: bool = False
     eager_slot: int = 0
     device_slot_selection: bool = False
     slot_bias: int = 0
@@ -1273,6 +1281,8 @@ class _CuTeOneshotBackend:
         self._lock = RLock()
         self._next_handle = 1
         self._states: dict[int, _CuTeOneshotState] = {}
+
+    supports_eager_storage_contract = True
 
     @staticmethod
     def meta_size() -> int:
@@ -1354,6 +1364,7 @@ class _CuTeOneshotBackend:
         pointers0: Sequence[int],
         pointers1: Sequence[int],
         eager_buffer_bytes: Optional[int] = None,
+        transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
     ) -> None:
         state = self._state(handle)
         ptrs0 = tuple(int(pointer) for pointer in pointers0)
@@ -1364,6 +1375,15 @@ class _CuTeOneshotBackend:
         state.eager_ptrs = (ptrs0, ptrs1)
         state.eager_buffer_bytes = (
             None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+        )
+        state.transport_policy = (
+            _transport_policy_contract()
+            if transport_policy is None
+            else tuple(bool(value) for value in transport_policy)
+        )
+        state.sharded_eager_storage = _uses_sharded_eager_storage(
+            state.world_size,
+            state.transport_policy,
         )
         state.registered_tables[ptrs0[state.rank]] = table0
         state.registered_tables[ptrs1[state.rank]] = table1
@@ -1404,26 +1424,22 @@ class _CuTeOneshotBackend:
         if hidden <= 0 or inp.numel() % hidden != 0:
             return None
         rows = inp.numel() // hidden
+        _, tp2_remote, tp4_remote, tp8_owner = state.transport_policy
         if (
             state.world_size == 8
-            and _tp8_owner_reduce_enabled()
+            and tp8_owner
             and hidden in (4096, 6144)
             and 2 <= rows <= 8
         ):
             return "stage_tp8_owner"
         if (
             state.world_size == 4
-            and _tp4_remote_push_enabled()
+            and tp4_remote
             and hidden in (4096, 6144)
             and 1 <= rows <= 32
         ):
             return "stage_remote_push"
-        if (
-            state.world_size == 2
-            and _tp2_remote_push_enabled()
-            and hidden == 4096
-            and 1 <= rows <= 32
-        ):
+        if state.world_size == 2 and tp2_remote and hidden == 4096 and 1 <= rows <= 32:
             return "stage_remote_push"
         return None
 
@@ -1454,7 +1470,7 @@ class _CuTeOneshotBackend:
             mode = topology_mode
         elif state.eager_tables is None:
             mode = "registered"
-        elif _push_mode_enabled():
+        elif state.transport_policy[0]:
             mode = "stage_push"
         else:
             mode = "stage_pull"
@@ -1843,6 +1859,7 @@ class PCIeOneshotAllReduce:
             normalized_eager_bytes = (
                 None if eager_buffer_bytes is None else int(eager_buffer_bytes)
             )
+            normalized_transport_policy = _transport_policy_contract()
             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
                 raise ValueError(f"unsupported world size {normalized_world_size}")
             if not 0 <= normalized_rank < normalized_world_size:
@@ -1909,6 +1926,7 @@ class PCIeOneshotAllReduce:
                 normalized_eager0,
                 normalized_eager1,
                 normalized_eager_bytes,
+                normalized_transport_policy,
                 normalized_max_size,
                 normalized_rank_data_bytes,
             )
@@ -1930,6 +1948,7 @@ class PCIeOneshotAllReduce:
             normalized_eager0,
             normalized_eager1,
             normalized_eager_bytes,
+            normalized_transport_policy,
             normalized_max_size,
             normalized_rank_data_bytes,
         ) = normalized
@@ -1942,6 +1961,7 @@ class PCIeOneshotAllReduce:
             eager_buffer_ptrs0=normalized_eager0,
             eager_buffer_ptrs1=normalized_eager1,
             eager_buffer_bytes=normalized_eager_bytes,
+            transport_policy=normalized_transport_policy,
             exchange_group=resolved_group,
             ipc=ipc,
             owned_buffers=owned_buffers,
@@ -1988,6 +2008,7 @@ class PCIeOneshotAllReduce:
                     self.rank_data_bytes,
                     self.eager_buffer_bytes,
                     self._pending_eager_ptrs is not None,
+                    self._transport_policy,
                 ),
             )
 
@@ -2018,6 +2039,7 @@ class PCIeOneshotAllReduce:
         eager_buffer_ptrs0: Optional[Sequence[int]],
         eager_buffer_ptrs1: Optional[Sequence[int]],
         eager_buffer_bytes: Optional[int],
+        transport_policy: tuple[bool, bool, bool, bool],
         exchange_group: Optional[ProcessGroup],
         ipc: Optional[CudaRTLibrary],
         owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
@@ -2035,6 +2057,11 @@ class PCIeOneshotAllReduce:
         self.rank_data_bytes = int(rank_data_bytes)
         self.eager_buffer_bytes = (
             None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+        )
+        self._transport_policy = tuple(bool(value) for value in transport_policy)
+        self._sharded_eager_storage = _uses_sharded_eager_storage(
+            self.world_size,
+            self._transport_policy,
         )
         self._ipc = ipc
         self._ext = ext_module
@@ -2070,12 +2097,17 @@ class PCIeOneshotAllReduce:
             )
             if self._pending_eager_ptrs is not None:
                 self._eager_ptrs = self._pending_eager_ptrs
-                if isinstance(self._ext, _CuTeOneshotBackend):
+                if getattr(
+                    self._ext,
+                    "supports_eager_storage_contract",
+                    False,
+                ):
                     self._ext.register_pcie_buffers(
                         self._ptr,
                         list(self._eager_ptrs[0]),
                         list(self._eager_ptrs[1]),
                         self.eager_buffer_bytes,
+                        self._transport_policy,
                     )
                 else:
                     self._ext.register_pcie_buffers(
@@ -2153,6 +2185,7 @@ class PCIeOneshotAllReduce:
             normalized_eager_bytes = int(eager_buffer_bytes)
             normalized_max_size = int(max_size)
             normalized_rank_data_bytes = int(rank_data_bytes)
+            normalized_transport_policy = _transport_policy_contract()
             if world_size not in SUPPORTED_WORLD_SIZES:
                 raise ValueError(f"unsupported world size {world_size}")
             if device_obj.type != "cuda":
@@ -2170,14 +2203,19 @@ class PCIeOneshotAllReduce:
                 normalized_eager_bytes,
                 normalized_max_size,
                 normalized_rank_data_bytes,
+                normalized_transport_policy,
             )
 
-        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
-            _run_collective_preallocation_setup(
-                owner="PCIe oneshot argument validation",
-                exchange_group=exchange_group,
-                setup=validate_factory_arguments,
-            )
+        (
+            device_obj,
+            eager_buffer_bytes,
+            max_size,
+            rank_data_bytes,
+            transport_policy,
+        ) = _run_collective_preallocation_setup(
+            owner="PCIe oneshot argument validation",
+            exchange_group=exchange_group,
+            setup=validate_factory_arguments,
         )
 
         _require_full_grid_residency(
@@ -2206,7 +2244,7 @@ class PCIeOneshotAllReduce:
                 eager_buffer_bytes,
                 max_size,
                 rank_data_bytes,
-                _transport_policy_contract(),
+                transport_policy,
             ),
         )
 
@@ -2214,6 +2252,10 @@ class PCIeOneshotAllReduce:
             exchange_group,
             signal_bytes=signal_bytes,
             eager_buffer_bytes=eager_buffer_bytes,
+            sharded_eager_storage=_uses_sharded_eager_storage(
+                world_size,
+                transport_policy,
+            ),
             ipc=ipc,
         )
         owned_buffers = [channel_buffers.owned_buffer]
@@ -2225,6 +2267,7 @@ class PCIeOneshotAllReduce:
             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
             eager_buffer_bytes=eager_buffer_bytes,
+            transport_policy=transport_policy,
             exchange_group=exchange_group,
             ipc=ipc,
             owned_buffers=owned_buffers,
@@ -2484,6 +2527,7 @@ class PCIeOneshotAllReduce:
         *,
         signal_bytes: int,
         eager_buffer_bytes: int,
+        sharded_eager_storage: bool,
         ipc: CudaRTLibrary,
     ) -> _ChannelSharedBuffers:
         signal_bytes = int(signal_bytes)
@@ -2492,9 +2536,8 @@ class PCIeOneshotAllReduce:
             raise ValueError("signal_bytes must be positive")
         if eager_buffer_bytes <= 0:
             raise ValueError("eager_buffer_bytes must be positive")
-        world_size = dist.get_world_size(group=exchange_group)
-        if _uses_sharded_eager_storage(world_size):
-            eager_buffer_bytes *= world_size
+        if sharded_eager_storage:
+            eager_buffer_bytes *= dist.get_world_size(group=exchange_group)
 
         signal_offset = 0
         eager0_offset = _align_up(signal_bytes, IPC_SLAB_ALIGNMENT)
@@ -3118,6 +3161,7 @@ class PCIeOneshotAllReducePool:
             normalized_rank_data_bytes = int(rank_data_bytes)
             normalized_single_channel = bool(single_channel)
             normalized_max_concurrent_channels = int(max_concurrent_channels)
+            normalized_transport_policy = _transport_policy_contract()
             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
                 raise ValueError(f"unsupported world size {normalized_world_size}")
             if not 0 <= normalized_rank < normalized_world_size:
@@ -3163,6 +3207,7 @@ class PCIeOneshotAllReducePool:
                 normalized_rank_data_bytes,
                 normalized_single_channel,
                 normalized_max_concurrent_channels,
+                normalized_transport_policy,
             )
 
         if channel_factory is None and resolved_group is not None:
@@ -3183,7 +3228,12 @@ class PCIeOneshotAllReducePool:
             self.rank_data_bytes,
             self.single_channel,
             self.max_concurrent_channels,
+            self._transport_policy,
         ) = normalized
+        self._sharded_eager_storage = _uses_sharded_eager_storage(
+            self.world_size,
+            self._transport_policy,
+        )
         self.exchange_group = resolved_group
         self.process_group = self.exchange_group
         self._channel_factory = channel_factory
@@ -3233,7 +3283,7 @@ class PCIeOneshotAllReducePool:
                     self.rank_data_bytes,
                     self.single_channel,
                     self.max_concurrent_channels,
-                    _transport_policy_contract(),
+                    self._transport_policy,
                 ),
             )
             # A genuine single-channel pool has no independent eager/graph
@@ -3311,6 +3361,7 @@ class PCIeOneshotAllReducePool:
             self.exchange_group,
             signal_bytes=self._signal_bytes,
             eager_buffer_bytes=self.eager_buffer_bytes,
+            sharded_eager_storage=self._sharded_eager_storage,
             ipc=self._ipc,
         )
         owned_buffers = [channel_buffers.owned_buffer]
@@ -3322,6 +3373,7 @@ class PCIeOneshotAllReducePool:
             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
             eager_buffer_bytes=self.eager_buffer_bytes,
+            transport_policy=self._transport_policy,
             exchange_group=self.exchange_group,
             ipc=self._ipc,
             owned_buffers=owned_buffers,

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -20,8 +20,11 @@ from b12x.comm.pcie.pcie_oneshot import (
     _require_full_grid_residency,
     _ABANDONED_PCIE_RUNTIME_QUARANTINE,
     _RETAINED_FAILED_IPC_EXPORTS,
+    _CuTeOneshotBackend,
     _CuTeOneshotState,
     _enable_device_slot_selection,
+    _transport_policy_contract,
+    _uses_sharded_eager_storage,
     parse_pcie_oneshot_max_size,
 )
 
@@ -250,6 +253,141 @@ def test_graph_slot_bias_preserves_the_next_host_slot() -> None:
     state.eager_slot = 8
     _enable_device_slot_selection(state, capturing=True)
     assert state.slot_bias == 1
+
+
+def _make_cute_state(world_size: int, *, eager: bool = True) -> _CuTeOneshotState:
+    return _CuTeOneshotState(
+        rank=0,
+        world_size=world_size,
+        signal_ptrs=tuple(range(100, 100 + world_size)),
+        rank_data=torch.empty(256, dtype=torch.uint8),
+        signal_table_address=0,
+        next_table_offset=128,
+        registered_tables={},
+        eager_tables=(300, 400) if eager else None,
+        eager_buffer_bytes=128 * 1024 if eager else None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("rows", "hidden", "dtype", "expected"),
+    (
+        (1, 6144, torch.bfloat16, "stage_pull"),
+        (2, 4096, torch.float16, "stage_tp8_owner"),
+        (4, 6144, torch.bfloat16, "stage_tp8_owner"),
+        (8, 6144, torch.bfloat16, "stage_tp8_owner"),
+        (9, 6144, torch.bfloat16, "stage_pull"),
+        (4, 8192, torch.bfloat16, "stage_pull"),
+        (4, 6144, torch.float32, "stage_pull"),
+    ),
+)
+def test_tp8_owner_reduce_default_has_a_bounded_shape_contract(
+    monkeypatch,
+    rows: int,
+    hidden: int,
+    dtype: torch.dtype,
+    expected: str,
+) -> None:
+    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
+    monkeypatch.delenv("B12X_PCIE_TP8_OWNER_REDUCE", raising=False)
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(8), torch.empty((rows, hidden), dtype=dtype)
+    )
+    assert mode == expected
+
+
+def test_tp8_owner_reduce_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(8), torch.empty((4, 6144), dtype=torch.bfloat16)
+    )
+    assert mode == "stage_pull"
+
+
+@pytest.mark.parametrize(
+    ("world_size", "env_name", "shape", "expected_when_enabled"),
+    (
+        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 4096), "stage_remote_push"),
+        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (32, 6144), "stage_remote_push"),
+    ),
+)
+def test_tp2_tp4_remote_push_is_opt_in(
+    monkeypatch,
+    world_size: int,
+    env_name: str,
+    shape: tuple[int, int],
+    expected_when_enabled: str,
+) -> None:
+    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
+    monkeypatch.delenv(env_name, raising=False)
+    inp = torch.empty(shape, dtype=torch.bfloat16)
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(world_size), inp
+    )
+    assert mode == "stage_pull"
+
+    monkeypatch.setenv(env_name, "1")
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(world_size), inp
+    )
+    assert mode == expected_when_enabled
+
+
+@pytest.mark.parametrize(
+    ("world_size", "env_name", "shape"),
+    (
+        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 6144)),
+        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (33, 4096)),
+        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (33, 6144)),
+        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (4, 8192)),
+    ),
+)
+def test_tp2_tp4_remote_push_falls_back_outside_qualified_shapes(
+    monkeypatch,
+    world_size: int,
+    env_name: str,
+    shape: tuple[int, int],
+) -> None:
+    monkeypatch.setenv(env_name, "1")
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(world_size),
+        torch.empty(shape, dtype=torch.bfloat16),
+    )
+    assert mode == "stage_pull"
+
+
+def test_registered_fused_input_never_selects_topology_transport(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        _make_cute_state(4, eager=False),
+        torch.empty((4, 6144), dtype=torch.bfloat16),
+    )
+    assert mode == "registered"
+
+
+def test_topology_transport_storage_policy_matches_opt_in_defaults(
+    monkeypatch,
+) -> None:
+    for name in (
+        "B12X_PCIE_ONESHOT_PUSH",
+        "B12X_PCIE_TP2_REMOTE_PUSH",
+        "B12X_PCIE_TP4_REMOTE_PUSH",
+        "B12X_PCIE_TP8_OWNER_REDUCE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert not _uses_sharded_eager_storage(2)
+    assert not _uses_sharded_eager_storage(4)
+    assert _uses_sharded_eager_storage(8)
+    assert _transport_policy_contract() == (False, False, False, True)
+
+    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
+    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
+    assert _uses_sharded_eager_storage(4)
+    assert not _uses_sharded_eager_storage(8)
+    assert _transport_policy_contract() == (False, False, True, False)
 
 
 def test_register_buffer_is_idempotent_for_same_mapping():
@@ -1486,9 +1624,7 @@ def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypat
         _requested, existing = local_state
         return [local_state, (("other",), existing)]
 
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
-    )
+    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
 
     with pytest.raises(RuntimeError, match="differs across ranks"):
         pool.prepare_channels(("target",))
@@ -1535,9 +1671,7 @@ def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch)
         _, existing = local_state
         return [local_state, (("peer-channel",), existing)]
 
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
-    )
+    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
 
     with pytest.raises(RuntimeError, match="differs across ranks"):
         pool.prepare_channels(())
@@ -1599,9 +1733,7 @@ def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatc
         assert requested == "graph:target"
         return [local_state, ("graph:draft", catalog)]
 
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
-    )
+    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
 
     with pool.capture(7, channel_id="graph:target") as channel:
         assert channel is target
@@ -1631,9 +1763,7 @@ def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypa
             return [(), ()]
         return [local_state, ("graph:target", ())]
 
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
-    )
+    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
 
     with (
         pytest.raises(RuntimeError, match="prepared channel catalog differs"),
@@ -1665,9 +1795,7 @@ def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
         _, catalog = local_state
         return [local_state, ("graph:unknown", catalog)]
 
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
-    )
+    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
 
     with (
         pytest.raises(RuntimeError, match="unprepared logical channels"),

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -27,6 +27,7 @@ from b12x.comm.pcie.pcie_oneshot import (
     _uses_sharded_eager_storage,
     parse_pcie_oneshot_max_size,
 )
+from b12x.comm.pcie._oneshot_cute import _FusedOneshotLaunch
 
 
 @pytest.fixture(autouse=True)
@@ -256,6 +257,7 @@ def test_graph_slot_bias_preserves_the_next_host_slot() -> None:
 
 
 def _make_cute_state(world_size: int, *, eager: bool = True) -> _CuTeOneshotState:
+    transport_policy = _transport_policy_contract()
     return _CuTeOneshotState(
         rank=0,
         world_size=world_size,
@@ -266,7 +268,27 @@ def _make_cute_state(world_size: int, *, eager: bool = True) -> _CuTeOneshotStat
         registered_tables={},
         eager_tables=(300, 400) if eager else None,
         eager_buffer_bytes=128 * 1024 if eager else None,
+        transport_policy=transport_policy,
+        sharded_eager_storage=_uses_sharded_eager_storage(
+            world_size,
+            transport_policy,
+        ),
     )
+
+
+def test_tp8_owner_launcher_rejects_float32() -> None:
+    with pytest.raises(ValueError, match="requires float16 or bfloat16"):
+        _FusedOneshotLaunch(
+            "float32",
+            world_size=8,
+            rank=0,
+            mode="stage_tp8_owner",
+            single_cta=True,
+            register_normalize=True,
+            device_slot_selection=False,
+            slot_bias=0,
+            threads=256,
+        )
 
 
 @pytest.mark.parametrize(
@@ -297,6 +319,7 @@ def test_tp8_owner_reduce_default_has_a_bounded_shape_contract(
 
 
 def test_tp8_owner_reduce_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
     monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
     mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
         _make_cute_state(8), torch.empty((4, 6144), dtype=torch.bfloat16)
@@ -333,6 +356,20 @@ def test_tp2_tp4_remote_push_is_opt_in(
     assert mode == expected_when_enabled
 
 
+def test_topology_policy_is_immutable_after_channel_setup(monkeypatch) -> None:
+    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
+    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
+    state = _make_cute_state(4)
+
+    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "0")
+    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
+        state,
+        torch.empty((4, 6144), dtype=torch.bfloat16),
+    )
+
+    assert mode == "stage_remote_push"
+
+
 @pytest.mark.parametrize(
     ("world_size", "env_name", "shape"),
     (
@@ -348,6 +385,7 @@ def test_tp2_tp4_remote_push_falls_back_outside_qualified_shapes(
     env_name: str,
     shape: tuple[int, int],
 ) -> None:
+    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
     monkeypatch.setenv(env_name, "1")
     mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
         _make_cute_state(world_size),
@@ -1356,6 +1394,7 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
         exchange_group,
         signal_bytes=signal_bytes,
         eager_buffer_bytes=eager_bytes,
+        sharded_eager_storage=False,
         ipc=ipc,
     )
 
@@ -1419,6 +1458,7 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
             object(),
             signal_bytes=300,
             eager_buffer_bytes=128,
+            sharded_eager_storage=False,
             ipc=ipc,
         )
 

--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
@@ -12,7 +12,10 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 from cuda.bindings import runtime as cudart
 
-from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+from b12x.comm.pcie.pcie_oneshot import (
+    PCIeOneshotAllReducePool,
+    _CuTeOneshotBackend,
+)
 
 
 pytestmark = pytest.mark.skipif(
@@ -255,6 +258,8 @@ def _run_graph(
     offset = 0
     if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0") or topology_remote:
         if world_size == 8 and topology_remote:
+            # TP8 owner mode publishes owner data into each rank's staging
+            # slot, so probe the island owner rather than a neighboring rank.
             remote_source = 0 if rank < 4 else 4
         else:
             remote_source = (rank + 1) % world_size
@@ -322,6 +327,8 @@ def _run_tp8_graph_mode_transition(
     channel = pool.for_stream(stream, channel_id=channel_id)
 
     calls = []
+    modes = []
+    state = channel._ext._state(channel._ptr)
     for rows, iteration in ((1, 41), (4, 43)):
         inp, residual, weight = _make_inputs(
             rows,
@@ -333,8 +340,10 @@ def _run_tp8_graph_mode_transition(
         )
         out = torch.empty_like(inp)
         calls.append((inp, residual, weight, out))
+        modes.append(_CuTeOneshotBackend._fused_launch_config(state, inp)[0])
         with torch.cuda.stream(stream):
             channel.prepare_graph_fused_add_rms_norm(inp)
+    assert modes == ["stage_pull", "stage_tp8_owner"]
 
     graph = torch.cuda.CUDAGraph(keep_graph=True)
     with (

--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
@@ -22,9 +22,7 @@ pytestmark = pytest.mark.skipif(
         "RMSNorm GPU tests"
     ),
 )
-TEST_TIMEOUT_SECONDS = float(
-    os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
-)
+TEST_TIMEOUT_SECONDS = float(os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300"))
 
 
 def _free_port() -> int:
@@ -145,10 +143,15 @@ def _run_eager(
     rank: int,
 ) -> None:
     epsilon = 1e-6
-    for dtype in (torch.float16, torch.bfloat16, torch.float32):
+    cases = [
+        (dtype, rows, hidden_size)
+        for dtype in (torch.float16, torch.bfloat16, torch.float32)
         for rows, hidden_size in (
             (1, 6144),
             (1, 8192),
+            (2, 4096),
+            (4, 4096),
+            (8, 4096),
             (2, 6144),
             (3, 6144),
             (4, 6144),
@@ -156,40 +159,47 @@ def _run_eager(
             (6, 6144),
             (8, 6144),
             (3, 128),
-        ):
-            if rows * hidden_size * dtype.itemsize > 128 * 1024:
-                continue
-            inp, residual, weight = _make_inputs(
-                rows,
-                hidden_size,
-                dtype,
-                device,
-                rank,
-            )
-            expected_out, expected_residual = _reference(
-                inp,
-                residual,
-                weight,
-                epsilon,
-            )
-            torch.cuda.synchronize(device)
-            wrong_device = (rank + 1) % dist.get_world_size()
-            exercise_device_guard = dtype == torch.float16 and rows == 1 and hidden_size == 6144
-            if exercise_device_guard:
-                torch.cuda.set_device(wrong_device)
-            out, residual_out = pool.all_reduce_fused_add_rms_norm(
-                inp,
-                residual,
-                weight,
-                epsilon,
-                channel_id="eager:fused-rmsnorm",
-            )
-            if exercise_device_guard:
-                assert torch.cuda.current_device() == wrong_device
-                torch.cuda.set_device(rank)
-            torch.cuda.synchronize(device)
-            _assert_close(out, expected_out, dtype)
-            _assert_close(residual_out, expected_residual, dtype)
+        )
+        if rows * hidden_size * dtype.itemsize <= 128 * 1024
+    ]
+    if os.getenv("B12X_PCIE_ONESHOT_RMS_TOPOLOGY_ONLY", "0") not in ("", "0"):
+        hidden_size = 4096 if dist.get_world_size() == 2 else 6144
+        cases = [(torch.bfloat16, rows, hidden_size) for rows in (1, 2, 4, 8)]
+
+    for dtype, rows, hidden_size in cases:
+        inp, residual, weight = _make_inputs(
+            rows,
+            hidden_size,
+            dtype,
+            device,
+            rank,
+        )
+        expected_out, expected_residual = _reference(
+            inp,
+            residual,
+            weight,
+            epsilon,
+        )
+        torch.cuda.synchronize(device)
+        wrong_device = (rank + 1) % dist.get_world_size()
+        exercise_device_guard = (
+            dtype == torch.float16 and rows == 1 and hidden_size == 6144
+        )
+        if exercise_device_guard:
+            torch.cuda.set_device(wrong_device)
+        out, residual_out = pool.all_reduce_fused_add_rms_norm(
+            inp,
+            residual,
+            weight,
+            epsilon,
+            channel_id="eager:fused-rmsnorm",
+        )
+        if exercise_device_guard:
+            assert torch.cuda.current_device() == wrong_device
+            torch.cuda.set_device(rank)
+        torch.cuda.synchronize(device)
+        _assert_close(out, expected_out, dtype)
+        _assert_close(residual_out, expected_residual, dtype)
 
 
 def _run_graph(
@@ -197,8 +207,8 @@ def _run_graph(
     device: torch.device,
     rank: int,
 ) -> None:
-    rows = 4
-    hidden_size = 6144
+    rows = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_ROWS", "4"))
+    hidden_size = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_HIDDEN", "6144"))
     epsilon = 1e-6
     dtype = torch.bfloat16
     inp, residual, weight = _make_inputs(
@@ -227,10 +237,28 @@ def _run_graph(
     # preserves the one-kernel production topology.
     _cuda_graph_kernel_chain(graph)
     stream = torch.cuda.current_stream(device)
+    world_size = dist.get_world_size()
+    topology_remote = (
+        (
+            world_size == 2
+            and os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
+        )
+        or (
+            world_size == 4
+            and os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
+        )
+        or (
+            world_size == 8
+            and os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
+        )
+    )
     offset = 0
-    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
-        remote_source = (rank + 1) % dist.get_world_size()
-        offset = remote_source * inp.numel() * inp.element_size()
+    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0") or topology_remote:
+        if world_size == 8 and topology_remote:
+            remote_source = 0 if rank < 4 else 4
+        else:
+            remote_source = (rank + 1) % world_size
+        offset = remote_source * channel.eager_buffer_bytes
     snapshots = [_local_eager_words(channel, stream, offset=offset)]
 
     for iteration in range(3):
@@ -273,6 +301,83 @@ def _run_graph(
     )
 
 
+def _run_tp8_graph_mode_transition(
+    pool: PCIeOneshotAllReducePool,
+    device: torch.device,
+    rank: int,
+) -> None:
+    """Replay C1 fallback followed by C4 owner reduction on one channel."""
+
+    if dist.get_world_size() != 8 or os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") in (
+        "",
+        "0",
+    ):
+        return
+
+    hidden_size = 6144
+    epsilon = 1e-6
+    dtype = torch.bfloat16
+    stream = torch.cuda.Stream(device=device)
+    channel_id = "graph:fused-transition"
+    channel = pool.for_stream(stream, channel_id=channel_id)
+
+    calls = []
+    for rows, iteration in ((1, 41), (4, 43)):
+        inp, residual, weight = _make_inputs(
+            rows,
+            hidden_size,
+            dtype,
+            device,
+            rank,
+            iteration=iteration,
+        )
+        out = torch.empty_like(inp)
+        calls.append((inp, residual, weight, out))
+        with torch.cuda.stream(stream):
+            channel.prepare_graph_fused_add_rms_norm(inp)
+
+    graph = torch.cuda.CUDAGraph(keep_graph=True)
+    with (
+        pool.capture(stream=stream, channel_id=channel_id),
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        for inp, residual, weight, out in calls:
+            pool.all_reduce_fused_add_rms_norm(
+                inp,
+                residual,
+                weight,
+                epsilon,
+                out=out,
+                residual_out=residual,
+                stream=stream,
+                channel_id=channel_id,
+            )
+
+    for replay in range(3):
+        expected = []
+        for rows, (inp, residual, weight, _out) in zip((1, 4), calls, strict=True):
+            next_inp, next_residual, _ = _make_inputs(
+                rows,
+                hidden_size,
+                dtype,
+                device,
+                rank,
+                iteration=47 + replay,
+            )
+            inp.copy_(next_inp)
+            residual.copy_(next_residual)
+            expected.append(_reference(inp, residual, weight, epsilon))
+
+        graph.replay()
+        stream.synchronize()
+        for (_inp, residual, _weight, out), (
+            expected_out,
+            expected_residual,
+        ) in zip(calls, expected, strict=True):
+            _assert_close(out, expected_out, dtype)
+            _assert_close(residual, expected_residual, dtype)
+
+
 def _worker(rank: int, world_size: int, port: int) -> None:
     torch.cuda.set_device(rank)
     device = torch.device(f"cuda:{rank}")
@@ -291,11 +396,19 @@ def _worker(rank: int, world_size: int, port: int) -> None:
         max_concurrent_channels=2,
     )
     try:
-        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
+        pool.prepare_channels(
+            (
+                "eager:fused-rmsnorm",
+                "graph:fused-rmsnorm",
+                "graph:fused-transition",
+            )
+        )
         pool.for_stream(channel_id="eager:fused-rmsnorm")
         _run_eager(pool, device, rank)
         dist.barrier()
         _run_graph(pool, device, rank)
+        dist.barrier()
+        _run_tp8_graph_mode_transition(pool, device, rank)
         torch.cuda.synchronize(device)
     finally:
         pool.close()


### PR DESCRIPTION
## Summary

This adds topology-scoped transports to the existing CuTe fused all-reduce + RMSNorm path:

- **TP8 is enabled by default** for the qualified small BF16/FP16 shapes used by decode.
- **TP4 and TP2 are included as explicit opt-ins** because their measured gains are small or workload-dependent.
- Registered inputs, generic/bare all-reduce, unsupported shapes, and larger messages retain the existing implementation.

The change is bounded by shape and topology rather than replacing the general collective.

## TP8 protocol

The current staged TP8 fused path synchronizes all eight ranks and has every rank consume all peer payloads. The new path uses the two four-GPU PCIe islands directly:

1. Each rank stages its chunk to one owner in its local four-rank island.
2. The four local owners form FP32 partial sums.
3. Paired owners exchange those partials across the islands.
4. Each owner forms the final FP32 sum and publishes it within its island.
5. RMSNorm consumes the result in the same kernel.

Every phase uses the existing system-scope release/acquire flag protocol. There is no payload-sentinel readiness scheme. C1 fallback and the TP8 owner protocol use separate barrier generations, so one CUDA graph channel can alternate between them safely.

## Runtime policy

| Topology | Default | Qualified fused shapes | Control |
|---|---|---|---|
| TP8 owner reduction | on | BF16/FP16, hidden 4096 or 6144, rows 2-8 | `B12X_PCIE_TP8_OWNER_REDUCE=0` disables it |
| TP4 remote write/local read | off | BF16/FP16, hidden 4096 or 6144, rows 1-32 | `B12X_PCIE_TP4_REMOTE_PUSH=1` |
| TP2 remote write/local read | off | BF16/FP16, hidden 4096, rows 1-32 | `B12X_PCIE_TP2_REMOTE_PUSH=1` |

All other cases fall back to `registered`, `stage_pull`, or the existing global `B12X_PCIE_ONESHOT_PUSH` policy. Transport settings are included in the collective initialization contract so ranks fail before IPC allocation if their environments disagree.

## Storage cost

Topology modes need one fixed-stride eager shard per source rank. At the default 8 MiB eager capacity and two graph slots, TP8 therefore reserves 128 MiB per channel instead of 16 MiB, an additional **112 MiB/GPU/channel**. TP2/TP4 pay this cost only when explicitly enabled.

## Performance evidence

Qualified r31 POC, 8x RTX PRO 6000 Blackwell, hidden 6144 fused add + RMSNorm:

| Rows | New TP8 path | Previous path | Latency change |
|---:|---:|---:|---:|
| 2 | 13.145 us | 15.220 us | -13.6% |
| 4 | 14.340 us | 17.599 us | -18.5% |
| 8 | 16.379 us | 24.085 us | -32.0% |

DS4 TP8/MTP0 end-to-end on the same r31 POC:

| Variant | C1 | C4 | C8 |
|---|---:|---:|---:|
| TP8 topology path | 202.284 | 645.072 | 975.300 |
| Same source, path disabled | 180.700 | 546.600 | 811.700 |
| Change | +12.0% | +18.0% | +20.2% |

GLM-5.2 NVFP4 TP8/DCP1/MTP0 improved by +0.85% / +11.37% / +7.67% at C1/C4/C8. A TP4 correctness-qualified A/B retained only +1.67% / +2.27% at C4/C8, so TP4 remains opt-in. TP2 has no demonstrated production E2E gain and also remains opt-in.

## Validation

- `ruff check`: pass
- `ruff format --check`: pass
- comm host suite: **392 passed, 2 skipped**
- TP8 default: BF16 rows 1/2/4/8 at hidden 6144, eager and CUDA graph, pass
- TP8 same-channel graph transition: C1 fallback -> C4 owner path, three replays, pass
- TP4 opt-in: BF16 rows 1/2/4/8 at hidden 6144, eager and CUDA graph, pass
- TP2 opt-in: BF16 rows 1/2/4/8 at hidden 4096, eager and CUDA graph, pass
- Earlier POC stress qualification: opposite-order multistream, alternating graph slots, and 512 eager + 1024 graph + 1024 multistream iterations, pass

GPU validation used the r31 CUDA 13.2 runtime image while mounting this exact branch. No vLLM change is required for the B12X policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fused PCIe transport support for TP2, TP4, and TP8 topologies, including remote-push and owner-reduction modes.
  - Added configurable eager-buffer sizing for PCIe all-reduce operations.
  - Added automatic transport selection with topology-aware fallbacks and opt-out controls.
  - Added Float32-to-Uint32 bit-casting support for low-level operations.

- **Bug Fixes**
  - Improved graph capture, replay, synchronization, and buffer handling across topology transitions.

- **Tests**
  - Expanded coverage for transport selection, eager buffering, graph transitions, tensor shapes, and device validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->