### PR TITLE
feat(kimi-k3): compose CuTe TP16 routing and island all-reduce

### DIFF
--- a/b12x/comm/pcie/_cute_intrinsics.py
+++ b/b12x/comm/pcie/_cute_intrinsics.py
@@ -488,3 +488,57 @@ def rsqrt_approx_f32(value: Float32, *, loc=None, ip=None) -> Float32:
             ip=ip,
         )
     )
+
+
+@dsl_user_op
+def float_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Map a float onto a u32 whose unsigned order matches float order.
+
+    Lets a (score, expert) pair be packed into one integer key, so "better
+    candidate" becomes a plain integer max and the tie-break stops costing a
+    second comparison.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .u32 bits, mask;
+                mov.b32 bits, $1;
+                shr.u32 mask, bits, 31;
+                mul.lo.u32 mask, mask, 0x7fffffff;
+                or.b32 mask, mask, 0x80000000;
+                xor.b32 $0, bits, mask;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def redux_max_u32(value: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Warp-wide unsigned max in one instruction.
+
+    ``cute.arch.warp_redux_sync`` exposes the float variant, which libNVVM
+    rejects for sm_120a; the integer one is what the kernel actually needs.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(value).ir_value(loc=loc, ip=ip)],
+            "redux.sync.max.u32 $0, $1, 0xffffffff;",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -23,6 +23,8 @@ from b12x._lib.utils import current_cuda_stream, make_ptr
 
 from ._dcp_cute_common import block_pair_barrier
 from ._cute_intrinsics import (
+    float_order_key,
+    redux_max_u32,
     ld_generic_f32,
     ld_relaxed_gpu_u32,
     pack_f32x2_to_bf16x2,
@@ -187,6 +189,72 @@ def _add_u64_opaque(
         )
     )
 
