### PR TITLE
Validate the wave-balanced W4A16 FC2 tile

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -442,6 +442,7 @@ def _candidate_tile_fits(
     weight_layout: str = "packed",
     weight_bits: int = 4,
     allow_logical_tail: bool = False,
+    allow_qualified_fc2_tile: bool = False,
 ) -> bool:
     if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
         return False
@@ -466,7 +467,10 @@ def _candidate_tile_fits(
     # Keep the generic tile floor while allowing that exact geometry to pass
     # through the explicit-pin path used by the Torch custom-op boundary.
     wide_n_fc2_tile = (
-        int(tile_k) == 32 and int(tile_n) == 512 and int(cta_threads) == 256
+        allow_qualified_fc2_tile
+        and int(tile_k) == 32
+        and int(tile_n) == 512
+        and int(cta_threads) == 256
     )
     if (
         int(tile_n) < 64
@@ -4345,9 +4349,7 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 local_n16 = Int32(4) * w_n + Int32(jj)
                 tile_base = Int32(0)
-                # CuTe resolves the equal-rate branch during specialization;
-                # keep it separate from the runtime K-region predicate.
-                if cutlass.const_expr(int(low_bits) == int(high_bits)):  # noqa: SIM114
+                if cutlass.const_expr(int(low_bits) == int(high_bits)):
                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits
@@ -9949,6 +9951,7 @@ def compile_w4a16_fused_moe(
             scale_format=scale_format,
             weight_layout=weight_layout,
             weight_bits=weight_bits,
+            allow_qualified_fc2_tile=True,
         ):
             fc2_tile_n = 512
             fc2_tile_k = ultra_fc2_tile_k
@@ -9984,6 +9987,7 @@ def compile_w4a16_fused_moe(
                 weight_layout=weight_layout,
                 weight_bits=weight_bits,
                 allow_logical_tail=allow_native_logical_tail,
+                allow_qualified_fc2_tile=name == "fc2",
             ):
                 raise ValueError(
                     f"force_tile_config {name} tile "

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -462,7 +462,17 @@ def _candidate_tile_fits(
         or int(tile_k) % scale_group_size != 0
     ):
         return False
-    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
+    # The FC2 wave-balanced decode schedule uses one qualified 32x512 tile.
+    # Keep the generic tile floor while allowing that exact geometry to pass
+    # through the explicit-pin path used by the Torch custom-op boundary.
+    wide_n_fc2_tile = (
+        int(tile_k) == 32 and int(tile_n) == 512 and int(cta_threads) == 256
+    )
+    if (
+        int(tile_n) < 64
+        or int(cta_threads) < 128
+        or (int(tile_k) < 64 and not wide_n_fc2_tile)
+    ):
         return False
     smem_bytes = _shared_memory_footprint(
         cta_m_blocks=cta_m_blocks,
@@ -4335,7 +4345,9 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 local_n16 = Int32(4) * w_n + Int32(jj)
                 tile_base = Int32(0)
-                if cutlass.const_expr(int(low_bits) == int(high_bits)):
+                # CuTe resolves the equal-rate branch during specialization;
+                # keep it separate from the runtime K-region predicate.
+                if cutlass.const_expr(int(low_bits) == int(high_bits)):  # noqa: SIM114
                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits
@@ -9926,28 +9938,26 @@ def compile_w4a16_fused_moe(
         and fc1_mn_after <= int(sms)
     ):
         ultra_fc2_tile_k = 32
-        ultra_smem = _shared_memory_footprint(
+        if _candidate_tile_fits(
+            problem_n=hidden_size,
+            problem_k=intermediate_size,
             cta_m_blocks=_covering_count(moe_block_size, 16),
             tile_n=512,
             tile_k=ultra_fc2_tile_k,
+            cta_threads=256,
+            max_shared_mem=int(max_shared_mem) - 512,
             scale_format=scale_format,
             weight_layout=weight_layout,
             weight_bits=weight_bits,
-        )
-        if (
-            int(intermediate_size) % ultra_fc2_tile_k == 0
-            and ultra_smem <= int(max_shared_mem) - 512
         ):
             fc2_tile_n = 512
             fc2_tile_k = ultra_fc2_tile_k
             fc2_cta_threads = 256
     if force_tile_config is not None:
-        # Explicit (fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n) pin. The
-        # Some weight layouts are packed for a specific CTA
-        # N-tile, so hybrid deployments pin ONE tile config across every m
-        # regime instead of the m-dependent auto selection (and TC-decode
-        # wide-N overrides) above. Overrides whatever was selected; the tiles
-        # land in the GEMM cache keys, so no cache collision is possible.
+        # Some weight layouts are packed for a specific CTA N-tile. An explicit
+        # (fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n) tuple therefore pins
+        # one geometry across every M regime. Tile values are part of the GEMM
+        # cache key, so distinct packed layouts cannot collide.
         fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (
             int(v) for v in force_tile_config
         )

--- a/tests/moe/test_w4a16_tile_selection.py
+++ b/tests/moe/test_w4a16_tile_selection.py
@@ -1,0 +1,25 @@
+from b12x.moe._shared.kernels.w4a16.kernel import _candidate_tile_fits
+
+
+def _fits(*, tile_k: int, tile_n: int, cta_threads: int) -> bool:
+    return _candidate_tile_fits(
+        problem_n=4096,
+        problem_k=512,
+        cta_m_blocks=1,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        cta_threads=cta_threads,
+        max_shared_mem=1 << 30,
+        scale_format="e8m0_k32",
+        weight_layout="modelopt",
+        weight_bits=4,
+    )
+
+
+def test_wave_balanced_fc2_tile_is_valid_as_an_explicit_pin() -> None:
+    assert _fits(tile_k=32, tile_n=512, cta_threads=256)
+
+
+def test_other_sub64_k_tiles_remain_unsupported() -> None:
+    assert not _fits(tile_k=32, tile_n=256, cta_threads=128)
+    assert not _fits(tile_k=16, tile_n=512, cta_threads=128)

--- a/tests/moe/test_w4a16_tile_selection.py
+++ b/tests/moe/test_w4a16_tile_selection.py
@@ -1,7 +1,13 @@
 from b12x.moe._shared.kernels.w4a16.kernel import _candidate_tile_fits
 
 
-def _fits(*, tile_k: int, tile_n: int, cta_threads: int) -> bool:
+def _fits(
+    *,
+    tile_k: int,
+    tile_n: int,
+    cta_threads: int,
+    allow_qualified_fc2_tile: bool = False,
+) -> bool:
     return _candidate_tile_fits(
         problem_n=4096,
         problem_k=512,
@@ -13,11 +19,21 @@ def _fits(*, tile_k: int, tile_n: int, cta_threads: int) -> bool:
         scale_format="e8m0_k32",
         weight_layout="modelopt",
         weight_bits=4,
+        allow_qualified_fc2_tile=allow_qualified_fc2_tile,
     )
 
 
 def test_wave_balanced_fc2_tile_is_valid_as_an_explicit_pin() -> None:
-    assert _fits(tile_k=32, tile_n=512, cta_threads=256)
+    assert _fits(
+        tile_k=32,
+        tile_n=512,
+        cta_threads=256,
+        allow_qualified_fc2_tile=True,
+    )
+
+
+def test_wave_balanced_fc2_tile_is_rejected_for_fc1() -> None:
+    assert not _fits(tile_k=32, tile_n=512, cta_threads=256)
 
 
 def test_other_sub64_k_tiles_remain_unsupported() -> None:


### PR DESCRIPTION
## Resulting behavior

W4A16 launch selection accepts the exact FC2 geometry `tile_k=32`, `tile_n=512`, `cta_threads=256`. The automatic wave-balanced selection and explicit `force_tile_config` path use the same divisibility and shared-memory validator. Other sub-64 K tiles remain unsupported.

## Technical reason

The FC2 wave-balanced decode schedule uses a 512-wide output tile with a 32-element K tile to preserve the 256-thread fused FC1/FC2 contract. The automatic path previously duplicated part of the validation logic, while the explicit configuration path rejected the same supported geometry through its generic `tile_k >= 64` floor.

## Compatibility

The exception applies only to the exact FC2 geometry. Existing tile choices, GEMM cache-key separation, generated CUDA kernel instructions, dependencies, and public interfaces are unchanged.

## Validation

Validated on a synthetic merge of PR head `fb4bc17b` with `master` at `85d3681b`:

- `python -m pytest -q tests/moe/test_w4a16_tile_selection.py`: 3 passed.
- `python -m compileall -q b12x/moe/_shared/kernels/w4a16/kernel.py tests/moe/test_w4a16_tile_selection.py`: passed.
- `git diff --check`: passed.
- GPU qualification was not rerun during merge review.
