### PR TITLE
fix(gemm): preserve dense API contracts with block FP8

### DIFF
--- a/b12x/_lib/dense_gemm.py
+++ b/b12x/_lib/dense_gemm.py
@@ -630,6 +630,7 @@ class DenseGemmKernel:
         mxfp6_fmt_b: Optional[str] = None,
         b_packed: bool = False,
         plain_fp8: bool = False,
+        fused_quant_bf16: Optional[bool] = None,
         block_fp8: bool = False,
     ):
         # When set, A/B operands are MX codes carried in Float8E4M3FN
@@ -1884,10 +1885,12 @@ class DenseGemmKernel:
         accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
         if cutlass.const_expr(self.block_fp8):
             stage_accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
-            c_identity = cute.make_identity_tensor(
+            block_c_identity = cute.make_identity_tensor(
                 cute.slice_(self.tile_shape_mnk, (None, None, 0))
             )
-            coord_mn = _reshape_acc_to_mn(thr_mma.partition_C(c_identity))
+            block_coord_mn = _reshape_acc_to_mn(
+                thr_mma.partition_C(block_c_identity)
+            )
 
         # Cluster/thread sync
         if cute.size(self.cluster_shape_mnk) > 1:
@@ -2340,7 +2343,7 @@ class DenseGemmKernel:
                                 self._accumulate_block_fp8_stage(
                                     accumulators,
                                     stage_accumulators,
-                                    coord_mn,
+                                    block_coord_mn,
                                     directSFA_mkl,
                                     directSFB_nkl,
                                     tile_coord_mnl,
@@ -2485,7 +2488,7 @@ class DenseGemmKernel:
                             self._accumulate_block_fp8_stage(
                                 accumulators,
                                 stage_accumulators,
-                                coord_mn,
+                                block_coord_mn,
                                 directSFA_mkl,
                                 directSFB_nkl,
                                 tile_coord_mnl,
@@ -7094,6 +7097,7 @@ def dense_gemm(
     x_bf16: Optional[torch.Tensor] = None,
     w_gscale: Optional[torch.Tensor] = None,
     plain_fp8: bool = False,
+    row_scale: Optional[torch.Tensor] = None,
     block_fp8: bool = False,
 ) -> torch.Tensor:
     """Execute dense block-scaled GEMM for one expert-major batch stack.
@@ -7133,6 +7137,11 @@ def dense_gemm(
     ``plain_fp8``: emit non-block-scaled E4M3 warp MMA while reusing the
     SM12x dense pipeline. The scalar ``alpha`` carries the combined activation
     and weight dequantization scale.
+
+    ``row_scale``: optional contiguous ``(M,)`` tensor in the C dtype, applied
+    per output row in the epilogue. It replaces a separate ``out.mul_(v)``
+    launch and reproduces that multiply bit-for-bit, including its second
+    rounding to the C dtype. MX-FP6 only.
 
     ``block_fp8``: accumulate ordinary E4M3 MMA over each K128 block, then
     apply compact FP32 activation ``[M,K/128]`` and weight

--- a/tests/gemm/test_fp6_packed_b.py
+++ b/tests/gemm/test_fp6_packed_b.py
@@ -7,12 +7,26 @@ streaming format differs.
 """
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import torch
 
 cuda_required = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="requires CUDA"
 )
+
+
+def test_dense_gemm_preserves_fp6_api_contracts():
+    """Keep the FP6 caller and dense GEMM implementation contracts in sync."""
+    from b12x._lib.dense_gemm import DenseGemmKernel, dense_gemm
+
+    parameter = inspect.signature(dense_gemm).parameters["row_scale"]
+    assert parameter.default is None
+    kernel_parameter = inspect.signature(DenseGemmKernel).parameters[
+        "fused_quant_bf16"
+    ]
+    assert kernel_parameter.default is None
 
 
 def _gemm_operands(m: int, n: int, k: int, source_format: str):


### PR DESCRIPTION
## Summary

- preserve the existing `fused_quant_bf16` and FP6 `row_scale` API contracts when adding the regular K128 block-FP8 path
- keep block-FP8 accumulator coordinates in distinct CuTe DSL locals
- add a focused signature regression test for both legacy parameters

## Root cause

Commit `fe92b95` added `block_fp8`, but two signatures replaced existing parameters instead of appending the new one:

- `DenseGemmKernel.fused_quant_bf16`
- `dense_gemm.row_scale`

The implementation and callers still used those parameters. This caused model warmup to fail on FP6 row-scale paths and removed the explicit fused-quant compile-key input.

The same change also introduced a block-FP8 local named `c_identity` in the shared CuTe DSL kernel. Legacy fused-quant compilation uses that name in other compile-time branches. CuTe therefore observed `None` on one control-flow path and a tensor on another and rejected the first real DSpark request with `TYPE_UNSTABLE_JOIN`. Distinct `block_c_identity` / `block_coord_mn` locals remove that cross-family type join without changing either kernel's arithmetic.

## Validation

- Ruff and `git diff --check`: pass
- targeted API, FP6 row-scale, block-FP8 correctness and graph tests: 9 passed
- legacy fused-quant GPU oracle plus CUDA graph replay: passed
- DS4-Flash-0731 TP4/K5 full-model boot: target, DSpark and context-KV FULL CUDA graph capture passed
- 64 concurrent deterministic requests: 64/64 correct, no runtime errors
- matched remote-host performance versus r31:
  - C1: 238.7 vs 229.7 tok/s
  - C64: 2551.3 vs 2540.5 tok/s
  - prefill 8k/64k: 15187/14904 tok/s

The full-model test used GPUs 4-7 on the same direct-attached host as the r31 reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-row scaling support for MX-FP6 dense matrix multiplication.
  * Added per-launch control over fused BF16 quantization.
  * Preserved the existing output rounding behavior for scaled operations.

* **Documentation**
  * Documented the new row-scaling behavior and optional controls.

* **Tests**
  * Added regression coverage to verify the public API defaults remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->