### PR TITLE
security: confine safetensors index shard paths

### DIFF
--- a/b12x/quantization/mxfp6/model_fp6.py
+++ b/b12x/quantization/mxfp6/model_fp6.py
@@ -60,28 +60,166 @@ _FUSED_GATE_UP = ("gate_up_proj", "w13")
 _ATTN_ORDER = ("q_proj", "k_proj", "v_proj", "o_proj")
 
 
+def _validate_shard_name(shard: object) -> str:
+    """Validate and return a single-component ``.safetensors`` shard filename.
+
+    Rejects non-strings, empty strings, POSIX/Windows path separators (``/``
+    and ``\\``), Windows drive/UNC forms, ``.``/``..``, and any name not
+    ending in ``.safetensors``.  The check is purely lexical and portable so
+    Windows spellings are rejected even when tests run on POSIX.
+    """
+    if not isinstance(shard, str):
+        raise ValueError(
+            f"invalid shard name: expected string, got {type(shard).__name__}"
+        )
+    if not shard:
+        raise ValueError("invalid shard name: empty string")
+    if "/" in shard or "\\" in shard:
+        raise ValueError(f"invalid shard name {shard!r}: contains a path separator")
+    if shard in (".", ".."):
+        raise ValueError(f"invalid shard name {shard!r}")
+    # Reject Windows drive-letter forms (e.g. ``C:foo``, ``1:foo``) even on
+    # POSIX.  ntpath treats any single-character-colon prefix as a drive, so
+    # we reject any ``X:`` where X is one character regardless of type.
+    if len(shard) >= 2 and shard[1] == ":":
+        raise ValueError(f"invalid shard name {shard!r}: Windows drive form")
+    if not shard.endswith(".safetensors"):
+        raise ValueError(f"invalid shard name {shard!r}: must end with .safetensors")
+    return shard
+
+
+def _hf_repo_root(root: pathlib.Path) -> pathlib.Path | None:
+    """Return the ``models--<repo>`` cache root if *root* is an HF snapshot dir.
+
+    A standard Hugging Face hub cache stores snapshots under
+    ``models--<org>--<model>/snapshots/<revision>/``.  Returns the
+    ``models--<repo>`` directory when *root* matches that layout, else ``None``.
+    """
+    parts = root.parts
+    if len(parts) >= 3 and parts[-2] == "snapshots" and parts[-3].startswith("models--"):
+        return root.parent.parent
+    return None
+
+
+def _resolve_shard(root: pathlib.Path, shard_name: str) -> pathlib.Path:
+    """Resolve a validated shard name to a canonical regular file under *root*.
+
+    Follows symlinks but confines the resolved target to either the model root
+    or, for recognized Hugging Face cache snapshots, the same repository's
+    ``blobs`` directory (preserving the standard
+    ``snapshots/<rev>/<basename> -> ../../blobs/<digest>`` layout).
+
+    Rejects missing paths, directories, devices, sockets, broken links, and
+    any target that escapes the model root or the narrow HF blob exception.
+
+    Concurrency/hardlink note: this check validates the path at resolution
+    time.  Concurrent mutation of model/cache ancestor directories, or a
+    hardlink whose other names lie outside the boundary, is outside this
+    containment contract.
+    """
+    candidate = root / shard_name
+    if not candidate.exists():
+        raise ValueError(f"shard {shard_name!r} not found under {root}")
+    resolved = candidate.resolve()
+    if not resolved.is_file():
+        raise ValueError(f"shard {shard_name!r} under {root} is not a regular file")
+    # Accept any resolved target that stays inside the model root.
+    if resolved.is_relative_to(root):
+        return resolved
+    # Narrow HF cache exception: a snapshot basename may be a symlink to
+    # ../../blobs/<digest> within the same repository cache.  Require the
+    # blobs directory to be a real (non-symlink) directory and compare the
+    # canonical target against the *unresolved* same-repo blobs path so a
+    # relocated or symlinked blobs directory cannot smuggle external files.
+    repo_root = _hf_repo_root(root)
+    if repo_root is not None and candidate.is_symlink():
+        blobs_dir = repo_root / "blobs"
+        if blobs_dir.is_dir() and not blobs_dir.is_symlink():
+            if resolved.is_relative_to(blobs_dir):
+                return resolved
+    raise ValueError(
+        f"shard {shard_name!r} under {root} resolves outside the model root"
+    )
+
+
 class SafetensorsModel:
