### PR TITLE
fix(moe): preallocate W4A16 route histograms for CUDA graph capture

### DIFF
--- a/b12x/moe/fused_moe/_impl.py
+++ b/b12x/moe/fused_moe/_impl.py
@@ -2783,12 +2783,12 @@ def _plan_core_workspace(
             _TensorAllocSpec("block_expert_ids", (route_blocks_capacity,), torch.int32),
             _TensorAllocSpec("packed_route_count", (1,), torch.int32),
             _TensorAllocSpec("expert_offsets", (route_E + 1,), torch.int32),
+            _TensorAllocSpec("expert_counts", (route_E,), torch.int32),
         ]
         if full_rotation:
             max_tokens = max(routed_capacity // max(int(num_topk), 1), 1)
             tensor_specs.extend(
                 (
-                    _TensorAllocSpec("expert_counts", (route_E,), torch.int32),
                     _TensorAllocSpec(
                         "full_rotation_output",
                         (max_tokens, int(k)),
@@ -9303,7 +9303,9 @@ def _get_dynamic_kernel(
         *(
             (
                 make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
-                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
+                make_ptr(
+                    cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
+                ),
                 make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
                 make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
                 make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
@@ -9334,9 +9336,7 @@ def _get_dynamic_kernel(
         current_cuda_stream(),
         *(
             (
-                make_ptr(
-                    cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16
-                ),
+                make_ptr(cutlass.Uint8, 16, cute.AddressSpace.gmem, assumed_align=16),
                 make_ptr(
                     cutlass.Float16,
                     16,
@@ -10948,11 +10948,7 @@ def b12x_moe_fp4(*, binding: TPMoEFP4Binding) -> torch.Tensor:
             block_expert_ids=block_expert_ids,
             packed_route_count=packed_route_count,
             expert_offsets=expert_offsets,
-            expert_counts=(
-                _require_binding_field(binding, "expert_counts")
-                if full_rotation
-                else None
-            ),
+            expert_counts=_require_binding_field(binding, "expert_counts"),
             expert_map=binding.route_expert_map,
             output_expert_map=binding.output_expert_map,
             activation_amax=activation_amax,

--- a/tests/moe/test_tp_moe_scratch_bindings.py
+++ b/tests/moe/test_tp_moe_scratch_bindings.py
@@ -893,6 +893,8 @@ def test_w4a16_scratch_binding_carries_activation_amax_to_kernel(
         activation_amax=activation_amax,
         layer_idx=2,
     )
+    assert binding.expert_counts is not None
+    assert tuple(binding.expert_counts.shape) == (8,)
     calls = {}
 
     import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
@@ -908,6 +910,7 @@ def test_w4a16_scratch_binding_carries_activation_amax_to_kernel(
     assert result is output
     assert calls["activation_amax"] is activation_amax
     assert calls["layer_idx"] == 2
+    assert calls["expert_counts"] is binding.expert_counts
 
 
 def test_activation_amax_is_w4a16_only() -> None:


### PR DESCRIPTION
## Resulting behavior

W4A16 MoE scratch plans reserve a caller-owned contiguous `int32[route_E]` route histogram. Standard W4A16 and full-rotation Trellis bindings pass that buffer to the existing route-packing implementation, preserving stable allocation and pointer identity across CUDA graph capture and replay.

## Technical reason

Both the single-launch decode route packer and the parallel prefill route packer count routed rows per expert. Without planned histogram storage, standard W4A16 execution asks the route packer to allocate `expert_counts` at runtime. CUDA graph capture rejects that allocation.

## Compatibility

This changes host-side scratch planning and binding only. It adds no kernel operations, kernel launches, runtime predicates, native modules, dependencies, or execution paths. Standard W4A16 plans reserve `4 * route_E` bytes: 1,024 bytes for 256 route experts and 4,096 bytes for 1,024 route experts. Full-rotation plans already reserve this buffer, so their total scratch size is unchanged.

## Validation

- `git diff --check` and Python byte-compilation passed.
- Eleven targeted CPU scratch-planning and binding checks passed.
- `tests/moe/test_tp_moe_scratch_bindings.py::test_packed_w4a16_plan_binds_global_route_map` fails identically at `master@09f731c8fc1888da412756cdaf65fe367baee314`: the test supplies 12 global route entries to a plan whose route extent resolves to eight. This patch does not alter that contract.
- `tests/moe/test_w4a16_route_pack.py::test_pack_topk_routes_by_expert_large_expert_decode_capture` passed for 896 and 1,024 route experts with 1, 8, and 64 tokens.