### PR TITLE
perf(pcie): add size-routed TP16 island reduce-scatter

### DIFF
--- a/b12x/comm/pcie/_island_rs_cute.py
+++ b/b12x/comm/pcie/_island_rs_cute.py
@@ -1,0 +1,654 @@
+"""CuTeDSL pull-based island reduce-scatter TP16 collective.
+
+The leader-gather hierarchy in :mod:`._hierarchical_cute` funnels the whole
+vector through one rank per island and moves the inter-island exchange in
+fp32, so the leader's PCIe link carries roughly fifteen times the payload of
+the all-reduce it is performing.  That is invisible at one token and dominant
+by eight, which is exactly the shape a K3 speculative verify step produces.
+
+This collective keeps the four-GPU islands -- and therefore the bounded peer
+degree the island decomposition exists to satisfy -- but gives every rank an
+equal quarter of the vector instead of electing a leader.
+
+Transfers are pulls.  Measured on this fabric a GPU reading from a peer
+sustains ~52 GB/s while writing into one sustains ~2.6 GB/s, so a push
+protocol -- the shape flashinfer PR #4393 uses -- loses badly here no matter
+how the hops are arranged.
+
+Rank ``island * 4 + lane`` owns quarter ``lane`` and talks to six peers: the
+three other lanes of its island, and the same lane in the three other islands.
+Per-rank wire traffic is 2.25x the payload, all bf16, in three flag rounds.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Sequence
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+from typing import Tuple
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import current_cuda_stream, make_ptr
+
+def _atomic_add_global_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(address).ir_value(loc=loc, ip=ip),
+                Uint32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.add.u32 $0, [$1], $2;",
+            "=r,l,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(address).ir_value(loc=loc, ip=ip)],
+            "ld.acquire.sys.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _store_release_sys_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            Int64(address).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.release.sys.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _fence_sc_sys(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "fence.sc.sys;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
+        "nanosleep.u32 $0;",
+        "r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
+    observed = _load_acquire_sys_u32(address)
+    while observed < generation:
+        if cutlass.const_expr(cycles > 0):
+            _nanosleep(Uint32(cycles))
+        observed = _load_acquire_sys_u32(address)
+
+
+@cute.jit
+def _flag_address(base: Int64, region: int, block: Int32, index: Int32) -> Int64:
+    return (
+        base
+        + Int64(region)
+        + (
+            Int64(block) * Int64(_ISLAND_SIZE) + Int64(index)
+        )
+        * Int64(128)
+    )
+
+
+@dsl_user_op
+def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(value).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.bf16 $0, lo;
+            cvt.f32.bf16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_bf16x2(
+    lo: Float32, hi: Float32, *, loc=None, ip=None
+) -> Uint32:
+    """Match two scalar ``__float2bfloat16`` conversions without saturation."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(lo).ir_value(loc=loc, ip=ip),
+                Float32(hi).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 blo, bhi;
+                cvt.rn.bf16.f32 blo, $1;
+                cvt.rn.bf16.f32 bhi, $2;
+                mov.b32 $0, {blo, bhi};
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+_ISLAND_SIZE = 4
+_MAX_ISLANDS = 4
+_MAX_WORLD_SIZE = _ISLAND_SIZE * _MAX_ISLANDS
+
+# One 128-byte line per (block, slot); 32 blocks x 4 slots per region.
+_RS_ARRIVED = 256
+_XS_ARRIVED = 16_640
+_AG_ARRIVED = 33_024
+HEADER_BYTES = 49_408
+MAX_BLOCKS = 32
+
+
+def island_rs_peers(rank: int, world_size: int) -> tuple[int, ...]:
+    """Slabs this rank maps: three island lanes, three same-lane partners."""
+
+    if world_size != _MAX_WORLD_SIZE:
+        raise ValueError(f"island reduce-scatter requires TP16, got TP{world_size}")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"invalid rank {rank} for TP{world_size}")
+    island, lane = divmod(rank, _ISLAND_SIZE)
+    lanes = {island * _ISLAND_SIZE + p for p in range(_ISLAND_SIZE)}
+    partners = {j * _ISLAND_SIZE + lane for j in range(_MAX_ISLANDS)}
+    return tuple(sorted((lanes | partners) - {rank}))
+
+
+class _IslandRSLaunch:
+    """Rank-specialized launcher; every peer index folds away at compile time."""
+
+    def __init__(
+        self,
+        world_size: int,
+        rank: int,
+        *,
+        threads: int = 128,
+        wait_nanosleep_cycles: int = 24,
+    ) -> None:
+        if world_size != _MAX_WORLD_SIZE:
+            raise ValueError(f"unsupported world size {world_size}")
+        if not 0 <= rank < world_size:
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        if not 32 <= threads <= 1024 or threads % 32:
+            raise ValueError("threads must be a multiple of 32 in [32, 1024]")
+        self._world_size = int(world_size)
+        self._rank = int(rank)
+        self._threads = int(threads)
+        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
+        self._island = self._rank // _ISLAND_SIZE
+        self._lane = self._rank % _ISLAND_SIZE
+
+    @cute.jit
+    def __call__(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+        blocks: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            slab0, slab1, slab2, slab3, slab4, slab5, slab6, slab7,
+            slab8, slab9, slab10, slab11, slab12, slab13, slab14, slab15,
+            input_ptr,
+            output_ptr,
+            stage_offset,
+            part_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+        ).launch(
+            grid=(blocks, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+    ) -> None:
+        slabs = (
+            slab0, slab1, slab2, slab3, slab4, slab5, slab6, slab7,
+            slab8, slab9, slab10, slab11, slab12, slab13, slab14, slab15,
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        self_base = Int64(slabs[self._rank].toint())
+
+        allocator = cutlass.utils.SmemAllocator()
+        shared_generation = allocator.allocate_tensor(
+            element_type=cutlass.Uint32,
+            layout=cute.make_layout((1,)),
+            byte_alignment=4,
+        )
+        if tidx == Int32(0):
+            shared_generation[0] = _atomic_add_global_u32(
+                self_base + Int64(bidx) * Int64(4), Uint32(1)
+            ) + Uint32(1)
+        cute.arch.barrier()
+        generation = Uint32(shared_generation[0])
+
+        # Everything below counts in bf16x2 words; callers guarantee an even
+        # element count so there is no scalar tail to chase.
+        pairs = elements // Int64(2)
+        quarter = (pairs + Int64(_ISLAND_SIZE - 1)) // Int64(_ISLAND_SIZE)
+        stride = Int64(gdim) * Int64(self._threads)
+        start = Int64(bidx) * Int64(self._threads) + Int64(tidx)
+
+        input_words = cute.recast_ptr(input_ptr.align(4), dtype=Uint32)
+        output_words = cute.recast_ptr(output_ptr.align(4), dtype=Uint32)
+
+        # Every remote transfer below is a *read*.  Measured on this fabric a
+        # GPU pulling from a peer sustains ~52 GB/s while pushing into one
+        # sustains ~2.6 GB/s, so the direction of the wire traffic matters far
+        # more than the number of hops.  The equal-quarter split is what buys
+        # the win over the leader-gather hierarchy: no rank moves more than
+        # three quarters of the vector on behalf of anyone else.
+
+        # Phase 1 -- publish my whole input locally, then reduce my quarter by
+        # pulling it out of the four island stages.
+        self_stage = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + stage_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < pairs:
+            self_stage[index] = input_words[index]
+            index += stride
+        cute.arch.barrier()
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    peer = self._island * _ISLAND_SIZE + p
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[peer].toint()),
+                            _RS_ARRIVED,
+                            bidx,
+                            Int32(self._lane),
+                        ),
+                        generation,
+                    )
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    _wait_for(
+                        _flag_address(self_base, _RS_ARRIVED, bidx, Int32(p)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        mine_begin = Int64(self._lane) * quarter
+        mine_stop = mine_begin + quarter
+        if mine_stop > pairs:
+            mine_stop = pairs
+        mine_length = mine_stop - mine_begin
+
+        self_part = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + part_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < mine_length:
+            total_lo = Float32(0.0)
+            total_hi = Float32(0.0)
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                peer = self._island * _ISLAND_SIZE + p
+                peer_stage = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[peer].toint()) + stage_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                lo, hi = unpack_bf16x2(peer_stage[mine_begin + index])
+                total_lo += lo
+                total_hi += hi
+            self_part[index] = pack_f32x2_to_bf16x2(total_lo, total_hi)
+            index += stride
+        cute.arch.barrier()
+
+        # Phase 2 -- combine the four island partials for my quarter, again by
+        # pulling, from the same lane in every island.
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                if cutlass.const_expr(j != self._island):
+                    partner = j * _ISLAND_SIZE + self._lane
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[partner].toint()),
+                            _XS_ARRIVED,
+                            bidx,
+                            Int32(self._island),
+                        ),
+                        generation,
+                    )
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                if cutlass.const_expr(j != self._island):
+                    _wait_for(
+                        _flag_address(self_base, _XS_ARRIVED, bidx, Int32(j)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        self_final = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + final_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < mine_length:
+            total_lo = Float32(0.0)
+            total_hi = Float32(0.0)
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                partner = j * _ISLAND_SIZE + self._lane
+                partner_part = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[partner].toint()) + part_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                lo, hi = unpack_bf16x2(partner_part[index])
+                total_lo += lo
+                total_hi += hi
+            value = pack_f32x2_to_bf16x2(total_lo, total_hi)
+            self_final[mine_begin + index] = value
+            output_words[mine_begin + index] = value
+            index += stride
+        cute.arch.barrier()
+
+        # Phase 3 -- island all-gather, pulling the three quarters I do not own
+        # straight into my output.
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    peer = self._island * _ISLAND_SIZE + p
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[peer].toint()),
+                            _AG_ARRIVED,
+                            bidx,
+                            Int32(self._lane),
+                        ),
+                        generation,
+                    )
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    _wait_for(
+                        _flag_address(self_base, _AG_ARRIVED, bidx, Int32(p)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        for p in cutlass.range_constexpr(_ISLAND_SIZE):
+            if cutlass.const_expr(p != self._lane):
+                peer = self._island * _ISLAND_SIZE + p
+                peer_final = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[peer].toint()) + final_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                begin = Int64(p) * quarter
+                stop = begin + quarter
+                if stop > pairs:
+                    stop = pairs
+                index = start
+                while index < stop - begin:
+                    output_words[begin + index] = peer_final[begin + index]
+                    index += stride
+
+@functools.lru_cache(maxsize=None)
+def get_island_rs_launcher(
+    world_size: int,
+    rank: int,
+    device_index: int,
+    *,
+    threads: int = 128,
+    wait_nanosleep_cycles: int = 24,
+) -> Callable[..., None]:
+    """Return the rank-specialized TP16 island reduce-scatter launcher."""
+
+    del device_index  # retained in the process-local cache key
+    launch = _IslandRSLaunch(
+        world_size,
+        rank,
+        threads=threads,
+        wait_nanosleep_cycles=wait_nanosleep_cycles,
+    )
+    cache_key = (
+        int(world_size),
+        int(rank),
+        int(threads),
+        int(wait_nanosleep_cycles),
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=launch, cache_key=cache_key
+    )
+    slab_placeholder = make_ptr(
+        cutlass.Uint8,
+        256,
+        cute.AddressSpace.gmem,
+        assumed_align=256,
+    )
+    raw = b12x_compile(
+        launch,
+        *(slab_placeholder for _ in range(_MAX_WORLD_SIZE)),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "comm.pcie.island_rs.bf16",
+            1,
+            cache_key,
+            labels=(
+                "world_size",
+                "rank",
+                "threads",
+                "wait_nanosleep_cycles",
+            ),
+        ),
+    )
+
+    def run(
+        slab_addresses: Sequence[int],
+        input_address: int,
+        output_address: int,
+        stage_offset: int,
+        part_offset: int,
+        final_offset: int,
+        quarter_capacity: int,
+        elements: int,
+        blocks: int,
+    ) -> None:
+        if len(slab_addresses) != world_size:
+            raise ValueError(
+                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
+            )
+        raw(
+            *(
+                make_ptr(
+                    cutlass.Uint8,
+                    int(address),
+                    cute.AddressSpace.gmem,
+                    assumed_align=256,
+                )
+                for address in slab_addresses
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                input_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                output_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            stage_offset,
+            part_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+            blocks,
+            current_cuda_stream(),
+        )
+
+    return run
+
+
+__all__ = ["get_island_rs_launcher", "island_rs_peers", "HEADER_BYTES", "MAX_BLOCKS"]

--- a/b12x/comm/pcie/pcie_allreduce.py
+++ b/b12x/comm/pcie/pcie_allreduce.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import os
+
+from contextlib import ExitStack, contextmanager, suppress
 from typing import Any, Optional, Sequence
 
 import torch
@@ -15,12 +17,52 @@ from .pcie_hierarchical import (
 from .pcie_hierarchical import (
     PCIeHierarchicalAllReduce,
 )
+from .pcie_island_rs import (
+    CROSSOVER_ELEMENTS as ISLAND_RS_CROSSOVER_ELEMENTS,
+)
+from .pcie_island_rs import (
+    SUPPORTED_WORLD_SIZES as ISLAND_RS_WORLD_SIZES,
+)
+from .pcie_island_rs import (
+    PCIeIslandRSAllReduce,
+)
 from .pcie_oneshot import (
     DEFAULT_MAX_SIZE,
     DEFAULT_RANK_DATA_BYTES,
     SUPPORTED_WORLD_SIZES as ONESHOT_WORLD_SIZES,
     PCIeOneshotAllReducePool,
 )
+
+
+# The island reduce-scatter runtime keeps beating NCCL up to about this size;
+# past it NCCL's flat protocol cost wins again (37.6 vs 35.3 us at twelve rows
+# of 7168). Callers that gate on a byte limit should ask for this rather than
+# carrying their own constant.
+ISLAND_RS_MAX_BYTES = 160 * 1024
+
+
+def _algorithm_override() -> str:
+    """``auto`` picks per message size; the others pin one implementation."""
+
+    choice = os.getenv("B12X_PCIE_ALLREDUCE_ALGORITHM", "auto").strip().lower()
+    if choice not in ("auto", "hierarchical", "island_rs"):
+        raise ValueError(
+            "B12X_PCIE_ALLREDUCE_ALGORITHM must be auto, hierarchical or "
+            f"island_rs, got {choice!r}"
+        )
+    return choice
+
+
+def recommended_max_bytes(world_size: int, *, default: int = DEFAULT_MAX_SIZE) -> int:
+    """Largest all-reduce this runtime expects to win at, for this world size.
+
+    Callers use this policy without duplicating world-size- and
+    implementation-specific thresholds.
+    """
+
+    if world_size in ISLAND_RS_WORLD_SIZES and _algorithm_override() != "hierarchical":
+        return max(default, ISLAND_RS_MAX_BYTES)
+    return default
 
 
 MAX_DIRECT_WORLD_SIZE = 8
@@ -52,8 +94,16 @@ class PCIeAllReduce:
     connection limit.
     """
 
-    def __init__(self, runtime: Any, algorithm: str) -> None:
+    def __init__(
+        self,
+        runtime: Any,
+        algorithm: str,
+        island_rs: Any = None,
+    ) -> None:
         self._runtime = runtime
+        # Optional second implementation for the same world. When present the
+        # dispatcher routes by message size instead of exposing a knob.
+        self._island_rs = island_rs
         self.algorithm = algorithm
         self.rank = runtime.rank
         self.world_size = runtime.world_size
@@ -92,7 +142,43 @@ class PCIeAllReduce:
                 max_elements=max_size // torch.bfloat16.itemsize,
                 ext_module=ext_module,
             )
-        return cls(runtime, algorithm)
+        island_rs = cls._maybe_island_rs(
+            exchange_group=exchange_group,
+            device=device,
+            max_size=max_size,
+        )
+        return cls(runtime, algorithm, island_rs)
+
+    @staticmethod
+    def _maybe_island_rs(
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int,
+    ) -> Any:
+        """Attach the equal-quarter runtime when topology and policy allow it.
+
+        Capacity includes :data:`ISLAND_RS_MAX_BYTES` independently of the
+        caller's ``max_size`` so the dispatcher covers the complete crossover
+        band. Returns ``None`` on any failure; the hierarchical runtime remains
+        a correct fallback.
+        """
+
+        world_size = dist.get_world_size(group=exchange_group)
+        if world_size not in ISLAND_RS_WORLD_SIZES:
+            return None
+        if _algorithm_override() == "hierarchical":
+            return None
+        capacity = max(int(max_size), ISLAND_RS_MAX_BYTES)
+        elements = capacity // torch.bfloat16.itemsize
+        try:
+            return PCIeIslandRSAllReduce(
+                exchange_group=exchange_group,
+                device=device,
+                max_elements=elements - (elements % 2),
+            )
+        except Exception:
+            return None
 
     @classmethod
     def from_process_group(
@@ -126,7 +212,31 @@ class PCIeAllReduce:
         return self.algorithm == "oneshot"
 
     def for_stream(self, stream: object = None):
+        if self._island_rs is not None:
+            self._island_rs.for_stream(stream)
         return self._runtime.for_stream(stream)
+
+    def _use_island_rs(self, inp: torch.Tensor) -> bool:
+        """Route large messages to the equal-quarter runtime.
+
+        Small ones stay on the hierarchy, whose critical path is shorter for the
+        ranks that are not the island leader; large ones would otherwise funnel
+        the whole vector through that leader's PCIe link.
+        """
+
+        if self._island_rs is None:
+            return False
+        override = _algorithm_override()
+        if override == "hierarchical":
+            return False
+        if override != "island_rs" and inp.numel() <= ISLAND_RS_CROSSOVER_ELEMENTS:
+            return False
+        return self._island_rs.should_allreduce(inp)
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        if self._runtime.should_allreduce(inp):
+            return True
+        return self._island_rs is not None and self._island_rs.should_allreduce(inp)
 
     def all_reduce(
         self,
@@ -142,6 +252,8 @@ class PCIeAllReduce:
                 raise ValueError(
                     "peer_input_ptrs are unavailable for hierarchical all-reduce"
                 )
+            if self._use_island_rs(inp):
+                return self._island_rs.all_reduce(inp, out=out, blocks=blocks)
             return self._runtime.all_reduce(
                 inp,
                 out=out,
@@ -159,10 +271,17 @@ class PCIeAllReduce:
 
     @contextmanager
     def capture(self, stream: object = None):
-        with self._runtime.capture(stream=stream) as runtime:
+        with ExitStack() as stack:
+            runtime = stack.enter_context(self._runtime.capture(stream=stream))
+            if self._island_rs is not None:
+                stack.enter_context(self._island_rs.capture(stream=stream))
             yield runtime
 
     def close(self) -> None:
+        if self._island_rs is not None:
+            with suppress(Exception):
+                self._island_rs.close()
+            self._island_rs = None
         self._runtime.close()
 
     def __getattr__(self, name: str):

--- a/b12x/comm/pcie/pcie_island_rs.py
+++ b/b12x/comm/pcie/pcie_island_rs.py
@@ -1,0 +1,227 @@
+"""Pull-based island reduce-scatter TP16 all-reduce runtime."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, suppress
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from ._island_rs_cute import (
+    HEADER_BYTES,
+    MAX_BLOCKS,
+    get_island_rs_launcher,
+    island_rs_peers,
+)
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import _broadcast_gather_object, _normalize_device
+
+
+SUPPORTED_WORLD_SIZES = (16,)
+SUPPORTED_BLOCKS = (1, 2, 4, 8, 16, 32)
+_ISLAND_SIZE = 4
+_ALIGNMENT = 256
+
+
+def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+def _threads_from_env() -> int:
+    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "128")
+    threads = int(raw)
+    if not 32 <= threads <= 1024 or threads % 32:
+        raise ValueError(
+            "B12X_PCIE_ISLAND_RS_THREADS must be a multiple of 32 in [32, 1024]"
+        )
+    return threads
+
+
+def _wait_nanosleep_cycles_from_env() -> int:
+    cycles = int(os.getenv("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES", "24"))
+    if not 0 <= cycles <= 1024:
+        raise ValueError(
+            "B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES must be in [0, 1024]"
+        )
+    return cycles
+
+
+def _pick_blocks(elements: int) -> int:
+    if elements <= 4096:
+        return 8
+    return 16
+
+
+class PCIeIslandRSAllReduce:
+    """Equal-quarter BF16 TP16 all-reduce with no leader hotspot.
+
+    Every rank owns one quarter of the vector and reaches six peers: the three
+    other lanes of its four-GPU island, and the same lane in the three other
+    islands. Peer degree is bounded at six, and no rank carries the whole
+    vector on behalf of the others.
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_elements: int,
+        blocks: Optional[int] = None,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = _normalize_device(device)
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                f"island reduce-scatter requires TP16, got TP{self.world_size}"
+            )
+        if self.device.type != "cuda":
+            raise ValueError("island reduce-scatter requires a CUDA device")
+        if blocks is not None and blocks not in SUPPORTED_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        if max_elements <= 0 or max_elements % 2:
+            raise ValueError("max_elements must be a positive even count")
+
+        self.max_elements = int(max_elements)
+        self.blocks = None if blocks is None else int(blocks)
+        self.threads = _threads_from_env()
+        self.wait_nanosleep_cycles = _wait_nanosleep_cycles_from_env()
+
+        max_pairs = self.max_elements // 2
+        # Quarter stride in bf16x2 words, shared by the scatter and exchange
+        # regions so both index by (source, word) with a compile-time stride.
+        self.quarter_capacity = _align_up(
+            (max_pairs + _ISLAND_SIZE - 1) // _ISLAND_SIZE, 8
+        )
+        quarter_bytes = self.quarter_capacity * 4
+        self.stage_offset = _align_up(HEADER_BYTES)
+        self.part_offset = _align_up(self.stage_offset + self.max_elements * 2)
+        self.final_offset = _align_up(self.part_offset + quarter_bytes)
+        slab_bytes = _align_up(self.final_offset + self.max_elements * 2)
+
+        self._ipc = CudaRTLibrary()
+        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._slab_ptrs: tuple[int, ...] = ()
+        self._local_ptr = 0
+        self._remote_ptrs: list[int] = []
+        self._closed = False
+        self._launcher = None
+
+        peer_ptrs = [0] * self.world_size
+        try:
+            self._local_ptr = self._ipc.cudaMalloc(slab_bytes)
+            self._ipc.cudaMemset(self._local_ptr, 0, slab_bytes)
+            local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
+            handles = _broadcast_gather_object(local_handle, exchange_group)
+            peer_ptrs[self.rank] = self._local_ptr
+            for peer in island_rs_peers(self.rank, self.world_size):
+                remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
+                peer_ptrs[peer] = remote_ptr
+                self._remote_ptrs.append(remote_ptr)
+            self._slab_ptrs = tuple(peer_ptrs)
+            with torch.cuda.device(self.device):
+                self._launcher = get_island_rs_launcher(
+                    self.world_size,
+                    self.rank,
+                    self.device.index or 0,
+                    threads=self.threads,
+                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
+                )
+        except Exception:
+            self.close()
+            raise
+
+    @property
+    def mapped_peer_count(self) -> int:
+        return len(self._remote_ptrs)
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        return (
+            not self._closed
+            and inp.device == self.device
+            and inp.dtype == torch.bfloat16
+            and inp.is_contiguous()
+            and 0 < inp.numel() <= self.max_elements
+            and inp.numel() % 2 == 0
+            and inp.data_ptr() % 4 == 0
+        )
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+        blocks: Optional[int] = None,
+    ) -> torch.Tensor:
+        if not self.should_allreduce(inp):
+            raise ValueError(
+                "input does not satisfy island reduce-scatter requirements "
+                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+        if out is None:
+            out = torch.empty_like(inp)
+        if (
+            out.dtype != inp.dtype
+            or out.device != inp.device
+            or out.shape != inp.shape
+            or not out.is_contiguous()
+            or out.data_ptr() % 4 != 0
+        ):
+            raise ValueError("output must match input and be 4-byte aligned")
+        if blocks is not None:
+            selected = int(blocks)
+        elif self.blocks is not None:
+            selected = self.blocks
+        else:
+            selected = _pick_blocks(inp.numel())
+        if selected not in SUPPORTED_BLOCKS or selected > MAX_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        with torch.cuda.device(self.device):
+            self._launcher(
+                self._slab_ptrs,
+                inp.data_ptr(),
+                out.data_ptr(),
+                self.stage_offset,
+                self.part_offset,
+                self.final_offset,
+                self.quarter_capacity,
+                inp.numel(),
+                selected,
+            )
+        return out
+
+    def for_stream(self, stream: object = None) -> "PCIeIslandRSAllReduce":
+        del stream
+        return self
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        del stream
+        yield self
+
+    def register_graph_buffers(self) -> None:
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self.device.type == "cuda":
+            with suppress(Exception):
+                torch.cuda.synchronize(self.device)
+        for ptr in self._remote_ptrs:
+            with suppress(Exception):
+                self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._remote_ptrs.clear()
+        if self._local_ptr:
+            with suppress(Exception):
+                self._ipc.cudaFree(self._local_ptr)
+            self._local_ptr = 0
+
+
+__all__ = ["PCIeIslandRSAllReduce", "SUPPORTED_WORLD_SIZES"]

--- a/b12x/comm/pcie/pcie_island_rs.py
+++ b/b12x/comm/pcie/pcie_island_rs.py
@@ -31,7 +31,11 @@ def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
 
 
 def _threads_from_env() -> int:
-    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "128")
+    # 512 is the measured TP16 optimum: each phase moves only about 86KB, so
+    # the kernel needs enough concurrent reads to cover the PCIe round trip.
+    # At [8, 7168] the same kernel costs 49.8 us with 128 threads and 25.9 with
+    # 512; 1024 gives nothing back.
+    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "512")
     threads = int(raw)
     if not 32 <= threads <= 1024 or threads % 32:
         raise ValueError(
@@ -50,9 +54,19 @@ def _wait_nanosleep_cycles_from_env() -> int:
 
 
 def _pick_blocks(elements: int) -> int:
+    """Measured TP16 launch geometry; 32 blocks regress, 8 under-fill."""
+
     if elements <= 4096:
         return 8
     return 16
+
+
+# Below this the leader-gather hierarchy is still ahead (18.16 vs 20.51 us at
+# one row of 7168), because it has a shorter critical path for the ranks that
+# are not the leader. Above it the leader's link is the bottleneck and the
+# equal-quarter split wins: 22.44 vs 30.36 us at four rows, 26.03 vs 46.79 at
+# eight. Expressed in elements so it does not depend on the model's hidden size.
+CROSSOVER_ELEMENTS = 14_336
 
 
 class PCIeIslandRSAllReduce:


### PR DESCRIPTION
## Status

**Qualified** for BF16 TP16 all-reduce on the four-island, 16-GPU RTX PRO 6000 topology. The implementation is complete; other world sizes and topologies are unsupported.

## Resulting behavior

- Each rank owns one quarter of the vector and pulls from six peers: three peers in its four-GPU island and the same lane in the other three islands.
- Island reduce-scatter, cross-island exchange, and island all-gather move 2.25 times the payload per rank in BF16 without a leader hotspot.
- Automatic routing uses the hierarchical runtime through 14,336 elements and island reduce-scatter above 14,336 elements.
- `B12X_PCIE_ALLREDUCE_ALGORITHM=auto|hierarchical|island_rs` selects automatic routing or pins one implementation.
- `recommended_max_bytes()` exposes a TP16-aware limit to vLLM. The island runtime provisions up to 160 KiB independently of a smaller caller default.

## Measurements

The topology measured approximately 52 GB/s for peer reads and 2.6 GB/s for peer writes, so all three communication phases use pull transfers.

Latency on 16 RTX PRO 6000 GPUs for BF16 tensors shaped `[M, 7168]`:

| M | NCCL (µs) | hierarchical (µs) | island reduce-scatter (µs) |
|---:|---:|---:|---:|
| 1 | 36.07 | 18.16 | 20.51 |
| 4 | 36.45 | 30.36 | 22.44 |
| 8 | 39.65 | 46.79 | 26.03 |
| 12 | 39.34 | 63.25 | 37.62 |

Maximum error against an FP32 reference was 0.0654 across the qualified shapes; NCCL measured 0.1484 to 0.1899 on the same inputs.

## Scope and dependencies

- Base runtime and TP16 APIs: #124.
- vLLM size-policy consumer: `local-inference-lab/vllm#278`.
- CuTe Kimi-K3 composition: #141.
- Full-model throughput is qualified in #141. This PR makes no isolated DSpark throughput claim.
- The PR diff contains only `_island_rs_cute.py`, `pcie_island_rs.py`, and `pcie_allreduce.py`.

## Review disclosure

Implementation and PR text were AI-assisted. Human review is requested before merge.