-    """Lazy reader for a HF safetensors checkpoint directory."""
+    """Lazy reader for a HF safetensors checkpoint directory.
+
+    Shard names from ``model.safetensors.index.json`` (and the single-file
+    ``model.safetensors`` fallback) are lexically validated eagerly at
+    construction time — every key/value type and shard spelling is checked,
+    including entries not selected by architecture discovery.  Filesystem
+    resolution (existence, containment, symlink confinement) is lazy and
+    memoized per shard name, performed in :meth:`_handle` immediately before
+    :func:`safetensors.safe_open`.  This preserves index-only dry runs for
+    :func:`convert_moe_model_to_fp6` and :func:`convert_dense_model_to_fp6`.
+    The full-checkpoint safetensors exporters still open selected shards to
+    inspect tensor shapes before their own dry-run return.
+
+    ``self.path`` is canonical (``.resolve()``) so a symlinked model root is
+    accepted transparently.  Handles are cached by validated canonical path so
+    multiple keys sharing one physical file deduplicate to a single handle.
+
+    Concurrency/hardlink note: containment is validated at resolution time
+    only.  Concurrent mutation of model/cache ancestor directories, or a
+    hardlink whose other names lie outside the boundary, is outside this
+    containment contract.
+    """
 
     def __init__(self, model_path: str | pathlib.Path):
-        self.path = pathlib.Path(model_path)
+        self.path = pathlib.Path(model_path).resolve()
         cfg = self.path / "config.json"
         self.config: dict = json.loads(cfg.read_text()) if cfg.exists() else {}
         self.text_config: dict = self.config.get("text_config", self.config)
+        self.weight_map: dict[str, str] = {}
+        self._resolved: dict[str, str] = {}   # shard name -> canonical path
+        self._handles: dict[str, object] = {}  # canonical path -> handle
         self.weight_map = self._build_weight_map()
-        self._handles: dict[str, object] = {}
 
     def _build_weight_map(self) -> dict[str, str]:
+        """Return ``{tensor_key: shard_name}`` with eager lexical validation.
+
+        For the single-file fallback the file must be opened to enumerate
+        keys, so its resolution happens here.  For the index case no shard
+        file is touched — resolution is deferred to :meth:`_handle`.
+        """
         index = self.path / "model.safetensors.index.json"
         if index.exists():
-            return json.loads(index.read_text())["weight_map"]
+            raw = json.loads(index.read_text())
+            weight_map = raw.get("weight_map")
+            if not isinstance(weight_map, dict):
+                raise ValueError(
+                    "model.safetensors.index.json: 'weight_map' is not a JSON object"
+                )
+            return self._validate_weight_map(weight_map)
         single = self.path / "model.safetensors"
         if single.exists():
+            # The single-file case must open the file to enumerate keys, so
+            # resolve it here (containment check included).
+            canonical = _resolve_shard(self.path, "model.safetensors")
+            canonical_str = str(canonical)
+            self._resolved["model.safetensors"] = canonical_str
             from safetensors import safe_open
 
-            with safe_open(str(single), framework="pt") as f:  # type: ignore[no-untyped-call]
+            with safe_open(canonical_str, framework="pt") as f:  # type: ignore[no-untyped-call]
                 return {k: "model.safetensors" for k in f.keys()}
         raise FileNotFoundError(f"no model.safetensors(.index.json) under {self.path}")
+
+    def _validate_weight_map(self, raw: dict) -> dict[str, str]:
+        """Lexically validate every key/value and return ``{key: shard_name}``.
+
+        Fails the model as a unit rather than silently skipping an invalid
+        mapping, even for entries not selected by architecture discovery.
+        Filesystem resolution is deferred to :meth:`_handle`.
+        """
+        result: dict[str, str] = {}
+        for key, shard in raw.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"invalid weight_map key: expected string, got {type(key).__name__}"
+                )
+            result[key] = _validate_shard_name(shard)
+        return result
 
     def keys(self) -> Iterable[str]:
         return self.weight_map.keys()
