### PR TITLE
fix(moe): realign mixed Trellis with QSRT ABI

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -441,7 +441,17 @@ def _candidate_tile_fits(
         or int(tile_k) % scale_group_size != 0
     ):
         return False
-    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
+    ultra_wide_fc2 = (
+        int(tile_n) == 512
+        and int(tile_k) == 32
+        and int(cta_threads) == 256
+        and _scale_group_size(scale_format) == 32
+    )
+    if (
+        int(tile_n) < 64
+        or (int(tile_k) < 64 and not ultra_wide_fc2)
+        or int(cta_threads) < 128
+    ):
         return False
     smem_bytes = _shared_memory_footprint(
         cta_m_blocks=cta_m_blocks,
@@ -1963,7 +1973,7 @@ class W4A16GemmKernel:
             reduce_slice_idx,
             lock_slot,
             active_size_m,
-            -1,
+            Int32(0),
         )
 
     @cute.jit
@@ -2466,6 +2476,7 @@ class W4A16GemmKernel:
             a_rows_per_iter,
             output_n_tile,
             expert_idx,
+            -1,
         )
 
         b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
@@ -2478,6 +2489,8 @@ class W4A16GemmKernel:
             s_sh_rd,
             Int32(0),
             Int32(0),
+            Int32(0),
+            0,
         )
         a0_regs_cur = cute.make_rmem_tensor((2,), Uint32)
         a0_regs_next = cute.make_rmem_tensor((2,), Uint32)
@@ -2524,6 +2537,7 @@ class W4A16GemmKernel:
             a_rows_per_iter,
             output_n_tile,
             expert_idx,
+            0,
         )
 
         self._finish_tile(
@@ -2979,6 +2993,7 @@ class W4A16GemmKernel:
         a_rows_per_iter: Int32,
         output_n_tile: Int32,
         expert_idx: Int32,
+        dynamic_pair_override: cutlass.Constexpr[int],
     ):
         b_frag = cute.make_rmem_tensor((2, 2), Uint32)
         tile_idx = Int32(0)
@@ -3000,6 +3015,7 @@ class W4A16GemmKernel:
                             kk,
                             tile_idx,
                             k_tiles,
+                            dynamic_pair_override,
                         )
 
                         self._prefetch_pipeline_step(
@@ -3028,6 +3044,7 @@ class W4A16GemmKernel:
                             a_rows_per_iter,
                             output_n_tile,
                             expert_idx,
+                            dynamic_pair_override,
                         )
 
                         for jj in cutlass.range_constexpr(4):
@@ -3068,6 +3085,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     Int32(0),
                     Int32(0),
+                    tile_idx,
+                    dynamic_pair_override,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_cur,
@@ -3856,6 +3875,7 @@ class W4A16GemmKernel:
         kk: cutlass.Constexpr[int],
         tile_idx: Int32,
         k_tiles: Int32,
+        dynamic_pair_override: cutlass.Constexpr[int],
     ):
         self._clear_b_scale_register_bundle(b_scale_next)
         self._clear_a_register_bundle_m8(a0_regs_next)
@@ -3871,6 +3891,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     Int32(pipe),
                     Int32(kk + 1),
+                    tile_idx,
+                    dynamic_pair_override,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_next,
@@ -3898,6 +3920,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     next_pipe,
                     Int32(0),
+                    next_tile,
+                    dynamic_pair_override,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_next,
@@ -4199,12 +4223,10 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 local_n16 = Int32(4) * w_n + Int32(jj)
                 tile_base = Int32(0)
-                if cutlass.const_expr(int(low_bits) == int(high_bits)):
-                    tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
-                    wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
-                        b_region, tile_base, lane, low_bits
-                    )
-                elif logical_k16 < Int32(8):
+                if (
+                    cutlass.const_expr(int(low_bits) == int(high_bits))
+                    or logical_k16 < Int32(8)
+                ):
                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits

--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -245,6 +245,9 @@ class W4A16MixedTrellisKernel:
         factor = gemm.schedule_route_block_factor
         first_route_block = route_block_idx * Int32(factor)
         first_lock_slot = lock_slot * Int32(factor)