+
+
+_KIMI_NEG_INF = float("-inf")
+
+
+@cute.jit
+def _kimi_pack_key(score: Float32, expert: Int32) -> cutlass.Uint64:
+    """Pack (score, expert) so that a plain integer max picks the winner.
+
+    The expert index goes in complemented, so a tie on score resolves to the
+    lower index -- the same order the native reference produces, without a
+    second comparison at every step.
+    """
+    return (cutlass.Uint64(float_order_key(score)) << cutlass.Uint64(32)) | (
+        cutlass.Uint64(0xFFFF) - cutlass.Uint64(expert)
+    )
+
+
+@cute.jit
+def _kimi_key_expert(key: cutlass.Uint64) -> Int32:
+    return Int32(cutlass.Uint64(0xFFFF) - (key & cutlass.Uint64(0xFFFF)))
+
+
+@cute.jit
+def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
+    """Warp-wide max of a 64-bit key in two instructions.
+
+    Reduces the high words, then only the low words of the lanes that tied on
+    the high word, which is cheaper than carrying a 64-bit value through a
+    shuffle chain.
+    """
+    hi = cutlass.Uint32(key >> cutlass.Uint64(32))
+    lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
+    max_hi = redux_max_u32(hi)
+    contribution = cutlass.Uint32(0)
+    if hi == max_hi:
+        contribution = lo
+    max_lo = redux_max_u32(contribution)
+    return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
+
+
+def _kimi_sort_desc(keys, count: int) -> None:
+    """Descending bitonic sort over a compile-time number of packed keys.
+
+    Every index is a Python constant, so the whole network unrolls and the
+    per-round selection can just read ``keys[0]``.
+    """
+    width = 2
+    while width <= count:
+        stride = width // 2
+        while stride > 0:
+            for index in range(count):
+                peer = index ^ stride
+                if peer <= index:
+                    continue
+                descending = (index & width) == 0
+                lower = keys[index]
+                upper = keys[peer]
+                if descending:
+                    keys[index] = cutlass.max(lower, upper)
+                    keys[peer] = cutlass.min(lower, upper)
+                else:
+                    keys[index] = cutlass.min(lower, upper)
+                    keys[peer] = cutlass.max(lower, upper)
+            stride //= 2
+        width *= 2
 
 class _DCPA2ABase:
     def __init__(
@@ -1253,12 +1321,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
-                # Per-thread partial argmax for the block-wide top-16 below.
-                reduce_scores: cute.struct.Align[
-                    cute.struct.MemRange[Float32, 512], 16
-                ]
-                reduce_ids: cute.struct.Align[
-                    cute.struct.MemRange[Int32, 512], 16
+                # The 64 survivors of the warp-local rounds, as packed keys.
+                reduce_keys: cute.struct.Align[
+                    cute.struct.MemRange[cutlass.Uint64, 64], 16
                 ]
 
             storage = smem_alloc.allocate(SharedStorage)
@@ -1268,11 +1333,8 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
             )
-            reduce_scores = storage.reduce_scores.get_tensor(
-                cute.make_layout((512,), stride=(1,))
-            )
-            reduce_ids = storage.reduce_ids.get_tensor(
-                cute.make_layout((512,), stride=(1,))
+            reduce_keys = storage.reduce_keys.get_tensor(
+                cute.make_layout((64,), stride=(1,))
             )
 
             expert = Int32(tidx)
@@ -1325,101 +1387,63 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             # survivors. A round costs two warp reductions instead of a
             # shared-memory scan, and the selection needs one block barrier
             # rather than two per round.
-            _NONE = Int32(0x7FFFFFFF)
+            # Two-level top-16 over packed (score, expert) keys, mirroring the
+            # kernel this path replaced. Four warps each reduce 256 experts held
+            # in registers (8 per lane); warp 0 then merges the 64 survivors.
+            # A round costs one warp reduction -- two instructions -- because the
+            # tie-break lives in the key rather than in a second comparison.
             lane = Int32(tidx) % Int32(32)
             warp = Int32(tidx) // Int32(32)
-            won_score = Float32(float("-inf"))
-            won_expert = _NONE
-            cand_scores = cute.make_rmem_tensor((8,), Float32)
-            cand_experts = cute.make_rmem_tensor((8,), Int32)
+            lane_key = cutlass.Uint64(0)
+            keys = cute.make_rmem_tensor((8,), cutlass.Uint64)
             if warp < Int32(4):
                 for item in cutlass.range_constexpr(8):
                     expert_id = warp * Int32(256) + Int32(item * 32) + lane
-                    value = Float32(float("-inf"))
+                    value = Float32(_KIMI_NEG_INF)
                     if expert_id < Int32(896):
                         value = selection_scores[expert_id]
-                    cand_scores[item] = value
-                    cand_experts[item] = expert_id
+                    keys[item] = _kimi_pack_key(value, expert_id)
+                _kimi_sort_desc(keys, 8)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    local_best = Float32(float("-inf"))
-                    local_id = _NONE
-                    for item in cutlass.range_constexpr(8):
-                        if cand_scores[item] > local_best or (
-                            cand_scores[item] == local_best
-                            and cand_experts[item] < local_id
-                        ):
-                            local_best = cand_scores[item]
-                            local_id = cand_experts[item]
-                    offset = Int32(16)
-                    while offset > Int32(0):
-                        peer_best = cute.arch.shuffle_sync_bfly(
-                            local_best, offset
-                        )
-                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                        if peer_best > local_best or (
-                            peer_best == local_best and peer_id < local_id
-                        ):
-                            local_best = peer_best
-                            local_id = peer_id
-                        offset = offset // Int32(2)
-                    round_best = local_best
-                    round_expert = local_id
+                    if cutlass.const_expr(selected > 0):
+                        if previous == keys[0]:
+                            tail_expert = _kimi_key_expert(keys[7])
+                            for item in cutlass.range_constexpr(7):
+                                keys[item] = keys[item + 1]
+                            keys[7] = _kimi_pack_key(
+                                Float32(_KIMI_NEG_INF), tail_expert
+                            )
+                    previous = _kimi_warp_max_key(keys[0])
                     if lane == Int32(selected):
-                        won_score = round_best
-                        won_expert = round_expert
-                    for item in cutlass.range_constexpr(8):
-                        if cand_experts[item] == round_expert:
-                            cand_scores[item] = Float32(float("-inf"))
+                        lane_key = previous
                 if lane < Int32(16):
-                    reduce_scores[warp * Int32(16) + lane] = won_score
-                    reduce_ids[warp * Int32(16) + lane] = won_expert
+                    reduce_keys[warp * Int32(16) + lane] = lane_key
             cute.arch.sync_threads()
             selected_ids = cute.make_rmem_tensor((16,), Int32)
             selected_weights = cute.make_rmem_tensor((16,), Float32)
             weight_sum = Float32(0.0)
             if warp == Int32(0):
-                merge_scores = cute.make_rmem_tensor((2,), Float32)
-                merge_experts = cute.make_rmem_tensor((2,), Int32)
+                merge_keys = cute.make_rmem_tensor((2,), cutlass.Uint64)
                 for item in cutlass.range_constexpr(2):
-                    merge_slot = Int32(item * 32) + lane
-                    merge_scores[item] = reduce_scores[merge_slot]
-                    merge_experts[item] = reduce_ids[merge_slot]
+                    merge_keys[item] = reduce_keys[Int32(item * 32) + lane]
+                _kimi_sort_desc(merge_keys, 2)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    local_best = Float32(float("-inf"))
-                    local_id = _NONE
-                    for item in cutlass.range_constexpr(2):
-                        if merge_scores[item] > local_best or (
-                            merge_scores[item] == local_best
-                            and merge_experts[item] < local_id
-                        ):
-                            local_best = merge_scores[item]
-                            local_id = merge_experts[item]
-                    offset = Int32(16)
-                    while offset > Int32(0):
-                        peer_best = cute.arch.shuffle_sync_bfly(
-                            local_best, offset
-                        )
-                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                        if peer_best > local_best or (
-                            peer_best == local_best and peer_id < local_id
-                        ):
-                            local_best = peer_best
-                            local_id = peer_id
-                        offset = offset // Int32(2)
-                    round_best = local_best
-                    round_expert = local_id
-                    final_expert = Int32(-1)
-                    if round_expert != _NONE:
-                        final_expert = round_expert
+                    if cutlass.const_expr(selected > 0):
+                        if previous == merge_keys[0]:
+                            tail_expert = _kimi_key_expert(merge_keys[1])
+                            merge_keys[0] = merge_keys[1]
+                            merge_keys[1] = _kimi_pack_key(
+                                Float32(_KIMI_NEG_INF), tail_expert
+                            )
+                    previous = _kimi_warp_max_key(merge_keys[0])
+                    # The reduction broadcasts, so every lane agrees here.
+                    final_expert = _kimi_key_expert(previous)
                     selected_ids[selected] = final_expert
-                    weight = Float32(0.0)
-                    if final_expert >= Int32(0):
-                        weight = unbiased_scores[final_expert]
+                    weight = unbiased_scores[final_expert]
                     selected_weights[selected] = weight
                     weight_sum += weight
-                    for item in cutlass.range_constexpr(2):
-                        if merge_experts[item] == round_expert:
-                            merge_scores[item] = Float32(float("-inf"))
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1526,12 +1526,6 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Two-level warp-local top-16, mirroring the C++ kernel this path
-            # replaced. Four warps each reduce 256 experts held in registers
-            # (8 per lane) with warp reductions, then warp 0 merges the 64
-            # survivors. A round costs two warp reductions instead of a
-            # shared-memory scan, and the selection needs one block barrier
-            # rather than two per round.
             # Two-level top-16 over packed (score, expert) keys, mirroring the
             # kernel this path replaced. Four warps each reduce 256 experts held
             # in registers (8 per lane); warp 0 then merges the 64 survivors.

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1319,73 +1319,107 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Block-wide top-16 selection. The previous implementation ran
-            # this on thread 0 alone: 16 rounds x 896 candidates x up to 15
-            # prior-selection checks, about 1e5 serial steps per row, which
-            # made this kernel 320 us against 39 us for the C++ original.
-            # Each round now argmaxes across every thread and masks the winner
-            # with -inf, the same scheme the C++ kernel used.
+            # Two-level warp-local top-16, mirroring the C++ kernel this path
+            # replaced. Four warps each reduce 256 experts held in registers
+            # (8 per lane) with warp reductions, then warp 0 merges the 64
+            # survivors. A round costs two warp reductions instead of a
+            # shared-memory scan, and the selection needs one block barrier
+            # rather than two per round.
+            _NONE = Int32(0x7FFFFFFF)
+            lane = Int32(tidx) % Int32(32)
+            warp = Int32(tidx) // Int32(32)
+            won_score = Float32(float("-inf"))
+            won_expert = _NONE
+            cand_scores = cute.make_rmem_tensor((8,), Float32)
+            cand_experts = cute.make_rmem_tensor((8,), Int32)
+            if warp < Int32(4):
+                for item in cutlass.range_constexpr(8):
+                    expert_id = warp * Int32(256) + Int32(item * 32) + lane
+                    value = Float32(float("-inf"))
+                    if expert_id < Int32(896):
+                        value = selection_scores[expert_id]
+                    cand_scores[item] = value
+                    cand_experts[item] = expert_id
+                for selected in cutlass.range_constexpr(16):
+                    local_best = Float32(float("-inf"))
+                    local_id = _NONE
+                    for item in cutlass.range_constexpr(8):
+                        if cand_scores[item] > local_best or (
+                            cand_scores[item] == local_best
+                            and cand_experts[item] < local_id
+                        ):
+                            local_best = cand_scores[item]
+                            local_id = cand_experts[item]
+                    offset = Int32(16)
+                    while offset > Int32(0):
+                        peer_best = cute.arch.shuffle_sync_bfly(
+                            local_best, offset
+                        )
+                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                        if peer_best > local_best or (
+                            peer_best == local_best and peer_id < local_id
+                        ):
+                            local_best = peer_best
+                            local_id = peer_id
+                        offset = offset // Int32(2)
+                    round_best = local_best
+                    round_expert = local_id
+                    if lane == Int32(selected):
+                        won_score = round_best
+                        won_expert = round_expert
+                    for item in cutlass.range_constexpr(8):
+                        if cand_experts[item] == round_expert:
+                            cand_scores[item] = Float32(float("-inf"))
+                if lane < Int32(16):
+                    reduce_scores[warp * Int32(16) + lane] = won_score
+                    reduce_ids[warp * Int32(16) + lane] = won_expert
+            cute.arch.sync_threads()
             selected_ids = cute.make_rmem_tensor((16,), Int32)
             selected_weights = cute.make_rmem_tensor((16,), Float32)
-            for selected in cutlass.range_constexpr(16):
-                selected_ids[selected] = Int32(-1)
-                selected_weights[selected] = Float32(0.0)
             weight_sum = Float32(0.0)
-            for selected in cutlass.range_constexpr(16):
-                local_best = Float32(float("-inf"))
-                local_id = Int32(-1)
-                candidate = Int32(tidx)
-                while candidate < Int32(896):
-                    score = selection_scores[candidate]
-                    if score > local_best or (
-                        score == local_best
-                        and (local_id < Int32(0) or candidate < local_id)
-                    ):
-                        local_best = score
-                        local_id = candidate
-                    candidate += Int32(self._threads)
-                # Reduce inside each warp with shuffles first: the shared
-                # round trip only has to carry one candidate per warp, so a
-                # round costs a single block sync instead of log2(threads).
-                offset = Int32(16)
-                while offset > Int32(0):
-                    peer_score = cute.arch.shuffle_sync_bfly(local_best, offset)
-                    peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
-                    if peer_id >= Int32(0):
-                        if peer_score > local_best or (
-                            peer_score == local_best
-                            and (local_id < Int32(0) or peer_id < local_id)
+            if warp == Int32(0):
+                merge_scores = cute.make_rmem_tensor((2,), Float32)
+                merge_experts = cute.make_rmem_tensor((2,), Int32)
+                for item in cutlass.range_constexpr(2):
+                    merge_slot = Int32(item * 32) + lane
+                    merge_scores[item] = reduce_scores[merge_slot]
+                    merge_experts[item] = reduce_ids[merge_slot]
+                for selected in cutlass.range_constexpr(16):
+                    local_best = Float32(float("-inf"))
+                    local_id = _NONE
+                    for item in cutlass.range_constexpr(2):
+                        if merge_scores[item] > local_best or (
+                            merge_scores[item] == local_best
+                            and merge_experts[item] < local_id
                         ):
-                            local_best = peer_score
+                            local_best = merge_scores[item]
+                            local_id = merge_experts[item]
+                    offset = Int32(16)
+                    while offset > Int32(0):
+                        peer_best = cute.arch.shuffle_sync_bfly(
+                            local_best, offset
+                        )
+                        peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                        if peer_best > local_best or (
+                            peer_best == local_best and peer_id < local_id
+                        ):
+                            local_best = peer_best
                             local_id = peer_id
-                    offset = offset // Int32(2)
-                warp = Int32(tidx) // Int32(32)
-                if Int32(tidx) % Int32(32) == Int32(0):
-                    reduce_scores[warp] = local_best
-                    reduce_ids[warp] = local_id
-                cute.arch.sync_threads()
-                best_score = Float32(float("-inf"))
-                best_expert = Int32(-1)
-                for slot in cutlass.range_constexpr(self._threads // 32):
-                    cand_score = reduce_scores[slot]
-                    cand_id = reduce_ids[slot]
-                    if cand_id >= Int32(0):
-                        if cand_score > best_score or (
-                            cand_score == best_score
-                            and (best_expert < Int32(0) or cand_id < best_expert)
-                        ):
-                            best_score = cand_score
-                            best_expert = cand_id
-                selected_ids[selected] = best_expert
-                weight = Float32(0.0)
-                if best_expert >= Int32(0):
-                    weight = unbiased_scores[best_expert]
-                selected_weights[selected] = weight
-                weight_sum += weight
-                if Int32(tidx) == Int32(0):
-                    if best_expert >= Int32(0):
-                        selection_scores[best_expert] = Float32(float("-inf"))
-                cute.arch.sync_threads()
+                        offset = offset // Int32(2)
+                    round_best = local_best
+                    round_expert = local_id
+                    final_expert = Int32(-1)
+                    if round_expert != _NONE:
+                        final_expert = round_expert
+                    selected_ids[selected] = final_expert
+                    weight = Float32(0.0)
+                    if final_expert >= Int32(0):
+                        weight = unbiased_scores[final_expert]
+                    selected_weights[selected] = weight
+                    weight_sum += weight
+                    for item in cutlass.range_constexpr(2):
+                        if merge_experts[item] == round_expert:
+                            merge_scores[item] = Float32(float("-inf"))
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -153,11 +153,10 @@ def _select_if_eq_u64(
 ) -> cutlass.Uint64:
     """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
 
-    A Python ``if`` on a runtime condition becomes a real branch region, and
-    the top-16 rounds update a register-held key array inside one. That
-    diverges the warp on every round and pushes the array to local memory. The
-    kernel this path replaced writes the same update as a ternary chain, which
-    is straight-line predicated code; ptxas folds the repeated setp.
+    A Python ``if`` on a runtime condition becomes a branch region. The top-16
+    rounds update a register-held key array, so a divergent branch can spill the
+    array to local memory. A ternary chain emits straight-line predicated code
+    and lets ptxas fold repeated ``setp`` operations.
     """
 
     return cutlass.Uint64(
@@ -255,7 +254,7 @@ def _add_u64_opaque(
     loc=None,
     ip=None,
 ) -> Int64:
-    """Add a payload offset without CSE into the earlier LSE address phase."""
+    """Add a payload offset without CSE into the LSE-address calculation."""
 
     return Int64(
         llvm.inline_asm(
@@ -1463,10 +1462,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 cute.make_layout((64,), stride=(1,))
             )
 
-            # Pull the router in 16B packs, the way the kernel this path
-            # replaced does. Reading it one float per expert costs 896 peer
-            # transactions instead of 224 for the same 3584 bytes, and over
-            # PCIe the transaction count is what the phase pays for.
+            # Pull the 3,584-byte router row in 16-byte packs. This uses 224
+            # peer transactions instead of 896 scalar transactions; PCIe
+            # transaction count dominates this phase.
             router_pack = Int32(tidx)
             router_packs_total = Int32(self._world_size) * second_packs
             while router_pack < router_packs_total:
@@ -1526,9 +1524,9 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            # Two-level top-16 over packed (score, expert) keys, mirroring the
-            # kernel this path replaced. Four warps each reduce 256 experts held
-            # in registers (8 per lane); warp 0 then merges the 64 survivors.
+            # Two-level top-16 over packed (score, expert) keys. Four warps each
+            # reduce 256 experts held in registers (8 per lane); warp 0 then
+            # merges the 64 survivors.
             # A round costs one warp reduction -- two instructions -- because the
             # tie-break lives in the key rather than in a second comparison.
             lane = Int32(tidx) % Int32(32)

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -17,6 +17,7 @@ from b12x._lib.intrinsics import (
     fmax_f32,
     ld_global_v4_u32,
     st_global_v4_u32,
+    u32_as_f32,
 )
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
@@ -106,6 +107,77 @@ def _a2a_graph_epoch_arrive(
 def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
     values = ld_global_v4_u32(source.toint())
     st_global_v4_u32(destination.toint(), *values)
+
+
+@dsl_user_op
+def _select_if_eq_u32(
+    lhs: Uint32,
+    rhs: Uint32,
+    on_equal: Uint32,
+    otherwise: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select."""
+
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Uint32(lhs).ir_value(loc=loc, ip=ip),
+                Uint32(rhs).ir_value(loc=loc, ip=ip),
+                Uint32(on_equal).ir_value(loc=loc, ip=ip),
+                Uint32(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u32 p, $1, $2; selp.b32 $0, $3, $4, p; }",
+            "=r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _select_if_eq_u64(
+    lhs: cutlass.Uint64,
+    rhs: cutlass.Uint64,
+    on_equal: cutlass.Uint64,
+    otherwise: cutlass.Uint64,
+    *,
+    loc=None,
+    ip=None,
+) -> cutlass.Uint64:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
+
+    A Python ``if`` on a runtime condition becomes a real branch region, and
+    the top-16 rounds update a register-held key array inside one. That
+    diverges the warp on every round and pushes the array to local memory. The
+    kernel this path replaced writes the same update as a ternary chain, which
+    is straight-line predicated code; ptxas folds the repeated setp.
+    """
+
+    return cutlass.Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [
+                cutlass.Uint64(lhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(rhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(on_equal).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u64 p, $1, $2; selp.b64 $0, $3, $4, p; }",
+            "=l,l,l,l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
 
 
 @cute.jit
@@ -236,9 +308,7 @@ def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
     hi = cutlass.Uint32(key >> cutlass.Uint64(32))
     lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
     max_hi = redux_max_u32(hi)
-    contribution = cutlass.Uint32(0)
-    if hi == max_hi:
-        contribution = lo
+    contribution = _select_if_eq_u32(hi, max_hi, lo, Uint32(0))
     max_lo = redux_max_u32(contribution)
     return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
 
@@ -1393,29 +1463,48 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 cute.make_layout((64,), stride=(1,))
             )
 
-            expert = Int32(tidx)
-            while expert < Int32(896):
-                source_rank = expert // Int32(56)
-                local_expert = expert - source_rank * Int32(56)
-                router_value = Float32(0.0)
+            # Pull the router in 16B packs, the way the kernel this path
+            # replaced does. Reading it one float per expert costs 896 peer
+            # transactions instead of 224 for the same 3584 bytes, and over
+            # PCIe the transaction count is what the phase pays for.
+            router_pack = Int32(tidx)
+            router_packs_total = Int32(self._world_size) * second_packs
+            while router_pack < router_packs_total:
+                source_rank = router_pack // second_packs
+                pack = router_pack - source_rank * second_packs
+                source_address = Int64(
+                    (local_second + Int64(pack) * Int64(4)).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
-                            source_router = cute.recast_ptr(
-                                local_second.align(4), dtype=Float32
-                            )
+                            source_words = local_second
+                            source_base = Int64(0)
                         else:
-                            source_router = cute.recast_ptr(
-                                (
-                                    staging[source]
-                                    + slot_offset
-                                    + Int64(first_packs) * Int64(16)
-                                ).align(4),
-                                dtype=Float32,
+                            source_words = self._staging_words(
+                                staging[source] + slot_offset
                             )
-                        router_value = cute.arch.load(
-                            source_router + Int64(local_expert), Float32
+                            source_base = Int64(first_packs)
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                word0, word1, word2, word3 = ld_global_v4_u32(source_address)
+                # linear pack index * 4 is exactly rank * 56 + 4 * pack, so the
+                # four floats land on their own global expert indices.
+                base_expert = router_pack * Int32(4)
+                selection_scores[base_expert] = u32_as_f32(word0)
+                selection_scores[base_expert + Int32(1)] = u32_as_f32(word1)
+                selection_scores[base_expert + Int32(2)] = u32_as_f32(word2)
+                selection_scores[base_expert + Int32(3)] = u32_as_f32(word3)
+                router_pack += Int32(self._threads)
+            cute.arch.sync_threads()
+
+            expert = Int32(tidx)
+            while expert < Int32(896):
+                router_value = selection_scores[expert]
                 bias = cute.arch.load(
                     correction_bias + Int64(expert), Float32
                 )
@@ -1463,16 +1552,26 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
                     if cutlass.const_expr(selected > 0):
-                        if previous == keys[0]:
-                            tail_expert = _kimi_key_expert(keys[7])
-                            for item in cutlass.range_constexpr(7):
-                                keys[item] = keys[item + 1]
-                            keys[7] = _kimi_pack_key(
-                                Float32(_KIMI_NEG_INF), tail_expert
+                        # Hold the head before the shift overwrites it, so
+                        # every element selects on the same condition.
+                        head = keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF), _kimi_key_expert(keys[7])
+                        )
+                        for item in cutlass.range_constexpr(7):
+                            keys[item] = _select_if_eq_u64(
+                                previous, head, keys[item + 1], keys[item]
                             )
+                        keys[7] = _select_if_eq_u64(
+                            previous, head, tail_key, keys[7]
+                        )
                     previous = _kimi_warp_max_key(keys[0])
-                    if lane == Int32(selected):
-                        lane_key = previous
+                    lane_key = _select_if_eq_u64(
+                        cutlass.Uint64(lane),
+                        cutlass.Uint64(selected),
+                        previous,
+                        lane_key,
+                    )
                 if lane < Int32(16):
                     reduce_keys[warp * Int32(16) + lane] = lane_key
             cute.arch.sync_threads()
@@ -1487,12 +1586,17 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
                     if cutlass.const_expr(selected > 0):
-                        if previous == merge_keys[0]:
-                            tail_expert = _kimi_key_expert(merge_keys[1])
-                            merge_keys[0] = merge_keys[1]
-                            merge_keys[1] = _kimi_pack_key(
-                                Float32(_KIMI_NEG_INF), tail_expert
-                            )
+                        head = merge_keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF),
+                            _kimi_key_expert(merge_keys[1]),
+                        )
+                        merge_keys[0] = _select_if_eq_u64(
+                            previous, head, merge_keys[1], merge_keys[0]
+                        )
+                        merge_keys[1] = _select_if_eq_u64(
+                            previous, head, tail_key, merge_keys[1]
+                        )
                     previous = _kimi_warp_max_key(merge_keys[0])
                     # The reduction broadcasts, so every lane agrees here.
                     final_expert = _kimi_key_expert(previous)

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -108,6 +108,19 @@ def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
     st_global_v4_u32(destination.toint(), *values)
 
 
+@cute.jit
+def _copy_16b_addr(source: Int64, destination: Int64) -> None:
+    """Copy 16B between two byte addresses already resolved by the caller.
+
+    The gather loops pick their source rank at runtime.  Selecting the address
+    first and issuing one copy keeps a single load in flight per thread; cloning
+    the copy once per peer inside a constexpr chain makes a warp that straddles
+    two source ranks issue its loads in two serialised batches.
+    """
+    values = ld_global_v4_u32(source)
+    st_global_v4_u32(destination, *values)
+
+
 @dsl_user_op
 def _fma_rn_f32(
     a: Float32,
@@ -1256,6 +1269,19 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             source_rank = row_pack // first_packs
             pack = row_pack - source_rank * first_packs
+            # Default to this rank's own slice so the address is always
+            # mappable; the chain below always overwrites it, because
+            # source_rank is derived from row_pack and is in range.
+            source_address = Int64(
+                (
+                    local_first
+                    + (
+                        Int64(batch_index) * Int64(first_packs)
+                        + Int64(pack)
+                    )
+                    * Int64(4)
+                ).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
@@ -1268,11 +1294,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                         source_base = (
                             Int64(batch_index) * Int64(combined_packs)
                         )
-                    _copy_16b(
-                        source_words
-                        + (source_base + Int64(pack)) * Int64(4),
-                        output_first + Int64(linear) * Int64(4),
+                    source_address = Int64(
+                        (
+                            source_words
+                            + (source_base + Int64(pack)) * Int64(4)
+                        ).toint()
                     )
+            _copy_16b_addr(
+                source_address,
+                Int64((output_first + Int64(linear) * Int64(4)).toint()),
+            )
             linear += Int32(self._threads)
 
         if cutlass.const_expr(not self._kimi_topk):
@@ -1289,6 +1320,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 )
                 source_rank = row_pack // second_packs
                 pack = row_pack - source_rank * second_packs
+                source_address = Int64(
+                    (
+                        local_second
+                        + (
+                            Int64(batch_index) * Int64(second_packs)
+                            + Int64(pack)
+                        )
+                        * Int64(4)
+                    ).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
@@ -1304,11 +1345,18 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                                 Int64(batch_index) * Int64(combined_packs)
                                 + Int64(first_packs)
                             )
-                        _copy_16b(
-                            source_words
-                            + (source_base + Int64(pack)) * Int64(4),
-                            output_second + Int64(linear) * Int64(4),
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                _copy_16b_addr(
+                    source_address,
+                    Int64(
+                        (output_second + Int64(linear) * Int64(4)).toint()
+                    ),
+                )
                 linear += Int32(self._threads)
         else:
             smem_alloc = cutlass.utils.SmemAllocator()

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1344,26 +1344,38 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                         local_best = score
                         local_id = candidate
                     candidate += Int32(self._threads)
-                reduce_scores[tidx] = local_best
-                reduce_ids[tidx] = local_id
+                # Reduce inside each warp with shuffles first: the shared
+                # round trip only has to carry one candidate per warp, so a
+                # round costs a single block sync instead of log2(threads).
+                offset = Int32(16)
+                while offset > Int32(0):
+                    peer_score = cute.arch.shuffle_sync_bfly(local_best, offset)
+                    peer_id = cute.arch.shuffle_sync_bfly(local_id, offset)
+                    if peer_id >= Int32(0):
+                        if peer_score > local_best or (
+                            peer_score == local_best
+                            and (local_id < Int32(0) or peer_id < local_id)
+                        ):
+                            local_best = peer_score
+                            local_id = peer_id
+                    offset = offset // Int32(2)
+                warp = Int32(tidx) // Int32(32)
+                if Int32(tidx) % Int32(32) == Int32(0):
+                    reduce_scores[warp] = local_best
+                    reduce_ids[warp] = local_id
                 cute.arch.sync_threads()
-                stride = Int32(self._threads // 2)
-                while stride > Int32(0):
-                    if Int32(tidx) < stride:
-                        other_score = reduce_scores[tidx + stride]
-                        other_id = reduce_ids[tidx + stride]
-                        this_score = reduce_scores[tidx]
-                        this_id = reduce_ids[tidx]
-                        if other_id >= Int32(0):
-                            if other_score > this_score or (
-                                other_score == this_score
-                                and (this_id < Int32(0) or other_id < this_id)
-                            ):
-                                reduce_scores[tidx] = other_score
-                                reduce_ids[tidx] = other_id
-                    cute.arch.sync_threads()
-                    stride = stride // Int32(2)
-                best_expert = reduce_ids[0]
+                best_score = Float32(float("-inf"))
+                best_expert = Int32(-1)
+                for slot in cutlass.range_constexpr(self._threads // 32):
+                    cand_score = reduce_scores[slot]
+                    cand_id = reduce_ids[slot]
+                    if cand_id >= Int32(0):
+                        if cand_score > best_score or (
+                            cand_score == best_score
+                            and (best_expert < Int32(0) or cand_id < best_expert)
+                        ):
+                            best_score = cand_score
+                            best_expert = cand_id
                 selected_ids[selected] = best_expert
                 weight = Float32(0.0)
                 if best_expert >= Int32(0):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1491,7 +1491,17 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                     selected_ids[selected] = final_expert
                     weight = unbiased_scores[final_expert]
                     selected_weights[selected] = weight
-                    weight_sum += weight
+                # The native kernel renormalises with cg::reduce over the warp,
+                # which folds by halves (lane l adds lane l+stride, stride
+                # halving from 16). Summing left to right instead lands a ULP
+                # away, so fold in the same order. Same fifteen adds.
+                eight = [
+                    selected_weights[item] + selected_weights[item + 8]
+                    for item in range(8)
+                ]
+                four = [eight[item] + eight[item + 4] for item in range(4)]
+                two = [four[item] + four[item + 2] for item in range(2)]
+                weight_sum = two[0] + two[1]
             if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -1253,6 +1253,13 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
+                # Per-thread partial argmax for the block-wide top-16 below.
+                reduce_scores: cute.struct.Align[
+                    cute.struct.MemRange[Float32, 512], 16
+                ]
+                reduce_ids: cute.struct.Align[
+                    cute.struct.MemRange[Int32, 512], 16
+                ]
 
             storage = smem_alloc.allocate(SharedStorage)
             selection_scores = storage.selection_scores.get_tensor(
@@ -1260,6 +1267,12 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
+            )
+            reduce_scores = storage.reduce_scores.get_tensor(
+                cute.make_layout((512,), stride=(1,))
+            )
+            reduce_ids = storage.reduce_ids.get_tensor(
+                cute.make_layout((512,), stride=(1,))
             )
 
             expert = Int32(tidx)
@@ -1306,43 +1319,62 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            if Int32(tidx) == Int32(0):
-                selected_ids = cute.make_rmem_tensor((16,), Int32)
-                selected_weights = cute.make_rmem_tensor((16,), Float32)
-                for selected in cutlass.range_constexpr(16):
-                    selected_ids[selected] = Int32(-1)
-                    selected_weights[selected] = Float32(0.0)
-                weight_sum = Float32(0.0)
-                for selected in cutlass.range_constexpr(16):
-                    best_score = Float32(float("-inf"))
-                    best_expert = Int32(-1)
-                    candidate = Int32(0)
-                    while candidate < Int32(896):
-                        already_selected = False
-                        for prior in cutlass.range_constexpr(selected):
-                            if selected_ids[prior] == candidate:
-                                already_selected = True
-                        score = selection_scores[candidate]
-                        if not already_selected:
-                            if (
-                                score > best_score
-                                or (
-                                    score == best_score
-                                    and (
-                                        best_expert < Int32(0)
-                                        or candidate < best_expert
-                                    )
-                                )
+            # Block-wide top-16 selection. The previous implementation ran
+            # this on thread 0 alone: 16 rounds x 896 candidates x up to 15
+            # prior-selection checks, about 1e5 serial steps per row, which
+            # made this kernel 320 us against 39 us for the C++ original.
+            # Each round now argmaxes across every thread and masks the winner
+            # with -inf, the same scheme the C++ kernel used.
+            selected_ids = cute.make_rmem_tensor((16,), Int32)
+            selected_weights = cute.make_rmem_tensor((16,), Float32)
+            for selected in cutlass.range_constexpr(16):
+                selected_ids[selected] = Int32(-1)
+                selected_weights[selected] = Float32(0.0)
+            weight_sum = Float32(0.0)
+            for selected in cutlass.range_constexpr(16):
+                local_best = Float32(float("-inf"))
+                local_id = Int32(-1)
+                candidate = Int32(tidx)
+                while candidate < Int32(896):
+                    score = selection_scores[candidate]
+                    if score > local_best or (
+                        score == local_best
+                        and (local_id < Int32(0) or candidate < local_id)
+                    ):
+                        local_best = score
+                        local_id = candidate
+                    candidate += Int32(self._threads)
+                reduce_scores[tidx] = local_best
+                reduce_ids[tidx] = local_id
+                cute.arch.sync_threads()
+                stride = Int32(self._threads // 2)
+                while stride > Int32(0):
+                    if Int32(tidx) < stride:
+                        other_score = reduce_scores[tidx + stride]
+                        other_id = reduce_ids[tidx + stride]
+                        this_score = reduce_scores[tidx]
+                        this_id = reduce_ids[tidx]
+                        if other_id >= Int32(0):
+                            if other_score > this_score or (
+                                other_score == this_score
+                                and (this_id < Int32(0) or other_id < this_id)
                             ):
-                                best_score = score
-                                best_expert = candidate
-                        candidate += Int32(1)
-                    selected_ids[selected] = best_expert
-                    weight = Float32(0.0)
+                                reduce_scores[tidx] = other_score
+                                reduce_ids[tidx] = other_id
+                    cute.arch.sync_threads()
+                    stride = stride // Int32(2)
+                best_expert = reduce_ids[0]
+                selected_ids[selected] = best_expert
+                weight = Float32(0.0)
+                if best_expert >= Int32(0):
+                    weight = unbiased_scores[best_expert]
+                selected_weights[selected] = weight
+                weight_sum += weight
+                if Int32(tidx) == Int32(0):
                     if best_expert >= Int32(0):
-                        weight = unbiased_scores[best_expert]
-                    selected_weights[selected] = weight
-                    weight_sum += weight
+                        selection_scores[best_expert] = Float32(float("-inf"))
+                cute.arch.sync_threads()
+            if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):
                     cute.arch.store(

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -983,23 +983,31 @@ class _AllGatherHeadsLaunch(_DCPA2ABase):
                 * Int64(packs_per_head)
             )
             output_base = Int64(row) * Int64(packs_per_head)
+            # Resolve the peer's base address first and copy once. Cloning the
+            # whole pack loop into all sixteen arms of the constexpr chain
+            # bloats the kernel and pays the chain on every row.
+            source_address = Int64(
+                (local_input + source_base * Int64(4)).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
                         source_words = local_input
                     else:
                         source_words = self._staging_words(staging[source])
-                    pack = lane
-                    while pack < packs_per_head:
-                        _copy_16b(
-                            source_words
-                            + source_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                            output
-                            + output_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                        )
-                        pack += Int32(32)
+                    source_address = Int64(
+                        (source_words + source_base * Int64(4)).toint()
+                    )
+            output_address = Int64(
+                (output + output_base * Int64(4)).toint()
+            )
+            pack = lane
+            while pack < packs_per_head:
+                _copy_16b_addr(
+                    source_address + Int64(pack) * Int64(16),
+                    output_address + Int64(pack) * Int64(16),
+                )
+                pack += Int32(32)
             row += warp_stride
 
         if cutlass.const_expr(self._device_slot_selection):

--- a/b12x/comm/pcie/_island_rs_cute.py
+++ b/b12x/comm/pcie/_island_rs_cute.py
@@ -1,0 +1,654 @@
+"""CuTeDSL pull-based island reduce-scatter TP16 collective.
+
+The leader-gather hierarchy in :mod:`._hierarchical_cute` funnels the whole
+vector through one rank per island and moves the inter-island exchange in
+fp32, so the leader's PCIe link carries roughly fifteen times the payload of
+the all-reduce it is performing.  That is invisible at one token and dominant
+by eight, which is exactly the shape a K3 speculative verify step produces.
+
+This collective keeps the four-GPU islands -- and therefore the bounded peer
+degree the island decomposition exists to satisfy -- but gives every rank an
+equal quarter of the vector instead of electing a leader.
+
+Transfers are pulls.  Measured on this fabric a GPU reading from a peer
+sustains ~52 GB/s while writing into one sustains ~2.6 GB/s, so a push
+protocol -- the shape flashinfer PR #4393 uses -- loses badly here no matter
+how the hops are arranged.
+
+Rank ``island * 4 + lane`` owns quarter ``lane`` and talks to six peers: the
+three other lanes of its island, and the same lane in the three other islands.
+Per-rank wire traffic is 2.25x the payload, all bf16, in three flag rounds.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Sequence
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+from typing import Tuple
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import current_cuda_stream, make_ptr
+
+def _atomic_add_global_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(address).ir_value(loc=loc, ip=ip),
+                Uint32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.add.u32 $0, [$1], $2;",
+            "=r,l,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(address).ir_value(loc=loc, ip=ip)],
+            "ld.acquire.sys.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _store_release_sys_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            Int64(address).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.release.sys.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _fence_sc_sys(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "fence.sc.sys;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
+        "nanosleep.u32 $0;",
+        "r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
+    observed = _load_acquire_sys_u32(address)
+    while observed < generation:
+        if cutlass.const_expr(cycles > 0):
+            _nanosleep(Uint32(cycles))
+        observed = _load_acquire_sys_u32(address)
+
+
+@cute.jit
+def _flag_address(base: Int64, region: int, block: Int32, index: Int32) -> Int64:
+    return (
+        base
+        + Int64(region)
+        + (
+            Int64(block) * Int64(_ISLAND_SIZE) + Int64(index)
+        )
+        * Int64(128)
+    )
+
+
+@dsl_user_op
+def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(value).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.bf16 $0, lo;
+            cvt.f32.bf16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_bf16x2(
+    lo: Float32, hi: Float32, *, loc=None, ip=None
+) -> Uint32:
+    """Match two scalar ``__float2bfloat16`` conversions without saturation."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(lo).ir_value(loc=loc, ip=ip),
+                Float32(hi).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .b16 blo, bhi;
+                cvt.rn.bf16.f32 blo, $1;
+                cvt.rn.bf16.f32 bhi, $2;
+                mov.b32 $0, {blo, bhi};
+            }
+            """,
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+_ISLAND_SIZE = 4
+_MAX_ISLANDS = 4
+_MAX_WORLD_SIZE = _ISLAND_SIZE * _MAX_ISLANDS
+
+# One 128-byte line per (block, slot); 32 blocks x 4 slots per region.
+_RS_ARRIVED = 256
+_XS_ARRIVED = 16_640
+_AG_ARRIVED = 33_024
+HEADER_BYTES = 49_408
+MAX_BLOCKS = 32
+
+
+def island_rs_peers(rank: int, world_size: int) -> tuple[int, ...]:
+    """Slabs this rank maps: three island lanes, three same-lane partners."""
+
+    if world_size != _MAX_WORLD_SIZE:
+        raise ValueError(f"island reduce-scatter requires TP16, got TP{world_size}")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"invalid rank {rank} for TP{world_size}")
+    island, lane = divmod(rank, _ISLAND_SIZE)
+    lanes = {island * _ISLAND_SIZE + p for p in range(_ISLAND_SIZE)}
+    partners = {j * _ISLAND_SIZE + lane for j in range(_MAX_ISLANDS)}
+    return tuple(sorted((lanes | partners) - {rank}))
+
+
+class _IslandRSLaunch:
+    """Rank-specialized launcher; every peer index folds away at compile time."""
+
+    def __init__(
+        self,
+        world_size: int,
+        rank: int,
+        *,
+        threads: int = 128,
+        wait_nanosleep_cycles: int = 24,
+    ) -> None:
+        if world_size != _MAX_WORLD_SIZE:
+            raise ValueError(f"unsupported world size {world_size}")
+        if not 0 <= rank < world_size:
+            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+        if not 32 <= threads <= 1024 or threads % 32:
+            raise ValueError("threads must be a multiple of 32 in [32, 1024]")
+        self._world_size = int(world_size)
+        self._rank = int(rank)
+        self._threads = int(threads)
+        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
+        self._island = self._rank // _ISLAND_SIZE
+        self._lane = self._rank % _ISLAND_SIZE
+
+    @cute.jit
+    def __call__(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+        blocks: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            slab0, slab1, slab2, slab3, slab4, slab5, slab6, slab7,
+            slab8, slab9, slab10, slab11, slab12, slab13, slab14, slab15,
+            input_ptr,
+            output_ptr,
+            stage_offset,
+            part_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+        ).launch(
+            grid=(blocks, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+    ) -> None:
+        slabs = (
+            slab0, slab1, slab2, slab3, slab4, slab5, slab6, slab7,
+            slab8, slab9, slab10, slab11, slab12, slab13, slab14, slab15,
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        self_base = Int64(slabs[self._rank].toint())
+
+        allocator = cutlass.utils.SmemAllocator()
+        shared_generation = allocator.allocate_tensor(
+            element_type=cutlass.Uint32,
+            layout=cute.make_layout((1,)),
+            byte_alignment=4,
+        )
+        if tidx == Int32(0):
+            shared_generation[0] = _atomic_add_global_u32(
+                self_base + Int64(bidx) * Int64(4), Uint32(1)
+            ) + Uint32(1)
+        cute.arch.barrier()
+        generation = Uint32(shared_generation[0])
+
+        # Everything below counts in bf16x2 words; callers guarantee an even
+        # element count so there is no scalar tail to chase.
+        pairs = elements // Int64(2)
+        quarter = (pairs + Int64(_ISLAND_SIZE - 1)) // Int64(_ISLAND_SIZE)
+        stride = Int64(gdim) * Int64(self._threads)
+        start = Int64(bidx) * Int64(self._threads) + Int64(tidx)
+
+        input_words = cute.recast_ptr(input_ptr.align(4), dtype=Uint32)
+        output_words = cute.recast_ptr(output_ptr.align(4), dtype=Uint32)
+
+        # Every remote transfer below is a *read*.  Measured on this fabric a
+        # GPU pulling from a peer sustains ~52 GB/s while pushing into one
+        # sustains ~2.6 GB/s, so the direction of the wire traffic matters far
+        # more than the number of hops.  The equal-quarter split is what buys
+        # the win over the leader-gather hierarchy: no rank moves more than
+        # three quarters of the vector on behalf of anyone else.
+
+        # Phase 1 -- publish my whole input locally, then reduce my quarter by
+        # pulling it out of the four island stages.
+        self_stage = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + stage_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < pairs:
+            self_stage[index] = input_words[index]
+            index += stride
+        cute.arch.barrier()
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    peer = self._island * _ISLAND_SIZE + p
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[peer].toint()),
+                            _RS_ARRIVED,
+                            bidx,
+                            Int32(self._lane),
+                        ),
+                        generation,
+                    )
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    _wait_for(
+                        _flag_address(self_base, _RS_ARRIVED, bidx, Int32(p)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        mine_begin = Int64(self._lane) * quarter
+        mine_stop = mine_begin + quarter
+        if mine_stop > pairs:
+            mine_stop = pairs
+        mine_length = mine_stop - mine_begin
+
+        self_part = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + part_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < mine_length:
+            total_lo = Float32(0.0)
+            total_hi = Float32(0.0)
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                peer = self._island * _ISLAND_SIZE + p
+                peer_stage = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[peer].toint()) + stage_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                lo, hi = unpack_bf16x2(peer_stage[mine_begin + index])
+                total_lo += lo
+                total_hi += hi
+            self_part[index] = pack_f32x2_to_bf16x2(total_lo, total_hi)
+            index += stride
+        cute.arch.barrier()
+
+        # Phase 2 -- combine the four island partials for my quarter, again by
+        # pulling, from the same lane in every island.
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                if cutlass.const_expr(j != self._island):
+                    partner = j * _ISLAND_SIZE + self._lane
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[partner].toint()),
+                            _XS_ARRIVED,
+                            bidx,
+                            Int32(self._island),
+                        ),
+                        generation,
+                    )
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                if cutlass.const_expr(j != self._island):
+                    _wait_for(
+                        _flag_address(self_base, _XS_ARRIVED, bidx, Int32(j)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        self_final = cute.recast_ptr(
+            cute.make_ptr(
+                cutlass.BFloat16,
+                self_base + final_offset,
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ).align(4),
+            dtype=Uint32,
+        )
+        index = start
+        while index < mine_length:
+            total_lo = Float32(0.0)
+            total_hi = Float32(0.0)
+            for j in cutlass.range_constexpr(_MAX_ISLANDS):
+                partner = j * _ISLAND_SIZE + self._lane
+                partner_part = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[partner].toint()) + part_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                lo, hi = unpack_bf16x2(partner_part[index])
+                total_lo += lo
+                total_hi += hi
+            value = pack_f32x2_to_bf16x2(total_lo, total_hi)
+            self_final[mine_begin + index] = value
+            output_words[mine_begin + index] = value
+            index += stride
+        cute.arch.barrier()
+
+        # Phase 3 -- island all-gather, pulling the three quarters I do not own
+        # straight into my output.
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    peer = self._island * _ISLAND_SIZE + p
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[peer].toint()),
+                            _AG_ARRIVED,
+                            bidx,
+                            Int32(self._lane),
+                        ),
+                        generation,
+                    )
+            for p in cutlass.range_constexpr(_ISLAND_SIZE):
+                if cutlass.const_expr(p != self._lane):
+                    _wait_for(
+                        _flag_address(self_base, _AG_ARRIVED, bidx, Int32(p)),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+
+        for p in cutlass.range_constexpr(_ISLAND_SIZE):
+            if cutlass.const_expr(p != self._lane):
+                peer = self._island * _ISLAND_SIZE + p
+                peer_final = cute.recast_ptr(
+                    cute.make_ptr(
+                        cutlass.BFloat16,
+                        Int64(slabs[peer].toint()) + final_offset,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ).align(4),
+                    dtype=Uint32,
+                )
+                begin = Int64(p) * quarter
+                stop = begin + quarter
+                if stop > pairs:
+                    stop = pairs
+                index = start
+                while index < stop - begin:
+                    output_words[begin + index] = peer_final[begin + index]
+                    index += stride
+
+@functools.lru_cache(maxsize=None)
+def get_island_rs_launcher(
+    world_size: int,
+    rank: int,
+    device_index: int,
+    *,
+    threads: int = 128,
+    wait_nanosleep_cycles: int = 24,
+) -> Callable[..., None]:
+    """Return the rank-specialized TP16 island reduce-scatter launcher."""
+
+    del device_index  # retained in the process-local cache key
+    launch = _IslandRSLaunch(
+        world_size,
+        rank,
+        threads=threads,
+        wait_nanosleep_cycles=wait_nanosleep_cycles,
+    )
+    cache_key = (
+        int(world_size),
+        int(rank),
+        int(threads),
+        int(wait_nanosleep_cycles),
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=launch, cache_key=cache_key
+    )
+    slab_placeholder = make_ptr(
+        cutlass.Uint8,
+        256,
+        cute.AddressSpace.gmem,
+        assumed_align=256,
+    )
+    raw = b12x_compile(
+        launch,
+        *(slab_placeholder for _ in range(_MAX_WORLD_SIZE)),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "comm.pcie.island_rs.bf16",
+            1,
+            cache_key,
+            labels=(
+                "world_size",
+                "rank",
+                "threads",
+                "wait_nanosleep_cycles",
+            ),
+        ),
+    )
+
+    def run(
+        slab_addresses: Sequence[int],
+        input_address: int,
+        output_address: int,
+        stage_offset: int,
+        part_offset: int,
+        final_offset: int,
+        quarter_capacity: int,
+        elements: int,
+        blocks: int,
+    ) -> None:
+        if len(slab_addresses) != world_size:
+            raise ValueError(
+                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
+            )
+        raw(
+            *(
+                make_ptr(
+                    cutlass.Uint8,
+                    int(address),
+                    cute.AddressSpace.gmem,
+                    assumed_align=256,
+                )
+                for address in slab_addresses
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                input_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                output_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            stage_offset,
+            part_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+            blocks,
+            current_cuda_stream(),
+        )
+
+    return run
+
+
+__all__ = ["get_island_rs_launcher", "island_rs_peers", "HEADER_BYTES", "MAX_BLOCKS"]

--- a/b12x/comm/pcie/pcie_allreduce.py
+++ b/b12x/comm/pcie/pcie_allreduce.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import os
+
+from contextlib import ExitStack, contextmanager, suppress
 from typing import Any, Optional, Sequence
 
 import torch
@@ -15,12 +17,52 @@ from .pcie_hierarchical import (
 from .pcie_hierarchical import (
     PCIeHierarchicalAllReduce,
 )
+from .pcie_island_rs import (
+    CROSSOVER_ELEMENTS as ISLAND_RS_CROSSOVER_ELEMENTS,
+)
+from .pcie_island_rs import (
+    SUPPORTED_WORLD_SIZES as ISLAND_RS_WORLD_SIZES,
+)
+from .pcie_island_rs import (
+    PCIeIslandRSAllReduce,
+)
 from .pcie_oneshot import (
     DEFAULT_MAX_SIZE,
     DEFAULT_RANK_DATA_BYTES,
     SUPPORTED_WORLD_SIZES as ONESHOT_WORLD_SIZES,
     PCIeOneshotAllReducePool,
 )
+
+
+# The island reduce-scatter runtime keeps beating NCCL up to about this size;
+# past it NCCL's flat protocol cost wins again (37.6 vs 35.3 us at twelve rows
+# of 7168). Callers that gate on a byte limit should ask for this rather than
+# carrying their own constant.
+ISLAND_RS_MAX_BYTES = 160 * 1024
+
+
+def _algorithm_override() -> str:
+    """``auto`` picks per message size; the others pin one implementation."""
+
+    choice = os.getenv("B12X_PCIE_ALLREDUCE_ALGORITHM", "auto").strip().lower()
+    if choice not in ("auto", "hierarchical", "island_rs"):
+        raise ValueError(
+            "B12X_PCIE_ALLREDUCE_ALGORITHM must be auto, hierarchical or "
+            f"island_rs, got {choice!r}"
+        )
+    return choice
+
+
+def recommended_max_bytes(world_size: int, *, default: int = DEFAULT_MAX_SIZE) -> int:
+    """Largest all-reduce this runtime expects to win at, for this world size.
+
+    Callers use this policy without duplicating world-size- and
+    implementation-specific thresholds.
+    """
+
+    if world_size in ISLAND_RS_WORLD_SIZES and _algorithm_override() != "hierarchical":
+        return max(default, ISLAND_RS_MAX_BYTES)
+    return default
 
 
 MAX_DIRECT_WORLD_SIZE = 8
@@ -52,8 +94,16 @@ class PCIeAllReduce:
     connection limit.
     """
 
-    def __init__(self, runtime: Any, algorithm: str) -> None:
+    def __init__(
+        self,
+        runtime: Any,
+        algorithm: str,
+        island_rs: Any = None,
+    ) -> None:
         self._runtime = runtime
+        # Optional second implementation for the same world. When present the
+        # dispatcher routes by message size instead of exposing a knob.
+        self._island_rs = island_rs
         self.algorithm = algorithm
         self.rank = runtime.rank
         self.world_size = runtime.world_size
@@ -92,7 +142,43 @@ class PCIeAllReduce:
                 max_elements=max_size // torch.bfloat16.itemsize,
                 ext_module=ext_module,
             )
-        return cls(runtime, algorithm)
+        island_rs = cls._maybe_island_rs(
+            exchange_group=exchange_group,
+            device=device,
+            max_size=max_size,
+        )
+        return cls(runtime, algorithm, island_rs)
+
+    @staticmethod
+    def _maybe_island_rs(
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int,
+    ) -> Any:
+        """Attach the equal-quarter runtime when topology and policy allow it.
+
+        Capacity includes :data:`ISLAND_RS_MAX_BYTES` independently of the
+        caller's ``max_size`` so the dispatcher covers the complete crossover
+        band. Returns ``None`` on any failure; the hierarchical runtime remains
+        a correct fallback.
+        """
+
+        world_size = dist.get_world_size(group=exchange_group)
+        if world_size not in ISLAND_RS_WORLD_SIZES:
+            return None
+        if _algorithm_override() == "hierarchical":
+            return None
+        capacity = max(int(max_size), ISLAND_RS_MAX_BYTES)
+        elements = capacity // torch.bfloat16.itemsize
+        try:
+            return PCIeIslandRSAllReduce(
+                exchange_group=exchange_group,
+                device=device,
+                max_elements=elements - (elements % 2),
+            )
+        except Exception:
+            return None
 
     @classmethod
     def from_process_group(
@@ -126,7 +212,31 @@ class PCIeAllReduce:
         return self.algorithm == "oneshot"
 
     def for_stream(self, stream: object = None):
+        if self._island_rs is not None:
+            self._island_rs.for_stream(stream)
         return self._runtime.for_stream(stream)
+
+    def _use_island_rs(self, inp: torch.Tensor) -> bool:
+        """Route large messages to the equal-quarter runtime.
+
+        Small ones stay on the hierarchy, whose critical path is shorter for the
+        ranks that are not the island leader; large ones would otherwise funnel
+        the whole vector through that leader's PCIe link.
+        """
+
+        if self._island_rs is None:
+            return False
+        override = _algorithm_override()
+        if override == "hierarchical":
+            return False
+        if override != "island_rs" and inp.numel() <= ISLAND_RS_CROSSOVER_ELEMENTS:
+            return False
+        return self._island_rs.should_allreduce(inp)
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        if self._runtime.should_allreduce(inp):
+            return True
+        return self._island_rs is not None and self._island_rs.should_allreduce(inp)
 
     def all_reduce(
         self,
@@ -142,6 +252,8 @@ class PCIeAllReduce:
                 raise ValueError(
                     "peer_input_ptrs are unavailable for hierarchical all-reduce"
                 )
+            if self._use_island_rs(inp):
+                return self._island_rs.all_reduce(inp, out=out, blocks=blocks)
             return self._runtime.all_reduce(
                 inp,
                 out=out,
@@ -159,10 +271,17 @@ class PCIeAllReduce:
 
     @contextmanager
     def capture(self, stream: object = None):
-        with self._runtime.capture(stream=stream) as runtime:
+        with ExitStack() as stack:
+            runtime = stack.enter_context(self._runtime.capture(stream=stream))
+            if self._island_rs is not None:
+                stack.enter_context(self._island_rs.capture(stream=stream))
             yield runtime
 
     def close(self) -> None:
+        if self._island_rs is not None:
+            with suppress(Exception):
+                self._island_rs.close()
+            self._island_rs = None
         self._runtime.close()
 
     def __getattr__(self, name: str):

--- a/b12x/comm/pcie/pcie_island_rs.py
+++ b/b12x/comm/pcie/pcie_island_rs.py
@@ -1,0 +1,227 @@
+"""Pull-based island reduce-scatter TP16 all-reduce runtime."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, suppress
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from ._island_rs_cute import (
+    HEADER_BYTES,
+    MAX_BLOCKS,
+    get_island_rs_launcher,
+    island_rs_peers,
+)
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import _broadcast_gather_object, _normalize_device
+
+
+SUPPORTED_WORLD_SIZES = (16,)
+SUPPORTED_BLOCKS = (1, 2, 4, 8, 16, 32)
+_ISLAND_SIZE = 4
+_ALIGNMENT = 256
+
+
+def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+def _threads_from_env() -> int:
+    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "128")
+    threads = int(raw)
+    if not 32 <= threads <= 1024 or threads % 32:
+        raise ValueError(
+            "B12X_PCIE_ISLAND_RS_THREADS must be a multiple of 32 in [32, 1024]"
+        )
+    return threads
+
+
+def _wait_nanosleep_cycles_from_env() -> int:
+    cycles = int(os.getenv("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES", "24"))
+    if not 0 <= cycles <= 1024:
+        raise ValueError(
+            "B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES must be in [0, 1024]"
+        )
+    return cycles
+
+
+def _pick_blocks(elements: int) -> int:
+    if elements <= 4096:
+        return 8
+    return 16
+
+
+class PCIeIslandRSAllReduce:
+    """Equal-quarter BF16 TP16 all-reduce with no leader hotspot.
+
+    Every rank owns one quarter of the vector and reaches six peers: the three
+    other lanes of its four-GPU island, and the same lane in the three other
+    islands. Peer degree is bounded at six, and no rank carries the whole
+    vector on behalf of the others.
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_elements: int,
+        blocks: Optional[int] = None,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = _normalize_device(device)
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                f"island reduce-scatter requires TP16, got TP{self.world_size}"
+            )
+        if self.device.type != "cuda":
+            raise ValueError("island reduce-scatter requires a CUDA device")
+        if blocks is not None and blocks not in SUPPORTED_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        if max_elements <= 0 or max_elements % 2:
+            raise ValueError("max_elements must be a positive even count")
+
+        self.max_elements = int(max_elements)
+        self.blocks = None if blocks is None else int(blocks)
+        self.threads = _threads_from_env()
+        self.wait_nanosleep_cycles = _wait_nanosleep_cycles_from_env()
+
+        max_pairs = self.max_elements // 2
+        # Quarter stride in bf16x2 words, shared by the scatter and exchange
+        # regions so both index by (source, word) with a compile-time stride.
+        self.quarter_capacity = _align_up(
+            (max_pairs + _ISLAND_SIZE - 1) // _ISLAND_SIZE, 8
+        )
+        quarter_bytes = self.quarter_capacity * 4
+        self.stage_offset = _align_up(HEADER_BYTES)
+        self.part_offset = _align_up(self.stage_offset + self.max_elements * 2)
+        self.final_offset = _align_up(self.part_offset + quarter_bytes)
+        slab_bytes = _align_up(self.final_offset + self.max_elements * 2)
+
+        self._ipc = CudaRTLibrary()
+        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._slab_ptrs: tuple[int, ...] = ()
+        self._local_ptr = 0
+        self._remote_ptrs: list[int] = []
+        self._closed = False
+        self._launcher = None
+
+        peer_ptrs = [0] * self.world_size
+        try:
+            self._local_ptr = self._ipc.cudaMalloc(slab_bytes)
+            self._ipc.cudaMemset(self._local_ptr, 0, slab_bytes)
+            local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
+            handles = _broadcast_gather_object(local_handle, exchange_group)
+            peer_ptrs[self.rank] = self._local_ptr
+            for peer in island_rs_peers(self.rank, self.world_size):
+                remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
+                peer_ptrs[peer] = remote_ptr
+                self._remote_ptrs.append(remote_ptr)
+            self._slab_ptrs = tuple(peer_ptrs)
+            with torch.cuda.device(self.device):
+                self._launcher = get_island_rs_launcher(
+                    self.world_size,
+                    self.rank,
+                    self.device.index or 0,
+                    threads=self.threads,
+                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
+                )
+        except Exception:
+            self.close()
+            raise
+
+    @property
+    def mapped_peer_count(self) -> int:
+        return len(self._remote_ptrs)
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        return (
+            not self._closed
+            and inp.device == self.device
+            and inp.dtype == torch.bfloat16
+            and inp.is_contiguous()
+            and 0 < inp.numel() <= self.max_elements
+            and inp.numel() % 2 == 0
+            and inp.data_ptr() % 4 == 0
+        )
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+        blocks: Optional[int] = None,
+    ) -> torch.Tensor:
+        if not self.should_allreduce(inp):
+            raise ValueError(
+                "input does not satisfy island reduce-scatter requirements "
+                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+        if out is None:
+            out = torch.empty_like(inp)
+        if (
+            out.dtype != inp.dtype
+            or out.device != inp.device
+            or out.shape != inp.shape
+            or not out.is_contiguous()
+            or out.data_ptr() % 4 != 0
+        ):
+            raise ValueError("output must match input and be 4-byte aligned")
+        if blocks is not None:
+            selected = int(blocks)
+        elif self.blocks is not None:
+            selected = self.blocks
+        else:
+            selected = _pick_blocks(inp.numel())
+        if selected not in SUPPORTED_BLOCKS or selected > MAX_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        with torch.cuda.device(self.device):
+            self._launcher(
+                self._slab_ptrs,
+                inp.data_ptr(),
+                out.data_ptr(),
+                self.stage_offset,
+                self.part_offset,
+                self.final_offset,
+                self.quarter_capacity,
+                inp.numel(),
+                selected,
+            )
+        return out
+
+    def for_stream(self, stream: object = None) -> "PCIeIslandRSAllReduce":
+        del stream
+        return self
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        del stream
+        yield self
+
+    def register_graph_buffers(self) -> None:
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self.device.type == "cuda":
+            with suppress(Exception):
+                torch.cuda.synchronize(self.device)
+        for ptr in self._remote_ptrs:
+            with suppress(Exception):
+                self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._remote_ptrs.clear()
+        if self._local_ptr:
+            with suppress(Exception):
+                self._ipc.cudaFree(self._local_ptr)
+            self._local_ptr = 0
+
+
+__all__ = ["PCIeIslandRSAllReduce", "SUPPORTED_WORLD_SIZES"]

--- a/b12x/comm/pcie/pcie_island_rs.py
+++ b/b12x/comm/pcie/pcie_island_rs.py
@@ -31,7 +31,11 @@ def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
 
 
 def _threads_from_env() -> int:
-    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "128")
+    # 512 is the measured TP16 optimum: each phase moves only about 86KB, so
+    # the kernel needs enough concurrent reads to cover the PCIe round trip.
+    # At [8, 7168] the same kernel costs 49.8 us with 128 threads and 25.9 with
+    # 512; 1024 gives nothing back.
+    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "512")
     threads = int(raw)
     if not 32 <= threads <= 1024 or threads % 32:
         raise ValueError(
@@ -50,9 +54,19 @@ def _wait_nanosleep_cycles_from_env() -> int:
 
 
 def _pick_blocks(elements: int) -> int:
+    """Measured TP16 launch geometry; 32 blocks regress, 8 under-fill."""
+
     if elements <= 4096:
         return 8
     return 16
+
+
+# Below this the leader-gather hierarchy is still ahead (18.16 vs 20.51 us at
+# one row of 7168), because it has a shorter critical path for the ranks that
+# are not the leader. Above it the leader's link is the bottleneck and the
+# equal-quarter split wins: 22.44 vs 30.36 us at four rows, 26.03 vs 46.79 at
+# eight. Expressed in elements so it does not depend on the model's hidden size.
+CROSSOVER_ELEMENTS = 14_336
 
 
 class PCIeIslandRSAllReduce:


### PR DESCRIPTION
## Status

**Qualified** as the b12x Kimi-K3 TP16 CuTe composition. This PR contains #138 pair/top-16 routing and #139 size-routed island all-reduce on the #124 DCP16 base. It is the integration review target and contains no native CUDA projection-gather overlay.

## Resulting composition

- CuTe pair and head gathers with aligned peer loads.
- Bit-identical fused sigmoid, top-16 expert selection, and routed-weight normalization.
- Hierarchical TP16 all-reduce for messages through 14,336 elements.
- Equal-quarter island reduce-scatter for larger TP16 messages.
- Explicit environment overrides for all-reduce algorithm selection.

## Full-model qualification

Conditions: full Kimi-K3 MXFP4 checkpoint, 16 RTX PRO 6000 GPUs, TP16, DCP16, FP8 KV cache, model limit 1,048,576 tokens, measured physical KV capacity 1,057,049 tokens, FULL decode graphs, concurrency 1, and no speculative draft model.

The benchmark kept the server CUDA context alive, waited until all 16 GPUs reported P8, then woke, warmed, and measured each arm. PCIe links remained Gen5 x16.

| runtime composition | decode runs (tok/s) | mean (tok/s) | mean CUDA-graph duration (ms) |
|---|---:|---:|---:|
| All-CuTe PR head | 56.501, 56.437 | **56.469** | 17.511 |
| Native CUDA 136-wide QKV-A projection-gather control | 56.283, 56.337 | 56.310 | 17.544 |

The 0.159 tok/s difference is 0.28% and within run noise. The qualified composition therefore uses the all-CuTe implementation without the native projection-gather control.

## Benchmark limitation

An idle transition changes the same executable graph from approximately 54.2 to 56.4 tok/s even though the GPUs return to P1 for measurement. The responsible NVIDIA driver, GSP, or PCIe state is not identified. P8 waiting is therefore a required benchmark-normalization condition, not a runtime feature or a claimed production optimization.

## Validation artifact

`voipmonitor/vllm:kimi-k3-hh-cute-r1-vllm290ef54-b12x15b4b98-cu132-20260809-gg3` validates the executable CuTe and island-collective paths. The PR head also includes #124 host-safety guards and prose corrections, so the image is validation evidence rather than a byte-identical build of the review head.

Static validation passes with `ruff check` and `git diff --check`. Numeric and microbenchmark evidence is specified in #138 and #139.

## Review order

1. #124 for dense-MLA scratch and TP16 vocabulary argmax contracts.
2. #138 for CuTe pair gathering and fused top-16.
3. #139 for island reduce-scatter and size routing.
4. #141 for composition and full-model evidence.

## Review disclosure

Implementation and PR text were AI-assisted. Human review is requested before merge.
