### PR TITLE
fix(gemm): restore capture-safe K6 small-M dispatch

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -4199,12 +4199,10 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 local_n16 = Int32(4) * w_n + Int32(jj)
                 tile_base = Int32(0)
-                if cutlass.const_expr(int(low_bits) == int(high_bits)):
-                    tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
-                    wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
-                        b_region, tile_base, lane, low_bits
-                    )
-                elif logical_k16 < Int32(8):
+                if (
+                    cutlass.const_expr(int(low_bits) == int(high_bits))
+                    or logical_k16 < Int32(8)
+                ):
                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits
@@ -11323,6 +11321,69 @@ def _run_trellis256_dense_current_device(
     external_hadamard_128 = (
         None if hadamard_128 is None else _resolve_exl3_hadamard_128(hadamard_128)
     )
+
+    # Keep the established K6/MCG decode path independent from the generic
+    # Trellis scheduler. It owns both H128 rotations, needs no GEMM scratch,
+    # and is safe to capture with only caller-owned output/rotation storage.
+    # Compact pair payloads and the newer SQG codebooks use the generic path.
+    use_k6_mcg_small = (
+        m <= 128
+        and trellis_bits == 6
+        and trellis_codebook == "mcg"
+        and trellis_pair_kind is None
+        and compute_dtype == torch.float16
+        and external_hadamard_128 is None
+    )
+    if use_k6_mcg_small:
+        if x.dtype == torch.float16:
+            x_f16 = x
+        else:
+            input_f16 = _trellis_dense_buffer(
+                "input_f16",
+                input_f16,
+                shape=(m, size_k),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            input_f16.copy_(x)
+            x_f16 = input_f16
+        rotated_f16 = _trellis_dense_buffer(
+            "rotated_f16",
+            rotated_f16,
+            shape=(m, size_k),
+            dtype=torch.float16,
+            device=x.device,
+        )
+        if output.dtype == torch.float16:
+            small_output = output
+        else:
+            output_f16 = _trellis_dense_buffer(
+                "output_f16",
+                output_f16,
+                shape=(m, size_n),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            small_output = output_f16
+        from b12x.gemm.trellis_linear._small_m import run_k6_mcg
+
+        trellis_i16 = prepared_dense.trellis.view(torch.int16).view(
+            size_k // 16,
+            size_n // 16,
+            96,
+        )
+        run_k6_mcg(
+            x_f16,
+            trellis_i16,
+            small_output,
+            prepared_dense.suh,
+            rotated_f16,
+            prepared_dense.svh,
+            prepared_dense.workspace,
+        )
+        if output.dtype != torch.float16:
+            output.copy_(small_output)
+        return output
 
     gemm_output = _trellis_dense_buffer(
         "gemm_output",

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -11239,6 +11239,28 @@ def _trellis_dense_buffer(
     return buffer
 
 
+def _use_k6_mcg_small(
+    *,
+    device: torch.device,
+    m: int,
+    trellis_bits: int,
+    trellis_codebook: str,
+    trellis_pair_kind,
+    compute_dtype: torch.dtype,
+    external_hadamard_128,
+) -> bool:
+    """Select the capture-safe K6/MCG kernel only on its compiled target."""
+    return (
+        tuple(torch.cuda.get_device_capability(device)) == (12, 0)
+        and m <= 128
+        and trellis_bits == 6
+        and trellis_codebook == "mcg"
+        and trellis_pair_kind is None
+        and compute_dtype == torch.float16
+        and external_hadamard_128 is None
+    )
+
+
 def _run_trellis256_dense_current_device(
     x: torch.Tensor,
     prepared_dense,
@@ -11326,13 +11348,14 @@ def _run_trellis256_dense_current_device(
     # Trellis scheduler. It owns both H128 rotations, needs no GEMM scratch,
     # and is safe to capture with only caller-owned output/rotation storage.
     # Compact pair payloads and the newer SQG codebooks use the generic path.
-    use_k6_mcg_small = (
-        m <= 128
-        and trellis_bits == 6
-        and trellis_codebook == "mcg"
-        and trellis_pair_kind is None
-        and compute_dtype == torch.float16
-        and external_hadamard_128 is None
+    use_k6_mcg_small = _use_k6_mcg_small(
+        device=x.device,
+        m=m,
+        trellis_bits=trellis_bits,
+        trellis_codebook=trellis_codebook,
+        trellis_pair_kind=trellis_pair_kind,
+        compute_dtype=compute_dtype,
+        external_hadamard_128=external_hadamard_128,
     )
     if use_k6_mcg_small:
         if x.dtype == torch.float16:

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -36,6 +36,7 @@ from b12x.moe._shared.kernels.trellis_w4a8_transform import (
 from b12x.moe._shared.kernels.w4a16.kernel import (
     _run_trellis_dense_hadamard128,
     _trellis256_dense_launch_geometry,
+    _use_k6_mcg_small,
 )
 from b12x.moe._shared.kernels.w4a16.prepare import (
     prepare_qsrt_pair_moe_weights,
@@ -411,6 +412,39 @@ def test_k6_small_m_rejects_unsupported_arch_before_jit(monkeypatch) -> None:
 
     with pytest.raises(NotImplementedError, match="built for sm_120 only"):
         _small_m.run_k6_mcg(*(torch.empty(0) for _ in range(7)))
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ((12, 0), True),
+        ((12, 1), False),
+        ((9, 0), False),
+    ],
+)
+def test_k6_small_m_dispatch_requires_compiled_target(
+    monkeypatch,
+    capability: tuple[int, int],
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda _device: capability,
+    )
+
+    assert (
+        _use_k6_mcg_small(
+            device=torch.device("cuda"),
+            m=128,
+            trellis_bits=6,
+            trellis_codebook="mcg",
+            trellis_pair_kind=None,
+            compute_dtype=torch.float16,
+            external_hadamard_128=None,
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Restore the established cooperative K6/MCG dense path for `M <= 128`.
- Keep the gate narrow: K6, MCG, unpaired payload, FP16 compute, and no external H128 callback. SQG/QSRT, paired payloads, BF16, and externally rotated calls remain on the generic scheduler.
- Reuse caller-owned output and rotation buffers, so vLLM decode graph capture does not require the generic W4A16 GEMM scratch arena.

## Root cause

`master` at `9bbae67` removed the K6/MCG small-M dispatch while retaining its implementation and CUDA-graph regression test. vLLM intentionally provisions only a one-element generic scratch placeholder for this qualified small-M path. Falling through to the generic scheduler therefore fails during graph capture with `W4A16 GEMM scratch is not initialized for CUDA graph capture`.

The fix restores the original ownership contract rather than increasing persistent scratch or disabling CUDA graphs.

## Validation

- Current `master`: `test_k6_small_m_cuda_graph_replay_is_stable` fails during capture.
- This branch: all K6 small-M tests -> **17 passed, 48 deselected** on SM120, including numerical comparison against the generic CuTe path and CUDA-graph replay.
- Ruff and `git diff --check`: pass.
- Live GLM-5.2 EXL3 3.36 bpw, TP4/DCP1/MTP3: FULL and PIECEWISE graph capture complete and coherent generation passes when combined with the mixed-ABI repair.
- Warm synthetic C1 regression gate: 139.5 and 144.4 tok/s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved quantized matrix multiplication tile selection for more efficient low-bit layouts.
  * Added a specialized path for small FP16 inputs to accelerate K6 MCG operations.
  * Reduced unnecessary metadata, transformations, and scheduling for eligible workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->