+        # Mixed K3/K4 execution is pinned to the MCG codebook, whose tile
+        # decoder does not consume the generic Trellis LUT ABI slot.
+        trellis_lut_addr = cutlass.Int64(0)
         if cutlass.const_expr(gemm.paired_m8_routes):
             gemm._run_tile_m8_pair(
                 a_flat,
@@ -257,6 +260,7 @@ class W4A16MixedTrellisKernel:
                 topk_weights,
                 c_tmp,
                 locks,
+                trellis_lut_addr,
                 smem_base,
                 tid,
                 first_route_block,
@@ -282,6 +286,7 @@ class W4A16MixedTrellisKernel:
                     topk_weights,
                     c_tmp,
                     locks,
+                    trellis_lut_addr,
                     smem_base,
                     tid,
                     first_route_block + Int32(subtile),
@@ -761,6 +766,10 @@ class W4A16MixedTrellisKernel:
             gate_suh,
             up_suh,
             descriptor_map,
+            # Mixed tier emit hooks own Trellis decoding, so the shared
+            # driver's LUT ABI slots are intentionally unused.
+            cutlass.Int64(0),
+            cutlass.Int64(0),
             total_experts,
             total_experts,
             smem_base,
@@ -834,6 +843,7 @@ def compile_mixed_trellis(
             scale_format="e4m3_k32",
             w13_layout="trellis3_t256_proj",
             trellis_bits=bits,
+            trellis_codebook="mcg",
             intermediate_rotation=True,
             full_rotation=True,
             rotation_input_dtype=rotation_input_dtype,

--- a/tests/moe/test_mixed_trellis_source_contract.py
+++ b/tests/moe/test_mixed_trellis_source_contract.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _method(path: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef) and member.name == method_name:
+                    return member
+    raise AssertionError(f"missing {class_name}.{method_name} in {path}")
+
+
+def test_mixed_trellis_call_tracks_shared_moe_body_abi() -> None:
+    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
+    body = _method(kernel_path, "W4A16FusedMoeKernel", "_moe_body")
+    mixed = _method(mixed_path, "W4A16MixedTrellisKernel", "kernel")
+
+    calls = [
+        node
+        for node in ast.walk(mixed)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_moe_body"
+    ]
+    assert len(calls) == 1
+    call = calls[0]
+    assert not call.keywords
+
+    parameters = [argument.arg for argument in body.args.args][1:]
+    arguments = [ast.unparse(argument) for argument in call.args]
+    assert len(arguments) == len(parameters)
+    bound = dict(zip(parameters, arguments, strict=True))
+
+    assert bound["fc1_trellis_lut_addr"] == "cutlass.Int64(0)"
+    assert bound["fc2_trellis_lut_addr"] == "cutlass.Int64(0)"
+    assert bound["weight_num_experts"] == "total_experts"
+    assert bound["route_num_experts"] == "total_experts"
+    assert bound["active_m"] == "active_m"
+    assert bound["fc1_emit_tile"] == "fc1_emit"
+    assert bound["fc2_emit_tile"] == "fc2_emit"
+
+
+def test_mixed_trellis_dispatch_tracks_tile_abis() -> None:
+    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
+    dispatch = _method(mixed_path, "W4A16MixedTrellisKernel", "_dispatch_tier_gemm")
+
+    for method_name in ("_run_tile", "_run_tile_m8_pair"):
+        target = _method(kernel_path, "W4A16GemmKernel", method_name)
+        calls = [
+            node
+            for node in ast.walk(dispatch)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == method_name
+        ]
+        assert len(calls) == 1
+        parameters = [argument.arg for argument in target.args.args][1:]
+        arguments = [ast.unparse(argument) for argument in calls[0].args]
+        assert len(arguments) == len(parameters)
+        bound = dict(zip(parameters, arguments, strict=True))
+        assert bound["trellis_lut_addr"] == "trellis_lut_addr"
+        assert bound["active_size_m"] == "active_size_m"
+
+
+def test_w4a16_internal_calls_supply_required_arguments() -> None:
+    path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    kernel = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "W4A16GemmKernel"
+    )
+    methods = {
+        node.name: node for node in kernel.body if isinstance(node, ast.FunctionDef)
+    }
+
+    mismatches: list[str] = []
+    for caller in methods.values():
+        for call in ast.walk(caller):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "self"
+                and call.func.attr in methods
+            ):
+                continue
+            callee = methods[call.func.attr]
+            maximum = len(callee.args.args) - 1
+            required = maximum - len(callee.args.defaults)
+            supplied = len(call.args) + len(call.keywords)
+            if not required <= supplied <= maximum:
+                mismatches.append(
+                    f"{caller.name}:{call.lineno} -> {callee.name}: "
+                    f"supplied={supplied}, required={required}, maximum={maximum}"
+                )
+
+    assert not mismatches, "\n".join(mismatches)

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -145,8 +145,10 @@ def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
 
     driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
     assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
-    assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
+    assert [ast.unparse(arg) for arg in calls[0].args[-12:]] == [
         "descriptor_map",
+        "cutlass.Int64(0)",
+        "cutlass.Int64(0)",
         "total_experts",
         "total_experts",
         "smem_base",


### PR DESCRIPTION
## Summary

- Realign the existing mixed K3/K4 MCG launcher with the shared W4A16 ABI added by the fixed-payload QSRT work.
- Supply the new LUT and paired-M8 helper arguments at every direct call site, while keeping the established mixed checkpoint path explicitly on the MCG codebook.
- Restore qualification of the existing 512x32 ultra-wide FC2 tile used by the GLM-5.2 mixed prefill geometry.
- Add AST contract tests so future shared-kernel signature changes fail in unit tests instead of at CuTe compilation or model startup.

## Root cause

`master` at `9bbae67` changed several shared W4A16 signatures without updating the existing mixed K3/K4 direct calls. Arguments shifted position, so `active_m` received a callable and compilation failed with `functools.partial * Int32`. The forced GLM FC2 tile was also rejected by the generic tile floor despite having a valid e4m3-k32 geometry.

This PR is deliberately narrower than #129: it restores the already-supported MCG mixed path on current `master`; it does not adopt the broader Fruit/SQG serving feature. If #129 is rebased, it should preserve or supersede these ABI regression contracts explicitly.

## Validation

- Current `master`: `tests/moe/test_w4a16_mixed_trellis.py` -> **10 failed, 5 passed**.
- This branch: mixed suite plus new ABI contracts -> **18 passed** on SM120.
- Ruff and `git diff --check`: pass.
- Live GLM-5.2 EXL3 3.36 bpw, TP4/DCP1/MTP3: mixed tiers load, FULL and PIECEWISE graph capture complete, coherent generation passes.
- Warm synthetic C1 regression gate after the paired K6 fix: 139.5 and 144.4 tok/s; this is an MTP-friendly stability gate, not a general workload headline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixed-trellis processing for low-bit layouts and equal-bitrate tile pairs.
  * Enabled an additional FC2 specialization for supported K/32 scaling configurations.
  * Corrected codebook and dynamic pair handling for more reliable kernel execution.

* **Tests**
  * Added coverage to validate mixed-trellis dispatch, argument contracts, and internal kernel calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->