### PR TITLE
[II] Serve projection-mixed EXL3 K3/K4/K5 weights

### DIFF
--- a/b12x/gemm/trellis_linear/api.py
+++ b/b12x/gemm/trellis_linear/api.py
@@ -86,7 +86,7 @@ def run(
     gemm_output_f16: Optional[torch.Tensor] = None,
     output_f16: Optional[torch.Tensor] = None,
     hadamard_128=None,
-    _moe_block_size: int = 64,
+    _moe_block_size: int | None = None,
     _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Execute Trellis GEMM, optionally reusing all capture-time storage."""

--- a/b12x/moe/_shared/kernels/w4a16/host.py
+++ b/b12x/moe/_shared/kernels/w4a16/host.py
@@ -190,6 +190,32 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
     return 1 << (max(int(tokens), 1) - 1).bit_length()
 
 
+def route_pack_warmup_token_counts(capacity: int) -> tuple[int, ...]:
+    """Return live row counts covering capacity and scalar specializations.
+
+    Triton specializes the runtime ``live_numel`` scalar on alignment as well
+    as the constexpr route-capacity bucket. For a power-of-two bucket, the
+    bucket maximum and its first live member cover both alignment classes
+    reached by the GLM top-k route counts (for example 8 and 5 rows in the
+    8-row bucket). Warming only bucket maxima leaves the less-aligned variant
+    to compile on the first odd-sized request.
+    """
+    capacity = int(capacity)
+    if capacity < 1:
+        raise ValueError(f"route-pack warmup capacity must be positive, got {capacity}")
+    counts: list[int] = []
+    bucket = 1
+    while True:
+        first_in_bucket = 1 if bucket == 1 else bucket // 2 + 1
+        if first_in_bucket > capacity:
+            break
+        for count in (first_in_bucket, min(bucket, capacity)):
+            if not counts or counts[-1] != count:
+                counts.append(count)
+        bucket *= 2
+    return tuple(counts)
+
+
 def route_pack_capacity(
     numel: int,
     block_size: int,
@@ -409,6 +435,7 @@ __all__ = [
     "route_pack_numel_capacity",
     "route_pack_capacity",
     "route_pack_token_capacity",
+    "route_pack_warmup_token_counts",
     "select_route_block_size_m",
     "unswizzle_block_scale",
     "unswizzle_expert_scales",

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -443,7 +443,6 @@ def _candidate_tile_fits(
     weight_layout: str = "packed",
     weight_bits: int = 4,
     allow_logical_tail: bool = False,
-    allow_ultra_wide_k32: bool = False,
 ) -> bool:
     if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
         return False
@@ -464,18 +463,7 @@ def _candidate_tile_fits(
         or int(tile_k) % scale_group_size != 0
     ):
         return False
-    ultra_wide_k32 = (
-        bool(allow_ultra_wide_k32)
-        and int(tile_n) == 512
-        and int(tile_k) == 32
-        and int(cta_threads) == 256
-        and scale_group_size == 32
-    )
-    if (
-        int(tile_n) < 64
-        or (int(tile_k) < 64 and not ultra_wide_k32)
-        or int(cta_threads) < 128
-    ):
+    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
         return False
     smem_bytes = _shared_memory_footprint(
         cta_m_blocks=cta_m_blocks,
@@ -9902,7 +9890,6 @@ def compile_w4a16_fused_moe(
                 weight_layout=weight_layout,
                 weight_bits=weight_bits,
                 allow_logical_tail=allow_native_logical_tail,
-                allow_ultra_wide_k32=(name == "fc2"),
             ):
                 raise ValueError(
                     f"force_tile_config {name} tile "

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -199,6 +199,7 @@ def _trellis256_execution_lut(
         return sqg_fp16_d3l_descriptors(device)
     return sqg_xor_cheb_t12_lut(device)
 
+
 # TC-decode: a small-M decode specialization that runs on the PACKED W4A16
 # object (the same weights/scales the prefill GEMM uses). It reuses the packed
 # tensor-core MMA inner loop but folds the top-k sum into the FC2 store
@@ -442,6 +443,7 @@ def _candidate_tile_fits(
     weight_layout: str = "packed",
     weight_bits: int = 4,
     allow_logical_tail: bool = False,
+    allow_ultra_wide_k32: bool = False,
 ) -> bool:
     if int(tile_k) == -1 or int(tile_n) == -1 or int(cta_threads) == -1:
         return False
@@ -462,7 +464,18 @@ def _candidate_tile_fits(
         or int(tile_k) % scale_group_size != 0
     ):
         return False
-    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
+    ultra_wide_k32 = (
+        bool(allow_ultra_wide_k32)
+        and int(tile_n) == 512
+        and int(tile_k) == 32
+        and int(cta_threads) == 256
+        and scale_group_size == 32
+    )
+    if (
+        int(tile_n) < 64
+        or (int(tile_k) < 64 and not ultra_wide_k32)
+        or int(cta_threads) < 128
+    ):
         return False
     smem_bytes = _shared_memory_footprint(
         cta_m_blocks=cta_m_blocks,
@@ -859,8 +872,7 @@ class W4A16GemmKernel:
                 )
             if trellis_bits != 3:
                 raise ValueError(
-                    "QSRT pair decoding requires the trellis_bits=3 base "
-                    "specialization"
+                    "QSRT pair decoding requires the trellis_bits=3 base specialization"
                 )
         if epilogue_activation not in (None, "relu2"):
             raise ValueError(
@@ -873,9 +885,7 @@ class W4A16GemmKernel:
                 "N-axis trellis pairs require size_n % 256 == 0 and "
                 "tile_n=256 so every CTA consumes one complete fixed-rate pair"
             )
-        if trellis_rate_axis == "k" and (
-            size_k != 256 or tile_k > 128 or 128 % tile_k
-        ):
+        if trellis_rate_axis == "k" and (size_k != 256 or tile_k > 128 or 128 % tile_k):
             raise ValueError(
                 "K-axis trellis pairs require size_k=256 and a tile_k that "
                 "divides one 128-channel record"
@@ -959,8 +969,8 @@ class W4A16GemmKernel:
             "P43": (4, 3),
             "P44": (4, 4),
         }
-        self.trellis_pair_low_bits, self.trellis_pair_high_bits = (
-            static_pair_rates.get(trellis_pair_kind, (3, 3))
+        self.trellis_pair_low_bits, self.trellis_pair_high_bits = static_pair_rates.get(
+            trellis_pair_kind, (3, 3)
         )
         self.sqg_xor_cheb_t12_smem = False
         # Small-M stripe split-K: opt out of the one-tile-per-CTA fast path
@@ -2518,6 +2528,7 @@ class W4A16GemmKernel:
             a_rows_per_iter,
             output_n_tile,
             expert_idx,
+            -1,
         )
 
         b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
@@ -2530,6 +2541,8 @@ class W4A16GemmKernel:
             s_sh_rd,
             Int32(0),
             Int32(0),
+            reduce_k_tile,
+            -1,
         )
         a0_regs_cur = cute.make_rmem_tensor((2,), Uint32)
         a0_regs_next = cute.make_rmem_tensor((2,), Uint32)
@@ -2902,9 +2915,7 @@ class W4A16GemmKernel:
                         )
 
                         if cutlass.const_expr(self.trellis_pair_dynamic):
-                            if cutlass.const_expr(
-                                int(dynamic_pair_override) != 0
-                            ):
+                            if cutlass.const_expr(int(dynamic_pair_override) != 0):
                                 self._dequant_and_accumulate_bundle(
                                     acc0,
                                     acc1,
@@ -3052,6 +3063,7 @@ class W4A16GemmKernel:
                             kk,
                             tile_idx,
                             k_tiles,
+                            reduce_k_tile,
                         )
 
                         self._prefetch_pipeline_step(
@@ -3080,6 +3092,7 @@ class W4A16GemmKernel:
                             a_rows_per_iter,
                             output_n_tile,
                             expert_idx,
+                            -1,
                         )
 
                         for jj in cutlass.range_constexpr(4):
@@ -3120,6 +3133,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     Int32(0),
                     Int32(0),
+                    reduce_k_tile + tile_idx,
+                    -1,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_cur,
@@ -3159,10 +3174,7 @@ class W4A16GemmKernel:
             and self.trellis_rate_axis == "k"
             and (
                 self.trellis_pair_kind in {"P24", "P43", "P44"}
-                or (
-                    self.trellis_pair_dynamic
-                    and int(dynamic_pair_override) in (1, 2)
-                )
+                or (self.trellis_pair_dynamic and int(dynamic_pair_override) in (1, 2))
             )
         ):
             # FC2 assigns an entire warp/kk fragment to one side of an
@@ -3265,21 +3277,13 @@ class W4A16GemmKernel:
             else:
                 for mb in cutlass.range_constexpr(self.cta_m_blocks):
                     if cutlass.const_expr(mb == 0):
-                        self._mma_accumulate_large_m(
-                            acc0, a_regs_cur, mb, jj, b_frag
-                        )
+                        self._mma_accumulate_large_m(acc0, a_regs_cur, mb, jj, b_frag)
                     elif cutlass.const_expr(mb == 1):
-                        self._mma_accumulate_large_m(
-                            acc1, a_regs_cur, mb, jj, b_frag
-                        )
+                        self._mma_accumulate_large_m(acc1, a_regs_cur, mb, jj, b_frag)
                     elif cutlass.const_expr(mb == 2):
-                        self._mma_accumulate_large_m(
-                            acc2, a_regs_cur, mb, jj, b_frag
-                        )
+                        self._mma_accumulate_large_m(acc2, a_regs_cur, mb, jj, b_frag)
                     else:
-                        self._mma_accumulate_large_m(
-                            acc3, a_regs_cur, mb, jj, b_frag
-                        )
+                        self._mma_accumulate_large_m(acc3, a_regs_cur, mb, jj, b_frag)
 
     @cute.jit
     def _finish_tile(
@@ -3930,6 +3934,7 @@ class W4A16GemmKernel:
         kk: cutlass.Constexpr[int],
         tile_idx: Int32,
         k_tiles: Int32,
+        reduce_k_tile: Int32,
     ):
         self._clear_b_scale_register_bundle(b_scale_next)
         self._clear_a_register_bundle_m8(a0_regs_next)
@@ -3945,6 +3950,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     Int32(pipe),
                     Int32(kk + 1),
+                    reduce_k_tile + tile_idx,
+                    -1,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_next,
@@ -3972,6 +3979,8 @@ class W4A16GemmKernel:
                     s_sh_rd,
                     next_pipe,
                     Int32(0),
+                    reduce_k_tile + next_tile,
+                    -1,
                 )
                 self._load_a_registers_m8_bundle(
                     a0_regs_next,
@@ -4004,7 +4013,6 @@ class W4A16GemmKernel:
         frag[0, 1] = b0_1
         frag[1, 0] = b1_0
         frag[1, 1] = b1_1
-
 
     @cute.jit
     def _trellis256_lane_geom_bits(
@@ -4244,10 +4252,7 @@ class W4A16GemmKernel:
         regs = cute.make_rmem_tensor((2, 4), Uint32)
         if cutlass.const_expr(
             self.trellis_pair_kind == "P24"
-            or (
-                self.trellis_pair_dynamic
-                and int(dynamic_pair_override) == 1
-            )
+            or (self.trellis_pair_dynamic and int(dynamic_pair_override) == 1)
         ):
             self._load_b_registers_trellis256_pair_bits(
                 regs, smem_base, tid, pipe, kk, tile_idx, 2, 4
@@ -4309,9 +4314,8 @@ class W4A16GemmKernel:
                 # original contiguous output-channel order.
                 if cutlass.const_expr(jj < 2):
                     record_n16 = Int32(2) * w_n + Int32(jj)
-                    tile_base = (
-                        kt_local * Int32(pair_span_u32)
-                        + record_n16 * Int32(8 * low_bits)
+                    tile_base = kt_local * Int32(pair_span_u32) + record_n16 * Int32(
+                        8 * low_bits
                     )
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits
@@ -4335,12 +4339,9 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 local_n16 = Int32(4) * w_n + Int32(jj)
                 tile_base = Int32(0)
-                if cutlass.const_expr(int(low_bits) == int(high_bits)):
-                    tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
-                    wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
-                        b_region, tile_base, lane, low_bits
-                    )
-                elif logical_k16 < Int32(8):
+                if cutlass.const_expr(
+                    int(low_bits) == int(high_bits)
+                ) or logical_k16 < Int32(8):
                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
                         b_region, tile_base, lane, low_bits
@@ -4803,19 +4804,13 @@ class W4A16GemmKernel:
                 high_bits = 3
                 if cutlass.const_expr(
                     self.trellis_pair_kind == "P24"
-                    or (
-                        self.trellis_pair_dynamic
-                        and int(dynamic_pair_override) == 1
-                    )
+                    or (self.trellis_pair_dynamic and int(dynamic_pair_override) == 1)
                 ):
                     low_bits = 2
                     high_bits = 4
                 elif cutlass.const_expr(
                     self.trellis_pair_kind == "P43"
-                    or (
-                        self.trellis_pair_dynamic
-                        and int(dynamic_pair_override) == 2
-                    )
+                    or (self.trellis_pair_dynamic and int(dynamic_pair_override) == 2)
                 ):
                     low_bits = 4
                     high_bits = 3
@@ -4826,17 +4821,13 @@ class W4A16GemmKernel:
                     # Preparation swizzles the reference record-major payload
                     # into one fixed-size compact pair span per K16 row.
                     pair_u32_per_k16 = Int32(8 * 8 * (low_bits + high_bits))
-                    t256_chunks_per_kt = self.cta_n_blocks * (
-                        low_bits + high_bits
-                    )
+                    t256_chunks_per_kt = self.cta_n_blocks * (low_bits + high_bits)
                     t256_total_chunks = self.cta_k_blocks * t256_chunks_per_kt
                     t256_pair_u32 = (self.size_k // 16) * pair_u32_per_k16
                     for i in cutlass.range_constexpr(self.b_sh_wr_iters_var):
                         t256_chunk = Int32(i * self.cta_threads) + tid
                         t256_kt = t256_chunk // Int32(t256_chunks_per_kt)
-                        t256_in_kt = (
-                            t256_chunk - t256_kt * Int32(t256_chunks_per_kt)
-                        )
+                        t256_in_kt = t256_chunk - t256_kt * Int32(t256_chunks_per_kt)
                         b_dst = (
                             smem_base
                             + Int32(self.sh_b_off * 16)
@@ -4851,23 +4842,23 @@ class W4A16GemmKernel:
                             pair_plane_u32 = Int64(cute.size(b_i32_flat)) // Int64(2)
                             if cutlass.const_expr(self.trellis_pair_compact_offsets):
                                 pair_descriptor = scales_i32_flat[expert_idx].to(Int64)
-                                pair_base_i64 = (
-                                    Int64(output_n_tile) * pair_plane_u32
-                                    + (pair_descriptor >> Int64(1))
-                                )
+                                pair_base_i64 = Int64(
+                                    output_n_tile
+                                ) * pair_plane_u32 + (pair_descriptor >> Int64(1))
                             else:
-                                pair_base_i64 = (
-                                    Int64(output_n_tile) * pair_plane_u32
-                                    + Int64(expert_idx) * Int64(t256_pair_u32)
+                                pair_base_i64 = Int64(
+                                    output_n_tile
+                                ) * pair_plane_u32 + Int64(expert_idx) * Int64(
+                                    t256_pair_u32
                                 )
                         else:
                             # Dense/expert-major payload: [E, pair, K16,
                             # compact-pair-row].
                             if cutlass.const_expr(self.trellis_pair_compact_offsets):
                                 pair_descriptor = scales_i32_flat[expert_idx].to(Int64)
-                                pair_base_i64 = (
-                                    pair_descriptor >> Int64(1)
-                                ) + Int64(output_n_tile) * Int64(t256_pair_u32)
+                                pair_base_i64 = (pair_descriptor >> Int64(1)) + Int64(
+                                    output_n_tile
+                                ) * Int64(t256_pair_u32)
                             else:
                                 pair_base_i64 = (
                                     Int64(expert_idx) * Int64(self.size_n // 256)
@@ -4894,21 +4885,14 @@ class W4A16GemmKernel:
                     # prefix.
                     max_chunks_per_kt = self.cta_n_blocks * 8
                     t256_expert_u32 = (
-                        (self.size_k // 16)
-                        * t256_n16
-                        * 4
-                        * (low_bits + high_bits)
+                        (self.size_k // 16) * t256_n16 * 4 * (low_bits + high_bits)
                     )
                     low_record_u32 = Int32(8 * t256_n16 * 8 * low_bits)
                     for i in cutlass.range_constexpr(self.b_sh_wr_iters_var):
                         t256_chunk = Int32(i * self.cta_threads) + tid
                         t256_kt = t256_chunk // Int32(max_chunks_per_kt)
-                        t256_in_kt = (
-                            t256_chunk - t256_kt * Int32(max_chunks_per_kt)
-                        )
-                        logical_k16 = (
-                            tile_idx * Int32(self.cta_k_blocks) + t256_kt
-                        )
+                        t256_in_kt = t256_chunk - t256_kt * Int32(max_chunks_per_kt)
+                        logical_k16 = tile_idx * Int32(self.cta_k_blocks) + t256_kt
                         high_record = (logical_k16 >= Int32(8)).to(Int32)
                         local_k16 = logical_k16 - high_record * Int32(8)
                         record_bits = Int32(low_bits)
@@ -4944,17 +4928,13 @@ class W4A16GemmKernel:
                         )
             else:
                 t256_tile_u32 = 8 * self.trellis_bits
-                t256_expert_u32 = (
-                    (self.size_k // 16) * t256_n16 * t256_tile_u32
-                )
+                t256_expert_u32 = (self.size_k // 16) * t256_n16 * t256_tile_u32
                 t256_chunks_per_kt = self.cta_n_blocks * (2 * self.trellis_bits)
                 t256_total_chunks = self.cta_k_blocks * t256_chunks_per_kt
                 for i in cutlass.range_constexpr(self.b_sh_wr_iters_var):
                     t256_chunk = Int32(i * self.cta_threads) + tid
                     t256_kt = t256_chunk // Int32(t256_chunks_per_kt)
-                    t256_in_kt = (
-                        t256_chunk - t256_kt * Int32(t256_chunks_per_kt)
-                    )
+                    t256_in_kt = t256_chunk - t256_kt * Int32(t256_chunks_per_kt)
                     b_dst = (
                         smem_base
                         + Int32(self.sh_b_off * 16)
@@ -4964,16 +4944,10 @@ class W4A16GemmKernel:
                     if cutlass.const_expr(self.weight_layout_trellis256_proj):
                         t256_half_n16 = t256_n16 // 2
                         t256_out_n16 = output_n_tile * Int32(self.cta_n_blocks)
-                        t256_proj = (
-                            t256_out_n16 >= Int32(t256_half_n16)
-                        ).to(Int32)
-                        t256_local_n16 = (
-                            t256_out_n16 - t256_proj * Int32(t256_half_n16)
-                        )
+                        t256_proj = (t256_out_n16 >= Int32(t256_half_n16)).to(Int32)
+                        t256_local_n16 = t256_out_n16 - t256_proj * Int32(t256_half_n16)
                         t256_proj_expert_u32 = (
-                            (self.size_k // 16)
-                            * t256_half_n16
-                            * t256_tile_u32
+                            (self.size_k // 16) * t256_half_n16 * t256_tile_u32
                         )
                         # Projection-major W13 is physically [2, E, ...].
                         t256_plane_u32 = Int64(cute.size(b_i32_flat)) // Int64(2)
@@ -5626,8 +5600,7 @@ class W4A16GemmKernel:
             for jj in cutlass.range_constexpr(4):
                 wr = c_sh_wr + Int32(16 * jj)
                 if cutlass.const_expr(
-                    self.weight_layout_trellis256_pair
-                    and self.trellis_rate_axis == "n"
+                    self.weight_layout_trellis256_pair and self.trellis_rate_axis == "n"
                 ):
                     # MMA register assignment is [L0,L1,H0,H1] per warp for
                     # balanced P24 work.  Scatter the four N16 fragments back
@@ -5638,11 +5611,7 @@ class W4A16GemmKernel:
                     warp_n = tid // Int32(32)
                     semantic_n16 = Int32(2) * warp_n + Int32(jj)
                     if cutlass.const_expr(jj >= 2):
-                        semantic_n16 = (
-                            Int32(8)
-                            + Int32(2) * warp_n
-                            + Int32(jj - 2)
-                        )
+                        semantic_n16 = Int32(8) + Int32(2) * warp_n + Int32(jj - 2)
                     compute_n16 = Int32(4) * warp_n + Int32(jj)
                     wr += Int32(16) * (semantic_n16 - compute_n16)
                 self._st_shared_elem_from_f32(
@@ -6065,18 +6034,13 @@ class W4A16GemmKernel:
         for jj in cutlass.range_constexpr(4):
             wr = c_sh_wr + Int32(8 * jj)
             if cutlass.const_expr(
-                self.weight_layout_trellis256_pair
-                and self.trellis_rate_axis == "n"
+                self.weight_layout_trellis256_pair and self.trellis_rate_axis == "n"
             ):
                 # Match the M<=8 epilogue: restore the reference record order
                 # from the balanced LLHH per-warp MMA assignment before H128.
                 semantic_n16 = Int32(2) * warp_n + Int32(jj)
                 if cutlass.const_expr(jj >= 2):
-                    semantic_n16 = (
-                        Int32(8)
-                        + Int32(2) * warp_n
-                        + Int32(jj - 2)
-                    )
+                    semantic_n16 = Int32(8) + Int32(2) * warp_n + Int32(jj - 2)
                 compute_n16 = Int32(4) * warp_n + Int32(jj)
                 wr += Int32(8) * (semantic_n16 - compute_n16)
             self._write_bf16x2_shared(
@@ -6279,9 +6243,7 @@ class W4A16FusedMoeKernel:
             if fc2_trellis_pair_kind is None
             else str(fc2_trellis_pair_kind).upper()
         )
-        if (self.fc1_trellis_pair_kind is None) != (
-            self.fc2_trellis_pair_kind is None
-        ):
+        if (self.fc1_trellis_pair_kind is None) != (self.fc2_trellis_pair_kind is None):
             raise ValueError(
                 "fused trellis pair weights require both FC1 and FC2 pair kinds"
             )
@@ -6290,8 +6252,7 @@ class W4A16FusedMoeKernel:
                 raise ValueError("fused trellis pairs require trellis3_t256 weights")
             if self.trellis_bits != 3:
                 raise ValueError(
-                    "fused QSRT pairs require the trellis_bits=3 base "
-                    "specialization"
+                    "fused QSRT pairs require the trellis_bits=3 base specialization"
                 )
             dynamic_kinds = {"PDYNAMIC", "P33_P43"}
             static_kinds = {"P24", "P33", "P43", "P44"}
@@ -6300,9 +6261,7 @@ class W4A16FusedMoeKernel:
                 or self.fc2_trellis_pair_kind in dynamic_kinds
             ):
                 if self.fc1_trellis_pair_kind != self.fc2_trellis_pair_kind:
-                    raise ValueError(
-                        "dynamic fused trellis pair kinds must match"
-                    )
+                    raise ValueError("dynamic fused trellis pair kinds must match")
             elif (
                 self.fc1_trellis_pair_kind not in static_kinds
                 or self.fc2_trellis_pair_kind not in static_kinds
@@ -6398,9 +6357,7 @@ class W4A16FusedMoeKernel:
             trellis_bits=self.trellis_bits,
             trellis_codebook=self.trellis_codebook,
             trellis_pair_kind=self.fc1_trellis_pair_kind,
-            trellis_rate_axis=(
-                "n" if self.fc1_trellis_pair_kind is not None else None
-            ),
+            trellis_rate_axis=("n" if self.fc1_trellis_pair_kind is not None else None),
             source_n_rotation=fc1_source_n_rotation,
             single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
@@ -6431,9 +6388,7 @@ class W4A16FusedMoeKernel:
             trellis_bits=self.trellis_bits,
             trellis_codebook=self.trellis_codebook,
             trellis_pair_kind=self.fc2_trellis_pair_kind,
-            trellis_rate_axis=(
-                "k" if self.fc2_trellis_pair_kind is not None else None
-            ),
+            trellis_rate_axis=("k" if self.fc2_trellis_pair_kind is not None else None),
             single_token_route_fast_path=size_m == 1 and not self.direct_topk_routes,
             direct_topk_routes=self.direct_topk_routes,
             fused_topk_sum=self.tc_decode_fused_sum,
@@ -6460,12 +6415,9 @@ class W4A16FusedMoeKernel:
         )
         self.sqg_xor_cheb_t12_smem_off = 0
         if self.sqg_xor_cheb_t12_smem:
-            self.sqg_xor_cheb_t12_smem_off = (
-                self.shared_words * 4 + 15
-            ) // 16 * 16
+            self.sqg_xor_cheb_t12_smem_off = (self.shared_words * 4 + 15) // 16 * 16
             self.shared_words = (
-                self.sqg_xor_cheb_t12_smem_off
-                + _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES
+                self.sqg_xor_cheb_t12_smem_off + _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES
             ) // 4
             self.fc1.sqg_xor_cheb_t12_smem = True
             self.fc2.sqg_xor_cheb_t12_smem = True
@@ -6889,9 +6841,7 @@ class W4A16FusedMoeKernel:
                 tid,
             )
             cute.arch.sync_threads()
-            table_addr = Int64(
-                smem_base + Int32(self.sqg_xor_cheb_t12_smem_off)
-            )
+            table_addr = Int64(smem_base + Int32(self.sqg_xor_cheb_t12_smem_off))
             fc1_phase_lut_addr = table_addr
             fc2_phase_lut_addr = table_addr
 
@@ -7029,9 +6979,7 @@ class W4A16FusedMoeKernel:
         fc1_phase_lut = fc1_trellis_lut_addr
         fc2_phase_lut = fc2_trellis_lut_addr
         if cutlass.const_expr(self.sqg_xor_cheb_t12_smem):
-            table_addr = Int64(
-                smem_base + Int32(self.sqg_xor_cheb_t12_smem_off)
-            )
+            table_addr = Int64(smem_base + Int32(self.sqg_xor_cheb_t12_smem_off))
             fc1_phase_lut = table_addr
             fc2_phase_lut = table_addr
         if cutlass.const_expr(self.full_rotation):
@@ -7409,9 +7357,7 @@ class W4A16FusedMoeKernel:
             route_pos = unit // nblk
             blk = unit - route_pos * nblk
             route = packed_route_indices[route_pos].to(Int32)
-            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(
-                Int32
-            )
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
             if cutlass.const_expr(self.direct_topk_routes):
                 route = route_pos
                 expert = packed_route_indices[route_pos].to(Int32)
@@ -7479,18 +7425,10 @@ class W4A16FusedMoeKernel:
                     x_input_flat[x_base + Int32(387)].to(cutlass.Float32)
                 ).to(cutlass.Float32)
 
-                h00, h01, h02, h03 = self._had128_quad(
-                    x00, x01, x02, x03, lane
-                )
-                h10, h11, h12, h13 = self._had128_quad(
-                    x10, x11, x12, x13, lane
-                )
-                h20, h21, h22, h23 = self._had128_quad(
-                    x20, x21, x22, x23, lane
-                )
-                h30, h31, h32, h33 = self._had128_quad(
-                    x30, x31, x32, x33, lane
-                )
+                h00, h01, h02, h03 = self._had128_quad(x00, x01, x02, x03, lane)
+                h10, h11, h12, h13 = self._had128_quad(x10, x11, x12, x13, lane)
+                h20, h21, h22, h23 = self._had128_quad(x20, x21, x22, x23, lane)
+                h30, h31, h32, h33 = self._had128_quad(x30, x31, x32, x33, lane)
                 c00, c10, c20, c30 = self._had4_normalized(h00, h10, h20, h30)
                 c01, c11, c21, c31 = self._had4_normalized(h01, h11, h21, h31)
                 c02, c12, c22, c32 = self._had4_normalized(h02, h12, h22, h32)
@@ -7609,9 +7547,7 @@ class W4A16FusedMoeKernel:
             route_pos = unit // nblk
             post_block = unit - route_pos * nblk
             row = packed_route_indices[route_pos].to(Int32)
-            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(
-                Int32
-            )
+            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
             if cutlass.const_expr(self.direct_topk_routes):
                 row = route_pos
                 expert = packed_route_indices[route_pos].to(Int32)
@@ -8186,8 +8122,6 @@ class W4A16FusedMoeKernel:
             idx += stride
 
 
-
-
 class W4A16ActivationKernel:
     def __init__(
         self,
@@ -8493,9 +8427,7 @@ class W4A16TopKSumKernel:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
-        if cutlass.const_expr(
-            self.coupled_hadamard and self.broadcast_svh
-        ):
+        if cutlass.const_expr(self.coupled_hadamard and self.broadcast_svh):
             # The output scale is shared by every expert.  Linearity therefore
             # permits route reduction before the ordinary H128 cancellation:
             #
@@ -8515,9 +8447,7 @@ class W4A16TopKSumKernel:
                 blk = unit - token * nblk
                 block_col = blk * Int32(512)
                 reduced_ptr = cute.arch.alloc_smem(cutlass.Float32, 512)
-                reduced = cute.make_tensor(
-                    reduced_ptr, cute.make_layout(512)
-                )
+                reduced = cute.make_tensor(reduced_ptr, cute.make_layout(512))
 
                 if warp < Int32(4):
                     sub = warp
@@ -8540,20 +8470,16 @@ class W4A16TopKSumKernel:
                             weight = topk_weights_flat[row].to(cutlass.Float32)
                             base = row * Int32(self.hidden_size) + col0
                             acc0 += (
-                                fc2_flat[base + Int32(0)].to(cutlass.Float32)
-                                * weight
+                                fc2_flat[base + Int32(0)].to(cutlass.Float32) * weight
                             )
                             acc1 += (
-                                fc2_flat[base + Int32(1)].to(cutlass.Float32)
-                                * weight
+                                fc2_flat[base + Int32(1)].to(cutlass.Float32) * weight
                             )
                             acc2 += (
-                                fc2_flat[base + Int32(2)].to(cutlass.Float32)
-                                * weight
+                                fc2_flat[base + Int32(2)].to(cutlass.Float32) * weight
                             )
                             acc3 += (
-                                fc2_flat[base + Int32(3)].to(cutlass.Float32)
-                                * weight
+                                fc2_flat[base + Int32(3)].to(cutlass.Float32) * weight
                             )
                     acc0, acc1, acc2, acc3 = self._had128_quad(
                         acc0, acc1, acc2, acc3, lane
@@ -8677,7 +8603,9 @@ class W4A16TopKSumKernel:
                     acc2 = cutlass.Float32(0.0)
                     acc3 = cutlass.Float32(0.0)
                     for route in cutlass.range_constexpr(self.topk):
-                        value_base = Int32(route * 512) + sub * Int32(128) + lane * Int32(4)
+                        value_base = (
+                            Int32(route * 512) + sub * Int32(128) + lane * Int32(4)
+                        )
                         weight = route_weights[Int32(route)]
                         acc0 += route_values[value_base + Int32(0)] * weight
                         acc1 += route_values[value_base + Int32(1)] * weight
@@ -9974,6 +9902,7 @@ def compile_w4a16_fused_moe(
                 weight_layout=weight_layout,
                 weight_bits=weight_bits,
                 allow_logical_tail=allow_native_logical_tail,
+                allow_ultra_wide_k32=(name == "fc2"),
             ):
                 raise ValueError(
                     f"force_tile_config {name} tile "
@@ -10117,9 +10046,7 @@ def compile_w4a16_fused_moe(
         assumed_align=16,
     )
     pair_metadata_cutlass_dtype = (
-        cutlass.Int64
-        if fc1_trellis_pair_kind == "P33_P43"
-        else cutlass.Int32
+        cutlass.Int64 if fc1_trellis_pair_kind == "P33_P43" else cutlass.Int32
     )
     w13_scales_fake = make_ptr(
         pair_metadata_cutlass_dtype, 16, cute.AddressSpace.gmem, assumed_align=16
@@ -10296,8 +10223,6 @@ def compile_w4a16_fused_moe(
     return result
 
 
-
-
 def _query_w4a16_kernel_resources(compiled: object) -> tuple[str, int, int] | None:
     """Return (symbol, registers/thread, local bytes/thread) for a one-kernel
     CUDA-dialect compile result, or None when the object does not expose the
@@ -10349,8 +10274,6 @@ def _w4a16_weight_flat_elements(
     if weight_layout == "modelopt":
         return int(num_experts) * int(size_n) * (int(size_k) // 2)
     return int(num_experts) * (int(size_k) // 16) * (int(size_n) // 16 * 32)
-
-
 
 
 def clear_w4a16_kernel_cache() -> None:
@@ -10957,11 +10880,26 @@ def _w4a16_fused_moe_launch_flat(
             )
         suh_gate_arg = suh_gate_table.reshape(-1)
         suh_up_arg = suh_up_table.reshape(-1)
-        broadcast_suh = suh_gate_arg.numel() == hidden_size
-        if broadcast_suh != (suh_up_arg.numel() == hidden_size):
+        expanded_suh_elements = num_experts * hidden_size
+        valid_suh_elements = {hidden_size, expanded_suh_elements}
+        if (
+            suh_gate_arg.numel() not in valid_suh_elements
+            or suh_up_arg.numel() not in valid_suh_elements
+        ):
+            raise ValueError(
+                "suh gate/up tables must contain either one broadcast row or "
+                f"one row per expert ({hidden_size} or {expanded_suh_elements} "
+                "elements)"
+            )
+        gate_broadcast_suh = suh_gate_arg.numel() == hidden_size
+        up_broadcast_suh = suh_up_arg.numel() == hidden_size
+        if gate_broadcast_suh != up_broadcast_suh:
             raise ValueError(
                 "suh gate/up tables must both be per-expert or both broadcast"
             )
+        # For one expert, per-expert and broadcast storage are identical.  Use
+        # the broadcast specialization so this valid tier remains unambiguous.
+        broadcast_suh = gate_broadcast_suh
         rotation_input_dtype = _normalize_element_dtype(rotation_input.dtype)
     else:
         suh_gate_arg = _rot_scales_dummy(w13_global_scale.device)
@@ -11014,9 +10952,7 @@ def _w4a16_fused_moe_launch_flat(
     )
     route_num_experts = 0 if expert_map is None else int(expert_map.numel())
     if weight_layout == "trellis3_t256":
-        trellis_rank_lut = _trellis256_execution_lut(
-            a_input.device, trellis_codebook
-        )
+        trellis_rank_lut = _trellis256_execution_lut(a_input.device, trellis_codebook)
         fc1_trellis_lut_addr = trellis_rank_lut.data_ptr()
         fc2_trellis_lut_addr = trellis_rank_lut.data_ptr()
     else:
@@ -11060,17 +10996,13 @@ def _w4a16_fused_moe_launch_flat(
         activated,
         fc2_out,
         make_ptr(
-            cutlass.Int64
-            if fc1_trellis_pair_kind == "P33_P43"
-            else cutlass.Int32,
+            cutlass.Int64 if fc1_trellis_pair_kind == "P33_P43" else cutlass.Int32,
             w13_scale_i32.data_ptr(),
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
         make_ptr(
-            cutlass.Int64
-            if fc2_trellis_pair_kind == "P33_P43"
-            else cutlass.Int32,
+            cutlass.Int64 if fc2_trellis_pair_kind == "P33_P43" else cutlass.Int32,
             w2_scale_i32.data_ptr(),
             cute.AddressSpace.gmem,
             assumed_align=16,
@@ -11565,9 +11497,7 @@ def _w4a16_topk_sum_launch_flat(
     )
     route_num_experts = 0 if expert_map is None else int(expert_map.numel())
     broadcast_svh = (
-        full_rotation
-        and svh_table is not None
-        and svh_table.numel() == hidden_size
+        full_rotation and svh_table is not None and svh_table.numel() == hidden_size
     )
     sum_kernel = compile_w4a16_topk_sum(
         m=m,
@@ -12078,6 +12008,30 @@ def _trellis_dense_buffer(
     return buffer
 
 
+def _use_k6_mcg_small(
+    *,
+    device: torch.device,
+    m: int,
+    trellis_bits: int,
+    trellis_codebook: str,
+    trellis_pair_kind,
+    compute_dtype: torch.dtype,
+    external_hadamard_128,
+    explicit_launch_config: bool,
+) -> bool:
+    """Select the capture-safe K6/MCG kernel only on its compiled target."""
+    return (
+        not explicit_launch_config
+        and tuple(torch.cuda.get_device_capability(device)) == (12, 0)
+        and m <= 128
+        and trellis_bits == 6
+        and trellis_codebook == "mcg"
+        and trellis_pair_kind is None
+        and compute_dtype == torch.float16
+        and external_hadamard_128 is None
+    )
+
+
 def _run_trellis256_dense_current_device(
     x: torch.Tensor,
     prepared_dense,
@@ -12092,7 +12046,7 @@ def _run_trellis256_dense_current_device(
     output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
-    _moe_block_size: int = 64,
+    _moe_block_size: int | None = None,
     _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Run one native EXL3 linear on the already-selected CUDA device.
@@ -12106,13 +12060,10 @@ def _run_trellis256_dense_current_device(
         raise ValueError("run_trellis256_dense requires prepared trellis3_t256 weights")
     if int(getattr(prepared_dense, "num_experts", 0)) != 1:
         raise ValueError("run_trellis256_dense requires an honest E=1 prepared weight")
-    trellis_codebook = str(
-        getattr(prepared_dense, "trellis_codebook", "")
-    ).lower()
+    trellis_codebook = str(getattr(prepared_dense, "trellis_codebook", "")).lower()
     if trellis_codebook not in _TRELLIS256_CODEBOOKS:
         raise NotImplementedError(
-            "run_trellis256_dense has no decoder for codebook "
-            f"{trellis_codebook!r}"
+            f"run_trellis256_dense has no decoder for codebook {trellis_codebook!r}"
         )
     trellis_bits = int(getattr(prepared_dense, "trellis_bits", 0))
     if trellis_bits not in _TRELLIS256_BITS:
@@ -12160,6 +12111,73 @@ def _run_trellis256_dense_current_device(
     external_hadamard_128 = (
         None if hadamard_128 is None else _resolve_exl3_hadamard_128(hadamard_128)
     )
+
+    # Keep the established K6/MCG decode path independent from the generic
+    # Trellis scheduler. It owns both H128 rotations, needs no GEMM scratch,
+    # and is safe to capture with only caller-owned output/rotation storage.
+    # Compact pair payloads and the newer SQG codebooks use the generic path.
+    use_k6_mcg_small = _use_k6_mcg_small(
+        device=x.device,
+        m=m,
+        trellis_bits=trellis_bits,
+        trellis_codebook=trellis_codebook,
+        trellis_pair_kind=trellis_pair_kind,
+        compute_dtype=compute_dtype,
+        external_hadamard_128=external_hadamard_128,
+        explicit_launch_config=(
+            _moe_block_size is not None or _force_tile_config is not None
+        ),
+    )
+    if use_k6_mcg_small:
+        if x.dtype == torch.float16:
+            x_f16 = x
+        else:
+            input_f16 = _trellis_dense_buffer(
+                "input_f16",
+                input_f16,
+                shape=(m, size_k),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            input_f16.copy_(x)
+            x_f16 = input_f16
+        rotated_f16 = _trellis_dense_buffer(
+            "rotated_f16",
+            rotated_f16,
+            shape=(m, size_k),
+            dtype=torch.float16,
+            device=x.device,
+        )
+        if output.dtype == torch.float16:
+            small_output = output
+        else:
+            output_f16 = _trellis_dense_buffer(
+                "output_f16",
+                output_f16,
+                shape=(m, size_n),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            small_output = output_f16
+        from b12x.gemm.trellis_linear._small_m import run_k6_mcg
+
+        trellis_i16 = prepared_dense.trellis.view(torch.int16).view(
+            size_k // 16,
+            size_n // 16,
+            trellis_bits * 16,
+        )
+        run_k6_mcg(
+            x_f16,
+            trellis_i16,
+            small_output,
+            prepared_dense.suh,
+            rotated_f16,
+            prepared_dense.svh,
+            prepared_dense.workspace,
+        )
+        if output.dtype != torch.float16:
+            output.copy_(small_output)
+        return output
 
     gemm_output = _trellis_dense_buffer(
         "gemm_output",
@@ -12213,8 +12231,8 @@ def _run_trellis256_dense_current_device(
     max_shared_mem = int(
         getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
     )
-    moe_block_size = int(_moe_block_size)
-    if _force_tile_config is None and moe_block_size == 64:
+    moe_block_size = 64 if _moe_block_size is None else int(_moe_block_size)
+    if _force_tile_config is None and _moe_block_size is None:
         moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
             size_m=m,
             size_k=size_k,
@@ -12355,7 +12373,7 @@ def run_trellis256_dense(
     output_f16: torch.Tensor | None = None,
     hadamard_128=None,
     stream: cuda.CUstream | None = None,
-    _moe_block_size: int = 64,
+    _moe_block_size: int | None = None,
     _force_tile_config: tuple[int, int] | None = None,
 ) -> torch.Tensor:
     """Run one native or compact P24/P33 EXL3 linear through the t256 GEMM.
@@ -12547,14 +12565,11 @@ def run_w4a16_moe(
             ):
                 raise ValueError("unsupported prepared static trellis pair kind")
             pair_metadata_dtype = (
-                torch.int64
-                if fc1_trellis_pair_kind == "P33_P43"
-                else torch.int32
+                torch.int64 if fc1_trellis_pair_kind == "P33_P43" else torch.int32
             )
             if trellis_bits != 3:
                 raise ValueError(
-                    "prepared QSRT pairs require the trellis_bits=3 base "
-                    "specialization"
+                    "prepared QSRT pairs require the trellis_bits=3 base specialization"
                 )
             if dynamic_pairs:
                 for name, modes in (
@@ -13004,9 +13019,7 @@ def run_w4a16_moe(
             prepared.w13_scale,
             prepared.w2_scale,
             expert_map=expert_map if use_direct_topk_routes else None,
-            w13_row_rotation=int(
-                getattr(prepared, "x4t_w13_row_rotation", 0)
-            ),
+            w13_row_rotation=int(getattr(prepared, "x4t_w13_row_rotation", 0)),
             expert_ids_unique=bool(use_direct_topk_routes and m == 1),
             stream=stream,
         )
@@ -13581,18 +13594,6 @@ def build_w4a16_tier_local_map(
     if device is not None:
         table = table.to(device)
     return table.contiguous()
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 __all__ = [

--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -2,8 +2,8 @@
 
 The route packer assigns every global expert to one combined expert namespace.
 Input/intermediate rotations therefore run once. Per-tile dispatch resolves the
-combined expert to a bitrate-specialized K3 or K4 decoder while preserving the
-single cooperative FC1/activation/FC2 grid used by homogeneous Trellis.
+combined expert to a bitrate-specialized decoder while preserving the single
+cooperative FC1/activation/FC2 grid used by homogeneous Trellis.
 
 The module stays internal because checkpoint interpretation and runtime planning
 belong to the serving framework; B12X owns only the prepared kernel path.
@@ -20,14 +20,19 @@ import cutlass
 import cutlass.cute as cute
 import torch
 from cutlass.base_dsl.compiler import OptLevel
-from cutlass.cutlass_dsl import Int32
+from cutlass.cutlass_dsl import Int32, Int64
 
 from b12x._lib.compiler import KernelCompileSpec, compile as b12x_compile
-from b12x._lib.intrinsics import shared_ptr_to_u32
+from b12x._lib.intrinsics import get_ptr_as_int64, shared_ptr_to_u32
+from b12x._lib.quant.sqg_e4m3 import sqg_xor_cheb_t12_lut
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
 
-from .host import max_packed_route_slots, packed_gemm_scratch_elements
+from .host import (
+    max_packed_route_slots,
+    packed_gemm_scratch_elements,
+    route_pack_warmup_token_counts,
+)
 from .kernel import (
     W4A16FusedMoeKernel,
     _cutlass_element_dtype,
@@ -50,6 +55,7 @@ class MixedTrellisCompileResult:
     tier1_num_experts: int
     tier0_bits: int
     tier1_bits: int
+    trellis_codebook: str
     fc1_tile_k: int
     fc1_tile_n: int
     fc2_tile_k: int
@@ -68,6 +74,14 @@ class MixedTrellisCompileResult:
     route_ids_dtype: torch.dtype
     broadcast_suh: bool
     broadcast_svh: bool
+
+
+@dataclass(frozen=True)
+class MixedTrellis3CompileResult(MixedTrellisCompileResult):
+    """Launch metadata for the K3/K4/K5 three-tier specialization."""
+
+    tier2_num_experts: int
+    tier2_bits: int
 
 
 @dataclass(frozen=True)
@@ -100,6 +114,7 @@ class MixedTrellisTier(Protocol):
     """Prepared Trellis tier fields consumed by the mixed launch."""
 
     num_experts: int
+    trellis_codebook: str
     intermediate_rotations: torch.Tensor
     gate_suh: torch.Tensor
     up_suh: torch.Tensor
@@ -115,7 +130,7 @@ class MixedTrellisTier(Protocol):
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
-    ABI_VERSION = 6
+    ABI_VERSION = 12
 
     def __init__(
         self,
@@ -201,6 +216,14 @@ class W4A16MixedTrellisKernel:
         self.shared_words = max(
             driver.shared_words, tier0.shared_words, tier1.shared_words
         )
+        # Each bitrate has a different GEMM scratch footprint. The shared T12
+        # table must follow the largest pre-LUT region, otherwise a wider tier
+        # can overwrite a table placed at the driver's (K3) offset.
+        self.sqg_xor_cheb_t12_smem_off = max(
+            driver.sqg_xor_cheb_t12_smem_off,
+            tier0.sqg_xor_cheb_t12_smem_off,
+            tier1.sqg_xor_cheb_t12_smem_off,
+        )
 
     @property
     def __cache_key__(self) -> tuple[object, ...]:
@@ -230,6 +253,7 @@ class W4A16MixedTrellisKernel:
         topk_weights: cute.Tensor,
         c_tmp: cute.Tensor,
         locks: cute.Tensor,
+        trellis_lut_addr: Int64,
         smem_base: Int32,
         tid: Int32,
         route_block_idx: Int32,
@@ -245,6 +269,10 @@ class W4A16MixedTrellisKernel:
         factor = gemm.schedule_route_block_factor
         first_route_block = route_block_idx * Int32(factor)
         first_lock_slot = lock_slot * Int32(factor)
+        # MCG does not consume the generic Trellis LUT ABI slot. SQG must keep
+        # the caller-provided address so every bitrate can decode through T12.
+        if cutlass.const_expr(self.driver.trellis_codebook == "mcg"):
+            trellis_lut_addr = cutlass.Int64(0)
         if cutlass.const_expr(gemm.paired_m8_routes):
             gemm._run_tile_m8_pair(
                 a_flat,
@@ -257,6 +285,7 @@ class W4A16MixedTrellisKernel:
                 topk_weights,
                 c_tmp,
                 locks,
+                trellis_lut_addr,
                 smem_base,
                 tid,
                 first_route_block,
@@ -282,6 +311,7 @@ class W4A16MixedTrellisKernel:
                     topk_weights,
                     c_tmp,
                     locks,
+                    trellis_lut_addr,
                     smem_base,
                     tid,
                     first_route_block + Int32(subtile),
@@ -314,11 +344,18 @@ class W4A16MixedTrellisKernel:
         topk_weights: cute.Tensor,
         c_tmp: cute.Tensor,
         locks: cute.Tensor,
+        trellis_lut_addr: Int64,
         smem_base: Int32,
         tid: Int32,
         active_size_m: Int32,
         tier0_num_experts: Int32,
         tier1_num_experts: Int32,
+        tier0_fc2_experts: Int32,
+        tier1_fc2_experts: Int32,
+        tier0_gate_experts: Int32,
+        tier1_gate_experts: Int32,
+        tier0_up_experts: Int32,
+        tier1_up_experts: Int32,
         route_block_idx: Int32,
         output_n_tile: Int32,
         reduce_k_tile: Int32,
@@ -338,12 +375,33 @@ class W4A16MixedTrellisKernel:
             )
         combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
         total_experts = tier0_num_experts + tier1_num_experts
+        # glm52-r7-projtiers: gate and up may sit in different tiers, so the
+        # descriptor row is chosen per projection. FC2 resolves at compile time;
+        # FC1 splits on the N half, which trellis3_t256_proj keeps aligned to
+        # whole CTA N tiles.
+        descriptor_row = Int32(2)
+        if cutlass.const_expr(is_fc1):
+            fc1_half_tiles = Int32(self.driver.fc1.n_tiles // 2)
+            descriptor_row = Int32(0)
+            if output_n_tile >= fc1_half_tiles:
+                descriptor_row = Int32(1)
         if combined_expert >= Int32(0) and combined_expert < total_experts:
-            descriptor = descriptor_map[combined_expert].to(Int32)
+            descriptor = descriptor_map[
+                descriptor_row * total_experts + combined_expert
+            ].to(Int32)
             if descriptor >= Int32(0):
                 tier = descriptor >> Int32(8)
                 local_expert = descriptor & Int32(0xFF)
-                if tier == Int32(0) and local_expert < tier0_num_experts:
+                # FC1 is bounded by the tier's FC1 slot count; FC2 by its own
+                # independent count, since per-projection membership lets the
+                # two differ. Both remain real bounds.
+                if cutlass.const_expr(is_fc1):
+                    tier0_in_bounds = local_expert < tier0_gate_experts
+                    if output_n_tile >= fc1_half_tiles:
+                        tier0_in_bounds = local_expert < tier0_up_experts
+                else:
+                    tier0_in_bounds = local_expert < tier0_fc2_experts
+                if tier == Int32(0) and tier0_in_bounds:
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier0.fc1
                     else:
@@ -360,6 +418,7 @@ class W4A16MixedTrellisKernel:
                         topk_weights,
                         c_tmp,
                         locks,
+                        trellis_lut_addr,
                         smem_base,
                         tid,
                         route_block_idx,
@@ -372,7 +431,13 @@ class W4A16MixedTrellisKernel:
                         lock_slot,
                         active_size_m,
                     )
-                elif tier == Int32(1) and local_expert < tier1_num_experts:
+                if cutlass.const_expr(is_fc1):
+                    tier1_in_bounds = local_expert < tier1_gate_experts
+                    if output_n_tile >= fc1_half_tiles:
+                        tier1_in_bounds = local_expert < tier1_up_experts
+                else:
+                    tier1_in_bounds = local_expert < tier1_fc2_experts
+                if tier == Int32(1) and tier1_in_bounds:
                     if cutlass.const_expr(is_fc1):
                         gemm = self.tier1.fc1
                     else:
@@ -389,6 +454,7 @@ class W4A16MixedTrellisKernel:
                         topk_weights,
                         c_tmp,
                         locks,
+                        trellis_lut_addr,
                         smem_base,
                         tid,
                         route_block_idx,
@@ -434,13 +500,33 @@ class W4A16MixedTrellisKernel:
         intermediate_rotations_ptr: cute.Pointer,
         gate_suh_ptr: cute.Pointer,
         up_suh_ptr: cute.Pointer,
+        trellis_lut_ptr: cute.Pointer,
         tier0_num_experts: cutlass.Int32,
         tier1_num_experts: cutlass.Int32,
+        tier0_fc2_experts: cutlass.Int32,
+        tier1_fc2_experts: cutlass.Int32,
         active_m: cutlass.Int32,
         grid_x: cutlass.Int32,
         stream: cuda.CUstream,
+        # Appended LAST so every existing positional call keeps its slots;
+        # passed by keyword. No default: the CuTe DSL types every parameter
+        # when it traces, and a None default is untypeable.
+        tier0_gate_experts: cutlass.Int32,
+        tier1_gate_experts: cutlass.Int32,
+        tier0_up_experts: cutlass.Int32,
+        tier1_up_experts: cutlass.Int32,
     ):
         tier0_experts = cutlass.Int64(tier0_num_experts)
+        # FC2 extents are independent of the FC1 slot counts.
+        tier0_fc2 = cutlass.Int64(tier0_fc2_experts)
+        tier1_fc2 = cutlass.Int64(tier1_fc2_experts)
+        # The w13 descriptor is sized by the GATE count so the gemm's
+        # cute.size(w13)//2 up-block base lands at gate_count*proj_stride over
+        # a tight [gate|up] buffer. run_mixed_trellis defaults these to the
+        # tier expert counts when a caller supplies none, which reproduces the
+        # historical padded sizing exactly.
+        tier0_gate = cutlass.Int64(tier0_gate_experts)
+        tier1_gate = cutlass.Int64(tier1_gate_experts)
         tier1_experts = cutlass.Int64(tier1_num_experts)
         total_experts = tier0_experts + tier1_experts
 
@@ -448,7 +534,7 @@ class W4A16MixedTrellisKernel:
             t0_w13_ptr,
             layout=cute.make_layout(
                 (
-                    tier0_experts
+                    tier0_gate
                     * cutlass.Int64(self.hidden_size // 16)
                     * cutlass.Int64(self.driver.fc1_cols // 16)
                     * cutlass.Int64(8 * self.tier0.trellis_bits),
@@ -460,7 +546,7 @@ class W4A16MixedTrellisKernel:
             t0_w2_ptr,
             layout=cute.make_layout(
                 (
-                    tier0_experts
+                    tier0_fc2
                     * cutlass.Int64(self.intermediate_size // 16)
                     * cutlass.Int64(self.hidden_size // 16)
                     * cutlass.Int64(8 * self.tier0.trellis_bits),
@@ -472,7 +558,7 @@ class W4A16MixedTrellisKernel:
             t1_w13_ptr,
             layout=cute.make_layout(
                 (
-                    tier1_experts
+                    tier1_gate
                     * cutlass.Int64(self.hidden_size // 16)
                     * cutlass.Int64(self.driver.fc1_cols // 16)
                     * cutlass.Int64(8 * self.tier1.trellis_bits),
@@ -484,7 +570,7 @@ class W4A16MixedTrellisKernel:
             t1_w2_ptr,
             layout=cute.make_layout(
                 (
-                    tier1_experts
+                    tier1_fc2
                     * cutlass.Int64(self.intermediate_size // 16)
                     * cutlass.Int64(self.hidden_size // 16)
                     * cutlass.Int64(8 * self.tier1.trellis_bits),
@@ -542,7 +628,7 @@ class W4A16MixedTrellisKernel:
         )
         t0_w2_global = cute.make_tensor(
             t0_w2_global_ptr,
-            layout=cute.make_layout((tier0_experts,), stride=(1,)),
+            layout=cute.make_layout((tier0_fc2,), stride=(1,)),
         )
         t1_w13_global = cute.make_tensor(
             t1_w13_global_ptr,
@@ -550,11 +636,13 @@ class W4A16MixedTrellisKernel:
         )
         t1_w2_global = cute.make_tensor(
             t1_w2_global_ptr,
-            layout=cute.make_layout((tier1_experts,), stride=(1,)),
+            layout=cute.make_layout((tier1_fc2,), stride=(1,)),
         )
+        # glm52-r7-projtiers: rows are gate, up, down. Row 0 alone is the
+        # historical layout, so three identical rows reproduce it exactly.
         descriptor_map = cute.make_tensor(
             descriptor_map_ptr,
-            layout=cute.make_layout((total_experts,), stride=(1,)),
+            layout=cute.make_layout((cutlass.Int64(3) * total_experts,), stride=(1,)),
         )
         intermediate_rotations = cute.make_tensor(
             intermediate_rotations_ptr,
@@ -578,6 +666,11 @@ class W4A16MixedTrellisKernel:
                 (suh_rows * cutlass.Int64(self.hidden_size),), stride=(1,)
             ),
         )
+        trellis_lut = cute.make_tensor(
+            trellis_lut_ptr,
+            layout=cute.make_layout((Int64(1 << 12),), stride=(1,)),
+        )
+        trellis_lut_addr = get_ptr_as_int64(trellis_lut, Int32(0))
         rotation_input = cute.make_tensor(
             rotation_input_ptr,
             layout=cute.make_layout(
@@ -622,8 +715,15 @@ class W4A16MixedTrellisKernel:
             intermediate_rotations,
             gate_suh,
             up_suh,
+            trellis_lut_addr,
             tier0_num_experts,
             tier1_num_experts,
+            tier0_fc2_experts,
+            tier1_fc2_experts,
+            tier0_gate_experts,
+            tier1_gate_experts,
+            tier0_up_experts,
+            tier1_up_experts,
             active_m,
         ).launch(
             grid=(grid_x, 1, 1),
@@ -665,8 +765,15 @@ class W4A16MixedTrellisKernel:
         intermediate_rotations: cute.Tensor,
         gate_suh: cute.Tensor,
         up_suh: cute.Tensor,
+        trellis_lut_addr: Int64,
         tier0_num_experts: cutlass.Int32,
         tier1_num_experts: cutlass.Int32,
+        tier0_fc2_experts: cutlass.Int32,
+        tier1_fc2_experts: cutlass.Int32,
+        tier0_gate_experts: cutlass.Int32,
+        tier1_gate_experts: cutlass.Int32,
+        tier0_up_experts: cutlass.Int32,
+        tier1_up_experts: cutlass.Int32,
         active_m: cutlass.Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
@@ -686,6 +793,16 @@ class W4A16MixedTrellisKernel:
 
         storage = smem.allocate(Storage)
         smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+        decode_lut_addr = trellis_lut_addr
+        if cutlass.const_expr(self.driver.sqg_xor_cheb_t12_smem):
+            self.driver._sqg_smem_copy(
+                trellis_lut_addr,
+                smem_base + Int32(self.sqg_xor_cheb_t12_smem_off),
+                1 << 12,
+                tid,
+            )
+            cute.arch.sync_threads()
+            decode_lut_addr = Int64(smem_base + Int32(self.sqg_xor_cheb_t12_smem_off))
         fc1_emit = partial(
             self._emit_tier_tile,
             True,
@@ -704,11 +821,18 @@ class W4A16MixedTrellisKernel:
             topk_weights,
             fc1_scratch,
             workspace,
+            decode_lut_addr,
             smem_base,
             tid,
             active_m,
             tier0_num_experts,
             tier1_num_experts,
+            tier0_fc2_experts,
+            tier1_fc2_experts,
+            tier0_gate_experts,
+            tier1_gate_experts,
+            tier0_up_experts,
+            tier1_up_experts,
         )
         fc2_emit = partial(
             self._emit_tier_tile,
@@ -728,11 +852,18 @@ class W4A16MixedTrellisKernel:
             topk_weights,
             fc2_scratch,
             workspace,
+            decode_lut_addr,
             smem_base,
             tid,
             active_m * Int32(self.top_k),
             tier0_num_experts,
             tier1_num_experts,
+            tier0_fc2_experts,
+            tier1_fc2_experts,
+            tier0_gate_experts,
+            tier1_gate_experts,
+            tier0_up_experts,
+            tier1_up_experts,
         )
         total_experts = tier0_num_experts + tier1_num_experts
         self.driver._moe_body(
@@ -761,6 +892,734 @@ class W4A16MixedTrellisKernel:
             gate_suh,
             up_suh,
             descriptor_map,
+            # Mixed tier emit hooks own Trellis decoding, so the shared
+            # driver's LUT ABI slots are intentionally unused.
+            cutlass.Int64(0),
+            cutlass.Int64(0),
+            total_experts,
+            total_experts,
+            smem_base,
+            tid,
+            cta,
+            grid_x,
+            active_m,
+            fc1_emit,
+            fc2_emit,
+        )
+
+
+class W4A16MixedTrellis3Kernel(W4A16MixedTrellisKernel):
+    """One cooperative grid over three native Trellis bitrates.
+
+    This is a separate specialization so the established two-tier K3/K4 kernel
+    keeps its existing ABI and generated code. The GLM R7 checkpoint uses this
+    path only for layers that actually contain K5 payloads.
+    """
+
+    ABI_VERSION = 4
+
+    def __init__(
+        self,
+        *,
+        driver: W4A16FusedMoeKernel,
+        tier0: W4A16FusedMoeKernel,
+        tier1: W4A16FusedMoeKernel,
+        tier2: W4A16FusedMoeKernel,
+    ):
+        kernels = (driver, tier0, tier1, tier2)
+        for name, moe in zip(
+            ("driver", "tier0", "tier1", "tier2"), kernels, strict=True
+        ):
+            if not moe.full_rotation or not moe.intermediate_rotation:
+                raise ValueError(f"mixed Trellis {name} requires full rotation")
+            if moe.direct_topk_routes or moe.tc_decode_fused_sum:
+                raise ValueError(f"mixed Trellis {name} requires route packing")
+            if moe.weight_layout != "trellis3_t256":
+                raise ValueError(f"mixed Trellis {name} requires native t256 weights")
+            if moe.element_dtype != "fp16":
+                raise ValueError(f"mixed Trellis {name} requires fp16 GEMM operands")
+        for attr in (
+            "size_m",
+            "hidden_size",
+            "intermediate_size",
+            "fc1_cols",
+            "top_k",
+            "moe_block_size",
+            "activation",
+            "rotation_input_dtype",
+            "broadcast_suh",
+            "cta_threads",
+            "sms",
+        ):
+            values = tuple(getattr(moe, attr) for moe in kernels)
+            if values[1:] != values[:-1]:
+                raise ValueError(f"mixed Trellis kernels disagree on {attr}: {values}")
+        for phase in ("fc1", "fc2"):
+            gemms = tuple(getattr(moe, phase) for moe in kernels)
+            geometry = tuple(
+                (
+                    gemm.n_tiles,
+                    gemm.k_tiles,
+                    gemm.tile_n,
+                    gemm.tile_k,
+                    gemm.cta_threads,
+                    gemm.moe_block_size,
+                    gemm.schedule_route_block_factor,
+                    gemm.paired_m8_routes,
+                )
+                for gemm in gemms
+            )
+            if geometry[1:] != geometry[:-1]:
+                raise ValueError(
+                    f"mixed Trellis kernels disagree on {phase} geometry: {geometry}"
+                )
+        fc2_factor = int(driver.fc2.schedule_route_block_factor)
+        expected_factor = int(driver.moe_block_size // driver.fc2.moe_block_size)
+        if fc2_factor < 1 or expected_factor % fc2_factor != 0:
+            raise ValueError(
+                "mixed Trellis FC2 schedule factor must divide one packed "
+                f"route block: factor={fc2_factor}, maximum={expected_factor}"
+            )
+        expected_pair = fc2_factor == 2 and driver.fc2.moe_block_size == 8
+        if bool(driver.fc2.paired_m8_routes) != expected_pair:
+            raise ValueError(
+                "mixed Trellis FC2 pair contract mismatch: "
+                f"factor={fc2_factor}, m={driver.fc2.moe_block_size}, "
+                f"paired={driver.fc2.paired_m8_routes}"
+            )
+        tiers = (tier0, tier1, tier2)
+        if any(tier.num_experts > _MAX_TIER_EXPERTS for tier in tiers):
+            raise ValueError("tier-local expert ids must fit in eight bits")
+        if driver.num_experts != sum(tier.num_experts for tier in tiers):
+            raise ValueError("driver expert count must equal the sum of all tiers")
+        self.driver = driver
+        self.tier0 = tier0
+        self.tier1 = tier1
+        self.tier2 = tier2
+        self.size_m = driver.size_m
+        self.hidden_size = driver.hidden_size
+        self.intermediate_size = driver.intermediate_size
+        self.top_k = driver.top_k
+        self.cta_threads = driver.cta_threads
+        self.sms = driver.sms
+        self.blocks_per_sm = min(tier.blocks_per_sm for tier in kernels)
+        self.shared_words = max(tier.shared_words for tier in kernels)
+        self.sqg_xor_cheb_t12_smem_off = max(
+            tier.sqg_xor_cheb_t12_smem_off for tier in kernels
+        )
+
+    @property
+    def __cache_key__(self) -> tuple[object, ...]:
+        return (
+            "w4a16_mixed_trellis3",
+            self.ABI_VERSION,
+            self.driver.__cache_key__,
+            self.tier0.__cache_key__,
+            self.tier1.__cache_key__,
+            self.tier2.__cache_key__,
+            self.blocks_per_sm,
+            self.shared_words,
+        )
+
+    @cute.jit
+    def _emit_tier_tile3(
+        self,
+        is_fc1: cutlass.Constexpr,
+        a_flat: cute.Tensor,
+        a_alt_flat: cute.Tensor,
+        t0_b_flat: cute.Tensor,
+        t0_scales_flat: cute.Tensor,
+        t0_global_scale: cute.Tensor,
+        t1_b_flat: cute.Tensor,
+        t1_scales_flat: cute.Tensor,
+        t1_global_scale: cute.Tensor,
+        t2_b_flat: cute.Tensor,
+        t2_scales_flat: cute.Tensor,
+        t2_global_scale: cute.Tensor,
+        c_flat: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        descriptor_map: cute.Tensor,
+        topk_weights: cute.Tensor,
+        c_tmp: cute.Tensor,
+        locks: cute.Tensor,
+        trellis_lut_addr: Int64,
+        smem_base: Int32,
+        tid: Int32,
+        active_size_m: Int32,
+        tier0_num_experts: Int32,
+        tier1_num_experts: Int32,
+        tier2_num_experts: Int32,
+        tier0_fc2_experts: Int32,
+        tier1_fc2_experts: Int32,
+        tier2_fc2_experts: Int32,
+        tier0_gate_experts: Int32,
+        tier1_gate_experts: Int32,
+        tier2_gate_experts: Int32,
+        tier0_up_experts: Int32,
+        tier1_up_experts: Int32,
+        tier2_up_experts: Int32,
+        route_block_idx: Int32,
+        output_n_tile: Int32,
+        reduce_k_tile: Int32,
+        reduce_tile_count: Int32,
+        reduce_slice_count: Int32,
+        reduce_slice_idx: Int32,
+        lock_slot: Int32,
+    ):
+        metadata_block_idx = route_block_idx
+        if cutlass.const_expr(not is_fc1):
+            metadata_block_idx = route_block_idx // Int32(
+                self.driver.moe_block_size
+                // (
+                    self.driver.fc2.moe_block_size
+                    * self.driver.fc2.schedule_route_block_factor
+                )
+            )
+        combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
+        total_experts = tier0_num_experts + tier1_num_experts + tier2_num_experts
+        descriptor_row = Int32(2)
+        if cutlass.const_expr(is_fc1):
+            fc1_half_tiles = Int32(self.driver.fc1.n_tiles // 2)
+            descriptor_row = Int32(0)
+            if output_n_tile >= fc1_half_tiles:
+                descriptor_row = Int32(1)
+        if combined_expert >= Int32(0) and combined_expert < total_experts:
+            descriptor = descriptor_map[
+                descriptor_row * total_experts + combined_expert
+            ].to(Int32)
+            if descriptor >= Int32(0):
+                tier = descriptor >> Int32(8)
+                local_expert = descriptor & Int32(0xFF)
+
+                if cutlass.const_expr(is_fc1):
+                    t0_in_bounds = local_expert < tier0_gate_experts
+                    if output_n_tile >= fc1_half_tiles:
+                        t0_in_bounds = local_expert < tier0_up_experts
+                else:
+                    t0_in_bounds = local_expert < tier0_fc2_experts
+                if tier == Int32(0) and t0_in_bounds:
+                    if cutlass.const_expr(is_fc1):
+                        gemm = self.tier0.fc1
+                    else:
+                        gemm = self.tier0.fc2
+                    self._dispatch_tier_gemm(
+                        gemm,
+                        a_flat,
+                        a_alt_flat,
+                        t0_b_flat,
+                        c_flat,
+                        t0_scales_flat,
+                        t0_global_scale,
+                        packed_route_indices,
+                        topk_weights,
+                        c_tmp,
+                        locks,
+                        trellis_lut_addr,
+                        smem_base,
+                        tid,
+                        route_block_idx,
+                        local_expert,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                        active_size_m,
+                    )
+
+                if cutlass.const_expr(is_fc1):
+                    t1_in_bounds = local_expert < tier1_gate_experts
+                    if output_n_tile >= fc1_half_tiles:
+                        t1_in_bounds = local_expert < tier1_up_experts
+                else:
+                    t1_in_bounds = local_expert < tier1_fc2_experts
+                if tier == Int32(1) and t1_in_bounds:
+                    if cutlass.const_expr(is_fc1):
+                        gemm = self.tier1.fc1
+                    else:
+                        gemm = self.tier1.fc2
+                    self._dispatch_tier_gemm(
+                        gemm,
+                        a_flat,
+                        a_alt_flat,
+                        t1_b_flat,
+                        c_flat,
+                        t1_scales_flat,
+                        t1_global_scale,
+                        packed_route_indices,
+                        topk_weights,
+                        c_tmp,
+                        locks,
+                        trellis_lut_addr,
+                        smem_base,
+                        tid,
+                        route_block_idx,
+                        local_expert,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                        active_size_m,
+                    )
+
+                if cutlass.const_expr(is_fc1):
+                    t2_in_bounds = local_expert < tier2_gate_experts
+                    if output_n_tile >= fc1_half_tiles:
+                        t2_in_bounds = local_expert < tier2_up_experts
+                else:
+                    t2_in_bounds = local_expert < tier2_fc2_experts
+                if tier == Int32(2) and t2_in_bounds:
+                    if cutlass.const_expr(is_fc1):
+                        gemm = self.tier2.fc1
+                    else:
+                        gemm = self.tier2.fc2
+                    self._dispatch_tier_gemm(
+                        gemm,
+                        a_flat,
+                        a_alt_flat,
+                        t2_b_flat,
+                        c_flat,
+                        t2_scales_flat,
+                        t2_global_scale,
+                        packed_route_indices,
+                        topk_weights,
+                        c_tmp,
+                        locks,
+                        trellis_lut_addr,
+                        smem_base,
+                        tid,
+                        route_block_idx,
+                        local_expert,
+                        output_n_tile,
+                        reduce_k_tile,
+                        reduce_tile_count,
+                        reduce_slice_count,
+                        reduce_slice_idx,
+                        lock_slot,
+                        active_size_m,
+                    )
+
+    @cute.jit
+    def __call__(
+        self,
+        rotation_input_ptr: cute.Pointer,
+        rotation_gate: cute.Tensor,
+        rotation_up: cute.Tensor,
+        t0_w13_ptr: cute.Pointer,
+        t0_w2_ptr: cute.Pointer,
+        t0_w13_scales_ptr: cute.Pointer,
+        t0_w2_scales_ptr: cute.Pointer,
+        t0_w13_global_ptr: cute.Pointer,
+        t0_w2_global_ptr: cute.Pointer,
+        t1_w13_ptr: cute.Pointer,
+        t1_w2_ptr: cute.Pointer,
+        t1_w13_scales_ptr: cute.Pointer,
+        t1_w2_scales_ptr: cute.Pointer,
+        t1_w13_global_ptr: cute.Pointer,
+        t1_w2_global_ptr: cute.Pointer,
+        t2_w13_ptr: cute.Pointer,
+        t2_w2_ptr: cute.Pointer,
+        t2_w13_scales_ptr: cute.Pointer,
+        t2_w2_scales_ptr: cute.Pointer,
+        t2_w13_global_ptr: cute.Pointer,
+        t2_w2_global_ptr: cute.Pointer,
+        fc1: cute.Tensor,
+        activated: cute.Tensor,
+        fc2: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        descriptor_map_ptr: cute.Pointer,
+        topk_weights_ptr: cute.Pointer,
+        fc1_scratch: cute.Tensor,
+        fc2_scratch: cute.Tensor,
+        workspace: cute.Tensor,
+        intermediate_rotations_ptr: cute.Pointer,
+        gate_suh_ptr: cute.Pointer,
+        up_suh_ptr: cute.Pointer,
+        trellis_lut_ptr: cute.Pointer,
+        tier0_num_experts: cutlass.Int32,
+        tier1_num_experts: cutlass.Int32,
+        tier2_num_experts: cutlass.Int32,
+        tier0_fc2_experts: cutlass.Int32,
+        tier1_fc2_experts: cutlass.Int32,
+        tier2_fc2_experts: cutlass.Int32,
+        active_m: cutlass.Int32,
+        grid_x: cutlass.Int32,
+        stream: cuda.CUstream,
+        tier0_gate_experts: cutlass.Int32,
+        tier1_gate_experts: cutlass.Int32,
+        tier2_gate_experts: cutlass.Int32,
+        tier0_up_experts: cutlass.Int32,
+        tier1_up_experts: cutlass.Int32,
+        tier2_up_experts: cutlass.Int32,
+    ):
+        tier0_experts = cutlass.Int64(tier0_num_experts)
+        tier1_experts = cutlass.Int64(tier1_num_experts)
+        tier2_experts = cutlass.Int64(tier2_num_experts)
+        tier0_fc2 = cutlass.Int64(tier0_fc2_experts)
+        tier1_fc2 = cutlass.Int64(tier1_fc2_experts)
+        tier2_fc2 = cutlass.Int64(tier2_fc2_experts)
+        tier0_gate = cutlass.Int64(tier0_gate_experts)
+        tier1_gate = cutlass.Int64(tier1_gate_experts)
+        tier2_gate = cutlass.Int64(tier2_gate_experts)
+        total_experts = tier0_experts + tier1_experts + tier2_experts
+
+        def weight_tensor(ptr, elements):
+            return cute.make_tensor(
+                ptr,
+                layout=cute.make_layout((elements,), stride=(1,)),
+            )
+
+        t0_w13 = weight_tensor(
+            t0_w13_ptr,
+            tier0_gate
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(self.driver.fc1_cols // 16)
+            * cutlass.Int64(8 * self.tier0.trellis_bits),
+        )
+        t0_w2 = weight_tensor(
+            t0_w2_ptr,
+            tier0_fc2
+            * cutlass.Int64(self.intermediate_size // 16)
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(8 * self.tier0.trellis_bits),
+        )
+        t1_w13 = weight_tensor(
+            t1_w13_ptr,
+            tier1_gate
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(self.driver.fc1_cols // 16)
+            * cutlass.Int64(8 * self.tier1.trellis_bits),
+        )
+        t1_w2 = weight_tensor(
+            t1_w2_ptr,
+            tier1_fc2
+            * cutlass.Int64(self.intermediate_size // 16)
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(8 * self.tier1.trellis_bits),
+        )
+        t2_w13 = weight_tensor(
+            t2_w13_ptr,
+            tier2_gate
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(self.driver.fc1_cols // 16)
+            * cutlass.Int64(8 * self.tier2.trellis_bits),
+        )
+        t2_w2 = weight_tensor(
+            t2_w2_ptr,
+            tier2_fc2
+            * cutlass.Int64(self.intermediate_size // 16)
+            * cutlass.Int64(self.hidden_size // 16)
+            * cutlass.Int64(8 * self.tier2.trellis_bits),
+        )
+
+        t0_w13_scales = weight_tensor(
+            t0_w13_scales_ptr,
+            tier0_experts
+            * cutlass.Int64(self.tier0.fc1.scale_k_groups)
+            * cutlass.Int64(self.tier0.fc1.scale_size_n // 4),
+        )
+        t0_w2_scales = weight_tensor(
+            t0_w2_scales_ptr,
+            tier0_experts
+            * cutlass.Int64(self.tier0.fc2.scale_k_groups)
+            * cutlass.Int64(self.tier0.fc2.scale_size_n // 4),
+        )
+        t1_w13_scales = weight_tensor(
+            t1_w13_scales_ptr,
+            tier1_experts
+            * cutlass.Int64(self.tier1.fc1.scale_k_groups)
+            * cutlass.Int64(self.tier1.fc1.scale_size_n // 4),
+        )
+        t1_w2_scales = weight_tensor(
+            t1_w2_scales_ptr,
+            tier1_experts
+            * cutlass.Int64(self.tier1.fc2.scale_k_groups)
+            * cutlass.Int64(self.tier1.fc2.scale_size_n // 4),
+        )
+        t2_w13_scales = weight_tensor(
+            t2_w13_scales_ptr,
+            tier2_experts
+            * cutlass.Int64(self.tier2.fc1.scale_k_groups)
+            * cutlass.Int64(self.tier2.fc1.scale_size_n // 4),
+        )
+        t2_w2_scales = weight_tensor(
+            t2_w2_scales_ptr,
+            tier2_experts
+            * cutlass.Int64(self.tier2.fc2.scale_k_groups)
+            * cutlass.Int64(self.tier2.fc2.scale_size_n // 4),
+        )
+        t0_w13_global = weight_tensor(t0_w13_global_ptr, tier0_experts)
+        t0_w2_global = weight_tensor(t0_w2_global_ptr, tier0_fc2)
+        t1_w13_global = weight_tensor(t1_w13_global_ptr, tier1_experts)
+        t1_w2_global = weight_tensor(t1_w2_global_ptr, tier1_fc2)
+        t2_w13_global = weight_tensor(t2_w13_global_ptr, tier2_experts)
+        t2_w2_global = weight_tensor(t2_w2_global_ptr, tier2_fc2)
+        descriptor_map = weight_tensor(
+            descriptor_map_ptr, cutlass.Int64(3) * total_experts
+        )
+        intermediate_rotations = weight_tensor(
+            intermediate_rotations_ptr,
+            total_experts * cutlass.Int64(3 * self.intermediate_size),
+        )
+        suh_rows = total_experts
+        if cutlass.const_expr(self.driver.broadcast_suh):
+            suh_rows = cutlass.Int64(1)
+        gate_suh = weight_tensor(
+            gate_suh_ptr, suh_rows * cutlass.Int64(self.hidden_size)
+        )
+        up_suh = weight_tensor(up_suh_ptr, suh_rows * cutlass.Int64(self.hidden_size))
+        trellis_lut = weight_tensor(trellis_lut_ptr, Int64(1 << 12))
+        trellis_lut_addr = get_ptr_as_int64(trellis_lut, Int32(0))
+        rotation_input = weight_tensor(
+            rotation_input_ptr,
+            active_m.to(cutlass.Int64) * cutlass.Int64(self.hidden_size),
+        )
+        topk_weights = weight_tensor(
+            topk_weights_ptr,
+            active_m.to(cutlass.Int64) * cutlass.Int64(self.top_k),
+        )
+        self.kernel3(
+            rotation_input,
+            rotation_gate,
+            rotation_up,
+            t0_w13,
+            t0_w2,
+            t0_w13_scales,
+            t0_w2_scales,
+            t0_w13_global,
+            t0_w2_global,
+            t1_w13,
+            t1_w2,
+            t1_w13_scales,
+            t1_w2_scales,
+            t1_w13_global,
+            t1_w2_global,
+            t2_w13,
+            t2_w2,
+            t2_w13_scales,
+            t2_w2_scales,
+            t2_w13_global,
+            t2_w2_global,
+            fc1,
+            activated,
+            fc2,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            descriptor_map,
+            topk_weights,
+            fc1_scratch,
+            fc2_scratch,
+            workspace,
+            intermediate_rotations,
+            gate_suh,
+            up_suh,
+            trellis_lut_addr,
+            tier0_num_experts,
+            tier1_num_experts,
+            tier2_num_experts,
+            tier0_fc2_experts,
+            tier1_fc2_experts,
+            tier2_fc2_experts,
+            tier0_gate_experts,
+            tier1_gate_experts,
+            tier2_gate_experts,
+            tier0_up_experts,
+            tier1_up_experts,
+            tier2_up_experts,
+            active_m,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self.cta_threads, 1, 1],
+            min_blocks_per_mp=self.blocks_per_sm,
+            cooperative=True,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel3(
+        self,
+        rotation_input: cute.Tensor,
+        rotation_gate: cute.Tensor,
+        rotation_up: cute.Tensor,
+        t0_w13: cute.Tensor,
+        t0_w2: cute.Tensor,
+        t0_w13_scales: cute.Tensor,
+        t0_w2_scales: cute.Tensor,
+        t0_w13_global: cute.Tensor,
+        t0_w2_global: cute.Tensor,
+        t1_w13: cute.Tensor,
+        t1_w2: cute.Tensor,
+        t1_w13_scales: cute.Tensor,
+        t1_w2_scales: cute.Tensor,
+        t1_w13_global: cute.Tensor,
+        t1_w2_global: cute.Tensor,
+        t2_w13: cute.Tensor,
+        t2_w2: cute.Tensor,
+        t2_w13_scales: cute.Tensor,
+        t2_w2_scales: cute.Tensor,
+        t2_w13_global: cute.Tensor,
+        t2_w2_global: cute.Tensor,
+        fc1: cute.Tensor,
+        activated: cute.Tensor,
+        fc2: cute.Tensor,
+        packed_route_indices: cute.Tensor,
+        block_expert_ids: cute.Tensor,
+        packed_route_count: cute.Tensor,
+        descriptor_map: cute.Tensor,
+        topk_weights: cute.Tensor,
+        fc1_scratch: cute.Tensor,
+        fc2_scratch: cute.Tensor,
+        workspace: cute.Tensor,
+        intermediate_rotations: cute.Tensor,
+        gate_suh: cute.Tensor,
+        up_suh: cute.Tensor,
+        trellis_lut_addr: Int64,
+        tier0_num_experts: cutlass.Int32,
+        tier1_num_experts: cutlass.Int32,
+        tier2_num_experts: cutlass.Int32,
+        tier0_fc2_experts: cutlass.Int32,
+        tier1_fc2_experts: cutlass.Int32,
+        tier2_fc2_experts: cutlass.Int32,
+        tier0_gate_experts: cutlass.Int32,
+        tier1_gate_experts: cutlass.Int32,
+        tier2_gate_experts: cutlass.Int32,
+        tier0_up_experts: cutlass.Int32,
+        tier1_up_experts: cutlass.Int32,
+        tier2_up_experts: cutlass.Int32,
+        active_m: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        grid_x_raw, _, _ = cute.arch.grid_dim()
+        tid = Int32(tidx)
+        cta = Int32(bidx)
+        grid_x = Int32(grid_x_raw)
+        smem = cutlass.utils.SmemAllocator()
+
+        @cute.struct
+        class Storage:
+            words: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Uint32, self.shared_words], 1024
+            ]
+
+        storage = smem.allocate(Storage)
+        smem_base = shared_ptr_to_u32(storage.words.data_ptr())
+        decode_lut_addr = trellis_lut_addr
+        if cutlass.const_expr(self.driver.sqg_xor_cheb_t12_smem):
+            self.driver._sqg_smem_copy(
+                trellis_lut_addr,
+                smem_base + Int32(self.sqg_xor_cheb_t12_smem_off),
+                1 << 12,
+                tid,
+            )
+            cute.arch.sync_threads()
+            decode_lut_addr = Int64(smem_base + Int32(self.sqg_xor_cheb_t12_smem_off))
+        common = (
+            packed_route_indices,
+            block_expert_ids,
+            descriptor_map,
+            topk_weights,
+        )
+        counts = (
+            tier0_num_experts,
+            tier1_num_experts,
+            tier2_num_experts,
+            tier0_fc2_experts,
+            tier1_fc2_experts,
+            tier2_fc2_experts,
+            tier0_gate_experts,
+            tier1_gate_experts,
+            tier2_gate_experts,
+            tier0_up_experts,
+            tier1_up_experts,
+            tier2_up_experts,
+        )
+        fc1_emit = partial(
+            self._emit_tier_tile3,
+            True,
+            rotation_gate,
+            rotation_up,
+            t0_w13,
+            t0_w13_scales,
+            t0_w13_global,
+            t1_w13,
+            t1_w13_scales,
+            t1_w13_global,
+            t2_w13,
+            t2_w13_scales,
+            t2_w13_global,
+            fc1,
+            *common,
+            fc1_scratch,
+            workspace,
+            decode_lut_addr,
+            smem_base,
+            tid,
+            active_m,
+            *counts,
+        )
+        fc2_emit = partial(
+            self._emit_tier_tile3,
+            False,
+            activated,
+            activated,
+            t0_w2,
+            t0_w2_scales,
+            t0_w2_global,
+            t1_w2,
+            t1_w2_scales,
+            t1_w2_global,
+            t2_w2,
+            t2_w2_scales,
+            t2_w2_global,
+            fc2,
+            *common,
+            fc2_scratch,
+            workspace,
+            decode_lut_addr,
+            smem_base,
+            tid,
+            active_m * Int32(self.top_k),
+            *counts,
+        )
+        total_experts = tier0_num_experts + tier1_num_experts + tier2_num_experts
+        self.driver._moe_body(
+            rotation_gate,
+            rotation_up,
+            rotation_input,
+            t0_w13,
+            t0_w2,
+            fc1,
+            activated,
+            fc2,
+            t0_w13_scales,
+            t0_w2_scales,
+            t0_w13_global,
+            t0_w2_global,
+            packed_route_indices,
+            block_expert_ids,
+            packed_route_count,
+            t0_w13_global,
+            Int32(0),
+            topk_weights,
+            fc1_scratch,
+            fc2_scratch,
+            workspace,
+            intermediate_rotations,
+            gate_suh,
+            up_suh,
+            descriptor_map,
+            # The tier emit hooks own Trellis decoding. The shared driver's
+            # generic LUT ABI slots must stay unused for every mixed bitrate.
+            cutlass.Int64(0),
+            cutlass.Int64(0),
             total_experts,
             total_experts,
             smem_base,
@@ -774,6 +1633,83 @@ class W4A16MixedTrellisKernel:
 
 
 _CACHE: dict[tuple[object, ...], MixedTrellisCompileResult] = {}
+_CACHE3: dict[tuple[object, ...], MixedTrellis3CompileResult] = {}
+_ROUTE_PACK_WARMED: set[tuple[object, ...]] = set()
+
+
+def _mixed_route_num_experts(
+    expert_map: torch.Tensor,
+    expected_route_num_experts: int,
+) -> int:
+    route_num_experts = int(expert_map.numel())
+    if route_num_experts != int(expected_route_num_experts):
+        raise ValueError(
+            "mixed Trellis route map must match the compiled route namespace: "
+            f"map={route_num_experts}, compiled={int(expected_route_num_experts)}"
+        )
+    return route_num_experts
+
+
+def warmup_mixed_trellis_route_pack(
+    launch: MixedTrellisCompileResult,
+    buffers: MixedTrellisBuffers,
+    *,
+    expert_map: torch.Tensor,
+) -> int:
+    """Materialize every route-pack specialization reachable by ``launch``.
+
+    Route packing buckets token capacity to powers of two. A profile pass at
+    the maximum batch therefore does not cover smaller decode, speculative,
+    or final-prefill-chunk buckets. Load those CUDA modules eagerly while the
+    serving framework is still profiling persistent memory, so KV sizing sees
+    their real driver footprint instead of discovering it under live traffic.
+    """
+    device = buffers.packed_route_indices.device
+    if device.type != "cuda":
+        raise RuntimeError("mixed Trellis route-pack warmup requires CUDA buffers")
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError("mixed Trellis route-pack warmup cannot run during capture")
+
+    route_num_experts = _mixed_route_num_experts(
+        expert_map, int(launch.topk_sum.route_num_experts)
+    )
+    warmed = 0
+    pending_keys: list[tuple[object, ...]] = []
+    with torch.cuda.device(device):
+        device_index = int(torch.cuda.current_device())
+        for token_count in route_pack_warmup_token_counts(launch.size_m):
+            key = (
+                device_index,
+                str(launch.route_ids_dtype),
+                int(token_count),
+                int(launch.top_k),
+                route_num_experts,
+                int(launch.moe_block_size),
+                True,
+            )
+            if key in _ROUTE_PACK_WARMED:
+                continue
+            dummy_topk_ids = torch.zeros(
+                (token_count, launch.top_k),
+                dtype=launch.route_ids_dtype,
+                device=device,
+            )
+            pack_topk_routes_by_expert(
+                dummy_topk_ids,
+                launch.moe_block_size,
+                route_num_experts,
+                expert_map=expert_map,
+                packed_route_indices=buffers.packed_route_indices,
+                block_expert_ids=buffers.block_expert_ids,
+                packed_route_count=buffers.packed_route_count,
+                expert_offsets=buffers.expert_offsets,
+                expert_counts=buffers.expert_counts,
+            )
+            pending_keys.append(key)
+            warmed += 1
+        torch.cuda.current_stream(device).synchronize()
+        _ROUTE_PACK_WARMED.update(pending_keys)
+    return warmed
 
 
 def compile_mixed_trellis(
@@ -790,11 +1726,13 @@ def compile_mixed_trellis(
     force_tile_config: tuple[int, int, int, int],
     tier0_bits: int = 3,
     tier1_bits: int = 4,
+    trellis_codebook: str = "mcg",
     moe_block_size: int = 8,
     rotation_input_dtype: str = "bf16",
     route_ids_dtype: torch.dtype = torch.int32,
     broadcast_suh: bool = False,
     broadcast_svh: bool = False,
+    route_num_experts: int | None = None,
 ) -> MixedTrellisCompileResult:
     if route_ids_dtype not in (torch.int32, torch.int64):
         raise TypeError("mixed Trellis route IDs must be int32 or int64")
@@ -808,7 +1746,13 @@ def compile_mixed_trellis(
             "mixed Trellis FC1 requires tile_k >= 128; narrower K tiles lose "
             "large-M cross-tier partial reductions"
         )
+    trellis_codebook = str(trellis_codebook).lower()
     total_experts = int(tier0_num_experts) + int(tier1_num_experts)
+    if route_num_experts is None:
+        route_num_experts = total_experts
+    route_num_experts = int(route_num_experts)
+    if route_num_experts <= 0:
+        raise ValueError("mixed Trellis route_num_experts must be positive")
     paired_m8_fc2 = int(moe_block_size) in (32, 64)
 
     def make_kernel(num_experts: int, bits: int) -> W4A16FusedMoeKernel:
@@ -834,6 +1778,7 @@ def compile_mixed_trellis(
             scale_format="e4m3_k32",
             w13_layout="trellis3_t256_proj",
             trellis_bits=bits,
+            trellis_codebook=trellis_codebook,
             intermediate_rotation=True,
             full_rotation=True,
             rotation_input_dtype=rotation_input_dtype,
@@ -872,7 +1817,7 @@ def compile_mixed_trellis(
         element_dtype="fp16",
         full_rotation=True,
         num_experts=total_experts,
-        route_num_experts=total_experts,
+        route_num_experts=route_num_experts,
         route_ids_dtype=route_ids_dtype,
         use_expert_map=True,
         broadcast_svh=broadcast_svh,
@@ -938,11 +1883,22 @@ def compile_mixed_trellis(
         make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
         make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
         make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        Int32(tier0_num_experts),
+        Int32(tier1_num_experts),
+        # FC2 counts are independent artifact data; trace with the FC1 values.
         Int32(tier0_num_experts),
         Int32(tier1_num_experts),
         1,
         1,
         current_cuda_stream(),
+        # Gate-count trace placeholders (keyword-only, last in the signature);
+        # real counts ride each launch.
+        Int32(tier0_num_experts),
+        Int32(tier1_num_experts),
+        # Up-count trace placeholders; real counts ride each launch too.
+        Int32(tier0_num_experts),
+        Int32(tier1_num_experts),
     )
     raise_if_kernel_resolution_frozen(
         "cute.compile", target=kernel, cache_key=cache_key
@@ -976,6 +1932,7 @@ def compile_mixed_trellis(
         tier1_num_experts=int(tier1_num_experts),
         tier0_bits=int(tier0_bits),
         tier1_bits=int(tier1_bits),
+        trellis_codebook=trellis_codebook,
         fc1_tile_k=fc1_tile_k,
         fc1_tile_n=fc1_tile_n,
         fc2_tile_k=fc2_tile_k,
@@ -1001,16 +1958,282 @@ def compile_mixed_trellis(
     return result
 
 
-def make_mixed_trellis_buffers(
-    launch: MixedTrellisCompileResult,
+def compile_mixed_trellis3(
+    *,
+    size_m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    tier0_num_experts: int,
+    tier1_num_experts: int,
+    tier2_num_experts: int,
+    top_k: int,
+    max_m_blocks: int,
+    sms: int,
+    max_shared_mem: int,
+    force_tile_config: tuple[int, int, int, int],
+    tier0_bits: int = 3,
+    tier1_bits: int = 4,
+    tier2_bits: int = 5,
+    trellis_codebook: str = "mcg",
+    moe_block_size: int = 8,
+    rotation_input_dtype: str = "bf16",
+    route_ids_dtype: torch.dtype = torch.int32,
+    broadcast_suh: bool = False,
+    broadcast_svh: bool = False,
+    route_num_experts: int | None = None,
+) -> MixedTrellis3CompileResult:
+    """Compile the dedicated three-bitrate cooperative Trellis grid."""
+
+    if route_ids_dtype not in (torch.int32, torch.int64):
+        raise TypeError("mixed Trellis route IDs must be int32 or int64")
+    if int(size_m) * int(top_k) > torch.iinfo(torch.int32).max:
+        raise ValueError("mixed Trellis routed-row count must fit in int32")
+    trellis_codebook = str(trellis_codebook).lower()
+    counts = tuple(
+        int(value)
+        for value in (
+            tier0_num_experts,
+            tier1_num_experts,
+            tier2_num_experts,
+        )
+    )
+    if any(value <= 0 or value > _MAX_TIER_EXPERTS for value in counts):
+        raise ValueError(
+            "three-tier mixed Trellis requires each tier to contain 1..256 slots"
+        )
+    bits = tuple(int(value) for value in (tier0_bits, tier1_bits, tier2_bits))
+    if len(set(bits)) != 3 or any(value not in (3, 4, 5, 6) for value in bits):
+        raise ValueError(
+            "three-tier mixed Trellis requires three distinct bitrates in 3..6"
+        )
+    fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n = (
+        int(value) for value in force_tile_config
+    )
+    if fc1_tile_k < 128:
+        raise ValueError(
+            "mixed Trellis FC1 requires tile_k >= 128; narrower K tiles lose "
+            "large-M cross-tier partial reductions"
+        )
+    total_experts = sum(counts)
+    if route_num_experts is None:
+        route_num_experts = total_experts
+    route_num_experts = int(route_num_experts)
+    if route_num_experts <= 0:
+        raise ValueError("mixed Trellis route_num_experts must be positive")
+    paired_m8_fc2 = int(moe_block_size) in (32, 64)
+
+    def make_kernel(num_experts: int, trellis_bits: int) -> W4A16FusedMoeKernel:
+        return W4A16FusedMoeKernel(
+            size_m=size_m,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            top_k=top_k,
+            activation="silu",
+            apply_router_weight_on_input=False,
+            zero_fc2_output=False,
+            fc1_tile_n=fc1_tile_n,
+            fc1_tile_k=fc1_tile_k,
+            fc2_tile_n=fc2_tile_n,
+            fc2_tile_k=fc2_tile_k,
+            moe_block_size=moe_block_size,
+            max_m_blocks=max_m_blocks,
+            fc2_moe_block_size=(8 if paired_m8_fc2 else moe_block_size),
+            fc2_schedule_route_block_factor=(2 if paired_m8_fc2 else 1),
+            element_dtype="fp16",
+            weight_layout="trellis3_t256",
+            scale_format="e4m3_k32",
+            w13_layout="trellis3_t256_proj",
+            trellis_bits=trellis_bits,
+            trellis_codebook=trellis_codebook,
+            intermediate_rotation=True,
+            full_rotation=True,
+            rotation_input_dtype=rotation_input_dtype,
+            broadcast_suh=broadcast_suh,
+            schedule_whole_tiles=True,
+        )
+
+    kernel = W4A16MixedTrellis3Kernel(
+        driver=make_kernel(total_experts, bits[0]),
+        tier0=make_kernel(counts[0], bits[0]),
+        tier1=make_kernel(counts[1], bits[1]),
+        tier2=make_kernel(counts[2], bits[2]),
+    )
+    if kernel.shared_words * 4 > int(max_shared_mem):
+        raise ValueError(
+            "mixed Trellis shared-memory requirement exceeds the device limit: "
+            f"required={kernel.shared_words * 4} limit={int(max_shared_mem)}"
+        )
+    device = int(torch.cuda.current_device())
+    cache_key = (
+        "mixed_trellis3",
+        device,
+        kernel.__cache_key__,
+        str(route_ids_dtype),
+        int(size_m),
+        int(max_m_blocks),
+    )
+    topk_sum = compile_w4a16_topk_sum(
+        m=size_m,
+        topk=top_k,
+        hidden_size=hidden_size,
+        element_dtype="fp16",
+        full_rotation=True,
+        num_experts=total_experts,
+        route_num_experts=route_num_experts,
+        route_ids_dtype=route_ids_dtype,
+        use_expert_map=True,
+        broadcast_svh=broadcast_svh,
+    )
+    cached = _CACHE3.get(cache_key)
+    if cached is not None:
+        return replace(
+            cached,
+            topk_sum=topk_sum,
+            tier0_num_experts=counts[0],
+            tier1_num_experts=counts[1],
+            tier2_num_experts=counts[2],
+            sms=int(sms),
+            broadcast_suh=bool(broadcast_suh),
+            broadcast_svh=bool(broadcast_svh),
+        )
+
+    compile_m = _fake_m_for_specialization(size_m)
+    compile_rows = compile_m * top_k
+    fc1_cols = 2 * intermediate_size
+    cutlass_dtype = cutlass.Float16
+    rotation_dtype = _cutlass_element_dtype(rotation_input_dtype)
+
+    def tensor(dtype, elements: int, *, align: int = 16):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype, (max(int(elements), 1),), assumed_align=align
+        )
+
+    def tier_args():
+        return (
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Int32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Float32, 16, cute.AddressSpace.gmem, assumed_align=16),
+        )
+
+    scratch_elements = max(
+        fc1_cols * compile_rows,
+        hidden_size * compile_rows,
+        4 * 256 * moe_block_size * 256,
+    )
+    compile_args = (
+        make_ptr(rotation_dtype, 16, cute.AddressSpace.gmem, assumed_align=16),
+        tensor(cutlass_dtype, compile_rows * hidden_size),
+        tensor(cutlass_dtype, compile_rows * hidden_size),
+        *tier_args(),
+        *tier_args(),
+        *tier_args(),
+        tensor(cutlass_dtype, compile_rows * fc1_cols),
+        tensor(cutlass_dtype, compile_rows * intermediate_size),
+        tensor(cutlass_dtype, compile_rows * hidden_size),
+        tensor(cutlass.Int32, moe_block_size),
+        tensor(cutlass.Int32, 1),
+        tensor(cutlass.Int32, 1, align=4),
+        make_ptr(cutlass.Int32, 4, cute.AddressSpace.gmem, assumed_align=4),
+        make_ptr(cutlass.Float32, 4, cute.AddressSpace.gmem, assumed_align=4),
+        tensor(cutlass.Float32, scratch_elements),
+        tensor(cutlass.Float32, scratch_elements),
+        tensor(cutlass.Int32, 4 * 256 + 2),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16),
+        make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+        Int32(counts[0]),
+        Int32(counts[1]),
+        Int32(counts[2]),
+        Int32(counts[0]),
+        Int32(counts[1]),
+        Int32(counts[2]),
+        1,
+        1,
+        current_cuda_stream(),
+        Int32(counts[0]),
+        Int32(counts[1]),
+        Int32(counts[2]),
+        Int32(counts[0]),
+        Int32(counts[1]),
+        Int32(counts[2]),
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=kernel, cache_key=cache_key
+    )
+    compiled = b12x_compile(
+        kernel,
+        *compile_args,
+        compile_spec=KernelCompileSpec.from_key(
+            "moe.w4a16.mixed_trellis3",
+            W4A16MixedTrellis3Kernel.ABI_VERSION,
+            cache_key,
+        ),
+        dsl_compile_options=OptLevel(2),
+    )
+    registers = -1
+    local_bytes = -1
+    resources = _query_w4a16_kernel_resources(compiled)
+    if resources is not None:
+        _, registers, local_bytes = resources
+        if local_bytes != 0:
+            raise RuntimeError(
+                "three-tier mixed Trellis codegen spills to local memory "
+                f"({local_bytes} bytes/thread)"
+            )
+    result = MixedTrellis3CompileResult(
+        compiled=compiled,
+        topk_sum=topk_sum,
+        size_m=int(size_m),
+        hidden_size=int(hidden_size),
+        intermediate_size=int(intermediate_size),
+        top_k=int(top_k),
+        tier0_num_experts=counts[0],
+        tier1_num_experts=counts[1],
+        tier2_num_experts=counts[2],
+        tier0_bits=bits[0],
+        tier1_bits=bits[1],
+        tier2_bits=bits[2],
+        trellis_codebook=trellis_codebook,
+        fc1_tile_k=fc1_tile_k,
+        fc1_tile_n=fc1_tile_n,
+        fc2_tile_k=fc2_tile_k,
+        fc2_tile_n=fc2_tile_n,
+        moe_block_size=int(moe_block_size),
+        fc2_moe_block_size=int(kernel.driver.fc2.moe_block_size),
+        fc2_schedule_route_block_factor=int(
+            kernel.driver.fc2.schedule_route_block_factor
+        ),
+        fc2_paired_m8_routes=bool(kernel.driver.fc2.paired_m8_routes),
+        max_m_blocks=int(max_m_blocks),
+        blocks_per_sm=int(kernel.blocks_per_sm),
+        sms=int(sms),
+        shared_memory_bytes=int(kernel.shared_words * 4),
+        registers_per_thread=registers,
+        local_memory_bytes=local_bytes,
+        rotation_input_dtype=str(rotation_input_dtype),
+        route_ids_dtype=route_ids_dtype,
+        broadcast_suh=bool(broadcast_suh),
+        broadcast_svh=bool(broadcast_svh),
+    )
+    _CACHE3[cache_key] = result
+    return result
+
+
+def _make_mixed_trellis_buffers(
+    launch: MixedTrellisCompileResult | MixedTrellis3CompileResult,
     *,
     device: torch.device,
     sms: int,
+    route_num_experts: int,
 ) -> MixedTrellisBuffers:
     capacity_rows = launch.size_m * launch.top_k
-    total_experts = launch.tier0_num_experts + launch.tier1_num_experts
     route_slots = max_packed_route_slots(
-        capacity_rows, launch.moe_block_size, total_experts
+        capacity_rows, launch.moe_block_size, route_num_experts
     )
     route_blocks = (route_slots + launch.moe_block_size - 1) // launch.moe_block_size
     if route_blocks > launch.max_m_blocks:
@@ -1044,8 +2267,10 @@ def make_mixed_trellis_buffers(
         packed_route_indices=torch.empty(route_slots, dtype=torch.int32, device=device),
         block_expert_ids=torch.empty(route_blocks, dtype=torch.int32, device=device),
         packed_route_count=torch.empty(1, dtype=torch.int32, device=device),
-        expert_offsets=torch.empty(total_experts + 1, dtype=torch.int32, device=device),
-        expert_counts=torch.empty(total_experts, dtype=torch.int32, device=device),
+        expert_offsets=torch.empty(
+            route_num_experts + 1, dtype=torch.int32, device=device
+        ),
+        expert_counts=torch.empty(route_num_experts, dtype=torch.int32, device=device),
         fc1_scratch=torch.empty(
             packed_gemm_scratch_elements(
                 size_n=fc1_cols,
@@ -1074,6 +2299,34 @@ def make_mixed_trellis_buffers(
     )
 
 
+def make_mixed_trellis_buffers(
+    launch: MixedTrellisCompileResult,
+    *,
+    device: torch.device,
+    sms: int,
+) -> MixedTrellisBuffers:
+    return _make_mixed_trellis_buffers(
+        launch,
+        device=device,
+        sms=sms,
+        route_num_experts=int(launch.topk_sum.route_num_experts),
+    )
+
+
+def make_mixed_trellis3_buffers(
+    launch: MixedTrellis3CompileResult,
+    *,
+    device: torch.device,
+    sms: int,
+) -> MixedTrellisBuffers:
+    return _make_mixed_trellis_buffers(
+        launch,
+        device=device,
+        sms=sms,
+        route_num_experts=int(launch.topk_sum.route_num_experts),
+    )
+
+
 def build_ordered_maps(
     tier0_num_experts: int,
     tier1_num_experts: int,
@@ -1087,6 +2340,10 @@ def build_ordered_maps(
         range(tier0_num_experts, tier0_num_experts + tier1_num_experts),
         device=device,
     )
+
+
+# One tier-local expert index is encoded in the descriptor's low 8 bits.
+_MAX_TIER_EXPERTS = 256
 
 
 def build_tiered_maps(
@@ -1114,25 +2371,178 @@ def build_tiered_maps(
     global_to_combined = torch.tensor(
         global_to_combined_host, dtype=torch.int32, device=device
     )
-    descriptor = torch.tensor(
+    descriptor_row = torch.tensor(
         [*range(len(tier0_ids)), *((1 << 8) | i for i in range(len(tier1_ids)))],
         dtype=torch.int32,
         device=device,
     )
+    # The descriptor table carries one row per projection (gate, up, down).
+    # Per-expert tiering is the degenerate case where all three rows are
+    # identical, reproducing single-row behaviour bit-for-bit.
+    descriptor = descriptor_row.repeat(3).contiguous()
+    # Publish the per-tier gate/up counts this descriptor encodes so
+    # run_mixed_trellis can fail closed on mismatched caller counts without a
+    # device sync. Per-expert tiering has gate == up == the tier partition.
+    counts = (len(tier0_ids), len(tier1_ids))
+    descriptor._mt_projection_counts = (counts, counts)
     return global_to_combined, descriptor
 
 
+def build_projection_tiered_maps(
+    gate_tiers: Sequence[int],
+    up_tiers: Sequence[int],
+    down_tiers: Sequence[int],
+    *,
+    tier_slots: Sequence[int],
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the route map and the three-row descriptor map for one R7 layer.
+
+    Each argument is one tier id per global expert, for that
+    projection. Combined expert ids are the global ids -- with per-projection
+    tiering there is no single tier-contiguous ordering, so all tier knowledge
+    lives in the descriptor rows and global_to_combined is the identity.
+
+    Returns (global_to_combined, descriptor_map) where descriptor_map is
+    int32[3 * sum(tier_slots)] laid out gate, up, down. Real entries are
+    (tier << 8) | tier_local_index and padding entries are -1.
+    glm52-r7-projtiers.
+    """
+
+    projections = (
+        ("gate", tuple(int(t) for t in gate_tiers)),
+        ("up", tuple(int(t) for t in up_tiers)),
+        ("down", tuple(int(t) for t in down_tiers)),
+    )
+    slots = tuple(int(value) for value in tier_slots)
+    if len(slots) not in (2, 3):
+        raise ValueError(
+            "mixed Trellis tier_slots must contain exactly two or three counts"
+        )
+    if any(value < 0 or value > 256 for value in slots):
+        raise ValueError("mixed Trellis tier slots must be in [0, 256]")
+    num_experts = len(projections[0][1])
+    rows: list[int] = []
+    projection_counts: list[tuple[int, ...]] = []
+    for name, tiers in projections:
+        if len(tiers) != num_experts:
+            raise ValueError(
+                "mixed Trellis projection tier lists must agree on expert count: "
+                f"{name} has {len(tiers)}, expected {num_experts}"
+            )
+        if any(t < 0 or t >= len(slots) for t in tiers):
+            raise ValueError(
+                f"mixed Trellis {name} tier ids must be in [0, {len(slots)})"
+            )
+        counters = [0] * len(slots)
+        row = []
+        for tier in tiers:
+            local = counters[tier]
+            counters[tier] += 1
+            if local > 0xFF:
+                raise ValueError(
+                    f"mixed Trellis {name} tier {tier} exceeds 256 experts"
+                )
+            row.append((tier << 8) | local)
+        projection_counts.append(tuple(counters))
+        rows.extend(row)
+    # The launch sizes the descriptor namespace as the sum of the tier slot
+    # counts. A tier slot is max(gate_count, up_count), so with per-projection
+    # tiering that sum can exceed the real expert count. Routing remains a
+    # separate, exact-size namespace; only the descriptor rows are padded.
+    required_fc1 = tuple(
+        max(projection_counts[0][tier], projection_counts[1][tier])
+        for tier in range(len(slots))
+    )
+    if any(slots[tier] < required_fc1[tier] for tier in range(len(slots))):
+        raise ValueError(
+            "mixed Trellis tier slots cannot address all gate/up locals: "
+            f"slots={slots}, required={required_fc1}"
+        )
+    stride = sum(slots)
+    if stride < num_experts:
+        raise ValueError(
+            f"mixed Trellis tier slots ({stride}) cannot address {num_experts} experts"
+        )
+    global_to_combined = torch.arange(num_experts, dtype=torch.int32, device=device)
+    descriptor = torch.full((3 * stride,), -1, dtype=torch.int32, device=device)
+    for row_index in range(3):
+        base = row_index * num_experts
+        descriptor[row_index * stride : row_index * stride + num_experts] = (
+            torch.tensor(
+                rows[base : base + num_experts], dtype=torch.int32, device=device
+            )
+        )
+    # Publish the gate/up counts this descriptor encodes so run_mixed_trellis
+    # can fail closed on mismatched caller counts without a device sync.
+    descriptor._mt_projection_counts = (
+        projection_counts[0],
+        projection_counts[1],
+    )
+    return global_to_combined, descriptor
+
+
+def _check_descriptor_projection_counts(
+    descriptor_map: torch.Tensor,
+    total_experts: int,
+    *,
+    gate_counts: tuple[int, ...],
+    up_counts: tuple[int, ...],
+) -> None:
+    """Fail closed when launch counts disagree with the descriptor map.
+
+    The device dispatch bounds gate/up locals by the launch counts, so a
+    descriptor entry at or beyond its projection's count is silently skipped
+    and the corresponding FC1 half stays zero. The in-tree builders publish
+    the counts their descriptor encodes; descriptors from other producers pay
+    one host copy here, memoized on the tensor, so steady-state launches
+    never synchronize.
+    """
+
+    encoded = getattr(descriptor_map, "_mt_projection_counts", None)
+    if encoded is None:
+        rows = descriptor_map.detach().cpu().view(3, total_experts)
+        derived = []
+        tier_count = len(gate_counts)
+        for row in rows[:2]:
+            live = row[row >= 0]
+            encoded_tiers = live >> 8
+            if bool((encoded_tiers >= tier_count).any()):
+                raise ValueError(
+                    "mixed Trellis descriptor contains a tier outside the "
+                    f"launch range [0, {tier_count})"
+                )
+            derived.append(
+                tuple(int((encoded_tiers == tier).sum()) for tier in range(tier_count))
+            )
+        encoded = (tuple(derived[0]), tuple(derived[1]))
+        descriptor_map._mt_projection_counts = encoded
+    expected_gate = tuple(int(value) for value in encoded[0])
+    expected_up = tuple(int(value) for value in encoded[1])
+    got_gate = tuple(int(value) for value in gate_counts)
+    got_up = tuple(int(value) for value in up_counts)
+    if got_gate != expected_gate or got_up != expected_up:
+        raise ValueError(
+            "mixed Trellis projection counts disagree with the descriptor "
+            f"map: gate {got_gate} vs encoded {expected_gate}, up {got_up} "
+            f"vs encoded {expected_up}"
+        )
+
+
 def combine_trellis_rotations(
-    tier0: MixedTrellisTier, tier1: MixedTrellisTier
+    tier0: MixedTrellisTier,
+    tier1: MixedTrellisTier,
+    *additional_tiers: MixedTrellisTier,
 ) -> MixedTrellisRotations:
     """Materialize one tier-ordered table set once during model preparation."""
+    tiers = (tier0, tier1, *additional_tiers)
     return MixedTrellisRotations(
         intermediate=torch.cat(
-            (tier0.intermediate_rotations, tier1.intermediate_rotations), dim=0
+            tuple(tier.intermediate_rotations for tier in tiers), dim=0
         ).contiguous(),
-        gate_suh=torch.cat((tier0.gate_suh, tier1.gate_suh), dim=0).contiguous(),
-        up_suh=torch.cat((tier0.up_suh, tier1.up_suh), dim=0).contiguous(),
-        down_svh=torch.cat((tier0.down_svh, tier1.down_svh), dim=0).contiguous(),
+        gate_suh=torch.cat(tuple(tier.gate_suh for tier in tiers), dim=0).contiguous(),
+        up_suh=torch.cat(tuple(tier.up_suh for tier in tiers), dim=0).contiguous(),
+        down_svh=torch.cat(tuple(tier.down_svh for tier in tiers), dim=0).contiguous(),
     )
 
 
@@ -1145,23 +2555,82 @@ def _validate_mixed_trellis_tier_storage(
     hidden_size: int,
     intermediate_size: int,
     device: torch.device,
+    gate_experts: int | None = None,
+    up_experts: int | None = None,
 ) -> None:
     """Fail closed before binding expert-sized storage as raw CuTe pointers."""
     expected_experts = int(expected_experts)
     bits = int(bits)
-    fc1_cols = 2 * int(intermediate_size)
+    # Per-projection membership lets a tier hold a different number of FC2
+    # (down) experts than FC1 (gate/up) slots, so the FC2 count cannot be
+    # assumed equal to expected_experts. Derive it from the W2 payload itself,
+    # which is the tensor that actually carries the data, then require the
+    # global-scale vector to agree. Deriving it from the scale vector instead
+    # would report a malformed scale as a confusing W2 extent error.
+    w2_expert_stride = (
+        (int(intermediate_size) // 16) * (int(hidden_size) // 16) * (8 * bits)
+    )
+    w2_elements = int(tier.w2.numel())
+    # The FC2 count is NOT bounded by the FC1 slot count: per-projection
+    # membership routinely gives a tier more down experts than gate/up slots
+    # (measured 231 down vs 77 gate/up on a real R7 layer). The real ceiling is
+    # the descriptor's 8-bit tier-local index.
+    if (
+        tier.w2.dtype != torch.int32
+        or w2_expert_stride <= 0
+        or w2_elements % w2_expert_stride != 0
+        or not 1 <= w2_elements // w2_expert_stride <= _MAX_TIER_EXPERTS
+    ):
+        raise ValueError(
+            f"mixed Trellis {name}.w2 must be torch.int32 holding "
+            f"1..{_MAX_TIER_EXPERTS} whole FC2 experts of "
+            f"{w2_expert_stride} elements, got {w2_elements}"
+        )
+    fc2_experts = w2_elements // w2_expert_stride
+    if gate_experts is None and up_experts is None:
+        gate_experts = expected_experts
+        up_experts = expected_experts
+    elif gate_experts is None or up_experts is None:
+        raise ValueError(
+            f"mixed Trellis {name} requires paired gate_experts/up_experts"
+        )
+    gate_experts = int(gate_experts)
+    up_experts = int(up_experts)
+    if not (
+        0 <= gate_experts <= expected_experts and 0 <= up_experts <= expected_experts
+    ):
+        raise ValueError(
+            f"mixed Trellis {name} projection counts must both be in "
+            f"[0, {expected_experts}], got gate={gate_experts}, up={up_experts}"
+        )
+    # Legacy callers have G=U=E and therefore require the historical 2E
+    # planes. Tight callers must couple the physical payload exactly to G+U.
+    # One dummy plane is permitted only for the empty/empty tier.
+    _proj_stride = (
+        (int(hidden_size) // 16) * (int(intermediate_size) // 16) * (8 * bits)
+    )
+    _w13_planes = int(tier.w13.numel()) // _proj_stride if _proj_stride else 0
+    _expected_w13_planes = max(gate_experts + up_experts, 1)
+    if (
+        tier.w13.dtype != torch.int32
+        or tier.w13.device != device
+        or not tier.w13.is_contiguous()
+        or _proj_stride <= 0
+        or int(tier.w13.numel()) % _proj_stride != 0
+        or _w13_planes != _expected_w13_planes
+        or int(tier.w13.data_ptr()) % 16 != 0
+    ):
+        raise ValueError(
+            f"mixed Trellis {name}.w13 must be contiguous int32 on {device} "
+            f"with exactly {_expected_w13_planes} projection planes, got "
+            f"{int(tier.w13.numel())} elements"
+        )
     expected = (
-        (
-            "w13",
-            tier.w13,
-            torch.int32,
-            expected_experts * (int(hidden_size) // 16) * (fc1_cols // 16) * (8 * bits),
-        ),
         (
             "w2",
             tier.w2,
             torch.int32,
-            expected_experts
+            fc2_experts
             * (int(intermediate_size) // 16)
             * (int(hidden_size) // 16)
             * (8 * bits),
@@ -1181,7 +2650,7 @@ def _validate_mixed_trellis_tier_storage(
             "w2_global_scale",
             tier.w2_global_scale,
             torch.float32,
-            expected_experts,
+            fc2_experts,
         ),
     )
     for field, tensor, expected_dtype, expected_elements in expected:
@@ -1210,7 +2679,34 @@ def run_mixed_trellis(
     rotations: MixedTrellisRotations,
     launch: MixedTrellisCompileResult,
     buffers: MixedTrellisBuffers,
+    gate_experts: tuple[int, int] | None = None,
+    up_experts: tuple[int, int] | None = None,
 ) -> torch.Tensor:
+    def projection_counts(name, values, defaults):
+        if values is None:
+            return defaults
+        if (
+            not isinstance(values, tuple)
+            or len(values) != 2
+            or any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in values
+            )
+        ):
+            raise TypeError(f"mixed Trellis {name} must be a pair of integer counts")
+        return values
+
+    if (gate_experts is None) != (up_experts is None):
+        raise ValueError(
+            "mixed Trellis projection-tight storage requires paired "
+            "gate_experts/up_experts"
+        )
+    defaults = (
+        int(launch.tier0_num_experts),
+        int(launch.tier1_num_experts),
+    )
+    _gate0, _gate1 = projection_counts("gate_experts", gate_experts, defaults)
+    _up0, _up1 = projection_counts("up_experts", up_experts, defaults)
     m = int(x.shape[0])
     if m <= 0:
         raise ValueError(f"mixed Trellis requires at least one active row, got {m}")
@@ -1239,8 +2735,14 @@ def run_mixed_trellis(
         actual_experts = int(tier.num_experts)
         if actual_experts != int(expected_experts):
             raise ValueError(
-                f"mixed Trellis {name} has {actual_experts} experts, but the "
-                f"launch plan describes {int(expected_experts)}"
+                f"mixed Trellis {name} has {actual_experts} experts, expected "
+                f"the launch-plan count {int(expected_experts)}"
+            )
+        tier_codebook = str(tier.trellis_codebook).lower()
+        if tier_codebook != launch.trellis_codebook:
+            raise ValueError(
+                f"mixed Trellis {name} uses codebook {tier_codebook!r}, expected "
+                f"the launch-plan codebook {launch.trellis_codebook!r}"
             )
     _validate_mixed_trellis_tier_storage(
         name="tier0",
@@ -1250,6 +2752,8 @@ def run_mixed_trellis(
         hidden_size=launch.hidden_size,
         intermediate_size=launch.intermediate_size,
         device=x.device,
+        gate_experts=_gate0,
+        up_experts=_up0,
     )
     _validate_mixed_trellis_tier_storage(
         name="tier1",
@@ -1259,22 +2763,35 @@ def run_mixed_trellis(
         hidden_size=launch.hidden_size,
         intermediate_size=launch.intermediate_size,
         device=x.device,
+        gate_experts=_gate1,
+        up_experts=_up1,
     )
     total_experts = launch.tier0_num_experts + launch.tier1_num_experts
-    for name, mapping in (
-        ("global_to_combined", global_to_combined),
-        ("descriptor_map", descriptor_map),
+    route_num_experts = _mixed_route_num_experts(
+        global_to_combined, int(launch.topk_sum.route_num_experts)
+    )
+    for name, mapping, expected_entries in (
+        ("global_to_combined", global_to_combined, route_num_experts),
+        ("descriptor_map", descriptor_map, 3 * total_experts),
     ):
+        # glm52-r7-projtiers: descriptor rows use the padded weight stride,
+        # while the route map covers only real global experts.
         if (
             mapping.dtype != torch.int32
             or mapping.device != x.device
             or not mapping.is_contiguous()
-            or int(mapping.numel()) != total_experts
+            or int(mapping.numel()) != expected_entries
         ):
             raise ValueError(
                 f"mixed Trellis {name} must be contiguous int32 on {x.device} "
-                f"with {total_experts} elements"
+                f"with {expected_entries} elements"
             )
+    _check_descriptor_projection_counts(
+        descriptor_map,
+        total_experts,
+        gate_counts=(_gate0, _gate1),
+        up_counts=(_up0, _up1),
+    )
     for name, table, expected_elements in (
         (
             "intermediate rotations",
@@ -1309,7 +2826,7 @@ def run_mixed_trellis(
                 f"with {expected_elements} elements and at least 16-byte alignment"
             )
     required_route_slots = max_packed_route_slots(
-        m * launch.top_k, launch.moe_block_size, total_experts
+        m * launch.top_k, launch.moe_block_size, route_num_experts
     )
     required_route_blocks = (
         required_route_slots + launch.moe_block_size - 1
@@ -1331,7 +2848,7 @@ def run_mixed_trellis(
     packed, block_experts, packed_count = pack_topk_routes_by_expert(
         topk_ids,
         launch.moe_block_size,
-        total_experts,
+        route_num_experts,
         expert_map=global_to_combined,
         packed_route_indices=buffers.packed_route_indices,
         block_expert_ids=buffers.block_expert_ids,
@@ -1340,6 +2857,7 @@ def run_mixed_trellis(
         expert_counts=buffers.expert_counts,
     )
     stream = current_cuda_stream()
+    trellis_rank_lut = sqg_xor_cheb_t12_lut(x.device)
     launch.compiled(
         make_ptr(
             _cutlass_element_dtype(launch.rotation_input_dtype),
@@ -1460,11 +2978,370 @@ def run_mixed_trellis(
             cute.AddressSpace.gmem,
             assumed_align=16,
         ),
+        make_ptr(
+            cutlass.Uint8,
+            trellis_rank_lut.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
         Int32(launch.tier0_num_experts),
         Int32(launch.tier1_num_experts),
+        Int32(int(tier0.w2_global_scale.numel())),
+        Int32(int(tier1.w2_global_scale.numel())),
         m,
         max(int(launch.blocks_per_sm) * int(launch.sms), 1),
         stream,
+        # Keyword, so the positional chain above stays intact.
+        tier0_gate_experts=Int32(_gate0),
+        tier1_gate_experts=Int32(_gate1),
+        tier0_up_experts=Int32(_up0),
+        tier1_up_experts=Int32(_up1),
+    )
+    launch.topk_sum.compiled(
+        make_ptr(
+            cutlass.Float16,
+            buffers.fc2.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            buffers.output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            topk_weights.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Int32 if topk_ids.dtype == torch.int32 else cutlass.Int64,
+            topk_ids.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4 if topk_ids.dtype == torch.int32 else 8,
+        ),
+        make_ptr(
+            cutlass.Int32,
+            global_to_combined.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            rotations.down_svh.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        Int32(launch.topk_sum.num_experts),
+        Int32(launch.topk_sum.route_num_experts),
+        m,
+        stream,
+    )
+    return buffers.output[:m]
+
+
+def run_mixed_trellis3(
+    x: torch.Tensor,
+    tier0: MixedTrellisTier,
+    tier1: MixedTrellisTier,
+    tier2: MixedTrellisTier,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    global_to_combined: torch.Tensor,
+    descriptor_map: torch.Tensor,
+    rotations: MixedTrellisRotations,
+    launch: MixedTrellis3CompileResult,
+    buffers: MixedTrellisBuffers,
+    gate_experts: tuple[int, int, int] | None = None,
+    up_experts: tuple[int, int, int] | None = None,
+) -> torch.Tensor:
+    """Run one graph-safe K3/K4/K5 cooperative MoE launch."""
+
+    def projection_counts(name, values, defaults):
+        if values is None:
+            return defaults
+        if (
+            not isinstance(values, tuple)
+            or len(values) != 3
+            or any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in values
+            )
+        ):
+            raise TypeError(
+                f"three-tier mixed Trellis {name} must contain three integer counts"
+            )
+        return values
+
+    if (gate_experts is None) != (up_experts is None):
+        raise ValueError(
+            "mixed Trellis projection-tight storage requires paired "
+            "gate_experts/up_experts"
+        )
+    counts = (
+        int(launch.tier0_num_experts),
+        int(launch.tier1_num_experts),
+        int(launch.tier2_num_experts),
+    )
+    gate_counts = projection_counts("gate_experts", gate_experts, counts)
+    up_counts = projection_counts("up_experts", up_experts, counts)
+    m = int(x.shape[0])
+    if m <= 0:
+        raise ValueError(f"mixed Trellis requires at least one active row, got {m}")
+    if m > launch.size_m:
+        raise ValueError(f"active rows {m} exceed launch capacity {launch.size_m}")
+    expected_input_dtype = (
+        torch.bfloat16 if launch.rotation_input_dtype == "bf16" else torch.float16
+    )
+    for name, tensor, expected_dtype in (
+        ("input", x, expected_input_dtype),
+        ("topk_ids", topk_ids, launch.route_ids_dtype),
+        ("topk_weights", topk_weights, torch.float32),
+    ):
+        if tensor.dtype != expected_dtype:
+            raise TypeError(
+                f"mixed Trellis {name} must be {expected_dtype}, got {tensor.dtype}"
+            )
+        if not tensor.is_contiguous():
+            raise ValueError(f"mixed Trellis {name} must be contiguous")
+    if int(x.data_ptr()) % 16 != 0:
+        raise ValueError("mixed Trellis input must have at least 16-byte alignment")
+
+    tiers = (tier0, tier1, tier2)
+    bits = (launch.tier0_bits, launch.tier1_bits, launch.tier2_bits)
+    for tier_id, (tier, expected_experts, tier_bits) in enumerate(
+        zip(tiers, counts, bits, strict=True)
+    ):
+        actual_experts = int(tier.num_experts)
+        if actual_experts != expected_experts:
+            raise ValueError(
+                f"mixed Trellis tier{tier_id} has {actual_experts} experts, "
+                f"expected the launch-plan count {expected_experts}"
+            )
+        tier_codebook = str(tier.trellis_codebook).lower()
+        if tier_codebook != launch.trellis_codebook:
+            raise ValueError(
+                f"mixed Trellis tier{tier_id} uses codebook {tier_codebook!r}, "
+                f"expected the launch-plan codebook {launch.trellis_codebook!r}"
+            )
+        _validate_mixed_trellis_tier_storage(
+            name=f"tier{tier_id}",
+            tier=tier,
+            expected_experts=expected_experts,
+            bits=tier_bits,
+            hidden_size=launch.hidden_size,
+            intermediate_size=launch.intermediate_size,
+            device=x.device,
+            gate_experts=gate_counts[tier_id],
+            up_experts=up_counts[tier_id],
+        )
+
+    total_experts = sum(counts)
+    route_num_experts = _mixed_route_num_experts(
+        global_to_combined, int(launch.topk_sum.route_num_experts)
+    )
+    for name, mapping, expected_entries in (
+        ("global_to_combined", global_to_combined, route_num_experts),
+        ("descriptor_map", descriptor_map, 3 * total_experts),
+    ):
+        if (
+            mapping.dtype != torch.int32
+            or mapping.device != x.device
+            or not mapping.is_contiguous()
+            or int(mapping.numel()) != expected_entries
+        ):
+            raise ValueError(
+                f"mixed Trellis {name} must be contiguous int32 on {x.device} "
+                f"with {expected_entries} elements"
+            )
+    _check_descriptor_projection_counts(
+        descriptor_map,
+        total_experts,
+        gate_counts=gate_counts,
+        up_counts=up_counts,
+    )
+    for name, table, expected_elements in (
+        (
+            "intermediate rotations",
+            rotations.intermediate,
+            total_experts * 3 * launch.intermediate_size,
+        ),
+        (
+            "gate SUH",
+            rotations.gate_suh,
+            (1 if launch.broadcast_suh else total_experts) * launch.hidden_size,
+        ),
+        (
+            "up SUH",
+            rotations.up_suh,
+            (1 if launch.broadcast_suh else total_experts) * launch.hidden_size,
+        ),
+        (
+            "down SVH",
+            rotations.down_svh,
+            (1 if launch.broadcast_svh else total_experts) * launch.hidden_size,
+        ),
+    ):
+        if (
+            table.dtype != torch.float16
+            or table.device != x.device
+            or not table.is_contiguous()
+            or int(table.numel()) != expected_elements
+            or int(table.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                f"mixed Trellis {name} must be contiguous fp16 on {x.device} "
+                f"with {expected_elements} elements and at least 16-byte alignment"
+            )
+
+    required_route_slots = max_packed_route_slots(
+        m * launch.top_k, launch.moe_block_size, route_num_experts
+    )
+    required_route_blocks = (
+        required_route_slots + launch.moe_block_size - 1
+    ) // launch.moe_block_size
+    if required_route_blocks > launch.max_m_blocks:
+        raise RuntimeError(
+            "mixed Trellis request requires "
+            f"{required_route_blocks} route blocks, but the launch supports "
+            f"{launch.max_m_blocks}"
+        )
+    if buffers.packed_route_indices.numel() < required_route_slots:
+        raise RuntimeError(
+            "mixed Trellis packed-route buffer is below request capacity"
+        )
+    if buffers.block_expert_ids.numel() < required_route_blocks:
+        raise RuntimeError(
+            "mixed Trellis block-expert buffer is below request capacity"
+        )
+    packed, block_experts, packed_count = pack_topk_routes_by_expert(
+        topk_ids,
+        launch.moe_block_size,
+        route_num_experts,
+        expert_map=global_to_combined,
+        packed_route_indices=buffers.packed_route_indices,
+        block_expert_ids=buffers.block_expert_ids,
+        packed_route_count=buffers.packed_route_count,
+        expert_offsets=buffers.expert_offsets,
+        expert_counts=buffers.expert_counts,
+    )
+    stream = current_cuda_stream()
+    trellis_rank_lut = sqg_xor_cheb_t12_lut(x.device)
+
+    def tier_pointers(tier):
+        return (
+            make_ptr(
+                cutlass.Int32,
+                tier.w13.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Int32,
+                tier.w2.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Int32,
+                tier.w13_scale.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Int32,
+                tier.w2_scale.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float32,
+                tier.w13_global_scale.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+            make_ptr(
+                cutlass.Float32,
+                tier.w2_global_scale.data_ptr(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            ),
+        )
+
+    launch.compiled(
+        make_ptr(
+            _cutlass_element_dtype(launch.rotation_input_dtype),
+            x.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        buffers.rotation_gate.view(-1),
+        buffers.rotation_up.view(-1),
+        *tier_pointers(tier0),
+        *tier_pointers(tier1),
+        *tier_pointers(tier2),
+        buffers.fc1.view(-1),
+        buffers.activated.view(-1),
+        buffers.fc2.view(-1),
+        packed,
+        block_experts,
+        packed_count,
+        make_ptr(
+            cutlass.Int32,
+            descriptor_map.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        make_ptr(
+            cutlass.Float32,
+            topk_weights.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        ),
+        buffers.fc1_scratch,
+        buffers.fc2_scratch,
+        buffers.workspace,
+        make_ptr(
+            cutlass.Float16,
+            rotations.intermediate.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            rotations.gate_suh.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Float16,
+            rotations.up_suh.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass.Uint8,
+            trellis_rank_lut.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        Int32(counts[0]),
+        Int32(counts[1]),
+        Int32(counts[2]),
+        Int32(int(tier0.w2_global_scale.numel())),
+        Int32(int(tier1.w2_global_scale.numel())),
+        Int32(int(tier2.w2_global_scale.numel())),
+        m,
+        max(int(launch.blocks_per_sm) * int(launch.sms), 1),
+        stream,
+        tier0_gate_experts=Int32(gate_counts[0]),
+        tier1_gate_experts=Int32(gate_counts[1]),
+        tier2_gate_experts=Int32(gate_counts[2]),
+        tier0_up_experts=Int32(up_counts[0]),
+        tier1_up_experts=Int32(up_counts[1]),
+        tier2_up_experts=Int32(up_counts[2]),
     )
     launch.topk_sum.compiled(
         make_ptr(
@@ -1514,11 +3391,18 @@ def run_mixed_trellis(
 __all__ = [
     "MixedTrellisBuffers",
     "MixedTrellisCompileResult",
+    "MixedTrellis3CompileResult",
     "MixedTrellisRotations",
+    "W4A16MixedTrellis3Kernel",
     "build_ordered_maps",
+    "build_projection_tiered_maps",
     "build_tiered_maps",
     "combine_trellis_rotations",
     "compile_mixed_trellis",
+    "compile_mixed_trellis3",
     "make_mixed_trellis_buffers",
+    "make_mixed_trellis3_buffers",
     "run_mixed_trellis",
+    "warmup_mixed_trellis_route_pack",
+    "run_mixed_trellis3",
 ]

--- a/b12x/moe/fused_moe/_impl.py
+++ b/b12x/moe/fused_moe/_impl.py
@@ -92,8 +92,7 @@ from b12x._lib.scratch import (
 
 logger = logging.getLogger(__name__)
 _B12X_TIMING = (
-    os.getenv("B12X_TIMING", "0") == "1"
-    or os.getenv("VLLM_B12X_TIMING", "0") == "1"
+    os.getenv("B12X_TIMING", "0") == "1" or os.getenv("VLLM_B12X_TIMING", "0") == "1"
 )
 _B12X_TIMING_THRESHOLD_MS = float(
     os.getenv(
@@ -2604,9 +2603,7 @@ def _plan_core_workspace(
             if qsrt_storage_format == "qsrt_atoms_v1" and (
                 int(trellis_bits) != 3 or int(n) != 256
             ):
-                raise ValueError(
-                    "QSRT atoms-v1 requires n=256 and trellis_bits=3"
-                )
+                raise ValueError("QSRT atoms-v1 requires n=256 and trellis_bits=3")
             if qsrt_storage_format == "qsrt_atoms_v2":
                 if int(trellis_bits) == 3 and int(n) != 256:
                     raise ValueError(
@@ -5143,9 +5140,7 @@ def prepare_b12x_fp4_moe_weights(
             # the unit activation-scale placeholders colocated with the
             # prepared weights so later binding and validation never inherit
             # the source extent's device.
-            input_scale = torch.ones(
-                (), dtype=torch.float32, device=value.w13.device
-            )
+            input_scale = torch.ones((), dtype=torch.float32, device=value.w13.device)
             return B12XFP4ExpertWeights(
                 plan=plan,
                 a1_gscale=a1_gscale if a1_gscale is not None else input_scale,
@@ -5241,9 +5236,7 @@ def prepare_b12x_fp4_moe_weights(
             layout=PreparedWeightLayout.TRELLIS_NATIVE,
             value=value,
         )
-        input_scale = torch.ones(
-            (), dtype=torch.float32, device=value.w13.device
-        )
+        input_scale = torch.ones((), dtype=torch.float32, device=value.w13.device)
         return B12XFP4ExpertWeights(
             plan=plan,
             a1_gscale=a1_gscale if a1_gscale is not None else input_scale,
@@ -6744,7 +6737,10 @@ def _plan_full_rotation_w4a16_launches(
     if torch.cuda.is_current_stream_capturing():
         raise RuntimeError("Trellis launch planning cannot run during capture")
 
-    from b12x.moe._shared.kernels.w4a16.host import route_pack_capacity
+    from b12x.moe._shared.kernels.w4a16.host import (
+        route_pack_capacity,
+        route_pack_warmup_token_counts,
+    )
     from b12x.moe._shared.kernels.w4a16.kernel import (
         _DEFAULT_MAX_SHARED_MEM,
         compile_w4a16_fused_moe,
@@ -6856,68 +6852,80 @@ def _plan_full_rotation_w4a16_launches(
             for ids_dtype in (torch.int32, torch.int64)
             for mapped in (False, True)
         )
-        for mapped in (False, True):
-            route_pack_key = (
-                core_plan.device.type,
-                int(torch.cuda.current_device()),
-                capacity_tokens * core_plan.num_topk,
-                int(block_size_m),
-                int(core_plan.route_E),
-                mapped,
-            )
-            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
-                continue
+        packed_route_indices = torch.empty(
+            capacity_route_slots,
+            dtype=torch.int32,
+            device=core_plan.device,
+        )
+        block_expert_ids = torch.empty(
+            capacity_m_blocks,
+            dtype=torch.int32,
+            device=core_plan.device,
+        )
+        packed_route_count = torch.empty(
+            1,
+            dtype=torch.int32,
+            device=core_plan.device,
+        )
+        expert_offsets = torch.empty(
+            core_plan.route_E + 1,
+            dtype=torch.int32,
+            device=core_plan.device,
+        )
+        expert_counts = torch.empty(
+            core_plan.route_E,
+            dtype=torch.int32,
+            device=core_plan.device,
+        )
+        pending_route_pack_keys: list[tuple[object, ...]] = []
+        for route_ids_dtype in (torch.int32, torch.int64):
             dummy_topk_ids = torch.zeros(
                 capacity_tokens,
                 core_plan.num_topk,
-                dtype=torch.int32,
+                dtype=route_ids_dtype,
                 device=core_plan.device,
             )
-            packed_route_indices = torch.empty(
-                capacity_route_slots,
-                dtype=torch.int32,
-                device=core_plan.device,
+            for mapped in (False, True):
+                expert_map = None
+                if mapped:
+                    expert_map = torch.arange(
+                        core_plan.route_E,
+                        dtype=torch.int32,
+                        device=core_plan.device,
+                    )
+                for token_count in route_pack_warmup_token_counts(capacity_tokens):
+                    route_pack_key = (
+                        core_plan.device.type,
+                        int(torch.cuda.current_device()),
+                        str(route_ids_dtype),
+                        token_count * core_plan.num_topk,
+                        int(block_size_m),
+                        int(core_plan.route_E),
+                        mapped,
+                    )
+                    if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
+                        continue
+                    pack_topk_routes_by_expert(
+                        dummy_topk_ids[:token_count],
+                        block_size_m,
+                        core_plan.route_E,
+                        expert_map=expert_map,
+                        packed_route_indices=packed_route_indices,
+                        block_expert_ids=block_expert_ids,
+                        packed_route_count=packed_route_count,
+                        expert_offsets=expert_offsets,
+                        expert_counts=expert_counts,
+                    )
+                    pending_route_pack_keys.append(route_pack_key)
+        torch.cuda.current_stream(core_plan.device).synchronize()
+        _W4A16_ROUTE_PACK_PREWARMED.update(pending_route_pack_keys)
+        if pending_route_pack_keys:
+            logger.info(
+                "Prewarmed %d full-rotation W4A16 route-pack variant(s) "
+                "for token capacity %d.",
+                len(pending_route_pack_keys),
+                capacity_tokens,
             )
-            block_expert_ids = torch.empty(
-                capacity_m_blocks,
-                dtype=torch.int32,
-                device=core_plan.device,
-            )
-            packed_route_count = torch.empty(
-                1,
-                dtype=torch.int32,
-                device=core_plan.device,
-            )
-            expert_offsets = torch.empty(
-                core_plan.route_E + 1,
-                dtype=torch.int32,
-                device=core_plan.device,
-            )
-            expert_counts = torch.empty(
-                core_plan.route_E,
-                dtype=torch.int32,
-                device=core_plan.device,
-            )
-            expert_map = None
-            if mapped:
-                expert_map = torch.arange(
-                    core_plan.route_E,
-                    dtype=torch.int32,
-                    device=core_plan.device,
-                )
-            pack_topk_routes_by_expert(
-                dummy_topk_ids,
-                block_size_m,
-                core_plan.route_E,
-                expert_map=expert_map,
-                packed_route_indices=packed_route_indices,
-                block_expert_ids=block_expert_ids,
-                packed_route_count=packed_route_count,
-                expert_offsets=expert_offsets,
-                expert_counts=expert_counts,
-            )
-            torch.cuda.current_stream(core_plan.device).synchronize()
-            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
     return fused_launches, topk_sum_launches
 
 
@@ -7267,6 +7275,7 @@ def _prewarm_w4a16_planned_launches(
             route_pack_key = (
                 workspace.device.type,
                 int(torch.cuda.current_device()),
+                str(torch.int32),
                 int(token_count) * int(workspace.num_topk),
                 int(block_size_m),
                 int(workspace.route_E),
@@ -8767,21 +8776,15 @@ class _DynamicMoEW4A8Launch:
             # [E][K16(I)][N16(K)]. SFB tensors are compile-time dead
             # (identity UE8M0 word).
             _tr_bits = int(self._kernel.trellis_bits)
-            _tr_w13_u32 = (
-                2 * (self._k // 16) * ((self._w1_n // 2) // 16) * 8 * _tr_bits
-            )
+            _tr_w13_u32 = 2 * (self._k // 16) * ((self._w1_n // 2) // 16) * 8 * _tr_bits
             _tr_down_u32 = (self._n // 16) * (self._k // 16) * 8 * _tr_bits
             w13_rp = cute.make_tensor(
                 w13_rp_ptr,
-                layout=cute.make_layout(
-                    (num_experts * _tr_w13_u32,), stride=(1,)
-                ),
+                layout=cute.make_layout((num_experts * _tr_w13_u32,), stride=(1,)),
             )
             down_rp = cute.make_tensor(
                 down_rp_ptr,
-                layout=cute.make_layout(
-                    (num_experts * _tr_down_u32,), stride=(1,)
-                ),
+                layout=cute.make_layout((num_experts * _tr_down_u32,), stride=(1,)),
             )
             _tr_sentinel = cute.make_layout((1,), stride=(1,))
             w13_sfb_rp = cute.make_tensor(w13_sfb_rp_ptr, layout=_tr_sentinel)
@@ -8915,9 +8918,7 @@ class _DynamicMoEW4A8Launch:
                             row_counts.shape[0]
                             * (
                                 6
-                                if getattr(
-                                    self._kernel, "trellis_coupled", False
-                                )
+                                if getattr(self._kernel, "trellis_coupled", False)
                                 else 3
                             )
                             * self._n,
@@ -9334,9 +9335,7 @@ def _get_dynamic_kernel(
         current_cuda_stream(),
         *(
             (
-                make_ptr(
-                    cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
-                ),
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
                 make_ptr(
                     cutlass.Float16,
                     16,
@@ -9432,9 +9431,7 @@ def _launch_dynamic_flat(
     # A trellis-native w4a8 binding carries the fp16 boundary rotations in
     # the sfb slot (the QMMA repack stores int32 scale words there); the
     # trellis geometry is recovered from the operand extents.
-    w4a8_trellis = (
-        _is_w4a8_quant_mode(quant_mode) and w13_sfb_rp.dtype == torch.float16
-    )
+    w4a8_trellis = _is_w4a8_quant_mode(quant_mode) and w13_sfb_rp.dtype == torch.float16
     trellis_bits = 0
     trellis_coupled = False
     trellis_lut_tensor = None
@@ -9443,16 +9440,11 @@ def _launch_dynamic_flat(
             _trellis256_execution_lut,
         )
 
-        trellis_lut_tensor = _trellis256_execution_lut(
-            a.device, "sqg_xor_cheb_t12"
-        )
+        trellis_lut_tensor = _trellis256_execution_lut(a.device, "sqg_xor_cheb_t12")
         payload_u32 = w13_rp.numel() * w13_rp.element_size() // 4
         window_words = 2 * E * (k // 16) * (n // 16) * 8
         trellis_bits = payload_u32 // window_words
-        if (
-            trellis_bits not in (2, 3, 4)
-            or trellis_bits * window_words != payload_u32
-        ):
+        if trellis_bits not in (2, 3, 4) or trellis_bits * window_words != payload_u32:
             raise RuntimeError(
                 "w4a8 trellis payload extent does not match the launch "
                 f"shape (E={E}, k={k}, n={n}, payload_u32={payload_u32})"
@@ -10594,9 +10586,7 @@ def _launch_micro(
     # activation wrappers such as SiTU keep is_supported False to hold the
     # nvfp4-family compact path closed while serving the trellis arm.
     shape_supported = (
-        MoEMicroKernelBackend.is_supported
-        if w4a8_trellis
-        else micro_cls.is_supported
+        MoEMicroKernelBackend.is_supported if w4a8_trellis else micro_cls.is_supported
     )
     use_micro_direct = (
         quant_mode == "nvfp4" or _is_w4a8_quant_mode(quant_mode)
@@ -11023,8 +11013,7 @@ def b12x_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
 
         micro_w4a8_trellis = (
             quant_mode == "w4a8_mx"
-            and getattr(prepared_payload, "weight_layout", None)
-            == "trellis3_t256"
+            and getattr(prepared_payload, "weight_layout", None) == "trellis3_t256"
         )
         if micro_w4a8_trellis:
             wv = _w4a8_trellis_weight_views(
@@ -11214,8 +11203,7 @@ def b12x_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
                 activation in ("relu2", "silu")
                 and m == 1
                 and a1_gscale.numel() == 1
-                and os.environ.get("B12X_MICRO_SHARE_INPUT_ACROSS_EXPERTS", "1")
-                != "0"
+                and os.environ.get("B12X_MICRO_SHARE_INPUT_ACROSS_EXPERTS", "1") != "0"
             ),
             share_expert_scales=(
                 activation in ("relu2", "silu")
@@ -11574,9 +11562,7 @@ def _select_experts_reference(
     )
 
 
-def b12x_route_experts_fast(
-    *, binding: TPMoERouteBinding
-) -> B12XTopKRouting:
+def b12x_route_experts_fast(*, binding: TPMoERouteBinding) -> B12XTopKRouting:
     """Public sparse-routing entrypoint for higher-level integrations.
 
     This is the optimization seam for future fast routing work. The current

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -11,22 +11,14 @@ from b12x.gemm import trellis_linear
 from b12x.gemm.trellis_linear import api
 from b12x.gemm.trellis_linear import _small_m
 from b12x.gemm.trellis_linear._small_m import _default_num_sms
-from b12x._lib.quant.mxfp8_rows import quantize_mxfp8_rows_cute
 from b12x._lib.quant.sqg_e4m3 import (
     sqg_cheb_normal_e4m3_direct_lut_cpu,
     sqg_xor_cheb_t12_direct_lut_cpu,
 )
-from b12x.gemm._shared.wo_mxfp8 import empty_mxfp8_rows_for_dense_gemm
-from b12x.moe._shared.kernels.activations import (
-    SITU_DEFAULT_BETA,
-    SITU_DEFAULT_LINEAR_BETA,
-)
 from b12x.moe._shared.kernels.w4a16.kernel import (
     _run_trellis_dense_hadamard128,
     _trellis256_dense_launch_geometry,
-)
-from b12x.moe._shared.kernels.w4a16.prepare import (
-    prepare_qsrt_pair_moe_weights,
+    _use_k6_mcg_small,
 )
 
 
@@ -94,10 +86,6 @@ def _decode_mul1_e4m3_fp16(window: np.ndarray) -> np.ndarray:
     )
 
 
-
-
-
-
 @lru_cache(maxsize=None)
 def _sqg_cheb_normal_e4m3_table(bits: int) -> np.ndarray:
     if bits not in (2, 3, 4):
@@ -109,9 +97,7 @@ def _sqg_cheb_normal_e4m3_table(bits: int) -> np.ndarray:
     return labels.view(torch.float8_e4m3fn).to(torch.float16).numpy()
 
 
-def _decode_sqg_cheb_normal_e4m3_fp16(
-    window: np.ndarray, bits: int
-) -> np.ndarray:
+def _decode_sqg_cheb_normal_e4m3_fp16(window: np.ndarray, bits: int) -> np.ndarray:
     indices = np.asarray(window, dtype=np.uint32) & np.uint32(0xFFFF)
     return _sqg_cheb_normal_e4m3_table(bits)[indices]
 
@@ -127,9 +113,7 @@ def _sqg_xor_cheb_t12_table(bits: int) -> np.ndarray:
     return labels.view(torch.float8_e4m3fn).to(torch.float16).numpy()
 
 
-def _decode_sqg_xor_cheb_t12_fp16(
-    window: np.ndarray, bits: int
-) -> np.ndarray:
+def _decode_sqg_xor_cheb_t12_fp16(window: np.ndarray, bits: int) -> np.ndarray:
     indices = np.asarray(window, dtype=np.uint32) & np.uint32(0xFFFF)
     return _sqg_xor_cheb_t12_table(bits)[indices]
 
@@ -152,9 +136,7 @@ def _decode_lane(
         first = tile_words[..., first_word % width].astype(np.uint64)
         last = tile_words[..., last_word % width].astype(np.uint64)
         merged = (first << np.uint64(32)) | last
-        window = ((merged >> np.uint64(shift)) & np.uint64(0xFFFF)).astype(
-            np.uint32
-        )
+        window = ((merged >> np.uint64(shift)) & np.uint64(0xFFFF)).astype(np.uint32)
         if codebook == "mcg":
             values.append(_decode_3inst_fp16(window))
         elif codebook == "mul1-e4m3":
@@ -183,9 +165,7 @@ def _reconstruct_native(
         for n_tile in range(n_tiles):
             lanes = np.stack(
                 [
-                    _decode_lane(
-                        words[k_tile, n_tile], lane, bits, codebook=codebook
-                    )
+                    _decode_lane(words[k_tile, n_tile], lane, bits, codebook=codebook)
                     for lane in range(32)
                 ]
             )
@@ -217,15 +197,7 @@ def _reference_mxfp8_rows(source: torch.Tensor) -> torch.Tensor:
     exponent = torch.ceil(torch.log2(safe)).clamp(-127, 127)
     scale = torch.pow(torch.tensor(2.0, device=source.device), exponent)
     scale = torch.where(max_abs > 0, scale, torch.ones_like(scale))
-    return (
-        (blocks / scale)
-        .to(torch.float8_e4m3fn)
-        .float()
-        .mul(scale)
-        .reshape(m, k)
-    )
-
-
+    return (blocks / scale).to(torch.float8_e4m3fn).float().mul(scale).reshape(m, k)
 
 
 def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
@@ -350,6 +322,8 @@ def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
     assert seen["kwargs"]["rotated_compute"] is rotated_compute
     assert seen["kwargs"]["gemm_output_f16"] is gemm_output_f16
     assert seen["kwargs"]["output_f16"] is output_f16
+    assert seen["kwargs"]["_moe_block_size"] is None
+    assert seen["kwargs"]["_force_tile_config"] is None
 
 
 def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
@@ -401,6 +375,42 @@ def test_k6_small_m_rejects_unsupported_arch_before_jit(monkeypatch) -> None:
 
     with pytest.raises(NotImplementedError, match="built for sm_120 only"):
         _small_m.run_k6_mcg(*(torch.empty(0) for _ in range(7)))
+
+
+@pytest.mark.parametrize(
+    ("capability", "explicit_launch_config", "expected"),
+    [
+        ((12, 0), False, True),
+        ((12, 0), True, False),
+        ((12, 1), False, False),
+        ((9, 0), False, False),
+    ],
+)
+def test_k6_small_m_dispatch_requires_compiled_target(
+    monkeypatch,
+    capability: tuple[int, int],
+    explicit_launch_config: bool,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda _device: capability,
+    )
+
+    assert (
+        _use_k6_mcg_small(
+            device=torch.device("cuda"),
+            m=128,
+            trellis_bits=6,
+            trellis_codebook="mcg",
+            trellis_pair_kind=None,
+            compute_dtype=torch.float16,
+            external_hadamard_128=None,
+            explicit_launch_config=explicit_launch_config,
+        )
+        is expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -645,9 +655,9 @@ def test_dense_sqg_xor_cheb_t12_matches_reference(bits: int) -> None:
         params_dtype=torch.float16,
     )
     assert weight.trellis_codebook == "sqg_xor_cheb_t12"
-    reference_weight = _reconstruct_native(
-        trellis, codebook="sqg_xor_cheb_t12"
-    ).to(device)
+    reference_weight = _reconstruct_native(trellis, codebook="sqg_xor_cheb_t12").to(
+        device
+    )
     x = (torch.randn((m, features), device=device) * 1.0e-3).to(torch.float16)
 
     def identity_hadamard(
@@ -750,11 +760,7 @@ def test_dense_pair_matches_independent_reference_and_captures(
     suh = torch.ones(reference_weight.shape[0], dtype=torch.float16, device=device)
     svh = torch.ones(reference_weight.shape[1], dtype=torch.float16, device=device)
     codebook_kwargs = (
-        {
-            "mcg": torch.tensor(
-                0xCBAC1FED, dtype=torch.uint32, device=device
-            )
-        }
+        {"mcg": torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device)}
         if codebook == "mcg"
         else {"codebook": codebook}
     )
@@ -829,12 +835,6 @@ def test_dense_pair_matches_independent_reference_and_captures(
     graph.replay()
     torch.cuda.synchronize(device)
     assert torch.equal(captured, actual)
-
-
-
-
-
-
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/moe/test_mixed_trellis_source_contract.py
+++ b/tests/moe/test_mixed_trellis_source_contract.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _method(path: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef) and member.name == method_name:
+                    return member
+    raise AssertionError(f"missing {class_name}.{method_name} in {path}")
+
+
+def _function(path: Path, function_name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise AssertionError(f"missing {function_name} in {path}")
+
+
+def test_mixed_trellis_compilers_select_dynamic_expert_layout() -> None:
+    path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
+    for function_name in ("compile_mixed_trellis", "compile_mixed_trellis3"):
+        function = _function(path, function_name)
+        constructors = [
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "W4A16FusedMoeKernel"
+        ]
+        assert len(constructors) == 1
+        keywords = {keyword.arg: keyword.value for keyword in constructors[0].keywords}
+        assert "dynamic_num_experts" not in keywords
+        assert ast.unparse(keywords["weight_layout"]) == repr("trellis3_t256")
+
+    # The outer fused-MoE constructor derives this behavior from the serving
+    # layout. Its public signature deliberately does not expose a second knob.
+    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    constructor = _method(kernel_path, "W4A16FusedMoeKernel", "__init__")
+    parameters = {argument.arg for argument in constructor.args.args}
+    parameters.update(argument.arg for argument in constructor.args.kwonlyargs)
+    assert "dynamic_num_experts" not in parameters
+    source = ast.unparse(constructor)
+    assert (
+        "self.dynamic_num_experts = weight_layout in {'packed', 'trellis3_t256'}"
+        in source
+    )
+
+
+def test_mixed_trellis_call_tracks_shared_moe_body_abi() -> None:
+    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
+    body = _method(kernel_path, "W4A16FusedMoeKernel", "_moe_body")
+    mixed = _method(mixed_path, "W4A16MixedTrellisKernel", "kernel")
+
+    calls = [
+        node
+        for node in ast.walk(mixed)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_moe_body"
+    ]
+    assert len(calls) == 1
+    call = calls[0]
+    assert not call.keywords
+
+    parameters = [argument.arg for argument in body.args.args][1:]
+    arguments = [ast.unparse(argument) for argument in call.args]
+    assert len(arguments) == len(parameters)
+    bound = dict(zip(parameters, arguments, strict=True))
+
+    assert bound["fc1_trellis_lut_addr"] == "cutlass.Int64(0)"
+    assert bound["fc2_trellis_lut_addr"] == "cutlass.Int64(0)"
+    assert bound["weight_num_experts"] == "total_experts"
+    assert bound["route_num_experts"] == "total_experts"
+    assert bound["active_m"] == "active_m"
+    assert bound["fc1_emit_tile"] == "fc1_emit"
+    assert bound["fc2_emit_tile"] == "fc2_emit"
+
+
+def test_mixed_trellis_dispatch_tracks_tile_abis() -> None:
+    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
+    dispatch = _method(mixed_path, "W4A16MixedTrellisKernel", "_dispatch_tier_gemm")
+
+    for method_name in ("_run_tile", "_run_tile_m8_pair"):
+        target = _method(kernel_path, "W4A16GemmKernel", method_name)
+        calls = [
+            node
+            for node in ast.walk(dispatch)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == method_name
+        ]
+        assert len(calls) == 1
+        parameters = [argument.arg for argument in target.args.args][1:]
+        arguments = [ast.unparse(argument) for argument in calls[0].args]
+        assert len(arguments) == len(parameters)
+        bound = dict(zip(parameters, arguments, strict=True))
+        assert bound["trellis_lut_addr"] == "trellis_lut_addr"
+        assert bound["active_size_m"] == "active_size_m"
+
+
+def test_w4a16_internal_calls_supply_required_arguments() -> None:
+    path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    kernel = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "W4A16GemmKernel"
+    )
+    methods = {
+        node.name: node for node in kernel.body if isinstance(node, ast.FunctionDef)
+    }
+
+    mismatches: list[str] = []
+    for caller in methods.values():
+        for call in ast.walk(caller):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and isinstance(call.func.value, ast.Name)
+                and call.func.value.id == "self"
+                and call.func.attr in methods
+            ):
+                continue
+            callee = methods[call.func.attr]
+            maximum = len(callee.args.args) - 1
+            required = maximum - len(callee.args.defaults)
+            supplied = len(call.args) + len(call.keywords)
+            if not required <= supplied <= maximum:
+                mismatches.append(
+                    f"{caller.name}:{call.lineno} -> {callee.name}: "
+                    f"supplied={supplied}, required={required}, maximum={maximum}"
+                )
+
+    assert not mismatches, "\n".join(mismatches)
+
+
+def test_static_trellis_pair_preserves_fixed_and_compact_decode_modes() -> None:
+    path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
+    method = _method(path, "W4A16GemmKernel", "_run_tile")
+    calls = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_run_tile_with_pair_override"
+    ]
+
+    assert {ast.unparse(call.args[-1]) for call in calls} == {
+        "-1",
+        "0",
+        "2 if cutlass.const_expr(self.trellis_pair_compact_offsets) else 1",
+    }

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -21,14 +22,22 @@ from b12x.moe._shared.kernels.w4a16.kernel import (
 )
 from b12x.moe._shared.kernels.w4a16.mixed_trellis import (
     MixedTrellisRotations,
+    W4A16MixedTrellis3Kernel,
     W4A16MixedTrellisKernel,
+    _check_descriptor_projection_counts,
+    _mixed_route_num_experts,
     _validate_mixed_trellis_tier_storage,
     build_ordered_maps,
+    build_projection_tiered_maps,
     build_tiered_maps,
     combine_trellis_rotations,
     compile_mixed_trellis,
+    compile_mixed_trellis3,
     make_mixed_trellis_buffers,
+    make_mixed_trellis3_buffers,
     run_mixed_trellis,
+    run_mixed_trellis3,
+    warmup_mixed_trellis_route_pack,
 )
 from b12x.moe._shared.kernels.w4a16.prepare import (
     prepare_trellis256_moe_weights,
@@ -73,12 +82,16 @@ def test_mixed_kernel_uses_runtime_expert_bounds() -> None:
 
     assert "tier0_num_experts" in call_parameters
     assert "tier1_num_experts" in call_parameters
+    assert "tier0_up_experts" in call_parameters
+    assert "tier1_up_experts" in call_parameters
     assert "self.tier0.num_experts" not in emit_source
     assert "self.tier1.num_experts" not in emit_source
     assert "self.total_experts" not in emit_source
     assert "self.total_experts" not in kernel_source
-    assert "local_expert < tier0_num_experts" in emit_source
-    assert "local_expert < tier1_num_experts" in emit_source
+    assert "local_expert < tier0_gate_experts" in emit_source
+    assert "local_expert < tier1_gate_experts" in emit_source
+    assert "local_expert < tier0_up_experts" in emit_source
+    assert "local_expert < tier1_up_experts" in emit_source
 
 
 def test_mixed_runtime_rejects_invalid_raw_tier_storage() -> None:
@@ -123,6 +136,51 @@ def test_mixed_runtime_rejects_invalid_raw_tier_storage() -> None:
             validate(candidate)
 
 
+def test_projection_tight_storage_requires_coupled_exact_counts() -> None:
+    device = torch.device("cpu")
+    experts, hidden, intermediate, bits = 4, 128, 128, 3
+    stride = (hidden // 16) * (intermediate // 16) * (8 * bits)
+
+    def tier(planes):
+        return SimpleNamespace(
+            num_experts=experts,
+            w13=torch.empty(planes * stride, dtype=torch.int32),
+            w2=torch.empty(experts * stride, dtype=torch.int32),
+            w13_scale=torch.empty(4, dtype=torch.uint8),
+            w2_scale=torch.empty(4, dtype=torch.uint8),
+            w13_global_scale=torch.empty(experts, dtype=torch.float32),
+            w2_global_scale=torch.empty(experts, dtype=torch.float32),
+        )
+
+    def validate(candidate, gate=None, up=None):
+        _validate_mixed_trellis_tier_storage(
+            name="tier0",
+            tier=candidate,
+            expected_experts=experts,
+            bits=bits,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            device=device,
+            gate_experts=gate,
+            up_experts=up,
+        )
+
+    # Physical [1 gate | 3 up] is the exact four-plane target contract.
+    validate(tier(4), gate=1, up=3)
+
+    with pytest.raises(ValueError, match="exactly 4 projection planes"):
+        validate(tier(5), gate=1, up=3)
+    with pytest.raises(ValueError, match="paired gate_experts/up_experts"):
+        validate(tier(4), gate=1)
+    with pytest.raises(ValueError, match="projection counts"):
+        validate(tier(5), gate=5, up=0)
+
+    # No explicit counts is the legacy padded contract: G=U=E, hence 2E.
+    with pytest.raises(ValueError, match="exactly 8 projection planes"):
+        validate(tier(4))
+    validate(tier(8))
+
+
 def _sm12x_available() -> bool:
     if not torch.cuda.is_available():
         return False
@@ -130,10 +188,21 @@ def _sm12x_available() -> bool:
     return major == 12 and minor in (0, 1)
 
 
-def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
+@pytest.mark.parametrize(
+    ("kernel_type", "entry_name"),
+    [
+        (W4A16MixedTrellisKernel, "kernel"),
+        (W4A16MixedTrellis3Kernel, "kernel3"),
+    ],
+)
+def test_mixed_kernel_tracks_shared_moe_body_contract(
+    kernel_type: type, entry_name: str
+) -> None:
     """Keep the direct CuTe call aligned with the shared driver's ABI."""
 
-    tree = ast.parse(textwrap.dedent(inspect.getsource(W4A16MixedTrellisKernel.kernel)))
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(getattr(kernel_type, entry_name)))
+    )
     calls = [
         node
         for node in ast.walk(tree)
@@ -145,8 +214,10 @@ def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
 
     driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
     assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
-    assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
+    assert [ast.unparse(arg) for arg in calls[0].args[-12:]] == [
         "descriptor_map",
+        "cutlass.Int64(0)",
+        "cutlass.Int64(0)",
         "total_experts",
         "total_experts",
         "smem_base",
@@ -194,6 +265,7 @@ def _prepared(
     device: torch.device,
     tile_config: tuple[int, int, int, int] = (128, 128, 128, 128),
     shared_h: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    codebook: str = "mcg",
 ):
     generator = torch.Generator(device=device).manual_seed(seed)
 
@@ -222,6 +294,7 @@ def _prepared(
         params_dtype=torch.float16,
         w13_layout="trellis3_t256_proj",
         trellis_bits=bits,
+        codebook=codebook,
         gate_suh=gate_suh,
         up_suh=up_suh,
         intermediate_rotations=intermediate_rotations,
@@ -463,6 +536,322 @@ def test_mixed_k3_k4_matches_serial_and_captures(
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_mixed_k3_k4_k5_mcg_matches_serial_and_captures() -> None:
+    """Close native R7 K5 dispatch and graph replay in the shared mixed grid."""
+
+    torch.manual_seed(20260809)
+    device = torch.device("cuda", torch.cuda.current_device())
+    m, hidden, intermediate, topk = 2, 128, 128, 3
+    codebook = "mcg"
+    tiers = tuple(
+        _prepared(
+            experts=2,
+            hidden=hidden,
+            intermediate=intermediate,
+            bits=bits,
+            seed=300 + bits,
+            device=device,
+            codebook=codebook,
+        )
+        for bits in (3, 4, 5)
+    )
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor([[0, 2, 4], [5, 3, 1]], dtype=torch.int32, device=device)
+    topk_weights = torch.tensor(
+        [[0.5, 0.3, 0.2], [0.25, 0.25, 0.5]],
+        dtype=torch.float32,
+        device=device,
+    )
+    tier_maps = (
+        torch.tensor([0, 1, -1, -1, -1, -1], dtype=torch.int32, device=device),
+        torch.tensor([-1, -1, 0, 1, -1, -1], dtype=torch.int32, device=device),
+        torch.tensor([-1, -1, -1, -1, 0, 1], dtype=torch.int32, device=device),
+    )
+    serial = sum(
+        (
+            _serial_tier(x, tier, topk_weights, topk_ids, expert_map)
+            for tier, expert_map in zip(tiers, tier_maps, strict=True)
+        ),
+        torch.zeros((m, hidden), dtype=torch.float32, device=device),
+    )
+    props = torch.cuda.get_device_properties(device)
+    launch = compile_mixed_trellis3(
+        size_m=m,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        tier0_num_experts=2,
+        tier1_num_experts=2,
+        tier2_num_experts=2,
+        top_k=topk,
+        max_m_blocks=8,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=(128, 128, 128, 128),
+        trellis_codebook=codebook,
+    )
+    assert launch.local_memory_bytes == 0
+    global_to_combined, descriptor = build_projection_tiered_maps(
+        [0, 0, 1, 1, 2, 2],
+        [0, 0, 1, 1, 2, 2],
+        [0, 0, 1, 1, 2, 2],
+        tier_slots=(2, 2, 2),
+        device=device,
+    )
+    rotations = combine_trellis_rotations(*tiers)
+    buffers = make_mixed_trellis3_buffers(
+        launch, device=device, sms=int(props.multi_processor_count)
+    )
+
+    mismatched_tier0 = replace(tiers[0], trellis_codebook="sqg_xor_cheb_t12")
+    with pytest.raises(ValueError, match="launch-plan codebook"):
+        run_mixed_trellis3(
+            x,
+            mismatched_tier0,
+            tiers[1],
+            tiers[2],
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            rotations,
+            launch,
+            buffers,
+        )
+
+    eager = run_mixed_trellis3(
+        x,
+        *tiers,
+        topk_weights,
+        topk_ids,
+        global_to_combined,
+        descriptor,
+        rotations,
+        launch,
+        buffers,
+    ).clone()
+    torch.cuda.synchronize(device)
+    assert not torch.isnan(eager).any()
+    relative = (eager - serial).norm() / serial.norm().clamp_min(1.0e-12)
+    assert float(relative) < 4.0e-3
+
+    repeated = run_mixed_trellis3(
+        x,
+        *tiers,
+        topk_weights,
+        topk_ids,
+        global_to_combined,
+        descriptor,
+        rotations,
+        launch,
+        buffers,
+    )
+    torch.cuda.synchronize(device)
+    assert torch.equal(repeated, eager)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run_mixed_trellis3(
+            x,
+            *tiers,
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            rotations,
+            launch,
+            buffers,
+        )
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, eager)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_mixed_k3_k4_k5_partition_reuses_one_compiled_object() -> None:
+    """Three-tier checkpoint counts are runtime data, not JIT geometry."""
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    props = torch.cuda.get_device_properties(device)
+
+    def compile_partition(counts: tuple[int, int, int]):
+        return compile_mixed_trellis3(
+            size_m=2,
+            hidden_size=128,
+            intermediate_size=128,
+            tier0_num_experts=counts[0],
+            tier1_num_experts=counts[1],
+            tier2_num_experts=counts[2],
+            top_k=3,
+            max_m_blocks=8,
+            sms=int(props.multi_processor_count),
+            max_shared_mem=int(props.shared_memory_per_block_optin),
+            force_tile_config=(128, 128, 128, 128),
+        )
+
+    counts_a = (2, 2, 2)
+    counts_b = (3, 2, 1)
+    launch_a = compile_partition(counts_a)
+    launch_b = compile_partition(counts_b)
+
+    assert launch_a.compiled is launch_b.compiled
+    assert (
+        launch_a.tier0_num_experts,
+        launch_a.tier1_num_experts,
+        launch_a.tier2_num_experts,
+    ) == counts_a
+    assert (
+        launch_b.tier0_num_experts,
+        launch_b.tier1_num_experts,
+        launch_b.tier2_num_experts,
+    ) == counts_b
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_projection_padded_launch_uses_exact_route_namespace() -> None:
+    """Projection padding must not enlarge routing or its JIT specialization."""
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    props = torch.cuda.get_device_properties(device)
+    launch = compile_mixed_trellis3(
+        size_m=2,
+        hidden_size=128,
+        intermediate_size=128,
+        tier0_num_experts=3,
+        tier1_num_experts=3,
+        tier2_num_experts=1,
+        route_num_experts=6,
+        top_k=3,
+        max_m_blocks=8,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=(128, 128, 128, 128),
+    )
+    buffers = make_mixed_trellis3_buffers(
+        launch, device=device, sms=int(props.multi_processor_count)
+    )
+    route_map = torch.arange(6, dtype=torch.int32, device=device)
+
+    assert launch.topk_sum.num_experts == 7
+    assert launch.topk_sum.route_num_experts == 6
+    assert warmup_mixed_trellis_route_pack(launch, buffers, expert_map=route_map) > 0
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_projection_padded_k345_runner_matches_serial_and_captures() -> None:
+    """Exercise the complete runner when descriptor slots exceed routes."""
+
+    torch.manual_seed(20260810)
+    device = torch.device("cuda", torch.cuda.current_device())
+    props = torch.cuda.get_device_properties(device)
+    m, hidden, intermediate, topk = 2, 128, 128, 3
+    tiers = tuple(
+        _prepared(
+            experts=experts,
+            hidden=hidden,
+            intermediate=intermediate,
+            bits=bits,
+            seed=500 + bits,
+            device=device,
+            codebook="mcg",
+        )
+        for bits, experts in ((3, 3), (4, 3), (5, 1))
+    )
+    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor([[0, 3, 5], [4, 2, 1]], dtype=torch.int32, device=device)
+    topk_weights = torch.tensor(
+        [[0.5, 0.3, 0.2], [0.25, 0.25, 0.5]],
+        dtype=torch.float32,
+        device=device,
+    )
+    tier_maps = (
+        torch.tensor([0, 1, 2, -1, -1, -1], dtype=torch.int32, device=device),
+        torch.tensor([-1, -1, -1, 0, 1, -1], dtype=torch.int32, device=device),
+        torch.tensor([-1, -1, -1, -1, -1, 0], dtype=torch.int32, device=device),
+    )
+    serial = sum(
+        (
+            _serial_tier(x, tier, topk_weights, topk_ids, expert_map)
+            for tier, expert_map in zip(tiers, tier_maps, strict=True)
+        ),
+        torch.zeros((m, hidden), dtype=torch.float32, device=device),
+    )
+    tier1_w13_stride = int(tiers[1].w13.numel()) // 6
+    tier1_w13 = tiers[1].w13.reshape(6, tier1_w13_stride)
+    runner_tiers = (
+        tiers[0],
+        replace(
+            tiers[1],
+            w13=torch.cat((tier1_w13[:2], tier1_w13[3:5])).contiguous(),
+        ),
+        tiers[2],
+    )
+    global_to_combined, descriptor = build_projection_tiered_maps(
+        [0, 0, 0, 1, 1, 2],
+        [0, 0, 0, 1, 1, 2],
+        [0, 0, 0, 1, 1, 2],
+        tier_slots=(3, 3, 1),
+        device=device,
+    )
+
+    def padded_rows(name: str) -> torch.Tensor:
+        rows = [getattr(tiers[0], name), getattr(tiers[1], name)[:2]]
+        rows.extend((getattr(tiers[2], name), getattr(tiers[1], name)[2:]))
+        return torch.cat(rows).contiguous()
+
+    rotations = MixedTrellisRotations(
+        intermediate=padded_rows("intermediate_rotations"),
+        gate_suh=padded_rows("gate_suh"),
+        up_suh=padded_rows("up_suh"),
+        down_svh=padded_rows("down_svh"),
+    )
+    launch = compile_mixed_trellis3(
+        size_m=m,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        tier0_num_experts=3,
+        tier1_num_experts=3,
+        tier2_num_experts=1,
+        route_num_experts=6,
+        top_k=topk,
+        max_m_blocks=8,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=(128, 128, 128, 128),
+        trellis_codebook="mcg",
+    )
+    buffers = make_mixed_trellis3_buffers(
+        launch, device=device, sms=int(props.multi_processor_count)
+    )
+
+    def run() -> torch.Tensor:
+        return run_mixed_trellis3(
+            x,
+            *runner_tiers,
+            topk_weights,
+            topk_ids,
+            global_to_combined,
+            descriptor,
+            rotations,
+            launch,
+            buffers,
+            gate_experts=(3, 2, 1),
+            up_experts=(3, 2, 1),
+        )
+
+    eager = run().clone()
+    torch.cuda.synchronize(device)
+    relative = (eager - serial).norm() / serial.norm().clamp_min(1.0e-12)
+    assert float(relative) < 4.0e-3
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, eager)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
 def test_mixed_k3_k4_shared_h_matches_expanded_and_captures() -> None:
     """A physical one-row H rotation must stay broadcast through mixed K3/K4."""
 
@@ -473,8 +862,7 @@ def test_mixed_k3_k4_shared_h_matches_expanded_and_captures() -> None:
 
     def shared_row() -> torch.Tensor:
         return (
-            0.875
-            + 0.25 * torch.rand((1, hidden), generator=generator, device=device)
+            0.875 + 0.25 * torch.rand((1, hidden), generator=generator, device=device)
         ).to(torch.float16)
 
     shared_h = (shared_row(), shared_row(), shared_row())
@@ -825,6 +1213,170 @@ def test_build_tiered_maps_rejects_invalid_partitions() -> None:
         build_tiered_maps((0, 1), (1, 2), device=torch.device("cpu"))
     with pytest.raises(ValueError, match="disjoint partition"):
         build_tiered_maps((0, 4), (1, 2), device=torch.device("cpu"))
+
+
+def test_build_tiered_maps_repeats_the_legacy_descriptor_row() -> None:
+    route, descriptor = build_tiered_maps((2, 0), (3, 1), device=torch.device("cpu"))
+    assert route.tolist() == [1, 3, 0, 2]
+    rows = descriptor.reshape(3, 4)
+    assert rows[0].tolist() == [0, 1, 1 << 8, (1 << 8) | 1]
+    assert torch.equal(rows[0], rows[1])
+    assert torch.equal(rows[0], rows[2])
+
+
+def test_build_projection_tiered_maps_pads_each_row_to_slot_stride() -> None:
+    gate = [0] * 129 + [1] * 127
+    up = [0] * 128 + [1] * 128
+    down = [0] * 77 + [1] * 179
+    route, descriptor = build_projection_tiered_maps(
+        gate,
+        up,
+        down,
+        tier_slots=(129, 128),
+        device=torch.device("cpu"),
+    )
+
+    assert route.dtype == torch.int32
+    assert route.tolist() == list(range(256))
+    assert _mixed_route_num_experts(route, 256) == 256
+    rows = descriptor.reshape(3, 257)
+    assert torch.equal(rows[:, -1], torch.full((3,), -1, dtype=torch.int32))
+    assert rows[0, 128].item() == 128
+    assert rows[0, 129].item() == 1 << 8
+    assert rows[1, 127].item() == 127
+    assert rows[1, 128].item() == 1 << 8
+    assert rows[2, 76].item() == 76
+    assert rows[2, 77].item() == 1 << 8
+
+
+def test_projection_route_namespace_must_fit_the_map() -> None:
+    route = torch.arange(4, dtype=torch.int32)
+    with pytest.raises(ValueError, match="compiled route namespace"):
+        _mixed_route_num_experts(route, 5)
+
+
+def test_descriptor_projection_count_check_fails_closed() -> None:
+    from b12x.moe._shared.kernels.w4a16.mixed_trellis import (
+        _check_descriptor_projection_counts,
+        build_tiered_maps,
+    )
+
+    gate = [0] * 129 + [1] * 127
+    up = [0] * 128 + [1] * 128
+    down = [0] * 77 + [1] * 179
+    _, descriptor = build_projection_tiered_maps(
+        gate,
+        up,
+        down,
+        tier_slots=(129, 128),
+        device=torch.device("cpu"),
+    )
+    total = 257
+    # The builder publishes the encoded counts; matching launch counts pass.
+    assert descriptor._mt_projection_counts == ((129, 127), (128, 128))
+    _check_descriptor_projection_counts(
+        descriptor, total, gate_counts=(129, 127), up_counts=(128, 128)
+    )
+    # A mismatched count is rejected instead of silently skipping experts.
+    with pytest.raises(ValueError, match="disagree with the descriptor"):
+        _check_descriptor_projection_counts(
+            descriptor, total, gate_counts=(1, 3), up_counts=(128, 128)
+        )
+    # Descriptors from other producers derive the counts from the map itself,
+    # then memoize them on the tensor.
+    stripped = descriptor.clone()
+    assert not hasattr(stripped, "_mt_projection_counts")
+    with pytest.raises(ValueError, match="disagree with the descriptor"):
+        _check_descriptor_projection_counts(
+            stripped, total, gate_counts=(129, 128), up_counts=(128, 128)
+        )
+    assert stripped._mt_projection_counts == ((129, 127), (128, 128))
+    _check_descriptor_projection_counts(
+        stripped, total, gate_counts=(129, 127), up_counts=(128, 128)
+    )
+    # The legacy per-expert builder publishes its tier partition for both
+    # projections, matching run_mixed_trellis's launch-count defaults.
+    _, legacy = build_tiered_maps([0, 2, 4], [1, 3], device=torch.device("cpu"))
+    assert legacy._mt_projection_counts == ((3, 2), (3, 2))
+    _check_descriptor_projection_counts(legacy, 5, gate_counts=(3, 2), up_counts=(3, 2))
+
+
+def test_build_projection_tiered_maps_supports_an_empty_tier() -> None:
+    tiers = [0] * 256
+    route, descriptor = build_projection_tiered_maps(
+        tiers,
+        tiers,
+        tiers,
+        tier_slots=(256, 0),
+        device=torch.device("cpu"),
+    )
+    assert route.tolist() == list(range(256))
+    rows = descriptor.reshape(3, 256)
+    assert rows[:, 255].tolist() == [255, 255, 255]
+
+
+def test_build_projection_tiered_maps_supports_three_tiers() -> None:
+    gate = [0, 1, 2, 0, 1, 2]
+    up = [2, 1, 0, 2, 1, 0]
+    down = [0, 0, 1, 1, 2, 2]
+
+    route, descriptor = build_projection_tiered_maps(
+        gate,
+        up,
+        down,
+        tier_slots=(2, 2, 2),
+        device=torch.device("cpu"),
+    )
+
+    assert route.tolist() == list(range(6))
+    assert descriptor.reshape(3, 6).tolist() == [
+        [0, 1 << 8, 2 << 8, 1, (1 << 8) | 1, (2 << 8) | 1],
+        [2 << 8, 1 << 8, 0, (2 << 8) | 1, (1 << 8) | 1, 1],
+        [0, 1, 1 << 8, (1 << 8) | 1, 2 << 8, (2 << 8) | 1],
+    ]
+    assert descriptor._mt_projection_counts == ((2, 2, 2), (2, 2, 2))
+    _check_descriptor_projection_counts(
+        descriptor,
+        6,
+        gate_counts=(2, 2, 2),
+        up_counts=(2, 2, 2),
+    )
+
+    with pytest.raises(ValueError, match="cannot address all gate/up locals"):
+        build_projection_tiered_maps(
+            [2],
+            [2],
+            [2],
+            tier_slots=(1, 1, 0),
+            device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.parametrize("slots", [(256,), (256, 0, 0, 0)])
+def test_build_projection_tiered_maps_rejects_wrong_slot_arity(slots) -> None:
+    with pytest.raises(ValueError, match="exactly two or three"):
+        build_projection_tiered_maps(
+            [0], [0], [0], tier_slots=slots, device=torch.device("cpu")
+        )
+
+
+@pytest.mark.parametrize("slots", [(-1, 2), (300, -44)])
+def test_build_projection_tiered_maps_rejects_invalid_slots(slots) -> None:
+    with pytest.raises(ValueError, match=r"\[0, 256\]"):
+        build_projection_tiered_maps(
+            [0], [0], [0], tier_slots=slots, device=torch.device("cpu")
+        )
+
+
+def test_build_projection_tiered_maps_rejects_per_tier_underallocation() -> None:
+    with pytest.raises(ValueError, match="cannot address all gate/up locals"):
+        build_projection_tiered_maps(
+            [0] * 129 + [1] * 127,
+            [0] * 128 + [1] * 128,
+            [0] * 256,
+            tier_slots=(128, 128),
+            device=torch.device("cpu"),
+        )
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/moe/test_w4a16_route_pack_warmup.py
+++ b/tests/moe/test_w4a16_route_pack_warmup.py
@@ -1,0 +1,54 @@
+import pytest
+
+from b12x.moe._shared.kernels.w4a16.host import (
+    route_pack_warmup_token_counts,
+)
+
+
+@pytest.mark.parametrize(
+    ("capacity", "expected"),
+    [
+        (1, (1,)),
+        (5, (1, 2, 3, 4, 5)),
+        (6, (1, 2, 3, 4, 5, 6)),
+        (32, (1, 2, 3, 4, 5, 8, 9, 16, 17, 32)),
+        (
+            3072,
+            (
+                1,
+                2,
+                3,
+                4,
+                5,
+                8,
+                9,
+                16,
+                17,
+                32,
+                33,
+                64,
+                65,
+                128,
+                129,
+                256,
+                257,
+                512,
+                513,
+                1024,
+                1025,
+                2048,
+                2049,
+                3072,
+            ),
+        ),
+    ],
+)
+def test_route_pack_warmup_covers_capacity_buckets(
+    capacity: int, expected: tuple[int, ...]
+) -> None:
+    assert route_pack_warmup_token_counts(capacity) == expected
+
+
+def test_route_pack_warmup_rejects_empty_capacity() -> None:
+    with pytest.raises(ValueError, match="capacity must be positive"):
+        route_pack_warmup_token_counts(0)


### PR DESCRIPTION
## Status

- Implementation: **implemented**
- Unit and kernel qualification: **qualified**
- GLM-5.2 checkpoint E2E qualification: **pending**

## Purpose

Serve EXL3 checkpoints that assign MCG K3, K4, and K5 independently to routed-expert gate, up, and down projections. The B12X runtime reads packed checkpoint storage directly and executes all projection tiers through one CUDA-graph-capturable mixed-Trellis launch plan.

## Resulting behavior

- Represent tier membership per expert and per projection with exact gate, up, and down bounds.
- Validate descriptor counts, packed extents, route identifiers, and projection counts before launch.
- Keep expert counts as runtime data so layer-dependent partitions reuse compiled kernels.
- Prewarm scheduler capacity, rank-sliced draft, route-identifier, and scalar-alignment specializations before graph capture.
- Preserve graph-stable scratch ownership for decode and prefill.
- Preserve QSRT atoms-v2 compact-offset pair modes and the qualified FC2 32x512 tile contract.

## Compatibility

The MCG codebook accepts K3, K4, and K5 for this mixed runtime. SQG-XOR-Cheb-T12 retains its K2/K3/K4 contract. Existing QSRT paths and the removed route-major W4A8 interface are unchanged. Malformed or incomplete projection maps fail closed.

The vLLM checkpoint loader is provided by a companion pull request against `dev/infernal-invocation`.

## Validation

Source base: `ac07f6746edce4852f01cc11f34dbe7abae1fdaa`.

- 58 host-runnable focused tests passed; 40 GPU-only cases skipped.
- 6 SM120 tests passed for K3/K4/K5 numerical parity, projection-tight payloads, CUDA graph replay, K6 small-M dispatch, one-grid prefill planning, and GLM-5.2 large-M execution.
- Ruff check and format: passed.
- `git diff --check`: passed.