### PR TITLE
perf(dcp-a2a): vectorize CuTe TP16 pair gather and exact top-16 routing

### DIFF
--- a/b12x/comm/pcie/_cute_intrinsics.py
+++ b/b12x/comm/pcie/_cute_intrinsics.py
@@ -488,3 +488,57 @@ def rsqrt_approx_f32(value: Float32, *, loc=None, ip=None) -> Float32:
             ip=ip,
         )
     )
+
+
+@dsl_user_op
+def float_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Map a float onto a u32 whose unsigned order matches float order.
+
+    Lets a (score, expert) pair be packed into one integer key, so "better
+    candidate" becomes a plain integer max and the tie-break stops costing a
+    second comparison.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .u32 bits, mask;
+                mov.b32 bits, $1;
+                shr.u32 mask, bits, 31;
+                mul.lo.u32 mask, mask, 0x7fffffff;
+                or.b32 mask, mask, 0x80000000;
+                xor.b32 $0, bits, mask;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def redux_max_u32(value: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Warp-wide unsigned max in one instruction.
+
+    ``cute.arch.warp_redux_sync`` exposes the float variant, which libNVVM
+    rejects for sm_120a; the integer one is what the kernel actually needs.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(value).ir_value(loc=loc, ip=ip)],
+            "redux.sync.max.u32 $0, $1, 0xffffffff;",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -23,6 +23,8 @@ from b12x._lib.utils import current_cuda_stream, make_ptr
 
 from ._dcp_cute_common import block_pair_barrier
 from ._cute_intrinsics import (
+    float_order_key,
+    redux_max_u32,
     ld_generic_f32,
     ld_relaxed_gpu_u32,
     pack_f32x2_to_bf16x2,
@@ -187,6 +189,72 @@ def _add_u64_opaque(
         )
     )
 