@@ -92,11 +230,15 @@ class SafetensorsModel:
     def _handle(self, key: str):
         from safetensors import safe_open
 
-        shard = self.weight_map[key]
-        handle = self._handles.get(shard)
+        shard_name = self.weight_map[key]
+        canonical = self._resolved.get(shard_name)
+        if canonical is None:
+            canonical = str(_resolve_shard(self.path, shard_name))
+            self._resolved[shard_name] = canonical
+        handle = self._handles.get(canonical)
         if handle is None:
-            handle = safe_open(str(self.path / shard), framework="pt")  # type: ignore[no-untyped-call]
-            self._handles[shard] = handle
+            handle = safe_open(canonical, framework="pt")  # type: ignore[no-untyped-call]
+            self._handles[canonical] = handle
         return handle
 
     def get_tensor(self, key: str) -> torch.Tensor:

--- a/docs/fp6-user-guide.md
+++ b/docs/fp6-user-guide.md
@@ -46,6 +46,19 @@ Preview what a run will do without writing anything:
 python scripts/quantize_model_fp6.py --model <dir> --out /tmp/x --arch auto --dry-run
 ```
 
+**Checkpoint path containment.** The converter validates every shard name
+in `model.safetensors.index.json` at load time: only single-component
+`.safetensors` filenames are accepted (no absolute paths, directory
+components, `..` traversal, or Windows drive/UNC forms). Resolved shard
+targets must stay inside the model root. The standard Hugging Face hub
+cache layout — `models--<repo>/snapshots/<rev>/<basename>` symlinking to
+`../../blobs/<digest>` within the same repository — is explicitly trusted
+and accepted. Arbitrary external symlinks, `local_dir` escape links,
+cross-repository blob links, symlinked `blobs` directories, broken links,
+and non-regular files are rejected. Concurrent mutation of model/cache
+ancestor directories and hardlinks whose other names lie outside the
+boundary are outside this containment contract.
+
 ### 1.2 Quant-time knobs
 
 | Flag | Default | What it controls |

--- a/tests/quantization/test_model_fp6_converter.py
+++ b/tests/quantization/test_model_fp6_converter.py
@@ -248,3 +248,336 @@ def test_export_dense_safetensors(tmp_path) -> None:
     assert w.dtype == torch.uint8 and tuple(w.shape) == (128, 128 * 3 // 4)
     assert "model.language_model.layers.0.mlp.gate_proj.weight_scale" in state
     assert config["quantization_config"]["quant_algo"] == "W6A6"
+
+
+# ---------------------------------------------------------------------------
+# Issue #171: safetensors shard path containment contract tests
+# ---------------------------------------------------------------------------
+
+
+def _save_safetensors(path: pathlib.Path, tensors: dict[str, torch.Tensor]) -> None:
+    """Write a single safetensors file (no config, no index)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    safetensors_torch.save_file(
+        {k: v.contiguous() for k, v in tensors.items()}, str(path)
+    )
+
+
+def _make_index(
+    root: pathlib.Path, weight_map: dict[str, str], *, with_config: bool = True
+) -> None:
+    """Write a model.safetensors.index.json with an arbitrary weight_map."""
+    root.mkdir(parents=True, exist_ok=True)
+    if with_config:
+        (root / "config.json").write_text(json.dumps({"model_type": "test"}))
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {"total_size": 0}, "weight_map": weight_map})
+    )
+
+
+# --- accepted layouts -------------------------------------------------------
+
+
+def test_accept_regular_in_root_shard(tmp_path) -> None:
+    """A normal basename index loads its tensor."""
+    root = tmp_path / "model"
+    shard = root / "model-00001-of-00001.safetensors"
+    sentinel = torch.tensor([1.0, 2.0, 3.0])
+    _save_safetensors(shard, {"weight": sentinel})
+    _make_index(root, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(root)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+def test_accept_in_root_symlink(tmp_path) -> None:
+    """An in-root basename symlink whose target stays inside root loads."""
+    root = tmp_path / "model"
+    real = root / "real-00001.safetensors"
+    sentinel = torch.tensor([5.0])
+    _save_safetensors(real, {"weight": sentinel})
+    (root / "model-00001-of-00001.safetensors").symlink_to(real.name)
+    _make_index(root, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(root)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+def test_accept_symlinked_root(tmp_path) -> None:
+    """A symlinked model root is canonicalized and loads normally."""
+    real_root = tmp_path / "real_model"
+    shard = real_root / "model-00001-of-00001.safetensors"
+    sentinel = torch.tensor([8.0])
+    _save_safetensors(shard, {"weight": sentinel})
+    _make_index(real_root, {"weight": "model-00001-of-00001.safetensors"})
+    link = tmp_path / "link_to_model"
+    link.symlink_to(real_root)
+    model = SafetensorsModel(link)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+def test_accept_standard_hf_same_repo_blob_link(tmp_path) -> None:
+    """Synthetic models--repo/snapshots/rev/shard -> ../../blobs/digest loads."""
+    repo = tmp_path / "models--org--model"
+    blobs = repo / "blobs"
+    snap = repo / "snapshots" / "abc123"
+    blobs.mkdir(parents=True)
+    snap.mkdir(parents=True)
+    digest = "deadbeef"
+    sentinel = torch.tensor([42.0])
+    _save_safetensors(blobs / digest, {"weight": sentinel})
+    # Standard HF layout: snapshot basename -> ../../blobs/<digest>
+    (snap / "model-00001-of-00001.safetensors").symlink_to(
+        pathlib.Path("..", "..", "blobs", digest)
+    )
+    _make_index(snap, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(snap)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+def test_accept_single_file_fallback(tmp_path) -> None:
+    """Plain model.safetensors (no index) still loads."""
+    root = tmp_path / "model"
+    root.mkdir(parents=True, exist_ok=True)
+    sentinel = torch.tensor([7.0])
+    _save_safetensors(root / "model.safetensors", {"weight": sentinel})
+    (root / "config.json").write_text(json.dumps({"model_type": "test"}))
+    model = SafetensorsModel(root)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+def test_accept_single_file_hf_blob_link(tmp_path) -> None:
+    """Single-file fallback with a recognized HF same-repo blob link loads."""
+    repo = tmp_path / "models--org--model"
+    blobs = repo / "blobs"
+    snap = repo / "snapshots" / "abc123"
+    blobs.mkdir(parents=True)
+    snap.mkdir(parents=True)
+    digest = "cafef00d"
+    sentinel = torch.tensor([99.0])
+    _save_safetensors(blobs / digest, {"weight": sentinel})
+    (snap / "model.safetensors").symlink_to(
+        pathlib.Path("..", "..", "blobs", digest)
+    )
+    (snap / "config.json").write_text(json.dumps({"model_type": "test"}))
+    model = SafetensorsModel(snap)
+    assert torch.equal(model.get_tensor("weight"), sentinel)
+
+
+# --- lexical rejections (fail at construction, before safe_open) -----------
+
+
+def test_reject_posix_absolute_shard(tmp_path) -> None:
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    _make_index(root, {"weight": "/etc/passwd.safetensors"})
+    with pytest.raises(ValueError, match="invalid shard name"):
+        SafetensorsModel(root)
+
+
+def test_reject_windows_absolute_unc_and_backslash_shards(tmp_path) -> None:
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    for bad in [
+        r"C:\Users\secret.safetensors",
+        r"\\server\share\secret.safetensors",
+        r"subdir\file.safetensors",
+    ]:
+        _make_index(root, {"weight": bad})
+        with pytest.raises(ValueError, match="invalid shard name"):
+            SafetensorsModel(root)
+
+
+def test_reject_windows_drive_separator_free(tmp_path) -> None:
+    """Separator-free ``C:`` and ``1:`` drive forms are rejected (ntpath rule)."""
+    root = tmp_path / "model"
+    _save_safetensors(root / "model.safetensors", {"weight": torch.tensor([1.0])})
+    for bad in ["C:model.safetensors", "1:model.safetensors"]:
+        _make_index(root, {"weight": bad})
+        with pytest.raises(ValueError, match="Windows drive form"):
+            SafetensorsModel(root)
+
+
+def test_reject_parent_traversal_shard(tmp_path) -> None:
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    for bad in ["../outside.safetensors", "../../etc/passwd.safetensors"]:
+        _make_index(root, {"weight": bad})
+        with pytest.raises(ValueError, match="invalid shard name"):
+            SafetensorsModel(root)
+
+
+def test_reject_nested_component(tmp_path) -> None:
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    _make_index(root, {"weight": "subdir/shard.safetensors"})
+    with pytest.raises(ValueError, match="invalid shard name"):
+        SafetensorsModel(root)
+
+
+def test_reject_non_safetensors_suffix(tmp_path) -> None:
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    _make_index(root, {"weight": "model.bin"})
+    with pytest.raises(ValueError, match="invalid shard name"):
+        SafetensorsModel(root)
+
+
+# --- type / structure rejections --------------------------------------------
+
+
+def test_reject_non_dict_weight_map(tmp_path) -> None:
+    root = tmp_path / "model"
+    root.mkdir()
+    (root / "config.json").write_text(json.dumps({"model_type": "test"}))
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": [1, 2, 3]})
+    )
+    with pytest.raises(ValueError, match="weight_map.*not a JSON object"):
+        SafetensorsModel(root)
+
+
+def test_reject_malformed_weight_map_types_eagerly(tmp_path) -> None:
+    """Non-string shard values (int, list, null) fail at construction."""
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    for bad_val in [123, ["model.safetensors"], None, True]:
+        _make_index(root, {"weight": bad_val})
+        with pytest.raises(ValueError, match="expected string"):
+            SafetensorsModel(root)
+
+
+def test_reject_bad_map_entry_eagerly_even_if_unused(tmp_path) -> None:
+    """A lexically invalid shard in an unused entry still fails at construction."""
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"good": torch.tensor([1.0])})
+    _make_index(
+        root,
+        {"good": "model.safetensors", "bad": "../escape.safetensors"},
+    )
+    with pytest.raises(ValueError, match="invalid shard name"):
+        SafetensorsModel(root)
+
+
+# --- symlink / resolution rejections (lazy — triggered on get_tensor) -------
+
+
+def test_reject_external_leaf_symlink(tmp_path) -> None:
+    """An in-root basename symlink to an external safetensors file fails."""
+    root = tmp_path / "model"
+    root.mkdir()
+    outside = tmp_path / "outside.safetensors"
+    _save_safetensors(outside, {"weight": torch.tensor([1.0])})
+    (root / "model-00001-of-00001.safetensors").symlink_to(outside)
+    _make_index(root, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(root)
+    with pytest.raises(ValueError, match="outside the model root"):
+        model.get_tensor("weight")
+
+
+def test_reject_hf_cross_repo_blob_link(tmp_path) -> None:
+    """A snapshot basename link resolving outside the same repo blobs fails."""
+    repo_a = tmp_path / "models--org--modelA"
+    repo_b = tmp_path / "models--org--modelB"
+    blobs_a = repo_a / "blobs"
+    blobs_b = repo_b / "blobs"
+    snap_a = repo_a / "snapshots" / "rev"
+    blobs_a.mkdir(parents=True)
+    blobs_b.mkdir(parents=True)
+    snap_a.mkdir(parents=True)
+    digest = "cross1234"
+    _save_safetensors(blobs_b / digest, {"weight": torch.tensor([1.0])})
+    # Link points to a *different* repo's blobs — outside same-repo boundary.
+    (snap_a / "model-00001-of-00001.safetensors").symlink_to(blobs_b / digest)
+    _make_index(snap_a, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(snap_a)
+    with pytest.raises(ValueError, match="outside the model root"):
+        model.get_tensor("weight")
+
+
+def test_reject_broken_symlink(tmp_path) -> None:
+    root = tmp_path / "model"
+    root.mkdir()
+    (root / "model-00001-of-00001.safetensors").symlink_to(
+        tmp_path / "nonexistent.safetensors"
+    )
+    _make_index(root, {"weight": "model-00001-of-00001.safetensors"})
+    model = SafetensorsModel(root)
+    with pytest.raises(ValueError, match="not found|not a regular file"):
+        model.get_tensor("weight")
+
+
+def test_reject_directory_as_shard(tmp_path) -> None:
+    root = tmp_path / "model"
+    (root / "subdir.safetensors").mkdir(parents=True)
+    _make_index(root, {"weight": "subdir.safetensors"})
+    model = SafetensorsModel(root)
+    with pytest.raises(ValueError, match="not a regular file"):
+        model.get_tensor("weight")
+
+
+def test_reject_missing_shard_file(tmp_path) -> None:
+    root = tmp_path / "model"
+    _make_index(root, {"weight": "nonexistent-00001-of-00001.safetensors"})
+    model = SafetensorsModel(root)
+    with pytest.raises(ValueError, match="not found"):
+        model.get_tensor("weight")
+
+
+# --- single-file fallback symlink escape (construction-time) ----------------
+
+
+def test_confine_single_file_fallback_symlink_escape(tmp_path) -> None:
+    """A model.safetensors symlink escape receives the same rejection."""
+    root = tmp_path / "model"
+    root.mkdir()
+    outside = tmp_path / "outside.safetensors"
+    _save_safetensors(outside, {"weight": torch.tensor([1.0])})
+    (root / "model.safetensors").symlink_to(outside)
+    (root / "config.json").write_text(json.dumps({"model_type": "test"}))
+    with pytest.raises(ValueError, match="outside the model root"):
+        SafetensorsModel(root)
+
+
+# --- no partial export on invalid index -------------------------------------
+
+
+def test_no_partial_export_on_invalid_index(tmp_path) -> None:
+    """Full exporter raises before creating output or emitting any shard."""
+    root = tmp_path / "model"
+    shard = root / "model.safetensors"
+    _save_safetensors(shard, {"weight": torch.tensor([1.0])})
+    _make_index(
+        root,
+        {"weight": "model.safetensors", "bad": "../escape.safetensors"},
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="invalid shard name"):
+        export_dense_model_to_fp6_safetensors(
+            root, out, device="cpu", use_gpu=False, verbose=False
+        )
+    assert not out.exists()
+
+
+# --- handle caching by validated identity -----------------------------------
+
+
+def test_cache_validated_identity(tmp_path) -> None:
+    """Multiple keys for one validated shard reuse a single handle."""
+    root = tmp_path / "model"
+    shard = root / "model-00001-of-00001.safetensors"
+    _save_safetensors(shard, {"a": torch.tensor([1.0]), "b": torch.tensor([2.0])})
+    _make_index(
+        root,
+        {"a": "model-00001-of-00001.safetensors", "b": "model-00001-of-00001.safetensors"},
+    )
+    model = SafetensorsModel(root)
+    model.get_tensor("a")
+    model.get_tensor("b")
+    # Both keys should share the same cached handle (one entry).
+    assert len(model._handles) == 1


### PR DESCRIPTION
## Problem

`SafetensorsModel` trusted `weight_map` shard strings. Absolute paths and traversal could escape the selected model root; a compatible external safetensors tensor could then be read and republished.

## Change

- eagerly require string tensor keys and single-component `.safetensors` shard basenames
- reject POSIX/Windows separators and drive forms
- lazily canonicalize each used shard immediately before `safe_open`
- require a regular file contained by the canonical model root
- narrowly preserve standard Hugging Face `snapshots/<rev> -> ../../blobs/<digest>` links within the same repository, while rejecting cross-repository/external/symlinked-blob escapes
- cache handles by canonical identity
- preserve index-only conversion dry runs
- document the containment, concurrent-mutation, and hardlink boundaries

## Verification

- Linux/Python 3.12: `python -m pytest tests/quantization/test_model_fp6_converter.py -q` — 32 passed
- direct actual-safetensors smoke: regular and in-root links accepted; symlinked root accepted; missing shard resolves lazily; lexical traversal, external links, and cross-repository blobs rejected; same-repository HF blob link accepted
- `ruff check b12x/quantization/mxfp6/model_fp6.py tests/quantization/test_model_fp6_converter.py`
- `python -m py_compile` on changed source/test

Closes #171