### PR TITLE
security: require Transformers 5.3.0 for CVE-2026-4372

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
   "nvidia-cutlass-dsl-libs-cu13==4.6.0",
   "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2",
   "rich>=13",
-  "transformers>=4.51",
+  "transformers>=5.3.0",  # CVE-2026-4372: all releases before 5.3.0 are affected
+  "packaging>=24",
   "safetensors>=0.6",
 ]
 

--- a/scripts/capture_hidden_states.py
+++ b/scripts/capture_hidden_states.py
@@ -26,8 +26,61 @@ import pathlib
 
 import torch
 
+# Minimum transformers version that patches CVE-2026-4372 (config-injection
+# RCE via _attn_implementation_internal that bypasses trust_remote_code).
+# All releases before 5.3.0 are affected; keep in sync with pyproject.toml.
+TRANSFORMERS_FLOOR = "5.3.0"
 
-def main() -> None:
+
+def assert_safe_transformers() -> None:
+    """Fail closed if the installed transformers is below the patched floor.
+
+    Packaging metadata (pyproject.toml) already excludes affected releases,
+    but a source checkout in an older environment can bypass that check, so
+    this runtime guard runs before any model-loading API is touched.
+
+    Raises SystemExit when transformers is missing or below 5.3.0, or when
+    the *packaging* library itself cannot be imported (we cannot safely
+    compare versions without it, so we fail closed).
+    """
+    import importlib.metadata
+
+    # Look up the installed version *before* importing packaging so that a
+    # missing-transformers error is surfaced first, without depending on
+    # packaging being importable for the lookup itself.
+    try:
+        raw_version = importlib.metadata.version("transformers")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise SystemExit(
+            f"[capture] transformers is not installed; this tool requires "
+            f"transformers>={TRANSFORMERS_FLOOR} (CVE-2026-4372)."
+        ) from exc
+
+    try:
+        from packaging.version import Version
+    except ImportError as exc:
+        raise SystemExit(
+            "[capture] the 'packaging' library is required to verify the "
+            "transformers version (CVE-2026-4372 guard); install it via "
+            "'pip install packaging>=24'."
+        ) from exc
+
+    installed = Version(raw_version)
+    if (
+        installed < Version(TRANSFORMERS_FLOOR)
+        or installed.is_prerelease
+        or installed.is_devrelease
+    ):
+        raise SystemExit(
+            f"[capture] transformers {installed} is installed but a final "
+            f"release >={TRANSFORMERS_FLOOR} is required; older, prerelease, "
+            f"and development versions are rejected by the CVE-2026-4372 "
+            f"guard (config-injection RCE that bypasses --trust-remote-code)."
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser (extracted for testability)."""
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -51,11 +104,23 @@ def main() -> None:
     parser.add_argument(
         "--trust-remote-code",
         action="store_true",
-        help="allow the checkpoint's custom modeling code to run (required "
-        "for e.g. Qwen3.6; off by default so untrusted repos never execute "
-        "code without an explicit opt-in)",
+        help="allow the checkpoint's custom modeling code to be imported "
+        "(required for e.g. Qwen3.6; off by default, which blocks "
+        "checkpoint-supplied modeling code). This flag alone does NOT make "
+        "loading untrusted models safe; only transformers>=5.3.0 (enforced "
+        "by this tool and the project dependency floor) blocks CVE-2026-4372 "
+        "config-injection RCE that bypasses this flag entirely.",
     )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
+
+    # Runtime guard before any model-loading API: a source checkout in an
+    # older environment can bypass the pyproject.toml dependency floor.
+    assert_safe_transformers()
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
+
+import pytest
 
 try:
     import tomllib
@@ -26,3 +27,351 @@ def test_pcie_collectives_are_python_only() -> None:
         assert "torch.utils.cpp_extension" not in text
         assert "cpp_extension.load" not in text
         assert "load_inline(" not in text
+
+
+# --- CVE-2026-4372: transformers dependency + runtime guard ------------------
+
+# Versions that the old floor (>=4.51) admitted but that are affected by
+# CVE-2026-4372 — they must be rejected by both the pyproject specifier
+# and the runtime guard.
+_AFFECTED_VERSIONS = ["4.51", "5.2.99", "5.3.0rc1", "5.3.0.dev0"]
+
+# Versions that are patched (>=5.3.0 final) — they must be accepted.
+_SAFE_VERSIONS = ["5.3.0", "5.3.0+local", "5.3.0.post0", "5.3.1"]
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+
+def _transformers_spec() -> str:
+    """Return the transformers specifier string from pyproject.toml, parsed
+    with packaging.requirements.Requirement for exact-name matching.
+    """
+    from packaging.requirements import Requirement
+
+    deps = _pyproject()["project"]["dependencies"]
+    tf_reqs = [Requirement(d) for d in deps if Requirement(d).name == "transformers"]
+    assert len(tf_reqs) == 1, f"expected exactly one transformers dep, got {tf_reqs}"
+    return str(tf_reqs[0].specifier)
+
+
+def _script_floor() -> str:
+    """Return TRANSFORMERS_FLOOR from the script, to verify it is bound to
+    the pyproject spec.
+    """
+    import ast
+
+    source = (ROOT / "scripts" / "capture_hidden_states.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "TRANSFORMERS_FLOOR":
+                    assert isinstance(node.value, ast.Constant)
+                    return node.value.value
+    raise AssertionError("TRANSFORMERS_FLOOR not found in capture_hidden_states.py")
+
+
+@pytest.mark.parametrize("version", _AFFECTED_VERSIONS)
+def test_pyproject_rejects_affected_versions(version: str) -> None:
+    """Every affected version must be excluded by the pyproject specifier."""
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    specs = SpecifierSet(_transformers_spec())
+    assert Version(version) not in specs, (
+        f"affected version {version} must be excluded by transformers "
+        f"specifier '{specs}'"
+    )
+
+
+@pytest.mark.parametrize("version", _SAFE_VERSIONS)
+def test_pyproject_accepts_safe_versions(version: str) -> None:
+    """Every patched version must be accepted by the pyproject specifier."""
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    specs = SpecifierSet(_transformers_spec())
+    assert Version(version) in specs, (
+        f"safe version {version} must be accepted by transformers "
+        f"specifier '{specs}'"
+    )
+
+
+def test_pyproject_floor_is_5_3_0() -> None:
+    """The pyproject specifier must include 5.3.0 exactly."""
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    specs = SpecifierSet(_transformers_spec())
+    assert Version("5.3.0") in specs, (
+        f"transformers specifier '{specs}' must include 5.3.0"
+    )
+
+
+def test_script_floor_bound_to_pyproject() -> None:
+    """TRANSFORMERS_FLOOR in the script must be '5.3.0', matching the
+    pyproject.toml floor.
+    """
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    floor = _script_floor()
+    assert floor == "5.3.0", f"script floor is {floor}, expected 5.3.0"
+
+    specs = SpecifierSet(_transformers_spec())
+    assert Version(floor) in specs, (
+        f"script floor {floor} must satisfy pyproject specifier '{specs}'"
+    )
+
+
+@pytest.mark.parametrize("version", _AFFECTED_VERSIONS)
+def test_guard_rejects_affected_versions(monkeypatch, version: str) -> None:
+    """The runtime guard must raise SystemExit for any affected version."""
+    pytest.importorskip("torch")
+    import importlib.metadata
+
+    monkeypatch.syspath_prepend(str(ROOT / "scripts"))
+    import capture_hidden_states
+
+    monkeypatch.setattr(
+        importlib.metadata, "version", lambda _name: version
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        capture_hidden_states.assert_safe_transformers()
+
+    msg = str(exc_info.value)
+    assert "5.3.0" in msg
+    assert "CVE-2026-4372" in msg
+
+
+@pytest.mark.parametrize("version", ["5.3.1rc1", "5.4.0.dev0"])
+def test_guard_rejects_nonfinal_versions(monkeypatch, version: str) -> None:
+    """The runtime guard must fail closed for future non-final releases."""
+    pytest.importorskip("torch")
+    import importlib.metadata
+
+    monkeypatch.syspath_prepend(str(ROOT / "scripts"))
+    import capture_hidden_states
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: version)
+
+    with pytest.raises(SystemExit) as exc_info:
+        capture_hidden_states.assert_safe_transformers()
+
+    msg = str(exc_info.value)
+    assert "final release" in msg
+    assert "CVE-2026-4372" in msg
+
+@pytest.mark.parametrize("version", _SAFE_VERSIONS)
+def test_guard_accepts_safe_versions(monkeypatch, version: str) -> None:
+    """The runtime guard must pass without error for patched versions."""
+    pytest.importorskip("torch")
+    import importlib.metadata
+
+    monkeypatch.syspath_prepend(str(ROOT / "scripts"))
+    import capture_hidden_states
+
+    monkeypatch.setattr(
+        importlib.metadata, "version", lambda _name: version
+    )
+
+    # Must not raise.
+    capture_hidden_states.assert_safe_transformers()
+
+
+def test_guard_refuses_missing_transformers(monkeypatch) -> None:
+    """If transformers is not installed at all, the guard must fail closed."""
+    pytest.importorskip("torch")
+    import importlib.metadata
+
+    monkeypatch.syspath_prepend(str(ROOT / "scripts"))
+    import capture_hidden_states
+
+    def _raise(name: str):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise)
+
+    with pytest.raises(SystemExit) as exc_info:
+        capture_hidden_states.assert_safe_transformers()
+
+    assert "not installed" in str(exc_info.value)
+
+
+def test_guard_fails_closed_when_packaging_missing(monkeypatch) -> None:
+    """If packaging itself cannot be imported, the guard must still give an
+    actionable SystemExit rather than an unhandled ImportError — this is the
+    fail-closed guarantee for environments that bypass the dependency floor.
+    """
+    pytest.importorskip("torch")
+    import importlib.metadata
+    import sys
+
+    monkeypatch.syspath_prepend(str(ROOT / "scripts"))
+    import capture_hidden_states
+
+    # Simulate transformers being installed but packaging unavailable.
+    monkeypatch.setattr(
+        importlib.metadata, "version", lambda _name: "5.2.0"
+    )
+
+    # Block the 'packaging' module from being imported.
+    monkeypatch.setitem(sys.modules, "packaging", None)
+    monkeypatch.setitem(sys.modules, "packaging.version", None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        capture_hidden_states.assert_safe_transformers()
+
+    msg = str(exc_info.value)
+    assert "packaging" in msg.lower()
+    assert "pip install packaging" in msg
+
+
+def test_guard_fails_closed_in_subprocess_without_transformers() -> None:
+    """Subprocess-level proof: with transformers reported as missing via a
+    monkeypatched importlib.metadata.version (not sys.modules blocking,
+    which importlib.metadata ignores), the guard must produce an actionable
+    SystemExit citing transformers and CVE-2026-4372 — even when packaging
+    is also unavailable. No raw packaging ImportError should leak.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, types, importlib.metadata; "
+        # Stub torch so the script's top-level 'import torch' succeeds.
+        "sys.modules['torch'] = types.ModuleType('torch'); "
+        # Monkeypatch importlib.metadata.version to raise PackageNotFoundError
+        # for transformers — this is what actually happens when transformers
+        # is not installed; sys.modules['transformers']=None would NOT prevent
+        # importlib.metadata.version from finding real metadata.
+        "importlib.metadata.version = lambda name: (_ for _ in ()).throw("
+        "importlib.metadata.PackageNotFoundError(name)); "
+        # Block packaging so the deepest fail-closed path is exercised.
+        "sys.modules['packaging'] = None; "
+        "sys.modules['packaging.version'] = None; "
+        "sys.path.insert(0, %r); "
+        "from capture_hidden_states import assert_safe_transformers; "
+        "assert_safe_transformers()"
+    ) % str(ROOT / "scripts")
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, (
+        "guard must not silently pass without transformers"
+    )
+    combined = result.stdout + result.stderr
+    # Must mention transformers and CVE-2026-4372 (the missing-transformers
+    # path fires before packaging is even touched).
+    assert "transformers is not installed" in combined, (
+        f"expected 'transformers is not installed' message; got: {combined!r}"
+    )
+    assert "CVE-2026-4372" in combined, (
+        f"expected CVE-2026-4372 in message; got: {combined!r}"
+    )
+    # SystemExit should surface only the actionable message, never a raw
+    # import traceback from the deliberately blocked packaging module.
+    assert "Traceback" not in combined, (
+        f"missing-transformers guard leaked a traceback: {combined!r}"
+    )
+
+
+def test_guard_runs_before_from_pretrained() -> None:
+    """AST proof: assert_safe_transformers() must be called before any
+    'from transformers import ...' in main(). Compare the max guard-call
+    line against the min transformers-import line.
+    """
+    import ast
+
+    source = (ROOT / "scripts" / "capture_hidden_states.py").read_text()
+    tree = ast.parse(source)
+
+    main_fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+
+    guard_lines = [
+        node.lineno
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "assert_safe_transformers"
+    ]
+    import_lines = [
+        node.lineno
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.ImportFrom) and node.module == "transformers"
+    ]
+
+    assert guard_lines, "assert_safe_transformers must be called in main()"
+    assert import_lines, "'from transformers import ...' must appear in main()"
+    assert max(guard_lines) < min(import_lines), (
+        f"guard call(s) at {guard_lines} must precede transformers import(s) "
+        f"at {import_lines}"
+    )
+
+
+def test_build_parser_help_text() -> None:
+    """Behavioral test of format_help(): must mention trust-remote-code and
+    CVE-2026-4372, and must NOT contain the false 'never execute code'
+    promise.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import sys, types; "
+        "sys.modules['torch'] = types.ModuleType('torch'); "
+        "sys.path.insert(0, %r); "
+        "from capture_hidden_states import build_parser; "
+        "print(build_parser().format_help())"
+    ) % str(ROOT / "scripts")
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"build_parser() failed: {result.stderr!r}"
+    )
+    help_text = result.stdout
+    # Normalize whitespace so argparse line-wrapping doesn't break assertions.
+    help_flat = " ".join(help_text.split())
+
+    assert "--trust-remote-code" in help_text
+    assert "CVE-2026-4372" in help_text
+    # The false promise that untrusted repos "never execute code" must be gone.
+    assert "never execute code" not in help_flat, (
+        "help text must not promise 'never execute code' — CVE-2026-4372 "
+        "bypasses trust_remote_code=False"
+    )
+    # Must explicitly say the flag alone is insufficient.
+    assert "does NOT make loading untrusted models safe" in help_flat, (
+        "help text must warn that the flag alone is insufficient"
+    )
+
+
+def test_packaging_declared_as_dependency() -> None:
+    """packaging>=24 must be a declared project dependency (used by the
+    runtime version guard).
+    """
+    from packaging.requirements import Requirement
+
+    deps = _pyproject()["project"]["dependencies"]
+    pkg_reqs = [Requirement(d) for d in deps if Requirement(d).name == "packaging"]
+    assert pkg_reqs, "packaging must be a declared dependency"
+    assert len(pkg_reqs) == 1
+    assert ">=24" in str(pkg_reqs[0].specifier), (
+        f"packaging specifier must be >=24, got {pkg_reqs[0].specifier}"
+    )


### PR DESCRIPTION
## Problem

`transformers>=4.51` admits releases affected by GHSA-29pf-2h5f-8g72 / CVE-2026-4372. `scripts/capture_hidden_states.py` reaches `AutoModelForCausalLM.from_pretrained`, and `trust_remote_code=False` does not block this configuration-injection path.

The upstream advisory rates this High (CVSS 7.8) and marks `<5.3.0` affected.

## Change

- raise the dependency floor to `transformers>=5.3.0`
- declare the `packaging` runtime dependency used by the fail-closed version gate
- check installed metadata before importing/loading Transformers
- reject missing, affected, prerelease, and development versions with actionable errors
- correct `--trust-remote-code` help so it does not promise that untrusted repositories are safe
- test dependency parsing, prerelease/local/post semantics, guard ordering, missing dependencies, and rendered CLI help

Transformers remains a core dependency in this narrow security fix because it is already part of the published installation contract. Moving it to a tooling extra would be a separate packaging/API change and is not required to close the admitted-vulnerable-version path.

## Verification

- Linux/Python 3.12: `python -m pytest tests/test_packaging.py -q` — 25 passed
- macOS/Python 3.12: same command — 25 passed
- `ruff check scripts/capture_hidden_states.py tests/test_packaging.py`
- `python -m py_compile scripts/capture_hidden_states.py tests/test_packaging.py`

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added protection against vulnerable or non-final Transformers versions by requiring version 5.3.0 or newer.
  - The application now fails safely when required security components are unavailable.
  - Expanded `--trust-remote-code` guidance to clarify security implications.

- **Dependencies**
  - Updated the minimum Transformers version.
  - Added `packaging` as a required dependency.

- **Tests**
  - Added coverage for version validation, missing dependencies, startup safeguards, dependency declarations, and CLI security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->