+
+
+_KIMI_NEG_INF = float("-inf")
+
+
+@cute.jit
+def _kimi_pack_key(score: Float32, expert: Int32) -> cutlass.Uint64:
+    """Pack (score, expert) so that a plain integer max picks the winner.
+
+    The expert index goes in complemented, so a tie on score resolves to the
+    lower index -- the same order the native reference produces, without a
+    second comparison at every step.
+    """
+    return (cutlass.Uint64(float_order_key(score)) << cutlass.Uint64(32)) | (
+        cutlass.Uint64(0xFFFF) - cutlass.Uint64(expert)
+    )
+
+
+@cute.jit
+def _kimi_key_expert(key: cutlass.Uint64) -> Int32:
+    return Int32(cutlass.Uint64(0xFFFF) - (key & cutlass.Uint64(0xFFFF)))
+
+
+@cute.jit
+def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
+    """Warp-wide max of a 64-bit key in two instructions.
+
+    Reduces the high words, then only the low words of the lanes that tied on
+    the high word, which is cheaper than carrying a 64-bit value through a
+    shuffle chain.
+    """
+    hi = cutlass.Uint32(key >> cutlass.Uint64(32))
+    lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
+    max_hi = redux_max_u32(hi)
+    contribution = cutlass.Uint32(0)
+    if hi == max_hi:
+        contribution = lo
+    max_lo = redux_max_u32(contribution)
+    return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
+
+
+def _kimi_sort_desc(keys, count: int) -> None:
+    """Descending bitonic sort over a compile-time number of packed keys.
+
+    Every index is a Python constant, so the whole network unrolls and the
+    per-round selection can just read ``keys[0]``.
+    """
+    width = 2
+    while width <= count:
+        stride = width // 2
+        while stride > 0:
+            for index in range(count):
+                peer = index ^ stride
+                if peer <= index:
+                    continue
+                descending = (index & width) == 0
+                lower = keys[index]
+                upper = keys[peer]
+                if descending:
+                    keys[index] = cutlass.max(lower, upper)
+                    keys[peer] = cutlass.min(lower, upper)
+                else:
+                    keys[index] = cutlass.min(lower, upper)
+                    keys[peer] = cutlass.max(lower, upper)
+            stride //= 2
+        width *= 2
 
 class _DCPA2ABase:
     def __init__(
@@ -1253,12 +1321,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
-                # Per-thread partial argmax for the block-wide top-16 below.
-                reduce_scores: cute.struct.Align[
-                    cute.struct.MemRange[Float32, 512], 16
-                ]
-                reduce_ids: cute.struct.Align[
-                    cute.struct.MemRange[Int32, 512], 16
+                # The 64 survivors of the warp-local rounds, as packed keys.
+                reduce_keys: cute.struct.Align[
+                    cute.struct.MemRange[cutlass.Uint64, 64], 16
                 ]
 
             storage = smem_alloc.allocate(SharedStorage)
@@ -1268,11 +1333,8 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
             )
-            reduce_scores = storage.reduce_scores.get_tensor(
-                cute.make_layout((512,), stride=(1,))
-            )
-            reduce_ids = storage.reduce_ids.get_tensor(
-                cute.make_layout((512,), stride=(1,))
+            reduce_keys = storage.reduce_keys.get_tensor(
+                cute.make_layout((64,), stride=(1,))
             )
 
             expert = Int32(tidx)
@@ -1325,101 +1387,63 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             # survivors. A round costs two warp reductions instead of a
             # shared-memory scan, and the selection needs one block barrier
             # rather than two per round.
-            _NONE = Int32(0x7FFFFFFF)
+            # Two-level top-16 over packed (score, expert) keys, mirroring the
+            # kernel this path replaced. Four warps each reduce 256 experts held
+            # in registers (8 per lane); warp 0 then merges the 64 survivors.
+            # A round costs one warp reduction -- two instructions -- because the
+            # tie-break lives in the key rather than in a second comparison.
             lane = Int32(tidx) % Int32(32)
             warp = Int32(tidx) // Int32(32)
-            won_score = Float32(float("-inf"))
-            won_expert = _NONE
-            cand_scores = cute.make_rmem_tensor((8,), Float32)
-            cand_experts = cute.make_rmem_tensor((8,), Int32)
+            lane_key = cutlass.Uint64(0)
+            keys = cute.make_rmem_tensor((8,), cutlass.Uint64)
             if warp < Int32(4):
                 for item in cutlass.range_constexpr(8):
                     expert_id = warp * Int32(256) + Int32(item * 32) + lane
-                    value = Float32(float("-inf"))
+                    value = Float32(_KIMI_NEG_INF)
                     if expert_id < Int32(896):
                         value = selection_scores[expert_id]
-                    cand_scores[item] = value
-                    cand_experts[item] = expert_id
+                    keys[item] = _kimi_pack_key(value, expert_id)
+                _kimi_sort_desc(keys, 8)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    local_best = Float32(float("-inf"))
-                    local_id = _NONE
-                    for item in cutlass.range_constexpr(8):
-                        if cand_scores[item] > local_best or (
-                            cand_scores[item] == local_best
-                            and cand_experts[item] < local_id
-                        ):
-                            local_best = cand_scores[item]
-                            local_id = cand_experts[item]
-                    offset = Int32(16)
-                    while offset > Int32(0):
-                        peer_best = cute.arch.shuffle_sync_bfly(
-                            local_best, offset
-                        )
-                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                        if peer_best > local_best or (
-                            peer_best == local_best and peer_id < local_id
-                        ):
-                            local_best = peer_best
-                            local_id = peer_id
-                        offset = offset // Int32(2)
-                    round_best = local_best
-                    round_expert = local_id
+                    if cutlass.const_expr(selected > 0):
+                        if previous == keys[0]:
+                            tail_expert = _kimi_key_expert(keys[7])
+                            for item in cutlass.range_constexpr(7):
+                                keys[item] = keys[item + 1]
+                            keys[7] = _kimi_pack_key(
+                                Float32(_KIMI_NEG_INF), tail_expert
+                            )
+                    previous = _kimi_warp_max_key(keys[0])
                     if lane == Int32(selected):
-                        won_score = round_best
-                        won_expert = round_expert
-                    for item in cutlass.range_constexpr(8):
-                        if cand_experts[item] == round_expert:
-                            cand_scores[item] = Float32(float("-inf"))
+                        lane_key = previous
                 if lane < Int32(16):
-                    reduce_scores[warp * Int32(16) + lane] = won_score
-                    reduce_ids[warp * Int32(16) + lane] = won_expert
+                    reduce_keys[warp * Int32(16) + lane] = lane_key
             cute.arch.sync_threads()
             selected_ids = cute.make_rmem_tensor((16,), Int32)
             selected_weights = cute.make_rmem_tensor((16,), Float32)
             weight_sum = Float32(0.0)
             if warp == Int32(0):
-                merge_scores = cute.make_rmem_tensor((2,), Float32)
-                merge_experts = cute.make_rmem_tensor((2,), Int32)
+                merge_keys = cute.make_rmem_tensor((2,), cutlass.Uint64)
                 for item in cutlass.range_constexpr(2):
-                    merge_slot = Int32(item * 32) + lane
-                    merge_scores[item] = reduce_scores[merge_slot]
-                    merge_experts[item] = reduce_ids[merge_slot]
+                    merge_keys[item] = reduce_keys[Int32(item * 32) + lane]
+                _kimi_sort_desc(merge_keys, 2)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    local_best = Float32(float("-inf"))
-                    local_id = _NONE
-                    for item in cutlass.range_constexpr(2):
-                        if merge_scores[item] > local_best or (
-                            merge_scores[item] == local_best
-                            and merge_experts[item] < local_id
-                        ):
-                            local_best = merge_scores[item]
-                            local_id = merge_experts[item]
-                    offset = Int32(16)
-                    while offset > Int32(0):
-                        peer_best = cute.arch.shuffle_sync_bfly(
-                            local_best, offset
-                        )
-                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                        if peer_best > local_best or (
-                            peer_best == local_best and peer_id < local_id
-                        ):
-                            local_best = peer_best
-                            local_id = peer_id
-                        offset = offset // Int32(2)
-                    round_best = local_best
-                    round_expert = local_id
-                    final_expert = Int32(-1)
-                    if round_expert != _NONE:
-                        final_expert = round_expert
+                    if cutlass.const_expr(selected > 0):
+                        if previous == merge_keys[0]:
+                            tail_expert = _kimi_key_expert(merge_keys[1])
+                            merge_keys[0] = merge_keys[1]
+                            merge_keys[1] = _kimi_pack_key(
+                                Float32(_KIMI_NEG_INF), tail_expert
+                            )
+                    previous = _kimi_warp_max_key(merge_keys[0])
+                    # The reduction broadcasts, so every lane agrees here.
+                    final_expert = _kimi_key_expert(previous)
                     selected_ids[selected] = final_expert
-                    weight = Float32(0.0)
-                    if final_expert >= Int32(0):
-                        weight = unbiased_scores[final_expert]
+                    weight = unbiased_scores[final_expert]
                     selected_weights[selected] = weight
                     weight_sum += weight
-                    for item in cutlass.range_constexpr(2):
-                        if merge_experts[item] == round_expert:
-                            merge_scores[item] = Float32(float("-inf"))
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1526,12 +1526,6 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Two-level warp-local top-16, mirroring the C++ kernel this path
-            # replaced. Four warps each reduce 256 experts held in registers
-            # (8 per lane) with warp reductions, then warp 0 merges the 64
-            # survivors. A round costs two warp reductions instead of a
-            # shared-memory scan, and the selection needs one block barrier
-            # rather than two per round.
             # Two-level top-16 over packed (score, expert) keys, mirroring the
             # kernel this path replaced. Four warps each reduce 256 experts held
             # in registers (8 per lane); warp 0 then merges the 64 survivors.

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1319,73 +1319,107 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Block-wide top-16 selection. The previous implementation ran
-            # this on thread 0 alone: 16 rounds x 896 candidates x up to 15
-            # prior-selection checks, about 1e5 serial steps per row, which
-            # made this kernel 320 us against 39 us for the C++ original.
-            # Each round now argmaxes across every thread and masks the winner
-            # with -inf, the same scheme the C++ kernel used.
+            # Two-level warp-local top-16, mirroring the C++ kernel this path
+            # replaced. Four warps each reduce 256 experts held in registers
+            # (8 per lane) with warp reductions, then warp 0 merges the 64
+            # survivors. A round costs two warp reductions instead of a
+            # shared-memory scan, and the selection needs one block barrier
+            # rather than two per round.
+            _NONE = Int32(0x7FFFFFFF)
+            lane = Int32(tidx) % Int32(32)
+            warp = Int32(tidx) // Int32(32)
+            won_score = Float32(float("-inf"))
+            won_expert = _NONE
+            cand_scores = cute.make_rmem_tensor((8,), Float32)
+            cand_experts = cute.make_rmem_tensor((8,), Int32)
+            if warp < Int32(4):
+                for item in cutlass.range_constexpr(8):
+                    expert_id = warp * Int32(256) + Int32(item * 32) + lane
+                    value = Float32(float("-inf"))
+                    if expert_id < Int32(896):
+                        value = selection_scores[expert_id]
+                    cand_scores[item] = value
+                    cand_experts[item] = expert_id
+                for selected in cutlass.range_constexpr(16):
+                    local_best = Float32(float("-inf"))
+                    local_id = _NONE
+                    for item in cutlass.range_constexpr(8):
+                        if cand_scores[item] > local_best or (
+                            cand_scores[item] == local_best
+                            and cand_experts[item] < local_id
+                        ):
+                            local_best = cand_scores[item]
+                            local_id = cand_experts[item]
+                    offset = Int32(16)
+                    while offset > Int32(0):
+                        peer_best = cute.arch.shuffle_sync_bfly(
+                            local_best, offset
+                        )
+                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                        if peer_best > local_best or (
+                            peer_best == local_best and peer_id < local_id
+                        ):
+                            local_best = peer_best
+                            local_id = peer_id
+                        offset = offset // Int32(2)
+                    round_best = local_best
+                    round_expert = local_id
+                    if lane == Int32(selected):
+                        won_score = round_best
+                        won_expert = round_expert
+                    for item in cutlass.range_constexpr(8):
+                        if cand_experts[item] == round_expert:
+                            cand_scores[item] = Float32(float("-inf"))
+                if lane < Int32(16):
+                    reduce_scores[warp * Int32(16) + lane] = won_score
+                    reduce_ids[warp * Int32(16) + lane] = won_expert
+            cute.arch.sync_threads()
             selected_ids = cute.make_rmem_tensor((16,), Int32)
             selected_weights = cute.make_rmem_tensor((16,), Float32)
-            for selected in cutlass.range_constexpr(16):
-                selected_ids[selected] = Int32(-1)
-                selected_weights[selected] = Float32(0.0)
             weight_sum = Float32(0.0)
-            for selected in cutlass.range_constexpr(16):
-                local_best = Float32(float("-inf"))
-                local_id = Int32(-1)
-                candidate = Int32(tidx)
-                while candidate < Int32(896):
-                    score = selection_scores[candidate]
-                    if score > local_best or (
-                        score == local_best
-                        and (local_id < Int32(0) or candidate < local_id)
-                    ):
-                        local_best = score
-                        local_id = candidate
-                    candidate += Int32(self._threads)
-                # Reduce inside each warp with shuffles first: the shared
-                # round trip only has to carry one candidate per warp, so a
-                # round costs a single block sync instead of log2(threads).
-                offset = Int32(16)
-                while offset > Int32(0):
-                    peer_score = cute.arch.shuffle_sync_bfly(local_best, offset)
-                    peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                    if peer_id >= Int32(0):
-                        if peer_score > local_best or (
-                            peer_score == local_best
-                            and (local_id < Int32(0) or peer_id < local_id)
+            if warp == Int32(0):
+                merge_scores = cute.make_rmem_tensor((2,), Float32)
+                merge_experts = cute.make_rmem_tensor((2,), Int32)
+                for item in cutlass.range_constexpr(2):
+                    merge_slot = Int32(item * 32) + lane
+                    merge_scores[item] = reduce_scores[merge_slot]
+                    merge_experts[item] = reduce_ids[merge_slot]
+                for selected in cutlass.range_constexpr(16):
+                    local_best = Float32(float("-inf"))
+                    local_id = _NONE
+                    for item in cutlass.range_constexpr(2):
+                        if merge_scores[item] > local_best or (
+                            merge_scores[item] == local_best
+                            and merge_experts[item] < local_id
                         ):
-                            local_best = peer_score
+                            local_best = merge_scores[item]
+                            local_id = merge_experts[item]
+                    offset = Int32(16)
+                    while offset > Int32(0):
+                        peer_best = cute.arch.shuffle_sync_bfly(
+                            local_best, offset
+                        )
+                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                        if peer_best > local_best or (
+                            peer_best == local_best and peer_id < local_id
+                        ):
+                            local_best = peer_best
                             local_id = peer_id
-                    offset = offset // Int32(2)
-                warp = Int32(tidx) // Int32(32)
-                if Int32(tidx) % Int32(32) == Int32(0):
-                    reduce_scores[warp] = local_best
-                    reduce_ids[warp] = local_id
-                cute.arch.sync_threads()
-                best_score = Float32(float("-inf"))
-                best_expert = Int32(-1)
-                for slot in cutlass.range_constexpr(self._threads // 32):
-                    cand_score = reduce_scores[slot]
-                    cand_id = reduce_ids[slot]
-                    if cand_id >= Int32(0):
-                        if cand_score > best_score or (
-                            cand_score == best_score
-                            and (best_expert < Int32(0) or cand_id < best_expert)
-                        ):
-                            best_score = cand_score
-                            best_expert = cand_id
-                selected_ids[selected] = best_expert
-                weight = Float32(0.0)
-                if best_expert >= Int32(0):
-                    weight = unbiased_scores[best_expert]
-                selected_weights[selected] = weight
-                weight_sum += weight
-                if Int32(tidx) == Int32(0):
-                    if best_expert >= Int32(0):
-                        selection_scores[best_expert] = Float32(float("-inf"))
-                cute.arch.sync_threads()
+                        offset = offset // Int32(2)
+                    round_best = local_best
+                    round_expert = local_id
+                    final_expert = Int32(-1)
+                    if round_expert != _NONE:
+                        final_expert = round_expert
+                    selected_ids[selected] = final_expert
+                    weight = Float32(0.0)
+                    if final_expert >= Int32(0):
+                        weight = unbiased_scores[final_expert]
+                    selected_weights[selected] = weight
+                    weight_sum += weight
+                    for item in cutlass.range_constexpr(2):
+                        if merge_experts[item] == round_expert:
+                            merge_scores[item] = Float32(float("-inf"))
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -153,11 +153,10 @@ def _select_if_eq_u64(
 ) -> cutlass.Uint64:
     """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
 
-    A Python ``if`` on a runtime condition becomes a real branch region, and
-    the top-16 rounds update a register-held key array inside one. That
-    diverges the warp on every round and pushes the array to local memory. The
-    kernel this path replaced writes the same update as a ternary chain, which
-    is straight-line predicated code; ptxas folds the repeated setp.
+    A Python ``if`` on a runtime condition becomes a branch region. The top-16
+    rounds update a register-held key array, so a divergent branch can spill the
+    array to local memory. A ternary chain emits straight-line predicated code
+    and lets ptxas fold repeated ``setp`` operations.
     """
 
     return cutlass.Uint64(
@@ -255,7 +254,7 @@ def _add_u64_opaque(
     loc=None,
     ip=None,
 ) -> Int64:
-    """Add a payload offset without CSE into the earlier LSE address phase."""
+    """Add a payload offset without CSE into the LSE-address calculation."""
 
     return Int64(
         llvm.inline_asm(
@@ -1463,10 +1462,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 cute.make_layout((64,), stride=(1,))
             )
 
-            # Pull the router in 16B packs, the way the kernel this path
-            # replaced does. Reading it one float per expert costs 896 peer
-            # transactions instead of 224 for the same 3584 bytes, and over
-            # PCIe the transaction count is what the phase pays for.
+            # Pull the 3,584-byte router row in 16-byte packs. This uses 224
+            # peer transactions instead of 896 scalar transactions; PCIe
+            # transaction count dominates this phase.
             router_pack = Int32(tidx)
             router_packs_total = Int32(self._world_size) * second_packs
             while router_pack < router_packs_total:
@@ -1526,9 +1524,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Two-level top-16 over packed (score, expert) keys, mirroring the
-            # kernel this path replaced. Four warps each reduce 256 experts held
-            # in registers (8 per lane); warp 0 then merges the 64 survivors.
+            # Two-level top-16 over packed (score, expert) keys. Four warps each
+            # reduce 256 experts held in registers (8 per lane); warp 0 then
+            # merges the 64 survivors.
             # A round costs one warp reduction -- two instructions -- because the
             # tie-break lives in the key rather than in a second comparison.
             lane = Int32(tidx) % Int32(32)

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -17,6 +17,7 @@ from b12x._lib.intrinsics import (
     fmax_f32,
     ld_global_v4_u32,
     st_global_v4_u32,
+    u32_as_f32,
 )
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
@@ -106,6 +107,77 @@ def _a2a_graph_epoch_arrive(
 def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
     values = ld_global_v4_u32(source.toint())
     st_global_v4_u32(destination.toint(), *values)
+
+
+@dsl_user_op
+def _select_if_eq_u32(
+    lhs: Uint32,
+    rhs: Uint32,
+    on_equal: Uint32,
+    otherwise: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select."""
+
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Uint32(lhs).ir_value(loc=loc, ip=ip),
+                Uint32(rhs).ir_value(loc=loc, ip=ip),
+                Uint32(on_equal).ir_value(loc=loc, ip=ip),
+                Uint32(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u32 p, $1, $2; selp.b32 $0, $3, $4, p; }",
+            "=r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _select_if_eq_u64(
+    lhs: cutlass.Uint64,
+    rhs: cutlass.Uint64,
+    on_equal: cutlass.Uint64,
+    otherwise: cutlass.Uint64,
+    *,
+    loc=None,
+    ip=None,
+) -> cutlass.Uint64:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
+
+    A Python ``if`` on a runtime condition becomes a real branch region, and
+    the top-16 rounds update a register-held key array inside one. That
+    diverges the warp on every round and pushes the array to local memory. The
+    kernel this path replaced writes the same update as a ternary chain, which
+    is straight-line predicated code; ptxas folds the repeated setp.
+    """
+
+    return cutlass.Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [
+                cutlass.Uint64(lhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(rhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(on_equal).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u64 p, $1, $2; selp.b64 $0, $3, $4, p; }",
+            "=l,l,l,l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
 
 
 @cute.jit
@@ -236,9 +308,7 @@ def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
     hi = cutlass.Uint32(key >> cutlass.Uint64(32))
     lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
     max_hi = redux_max_u32(hi)
-    contribution = cutlass.Uint32(0)
-    if hi == max_hi:
-        contribution = lo
+    contribution = _select_if_eq_u32(hi, max_hi, lo, Uint32(0))
     max_lo = redux_max_u32(contribution)
     return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
 
@@ -1393,29 +1463,48 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 cute.make_layout((64,), stride=(1,))
             )
 
-            expert = Int32(tidx)
-            while expert < Int32(896):
-                source_rank = expert // Int32(56)
-                local_expert = expert - source_rank * Int32(56)
-                router_value = Float32(0.0)
+            # Pull the router in 16B packs, the way the kernel this path
+            # replaced does. Reading it one float per expert costs 896 peer
+            # transactions instead of 224 for the same 3584 bytes, and over
+            # PCIe the transaction count is what the phase pays for.
+            router_pack = Int32(tidx)
+            router_packs_total = Int32(self._world_size) * second_packs
+            while router_pack < router_packs_total:
+                source_rank = router_pack // second_packs
+                pack = router_pack - source_rank * second_packs
+                source_address = Int64(
+                    (local_second + Int64(pack) * Int64(4)).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
-                            source_router = cute.recast_ptr(
-                                local_second.align(4), dtype=Float32
-                            )
+                            source_words = local_second
+                            source_base = Int64(0)
                         else:
-                            source_router = cute.recast_ptr(
-                                (
-                                    staging[source]
-                                    + slot_offset
-                                    + Int64(first_packs) * Int64(16)
-                                ).align(4),
-                                dtype=Float32,
+                            source_words = self._staging_words(
+                                staging[source] + slot_offset
                             )
-                        router_value = cute.arch.load(
-                            source_router + Int64(local_expert), Float32
+                            source_base = Int64(first_packs)
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                word0, word1, word2, word3 = ld_global_v4_u32(source_address)
+                # linear pack index * 4 is exactly rank * 56 + 4 * pack, so the
+                # four floats land on their own global expert indices.
+                base_expert = router_pack * Int32(4)
+                selection_scores[base_expert] = u32_as_f32(word0)
+                selection_scores[base_expert + Int32(1)] = u32_as_f32(word1)
+                selection_scores[base_expert + Int32(2)] = u32_as_f32(word2)
+                selection_scores[base_expert + Int32(3)] = u32_as_f32(word3)
+                router_pack += Int32(self._threads)
+            cute.arch.sync_threads()
+
+            expert = Int32(tidx)
+            while expert < Int32(896):
+                router_value = selection_scores[expert]
                 bias = cute.arch.load(
                     correction_bias + Int64(expert), Float32
                 )
@@ -1463,16 +1552,26 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
                     if cutlass.const_expr(selected > 0):
-                        if previous == keys[0]:
-                            tail_expert = _kimi_key_expert(keys[7])
-                            for item in cutlass.range_constexpr(7):
-                                keys[item] = keys[item + 1]
-                            keys[7] = _kimi_pack_key(
-                                Float32(_KIMI_NEG_INF), tail_expert
+                        # Hold the head before the shift overwrites it, so
+                        # every element selects on the same condition.
+                        head = keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF), _kimi_key_expert(keys[7])
+                        )
+                        for item in cutlass.range_constexpr(7):
+                            keys[item] = _select_if_eq_u64(
+                                previous, head, keys[item + 1], keys[item]
                             )
+                        keys[7] = _select_if_eq_u64(
+                            previous, head, tail_key, keys[7]
+                        )
                     previous = _kimi_warp_max_key(keys[0])
-                    if lane == Int32(selected):
-                        lane_key = previous
+                    lane_key = _select_if_eq_u64(
+                        cutlass.Uint64(lane),
+                        cutlass.Uint64(selected),
+                        previous,
+                        lane_key,
+                    )
                 if lane < Int32(16):
                     reduce_keys[warp * Int32(16) + lane] = lane_key
             cute.arch.sync_threads()
@@ -1487,12 +1586,17 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
                     if cutlass.const_expr(selected > 0):
-                        if previous == merge_keys[0]:
-                            tail_expert = _kimi_key_expert(merge_keys[1])
-                            merge_keys[0] = merge_keys[1]
-                            merge_keys[1] = _kimi_pack_key(
-                                Float32(_KIMI_NEG_INF), tail_expert
-                            )
+                        head = merge_keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF),
+                            _kimi_key_expert(merge_keys[1]),
+                        )
+                        merge_keys[0] = _select_if_eq_u64(
+                            previous, head, merge_keys[1], merge_keys[0]
+                        )
+                        merge_keys[1] = _select_if_eq_u64(
+                            previous, head, tail_key, merge_keys[1]
+                        )
                     previous = _kimi_warp_max_key(merge_keys[0])
                     # The reduction broadcasts, so every lane agrees here.
                     final_expert = _kimi_key_expert(previous)

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -108,6 +108,19 @@ def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
     st_global_v4_u32(destination.toint(), *values)
 
 
+@cute.jit
+def _copy_16b_addr(source: Int64, destination: Int64) -> None:
+    """Copy 16B between two byte addresses already resolved by the caller.
+
+    The gather loops pick their source rank at runtime.  Selecting the address
+    first and issuing one copy keeps a single load in flight per thread; cloning
+    the copy once per peer inside a constexpr chain makes a warp that straddles
+    two source ranks issue its loads in two serialised batches.
+    """
+    values = ld_global_v4_u32(source)
+    st_global_v4_u32(destination, *values)
+
+
 @dsl_user_op
 def _fma_rn_f32(
     a: Float32,
@@ -1256,6 +1269,19 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             source_rank = row_pack // first_packs
             pack = row_pack - source_rank * first_packs
+            # Default to this rank's own slice so the address is always
+            # mappable; the chain below always overwrites it, because
+            # source_rank is derived from row_pack and is in range.
+            source_address = Int64(
+                (
+                    local_first
+                    + (
+                        Int64(batch_index) * Int64(first_packs)
+                        + Int64(pack)
+                    )
+                    * Int64(4)
+                ).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
@@ -1268,11 +1294,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                         source_base = (
                             Int64(batch_index) * Int64(combined_packs)
                         )
-                    _copy_16b(
-                        source_words
-                        + (source_base + Int64(pack)) * Int64(4),
-                        output_first + Int64(linear) * Int64(4),
+                    source_address = Int64(
+                        (
+                            source_words
+                            + (source_base + Int64(pack)) * Int64(4)
+                        ).toint()
                     )
+            _copy_16b_addr(
+                source_address,
+                Int64((output_first + Int64(linear) * Int64(4)).toint()),
+            )
             linear += Int32(self._threads)
 
         if cutlass.const_expr(not self._kimi_topk):
@@ -1289,6 +1320,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 )
                 source_rank = row_pack // second_packs
                 pack = row_pack - source_rank * second_packs
+                source_address = Int64(
+                    (
+                        local_second
+                        + (
+                            Int64(batch_index) * Int64(second_packs)
+                            + Int64(pack)
+                        )
+                        * Int64(4)
+                    ).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
@@ -1304,11 +1345,18 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                                 Int64(batch_index) * Int64(combined_packs)
                                 + Int64(first_packs)
                             )
-                        _copy_16b(
-                            source_words
-                            + (source_base + Int64(pack)) * Int64(4),
-                            output_second + Int64(linear) * Int64(4),
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                _copy_16b_addr(
+                    source_address,
+                    Int64(
+                        (output_second + Int64(linear) * Int64(4)).toint()
+                    ),
+                )
                 linear += Int32(self._threads)
         else:
             smem_alloc = cutlass.utils.SmemAllocator()

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1344,26 +1344,38 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                         local_best = score
                         local_id = candidate
                     candidate += Int32(self._threads)
-                reduce_scores[tidx] = local_best
-                reduce_ids[tidx] = local_id
+                # Reduce inside each warp with shuffles first: the shared
+                # round trip only has to carry one candidate per warp, so a
+                # round costs a single block sync instead of log2(threads).
+                offset = Int32(16)
+                while offset > Int32(0):
+                    peer_score = cute.arch.shuffle_sync_bfly(local_best, offset)
+                    peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                    if peer_id >= Int32(0):
+                        if peer_score > local_best or (
+                            peer_score == local_best
+                            and (local_id < Int32(0) or peer_id < local_id)
+                        ):
+                            local_best = peer_score
+                            local_id = peer_id
+                    offset = offset // Int32(2)
+                warp = Int32(tidx) // Int32(32)
+                if Int32(tidx) % Int32(32) == Int32(0):
+                    reduce_scores[warp] = local_best
+                    reduce_ids[warp] = local_id
                 cute.arch.sync_threads()
-                stride = Int32(self._threads // 2)
-                while stride > Int32(0):
-                    if Int32(tidx) < stride:
-                        other_score = reduce_scores[tidx + stride]
-                        other_id = reduce_ids[tidx + stride]
-                        this_score = reduce_scores[tidx]
-                        this_id = reduce_ids[tidx]
-                        if other_id >= Int32(0):
-                            if other_score > this_score or (
-                                other_score == this_score
-                                and (this_id < Int32(0) or other_id < this_id)
-                            ):
-                                reduce_scores[tidx] = other_score
-                                reduce_ids[tidx] = other_id
-                    cute.arch.sync_threads()
-                    stride = stride // Int32(2)
-                best_expert = reduce_ids[0]
+                best_score = Float32(float("-inf"))
+                best_expert = Int32(-1)
+                for slot in cutlass.range_constexpr(self._threads // 32):
+                    cand_score = reduce_scores[slot]
+                    cand_id = reduce_ids[slot]
+                    if cand_id >= Int32(0):
+                        if cand_score > best_score or (
+                            cand_score == best_score
+                            and (best_expert < Int32(0) or cand_id < best_expert)
+                        ):
+                            best_score = cand_score
+                            best_expert = cand_id
                 selected_ids[selected] = best_expert
                 weight = Float32(0.0)
                 if best_expert >= Int32(0):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1491,7 +1491,17 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                     selected_ids[selected] = final_expert
                     weight = unbiased_scores[final_expert]
                     selected_weights[selected] = weight
-                    weight_sum += weight
+                # The native kernel renormalises with cg::reduce over the warp,
+                # which folds by halves (lane l adds lane l+stride, stride
+                # halving from 16). Summing left to right instead lands a ULP
+                # away, so fold in the same order. Same fifteen adds.
+                eight = [
+                    selected_weights[item] + selected_weights[item + 8]
+                    for item in range(8)
+                ]
+                four = [eight[item] + eight[item + 4] for item in range(4)]
+                two = [four[item] + four[item + 2] for item in range(2)]
+                weight_sum = two[0] + two[1]
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1253,6 +1253,13 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
+                # Per-thread partial argmax for the block-wide top-16 below.
+                reduce_scores: cute.struct.Align[
+                    cute.struct.MemRange[Float32, 512], 16
+                ]
+                reduce_ids: cute.struct.Align[
+                    cute.struct.MemRange[Int32, 512], 16
+                ]
 
             storage = smem_alloc.allocate(SharedStorage)
             selection_scores = storage.selection_scores.get_tensor(
@@ -1260,6 +1267,12 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
+            )
+            reduce_scores = storage.reduce_scores.get_tensor(
+                cute.make_layout((512,), stride=(1,))
+            )
+            reduce_ids = storage.reduce_ids.get_tensor(
+                cute.make_layout((512,), stride=(1,))
             )
 
             expert = Int32(tidx)
@@ -1306,43 +1319,62 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            if Int32(tidx) == Int32(0):
-                selected_ids = cute.make_rmem_tensor((16,), Int32)
-                selected_weights = cute.make_rmem_tensor((16,), Float32)
-                for selected in cutlass.range_constexpr(16):
-                    selected_ids[selected] = Int32(-1)
-                    selected_weights[selected] = Float32(0.0)
-                weight_sum = Float32(0.0)
-                for selected in cutlass.range_constexpr(16):
-                    best_score = Float32(float("-inf"))
-                    best_expert = Int32(-1)
-                    candidate = Int32(0)
-                    while candidate < Int32(896):
-                        already_selected = False
-                        for prior in cutlass.range_constexpr(selected):
-                            if selected_ids[prior] == candidate:
-                                already_selected = True
-                        score = selection_scores[candidate]
-                        if not already_selected:
-                            if (
-                                score > best_score
-                                or (
-                                    score == best_score
-                                    and (
-                                        best_expert < Int32(0)
-                                        or candidate < best_expert
-                                    )
-                                )
+            # Block-wide top-16 selection. The previous implementation ran
+            # this on thread 0 alone: 16 rounds x 896 candidates x up to 15
+            # prior-selection checks, about 1e5 serial steps per row, which
+            # made this kernel 320 us against 39 us for the C++ original.
+            # Each round now argmaxes across every thread and masks the winner
+            # with -inf, the same scheme the C++ kernel used.
+            selected_ids = cute.make_rmem_tensor((16,), Int32)
+            selected_weights = cute.make_rmem_tensor((16,), Float32)
+            for selected in cutlass.range_constexpr(16):
+                selected_ids[selected] = Int32(-1)
+                selected_weights[selected] = Float32(0.0)
+            weight_sum = Float32(0.0)
+            for selected in cutlass.range_constexpr(16):
+                local_best = Float32(float("-inf"))
+                local_id = Int32(-1)
+                candidate = Int32(tidx)
+                while candidate < Int32(896):
+                    score = selection_scores[candidate]
+                    if score > local_best or (
+                        score == local_best
+                        and (local_id < Int32(0) or candidate < local_id)
+                    ):
+                        local_best = score
+                        local_id = candidate
+                    candidate += Int32(self._threads)
+                reduce_scores[tidx] = local_best
+                reduce_ids[tidx] = local_id
+                cute.arch.sync_threads()
+                stride = Int32(self._threads // 2)
+                while stride > Int32(0):
+                    if Int32(tidx) < stride:
+                        other_score = reduce_scores[tidx + stride]
+                        other_id = reduce_ids[tidx + stride]
+                        this_score = reduce_scores[tidx]
+                        this_id = reduce_ids[tidx]
+                        if other_id >= Int32(0):
+                            if other_score > this_score or (
+                                other_score == this_score
+                                and (this_id < Int32(0) or other_id < this_id)
                             ):
-                                best_score = score
-                                best_expert = candidate
-                        candidate += Int32(1)
-                    selected_ids[selected] = best_expert
-                    weight = Float32(0.0)
+                                reduce_scores[tidx] = other_score
+                                reduce_ids[tidx] = other_id
+                    cute.arch.sync_threads()
+                    stride = stride // Int32(2)
+                best_expert = reduce_ids[0]
+                selected_ids[selected] = best_expert
+                weight = Float32(0.0)
+                if best_expert >= Int32(0):
+                    weight = unbiased_scores[best_expert]
+                selected_weights[selected] = weight
+                weight_sum += weight
+                if Int32(tidx) == Int32(0):
                     if best_expert >= Int32(0):
-                        weight = unbiased_scores[best_expert]
-                    selected_weights[selected] = weight
-                    weight_sum += weight
+                        selection_scores[best_expert] = Float32(float("-inf"))
+                cute.arch.sync_threads()
+            if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):
                     cute.arch.store(

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -983,23 +983,31 @@ class _AllGatherHeadsLaunch(_DCPA2ABase):
                 * Int64(packs_per_head)
             )
             output_base = Int64(row) * Int64(packs_per_head)
+            # Resolve the peer's base address first and copy once. Cloning the
+            # whole pack loop into all sixteen arms of the constexpr chain
+            # bloats the kernel and pays the chain on every row.
+            source_address = Int64(
+                (local_input + source_base * Int64(4)).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
                         source_words = local_input
                     else:
                         source_words = self._staging_words(staging[source])
-                    pack = lane
-                    while pack < packs_per_head:
-                        _copy_16b(
-                            source_words
-                            + source_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                            output
-                            + output_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                        )
-                        pack += Int32(32)
+                    source_address = Int64(
+                        (source_words + source_base * Int64(4)).toint()
+                    )
+            output_address = Int64(
+                (output + output_base * Int64(4)).toint()
+            )
+            pack = lane
+            while pack < packs_per_head:
+                _copy_16b_addr(
+                    source_address + Int64(pack) * Int64(16),
+                    output_address + Int64(pack) * Int64(16),
+                )
+                pack += Int32(32)
             row += warp_stride
 
         if cutlass.const_expr(self._device_slot_selection):


### PR DESCRIPTION
## Status

**Qualified** for Kimi-K3 TP16 pair gathering and fused top-16 routing on 16 RTX PRO 6000 GPUs. The implementation is complete; human review is required before merge.

## Resulting behavior

- Pair and head gathers resolve each peer address once and execute the 16-byte copy outside the rank-selection chain.
- The fused Kimi-K3 router reads the 3,584-byte row as 224 aligned 16-byte peer transactions rather than 896 scalar peer transactions.
- Top-16 selection uses packed `(score, expert)` keys, deterministic expert-ID tie breaking, predicated register updates, and two-level warp reduction.
- Routed-weight normalization uses the same balanced reduction order as the native CUDA reference.
- `all_gather_heads` uses the same single-copy address-resolution structure without changing its numeric contract.

## Numeric contract

- `all_gather_pair` is bit-identical to NCCL all-gather at batches 1, 2, 4, and 8 in eager execution and CUDA graphs.
- Fused routing is bit-identical to the native CUDA reference for random inputs, exact ties, near ties, and wide-value inputs containing NaN and infinity.
- The Kimi-specific fused path assumes TP16, 896 routed experts, and top-16 selection.

## Measurements

Repository microbenchmarks on 16 RTX PRO 6000 GPUs, TP16, batch 1:

| implementation | pair gather (µs) | fused pair + top-16 (µs) |
|---|---:|---:|
| Native CUDA reference | 15.40 | 14.07 |
| CuTe PR head | 13.86 | 12.87 |

The P8-normalized full-model composition is reported in #141. No native-kernel overlay is required by this PR.

## Dependencies and scope

- Base: `master`.
- Composition with TP16 island all-reduce: #141.
- This PR modifies only `_cute_intrinsics.py` and `_dcp_a2a_cute.py`.

## Review disclosure

Implementation and PR text were AI-assisted. Human review is requested before merge.
