### PR TITLE
security: validate paged-indexer output devices

### DIFF
--- a/b12x/attention/nsa_indexer/fused_indexer.py
+++ b/b12x/attention/nsa_indexer/fused_indexer.py
@@ -2581,6 +2581,10 @@ def run_fused_paged_indexer(
             topk=int(topk),
         )
 
+    if out_indices is not None and out_indices.device != dev:
+        raise ValueError("out_indices device must match the query device")
+    if out_values is not None and out_values.device != dev:
+        raise ValueError("out_values device must match the query device")
     out_i = (
         torch.empty((rows, topk), dtype=torch.int32, device=dev)
         if out_indices is None

--- a/b12x/attention/nsa_indexer/paged.py
+++ b/b12x/attention/nsa_indexer/paged.py
@@ -814,6 +814,8 @@ def index_topk_fp8(
             )
         if out_indices.dtype != torch.int32 or not out_indices.is_contiguous():
             raise ValueError("out_indices must be contiguous torch.int32")
+        if out_indices.device != q_fp8.device:
+            raise ValueError("out_indices device must match q_fp8")
     if out_scores is not None:
         if out_scores.shape != (q_rows, topk):
             raise ValueError(

--- a/tests/attention/test_fused_indexer.py
+++ b/tests/attention/test_fused_indexer.py
@@ -540,8 +540,11 @@ def test_fused_indexer_mla_matches_reference(rows):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
-def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
-    """Direct-K addressing stays exact after the packed-page Int32 boundary."""
+@pytest.mark.parametrize("caller_owned_outputs", [False, True])
+def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets(
+    caller_owned_outputs,
+):
+    """Direct-K addressing and both output modes stay exact past Int32."""
     device = torch.device("cuda")
     record_bytes = 1_077_120
     pid_lo, pages_used = 2000, 64
@@ -560,7 +563,7 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
     rows, heads, topk = 4, 64, 512
     seqlen = pages_used * _PS
     g = torch.Generator(device="cpu").manual_seed(7)
-    pool = torch.zeros(pool_pages * record_bytes, dtype=torch.uint8, device=device)
+    pool = torch.empty(pool_pages * record_bytes, dtype=torch.uint8, device=device)
     k_quant = pool.as_strided((pool_pages, _PS, 128), (record_bytes, 128, 1))
     k_scales = pool.view(torch.float32).as_strided(
         (pool_pages, _PS), (record_bytes // 4, 1), storage_offset=2048
@@ -584,6 +587,12 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
     )
     seqlens = torch.full((rows,), seqlen, dtype=torch.int32, device=device)
 
+    output_kwargs = {}
+    if caller_owned_outputs:
+        output_kwargs = {
+            "out_indices": torch.empty((rows, topk), dtype=torch.int32, device=device),
+            "out_values": torch.empty((rows, topk), dtype=torch.float32, device=device),
+        }
     idx, val = run_fused_paged_indexer(
         q_bytes=q_fp8.view(torch.uint8),
         weights=weights,
@@ -594,8 +603,12 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
         num_heads=heads,
         topk=topk,
         ctas_per_group=8,
+        **output_kwargs,
     )
     torch.cuda.synchronize(device)
+    if caller_owned_outputs:
+        assert idx.data_ptr() == output_kwargs["out_indices"].data_ptr()
+        assert val.data_ptr() == output_kwargs["out_values"].data_ptr()
 
     gold_vals, gold_idx_sets, gold_scores = _golden_topk(
         q_fp8,
@@ -623,3 +636,129 @@ def test_fused_indexer_paged_direct_k_high_page_id_i64_offsets():
         # to ties at the top-k boundary.
         paired = gold_scores[row].index_select(0, idx[row].long())
         assert torch.allclose(val[row].float(), paired.float(), atol=1e-2, rtol=0)
+
+
+def _make_fused_kwargs(*, device, rows=2, heads=16, seqlen=4096, topk=512, seed=7):
+    q_fp8, weights, k_fp8, k_scales, page_table, seqlens = _build_case(
+        rows, heads, seqlen, topk, seed=seed, device=device
+    )
+    return dict(
+        q_bytes=q_fp8.view(torch.uint8),
+        weights=weights,
+        k_quant_bytes=k_fp8.view(torch.uint8).contiguous(),
+        k_scales=k_scales,
+        real_page_table=page_table,
+        seqlens=seqlens,
+        num_heads=heads,
+        topk=topk,
+    )
+
+
+def _kernel_sentinel(*_args, **_kwargs):
+    raise AssertionError(
+        "device guard regressed: _to_kernel_tensor reached with a wrong-device output"
+    )
+
+
+@pytest.fixture
+def _no_fused_launch(monkeypatch):
+    """Exercise host output handling without launching a paged-pool kernel."""
+    import b12x.attention.nsa_indexer.fused_indexer as fused
+
+    monkeypatch.setattr(fused, "_to_kernel_tensor", lambda tensor, *_args, **_kwargs: tensor)
+    monkeypatch.setattr(fused, "_build_fused_indexer_kernel", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(fused, "_launch_fused", lambda *_args, **_kwargs: None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_paged_indexer_rejects_cpu_out_indices(monkeypatch):
+    """Defense-in-depth: the fused helper rejects a CPU ``out_indices`` before
+    any DLPack conversion or kernel launch.  ``_to_kernel_tensor`` is replaced
+    with a sentinel so a guard regression fails safely."""
+    device = torch.device("cuda")
+    kwargs = _make_fused_kwargs(device=device)
+    bad_out = torch.empty((2, 512), dtype=torch.int32, device="cpu")
+    monkeypatch.setattr(
+        "b12x.attention.nsa_indexer.fused_indexer._to_kernel_tensor",
+        _kernel_sentinel,
+    )
+    with pytest.raises(ValueError, match="out_indices device must match"):
+        run_fused_paged_indexer(out_indices=bad_out, **kwargs)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_paged_indexer_rejects_cpu_out_values(monkeypatch):
+    """The fused helper also rejects a wrong-device ``out_values``."""
+    device = torch.device("cuda")
+    kwargs = _make_fused_kwargs(device=device)
+    bad_vals = torch.empty((2, 512), dtype=torch.float32, device="cpu")
+    monkeypatch.setattr(
+        "b12x.attention.nsa_indexer.fused_indexer._to_kernel_tensor",
+        _kernel_sentinel,
+    )
+    with pytest.raises(ValueError, match="out_values device must match"):
+        run_fused_paged_indexer(out_values=bad_vals, **kwargs)
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.device_count() >= 2),
+    reason="Two CUDA devices required",
+)
+def test_fused_paged_indexer_rejects_wrong_cuda_device_out_indices(monkeypatch):
+    """A foreign-CUDA ``out_indices`` is rejected before the kernel launch."""
+    device = torch.device("cuda", 0)
+    kwargs = _make_fused_kwargs(device=device)
+    bad_out = torch.empty((2, 512), dtype=torch.int32, device=torch.device("cuda", 1))
+    monkeypatch.setattr(
+        "b12x.attention.nsa_indexer.fused_indexer._to_kernel_tensor",
+        _kernel_sentinel,
+    )
+    with pytest.raises(ValueError, match="out_indices device must match"):
+        run_fused_paged_indexer(out_indices=bad_out, **kwargs)
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.device_count() >= 2),
+    reason="Two CUDA devices required",
+)
+def test_fused_paged_indexer_rejects_wrong_cuda_device_out_values(monkeypatch):
+    """A foreign-CUDA ``out_values`` is rejected before kernel launch."""
+    device = torch.device("cuda", 0)
+    kwargs = _make_fused_kwargs(device=device)
+    bad_vals = torch.empty(
+        (2, 512), dtype=torch.float32, device=torch.device("cuda", 1)
+    )
+    monkeypatch.setattr(
+        "b12x.attention.nsa_indexer.fused_indexer._to_kernel_tensor",
+        _kernel_sentinel,
+    )
+    with pytest.raises(ValueError, match="out_values device must match"):
+        run_fused_paged_indexer(out_values=bad_vals, **kwargs)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_paged_indexer_accepts_correct_device_and_preserves_ptr(
+    _no_fused_launch,
+):
+    """Correct-device caller outputs are forwarded unchanged before launch."""
+    device = torch.device("cuda")
+    kwargs = _make_fused_kwargs(device=device)
+    out_indices = torch.empty((2, 512), dtype=torch.int32, device=device)
+    out_values = torch.empty((2, 512), dtype=torch.float32, device=device)
+    idx, val = run_fused_paged_indexer(
+        out_indices=out_indices, out_values=out_values, **kwargs
+    )
+    assert idx.data_ptr() == out_indices.data_ptr()
+    assert val.data_ptr() == out_values.data_ptr()
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_paged_indexer_omitted_outputs_allocated_on_q_device(
+    _no_fused_launch,
+):
+    """Omitted outputs are allocated on the query device before launch."""
+    device = torch.device("cuda")
+    kwargs = _make_fused_kwargs(device=device)
+    idx, val = run_fused_paged_indexer(**kwargs)
+    assert idx.device == kwargs["q_bytes"].device
+    assert val.device == kwargs["q_bytes"].device
+    assert idx.dtype == torch.int32
+    assert val.dtype == torch.float32

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -1094,3 +1094,160 @@ def test_index_topk_fp8_graph_unaligned_single_chunk(
         torch.sort(actual, dim=1).values,
         torch.sort(expected_raw1, dim=1).values,
     )
+
+
+
+_ROWS = 2
+_NUM_HEADS = 64
+_WIDTH_BLOCKS = 16
+_TOPK = 512
+
+
+def _make_device_test_case(
+    *,
+    device: torch.device,
+    route: str = "paged_fused",
+):
+    """Build the minimal tensors + binding for an ``index_topk_fp8`` device test.
+
+    Fixed two-row fixture; all shapes derive from ``_ROWS``.
+    """
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(91_100)
+    seqlens_list = [900, 960]
+    real_page_table = _make_real_page_table(
+        page_starts=[2, 40],
+        seqlens=seqlens_list,
+        width_blocks=_WIDTH_BLOCKS,
+        device=device,
+    )
+    seqlens = torch.tensor(seqlens_list, dtype=torch.int32, device=device)
+    q_fp8 = _rand_fp8_q((_ROWS, _NUM_HEADS, 128), gen=gen, device=device)
+    weights = torch.randn(
+        (_ROWS, _NUM_HEADS), generator=gen, dtype=torch.float32
+    ).to(device=device)
+    api_weights = weights.unsqueeze(-1)
+    index_k_cache = pack_paged_index_k_cache_reference(
+        torch.randn(
+            (80 * 64, 128), generator=gen, dtype=torch.float32
+        ).to(device=device)
+        / 3
+    )
+    binding = _bind_paged_indexer(
+        device=device,
+        num_heads=_NUM_HEADS,
+        rows=_ROWS,
+        width_blocks=_WIDTH_BLOCKS,
+        topk=_TOPK,
+        real_page_table=real_page_table,
+        seqlens=seqlens,
+        route=route,
+    )
+    return q_fp8, api_weights, index_k_cache, binding
+
+
+def _fused_sentinel(**_kwargs):
+    raise AssertionError(
+        "device guard regressed: run_fused_paged_indexer reached "
+        "with a wrong-device output"
+    )
+
+
+def _fused_output_passthrough(**kwargs):
+    """Stand in for the raw kernel after public-boundary validation."""
+    out_indices = kwargs["out_indices"]
+    if out_indices is None:
+        raise AssertionError("public wrapper failed to provide out_indices")
+    out_values = kwargs["out_values"]
+    if out_values is None:
+        out_values = torch.empty_like(out_indices, dtype=torch.float32)
+    return out_indices, out_values
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("route", ["paged_fused", "paged_tiled", "packed_contiguous"])
+def test_index_topk_fp8_rejects_cpu_out_indices(route, monkeypatch) -> None:
+    """A CPU ``out_indices`` must be rejected before any route dispatch/kernel launch.
+
+    The public boundary check fires before route selection, so the rejection is
+    identical for fused, tiled, and packed routes.  For the fused route a
+    sentinel replaces ``run_fused_paged_indexer`` so that a guard regression
+    fails safely without enqueuing the vulnerable kernel.
+    """
+    device = torch.device("cuda")
+    q_fp8, api_weights, index_k_cache, binding = _make_device_test_case(
+        device=device, route=route
+    )
+    if route == "paged_fused":
+        import b12x.attention.nsa_indexer.fused_indexer as _fi
+
+        monkeypatch.setattr(_fi, "run_fused_paged_indexer", _fused_sentinel)
+    bad_out = torch.empty((_ROWS, _TOPK), dtype=torch.int32, device="cpu")
+    with pytest.raises(ValueError, match="out_indices device must match q_fp8"):
+        index_topk_fp8(
+            q_fp8=q_fp8,
+            weights=api_weights,
+            index_k_cache=index_k_cache,
+            topk=_TOPK,
+            expected_num_q_heads=_NUM_HEADS,
+            binding=binding,
+            out_indices=bad_out,
+        )
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.device_count() >= 2),
+    reason="Two CUDA devices required",
+)
+@pytest.mark.parametrize("route", ["paged_fused", "paged_tiled", "packed_contiguous"])
+def test_index_topk_fp8_rejects_wrong_cuda_device_out_indices(
+    route, monkeypatch
+) -> None:
+    """An ``out_indices`` on a different CUDA device must be rejected before launch."""
+    device = torch.device("cuda", 0)
+    q_fp8, api_weights, index_k_cache, binding = _make_device_test_case(
+        device=device, route=route
+    )
+    if route == "paged_fused":
+        import b12x.attention.nsa_indexer.fused_indexer as _fi
+
+        monkeypatch.setattr(_fi, "run_fused_paged_indexer", _fused_sentinel)
+    bad_out = torch.empty(
+        (_ROWS, _TOPK), dtype=torch.int32, device=torch.device("cuda", 1)
+    )
+    with pytest.raises(ValueError, match="out_indices device must match q_fp8"):
+        index_topk_fp8(
+            q_fp8=q_fp8,
+            weights=api_weights,
+            index_k_cache=index_k_cache,
+            topk=_TOPK,
+            expected_num_q_heads=_NUM_HEADS,
+            binding=binding,
+            out_indices=bad_out,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_index_topk_fp8_accepts_correct_device_out_indices_and_preserves_ptr(
+    monkeypatch,
+) -> None:
+    """A correct-device caller output is forwarded without reallocation."""
+    device = torch.device("cuda")
+    q_fp8, api_weights, index_k_cache, binding = _make_device_test_case(
+        device=device, route="paged_fused"
+    )
+    monkeypatch.setattr(
+        "b12x.attention.nsa_indexer.fused_indexer.run_fused_paged_indexer",
+        _fused_output_passthrough,
+    )
+    out_indices = torch.empty((_ROWS, _TOPK), dtype=torch.int32, device=device)
+    result = index_topk_fp8(
+        q_fp8=q_fp8,
+        weights=api_weights,
+        index_k_cache=index_k_cache,
+        topk=_TOPK,
+        expected_num_q_heads=_NUM_HEADS,
+        binding=binding,
+        out_indices=out_indices,
+    )
+    assert result.data_ptr() == out_indices.data_ptr()


### PR DESCRIPTION
## Problem

Caller-owned `out_indices`/`out_values` can reach the fused paged-indexer launch on a different CUDA device from the query. Raw pointers are then consumed by a kernel launched for the query device, permitting peer/UVA writes or invalid-address failures.

## Change

- validate public `out_indices.device == q_fp8.device` before route selection
- repeat output-device validation in the fused helper before DLPack conversion or launch
- preserve omitted-output allocation on the query device and correct-device pointer identity
- add safe regression tests for CPU and foreign-CUDA outputs across fused, tiled, and packed routes
- use sentinels at post-validation boundaries so a future guard regression fails before enqueuing the unsafe kernel

## Verification

Physical host: 2x NVIDIA RTX PRO 6000 Blackwell, CUDA 13.2 driver 595.58.03, Python 3.12, PyTorch 2.13.0, CUTLASS DSL 4.6.0.

Targeted GPU command covered all added tests; result: 13 passed, including both-device rejection, all three public routes, pointer preservation, and omitted-output allocation.

Also:
- `python -m py_compile` on both changed sources and tests
- `ruff check tests/attention/test_paged_indexer_integration.py tests/attention/test_fused_indexer.py`

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure output tensors are placed on the same device as the query tensor.
  * Clear errors are now raised for CPU or mismatched-device outputs before processing begins.
  * Correctly placed caller-provided outputs continue to be reused without unnecessary allocation.

* **Tests**
  * Added coverage for device validation, output reuse, automatic output allocation, and high page IDs across supported indexing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->