### PR TITLE
security: reject auxiliary-file symlink escapes

### DIFF
--- a/b12x/quantization/mxfp6/__init__.py
+++ b/b12x/quantization/mxfp6/__init__.py
@@ -254,6 +254,7 @@ from b12x.quantization.mxfp6.model_fp6 import (  # noqa: E402
     ConvertReport,
 )
 from b12x.quantization.mxfp6.fp6_safetensors_export import (  # noqa: E402
+    UnsafeAuxiliaryFileError,
     ExportReport,
     export_model_to_fp6_safetensors,
     export_moe_model_to_fp6_safetensors,
@@ -308,6 +309,7 @@ __all__ = [
     "dequantize_fp6_checkpoint_to_bf16",
     "load_fp6_moe_weights_from_safetensors",
     "load_fp6_moe_checkpoint",
+    "UnsafeAuxiliaryFileError",
     "load_fp6_dense_weight_from_safetensors",
     "load_fp6_dense_checkpoint",
 ]

--- a/b12x/quantization/mxfp6/fp6_safetensors_export.py
+++ b/b12x/quantization/mxfp6/fp6_safetensors_export.py
@@ -19,11 +19,14 @@ its original dtype and recorded in ``quantization_config.exclude_modules``.
 * Dense: MLP (+ optional attention) linears are quantized in place.
 """
 from __future__ import annotations
-
+import errno
 import json
+import os
 import pathlib
 import re
 import shutil
+import stat
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -244,18 +247,185 @@ class _ShardWriter:
         return n
 
 
+class UnsafeAuxiliaryFileError(RuntimeError):
+    """Raised when an eligible auxiliary source entry is identified as unsafe.
+
+    The FP6 exporters must never follow attacker-authored symlinks or copy
+    special file types: doing so would embed arbitrary victim-readable bytes
+    into the output bundle.  Every *eligible* auxiliary candidate (any
+    top-level entry that is not ``*.safetensors``, ``config.json``, or a
+    shard index) that is a symlink or non-regular file fails closed — it is
+    never copied.  This exception is raised when the unsafe kind can be
+    identified through the no-follow open + ``fstat`` path (symlinks detected
+    via ``O_NOFOLLOW``/``ELOOP``, or special files identified by ``fstat``
+    after a successful open).  When the underlying ``os.open`` itself rejects
+    the entry (e.g. ``ENXIO`` for a device node), the original ``OSError`` is
+    allowed to propagate.  Entries that are intentionally skipped — model
+    weights, the generated ``config.json``, and shard index files — are never
+    inspected and therefore never trigger this error.  Standard Hugging Face
+    cache snapshot links are deliberately rejected; see
+    :func:`_copy_aux_files` for guidance.
+    """
+
+
 def _copy_aux_files(src: pathlib.Path, dst: pathlib.Path) -> None:
-    """Copy tokenizer / generation / misc files so the output dir is fully loadable."""
+    """Copy tokenizer / generation / misc files so the output dir is fully loadable.
+
+    Security contract: only ordinary regular files from ``src`` are copied.
+    Every *eligible* auxiliary candidate (i.e. any top-level entry that is
+    not ``*.safetensors``, ``config.json``, or a shard index) that is a
+    symlink or non-regular file fails closed — it is never copied.  When the
+    unsafe kind can be identified through the no-follow open + ``fstat``
+    path, :class:`UnsafeAuxiliaryFileError` is raised with a descriptive
+    message; when the underlying ``os.open`` itself rejects the entry (e.g.
+    ``ENXIO`` for a device node), the original ``OSError`` propagates.  In
+    either case no bytes from the entry enter the output bundle.  Skipped
+    names (model weights, generated config, shard indices) are never
+    inspected and cannot trigger this error.
+
+    Race resistance: the source root is opened with ``O_DIRECTORY | O_NOFOLLOW``
+    (rejecting a symlinked root), and each candidate is opened with
+    ``O_NOFOLLOW | O_NONBLOCK`` relative to the source-directory descriptor,
+    then ``fstat``-ed and required to be a regular file before copying.  There
+    is no separate ``lstat`` before the open, so a swap to a symlink between
+    validation and open is rejected atomically by the kernel rather than
+    followed.
+
+    Capabilities: this function requires ``O_NOFOLLOW``, ``O_DIRECTORY``,
+    ``O_NONBLOCK``, fd-relative ``os.open`` (``dir_fd`` — verified via
+    ``os.supports_dir_fd``), and fd-based ``os.listdir`` (verified via
+    ``os.supports_fd``).  If any are unavailable the function fails closed
+    rather than silently degrading to symlink-following behavior.
+
+    Hugging Face cache snapshot inputs present files as client-generated
+    symlinks to content-addressed blobs outside the snapshot directory.  These
+    are rejected here by design.  Operators who trust the HF client's own
+    cache links should materialize the snapshot as real files through the
+    HF client's vetted download path (e.g. ``huggingface_hub`` ``local_dir``
+    mode, which writes real files, not symlinks) before export.  **Never**
+    dereference symlinks from an untrusted or attacker-authored checkout —
+    copy only real files.
+    """
+    _require_aux_capabilities()
     skip_suffixes = (".safetensors",)
     skip_names = {"model.safetensors.index.json", "config.json"}
-    for item in src.iterdir():
-        if not item.is_file():
-            continue
-        if item.name in skip_names or item.suffix in skip_suffixes:
-            continue
-        if item.name.endswith(".safetensors.index.json"):
-            continue
-        shutil.copy2(item, dst / item.name)
+    src = pathlib.Path(src)
+    dst = pathlib.Path(dst)
+    # O_NOFOLLOW on the root rejects a symlinked source directory.
+    src_fd = os.open(str(src), os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        for entry in os.listdir(src_fd):
+            if entry in skip_names:
+                continue
+            if entry.endswith(".safetensors.index.json"):
+                continue
+            _copy_one_aux(src_fd, str(src), entry, skip_suffixes, dst)
+    finally:
+        os.close(src_fd)
+
+
+# Module-local seam for the candidate open.  Tests monkeypatch this to
+# simulate races (swap-to-symlink, file-vanishes) without disturbing the
+# real os.open used by the capability check and the source-root open.
+_candidate_open = os.open
+
+
+_AUX_CAPABILITIES: tuple[str, ...] = (
+    "O_NOFOLLOW",
+    "O_DIRECTORY",
+    "O_NONBLOCK",
+)
+
+
+def _require_aux_capabilities() -> None:
+    """Fail closed if the OS lacks the flags *and* fd APIs needed for safe copying.
+
+    The fd-relative ``os.open(dir_fd=...)`` and fd-based ``os.listdir(fd)``
+    APIs are essential: without them the helper cannot open candidates
+    relative to a pinned source-directory descriptor, which would reopen
+    the lstat+open TOCTOU window.  We fail closed rather than silently
+    degrading to symlink-following behavior.
+    """
+    missing_flags = [name for name in _AUX_CAPABILITIES if not hasattr(os, name)]
+    if missing_flags:
+        raise UnsafeAuxiliaryFileError(
+            f"cannot safely copy auxiliary files: missing OS flags {missing_flags}"
+        )
+    if os.open not in os.supports_dir_fd:
+        raise UnsafeAuxiliaryFileError(
+            "cannot safely copy auxiliary files: "
+            "os.open does not support dir_fd on this platform"
+        )
+    if os.listdir not in os.supports_fd:
+        raise UnsafeAuxiliaryFileError(
+            "cannot safely copy auxiliary files: "
+            "os.listdir does not support fd on this platform"
+        )
+
+def _copy_one_aux(
+    src_fd: int,
+    src_dir: str,
+    name: str,
+    skip_suffixes: tuple[str, ...],
+    dst: pathlib.Path,
+) -> None:
+    """Open ``name`` no-follow relative to ``src_fd`` and copy it if regular."""
+    if "." in name and ("." + name.rsplit(".", 1)[-1]) in skip_suffixes:
+        return
+    # O_NOFOLLOW rejects symlinks atomically at the kernel level.
+    # O_NONBLOCK prevents a FIFO/special file from blocking the open.
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+    try:
+        fd = _candidate_open(name, flags, dir_fd=src_fd)
+    except OSError as exc:
+        # O_NOFOLLOW on a symlink raises ELOOP (Linux) / EFTYPE (macOS).
+        # These are refused rather than followed.
+        if exc.errno in (
+            errno.ELOOP,
+            getattr(errno, "EFTYPE", errno.ELOOP),
+        ):
+            raise UnsafeAuxiliaryFileError(
+                f"refusing to follow auxiliary symlink {src_dir!r}/{name!r}; "
+                "only real regular files are copied"
+            ) from exc
+        # ENOENT (broken link / vanished entry) is a changing-source condition,
+        # not a symlink — propagate the original error.
+        raise
+    try:
+        mode = os.fstat(fd).st_mode
+        if stat.S_ISDIR(mode):
+            # Preserve old behavior: silently skip real subdirectories.
+            return
+        if not stat.S_ISREG(mode):
+            kind = _unsafe_kind(mode)
+            raise UnsafeAuxiliaryFileError(
+                f"refusing to copy {kind} {src_dir!r}/{name!r}; "
+                "only real regular files are copied"
+            )
+        # fdopen takes ownership of fd on success.
+        srcf = os.fdopen(fd, "rb")
+        fd = -1
+        with srcf, open(dst / name, "wb") as dstf:
+            shutil.copyfileobj(srcf, dstf)
+    finally:
+        if fd >= 0:
+            with suppress(OSError):
+                os.close(fd)
+
+
+def _unsafe_kind(mode: int) -> str:
+    """Return a human-readable name for a non-regular, non-directory mode."""
+    if stat.S_ISLNK(mode):
+        return "symlink"
+    if stat.S_ISFIFO(mode):
+        return "FIFO"
+    if stat.S_ISSOCK(mode):
+        return "socket"
+    if stat.S_ISCHR(mode):
+        return "character device"
+    if stat.S_ISBLK(mode):
+        return "block device"
+    return "non-regular file"
 
 
 def _write_config(

--- a/docs/fp6-user-guide.md
+++ b/docs/fp6-user-guide.md
@@ -33,6 +33,27 @@ with ModelOpt-mirror tensor keys (`.weight` / `.weight_scale` /
 `.weight_scale_2` / `.input_scale`), and copies of the tokenizer/chat
 template files. Routed MoE experts are written per-expert.
 
+> **Security: auxiliary files and symlinks.** The exporter copies tokenizer /
+> chat-template / generation-config files from the source directory into the
+> output, but only if they are **real regular files**. Every *eligible*
+> auxiliary candidate — any top-level entry that is not `*.safetensors`,
+> `config.json`, or a shard index — that is a symlink (absolute, relative,
+> broken, or a standard Hugging Face cache snapshot link
+> `snapshots/<rev>/<file> → ../../blobs/<hash>`) or a non-regular special
+> file **fails closed**: it is never copied. When the unsafe kind can be
+> identified the exporter raises `UnsafeAuxiliaryFileError`; when the OS
+> itself rejects the open (e.g. a device node) the underlying `OSError`
+> propagates. In either case no bytes from the entry enter the output
+> bundle. This prevents an attacker-authored symlink from embedding arbitrary
+> victim-readable bytes into the output bundle.
+>
+> If you are converting a model downloaded via `huggingface_hub` and the
+> cache snapshot uses symlink-to-blob links, re-download or materialize the
+> checkpoint as real files through the HF client's vetted download path
+> (e.g. `huggingface_hub` `local_dir` mode, which writes real files, not
+> symlinks) before running the exporter. **Never** dereference symlinks from
+> an untrusted or attacker-authored checkout — copy only real files.
+
 **What gets quantized (the "golden rule" walk):** MLP projections,
 attention q/k/v/o, MoE routed experts (gate/up/down) and the shared expert.
 **Kept BF16:** norms, embeddings, router gates, `lm_head`, the MTP head,

--- a/tests/quantization/test_aux_symlink_security.py
+++ b/tests/quantization/test_aux_symlink_security.py
@@ -1,0 +1,471 @@
+"""Security contract tests for auxiliary-file handling in FP6 export.
+
+Covers issue #172: the exporters must never follow attacker-authored symlinks
+or copy special file types when copying auxiliary files (tokenizer.json,
+generation_config.json, etc.) into the output bundle. Every eligible
+auxiliary symlink — absolute, relative, broken, same-repository HF cache
+blob link — is rejected with :class:`UnsafeAuxiliaryFileError`; only ordinary
+regular files are copied and real subdirectories are silently skipped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+
+import pytest
+import torch
+
+from b12x.quantization.mxfp6.fp6_safetensors_export import (
+    UnsafeAuxiliaryFileError,
+    _copy_aux_files,
+    export_dense_model_to_fp6_safetensors,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal checkpoint helpers (same shape as test_model_fp6_converter).
+# ---------------------------------------------------------------------------
+
+def _write_ckpt(path: pathlib.Path, tensors: dict[str, torch.Tensor]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    from safetensors.torch import save_file
+
+    save_file(tensors, str(path / "model.safetensors"))
+    (path / "config.json").write_text(json.dumps({"model_type": "test"}))
+
+
+def _fake_dense(path: pathlib.Path, *, layers: int, k: int, n: int) -> None:
+    t: dict[str, torch.Tensor] = {}
+    for i in range(layers):
+        t[f"model.language_model.layers.{i}.mlp.gate_proj.weight"] = torch.randn(n, k, dtype=torch.bfloat16)
+        t[f"model.language_model.layers.{i}.mlp.down_proj.weight"] = torch.randn(k, n, dtype=torch.bfloat16)
+    _write_ckpt(path, t)
+
+
+SENTINEL = b"EXTERNAL_SECRET_SENTINEL_BYTES_42"
+
+
+# ---------------------------------------------------------------------------
+# Capability check.
+# ---------------------------------------------------------------------------
+
+def test_capabilities_available() -> None:
+    """The safe-copy path requires O_NOFOLLOW, O_DIRECTORY, O_NONBLOCK,
+    fd-relative os.open (os.supports_dir_fd), and fd-based os.listdir
+    (os.supports_fd).  If any are missing the helper must fail closed.
+    """
+    for flag in ("O_NOFOLLOW", "O_DIRECTORY", "O_NONBLOCK"):
+        assert hasattr(os, flag), f"missing required OS flag: {flag}"
+    assert os.open in os.supports_dir_fd, "os.open must support dir_fd"
+    assert os.listdir in os.supports_fd, "os.listdir must support fd"
+
+
+def test_fails_closed_if_dir_fd_unsupported(tmp_path: pathlib.Path, monkeypatch) -> None:
+    """If os.open does not support dir_fd, _copy_aux_files fails closed."""
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    monkeypatch.setattr(os, "supports_dir_fd", set())
+    with pytest.raises(UnsafeAuxiliaryFileError, match="dir_fd"):
+        _copy_aux_files(src, dst)
+
+
+def test_fails_closed_if_listdir_fd_unsupported(tmp_path: pathlib.Path, monkeypatch) -> None:
+    """If os.listdir does not support fd, _copy_aux_files fails closed."""
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    monkeypatch.setattr(os, "supports_fd", set())
+    with pytest.raises(UnsafeAuxiliaryFileError, match="listdir"):
+        _copy_aux_files(src, dst)
+
+
+# ---------------------------------------------------------------------------
+# _copy_aux_files — unit-level policy tests.
+# ---------------------------------------------------------------------------
+
+def test_regular_aux_files_copied_byte_for_byte(tmp_path: pathlib.Path) -> None:
+    """Ordinary regular auxiliary files are preserved exactly."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").write_bytes(b'{"hello": "world"}')
+    (src / "tokenizer_config.json").write_bytes(b'{"name": "cfg"}')
+    (src / "generation_config.json").write_bytes(b'{"temp": 0}')
+    (src / "chat_template.jinja").write_bytes(b"{{ messages }}")
+    # Files that must be skipped (exporter generates its own).
+    (src / "config.json").write_bytes(b'{"should": "skip"}')
+    (src / "model.safetensors").write_bytes(b"\x00" * 16)
+    (src / "model.safetensors.index.json").write_bytes(b'{"skip": true}')
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    _copy_aux_files(src, dst)
+
+    assert (dst / "tokenizer.json").read_bytes() == b'{"hello": "world"}'
+    assert (dst / "tokenizer_config.json").read_bytes() == b'{"name": "cfg"}'
+    assert (dst / "generation_config.json").read_bytes() == b'{"temp": 0}'
+    assert (dst / "chat_template.jinja").read_bytes() == b"{{ messages }}"
+
+    # Skipped files must not appear in the output.
+    assert not (dst / "config.json").exists()
+    assert not (dst / "model.safetensors").exists()
+    assert not (dst / "model.safetensors.index.json").exists()
+
+
+def test_real_subdirectories_silently_skipped(tmp_path: pathlib.Path) -> None:
+    """Real subdirectories (not symlinks) are skipped, preserving old behavior."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").write_bytes(b"ok")
+    # A real subdirectory — must be silently skipped, not an error.
+    (src / ".git").mkdir()
+    (src / ".git" / "HEAD").write_bytes(b"ref: refs/heads/main")
+    (src / ".cache").mkdir()
+    (src / ".cache" / "data").write_bytes(b"cached")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    _copy_aux_files(src, dst)
+
+    assert (dst / "tokenizer.json").read_bytes() == b"ok"
+    assert not (dst / ".git").exists()
+    assert not (dst / ".cache").exists()
+
+
+def test_absolute_symlink_rejected(tmp_path: pathlib.Path) -> None:
+    """An absolute symlink to an external file is refused."""
+    src = tmp_path / "src"
+    src.mkdir()
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_bytes(SENTINEL)
+    (src / "tokenizer.json").symlink_to(sentinel)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(src, dst)
+
+    # Sentinel bytes must not enter the output.
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_relative_symlink_outside_source_rejected(tmp_path: pathlib.Path) -> None:
+    """A relative symlink escaping the source directory is refused."""
+    src = tmp_path / "src"
+    src.mkdir()
+    secret_dir = tmp_path / "secrets"
+    secret_dir.mkdir()
+    (secret_dir / "secret.txt").write_bytes(SENTINEL)
+    (src / "tokenizer.json").symlink_to(pathlib.Path("..") / "secrets" / "secret.txt")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(src, dst)
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_relative_symlink_inside_source_rejected(tmp_path: pathlib.Path) -> None:
+    """A relative symlink whose target is inside the source dir is still refused.
+
+    The policy rejects *all* symlinks regardless of where the target lives.
+    A same-repository link is not trusted merely because its target is nearby.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "real_tokenizer.json").write_bytes(SENTINEL)
+    (src / "tokenizer.json").symlink_to("real_tokenizer.json")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(src, dst)
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_broken_symlink_rejected(tmp_path: pathlib.Path) -> None:
+    """A dangling symlink (target does not exist) is rejected as a symlink.
+
+    ``O_NOFOLLOW`` rejects the final component because it *is* a symlink,
+    regardless of whether the target exists (ELOOP on Linux/macOS).  The
+    broken link is refused, not silently skipped or followed.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").symlink_to(tmp_path / "nonexistent")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(src, dst)
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_vanished_file_propagates_file_not_found(tmp_path: pathlib.Path) -> None:
+    """A regular file deleted between listdir and open propagates ENOENT.
+
+    ENOENT on a *non-symlink* (the entry vanished) is a changing-source
+    condition, not a symlink safety violation.  The original ``OSError`` is
+    propagated as-is rather than masked as ``UnsafeAuxiliaryFileError``.
+    """
+    import b12x.quantization.mxfp6.fp6_safetensors_export as mod
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").write_bytes(b"ok")
+
+    real_open = os.open
+    deleted: list[bool] = []
+
+    def deleting_open(path, flags, *args, **kwargs):
+        if isinstance(path, str) and path == "tokenizer.json" and not deleted:
+            deleted.append(True)
+            os.unlink(src / "tokenizer.json")
+        return real_open(path, flags, *args, **kwargs)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    orig = mod._candidate_open
+    mod._candidate_open = deleting_open
+    try:
+        with pytest.raises(FileNotFoundError, match="tokenizer.json"):
+            _copy_aux_files(src, dst)
+    finally:
+        mod._candidate_open = orig
+    assert deleted, "monkeypatched open was never called for tokenizer.json"
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_hf_cache_snapshot_symlink_rejected(tmp_path: pathlib.Path) -> None:
+    """Standard Hugging Face cache layout (snapshot -> blob) is rejected.
+
+    HF hub cache stores files as ``snapshots/<rev>/<name>`` symlinking to
+    ``../../blobs/<hash>``.  These are client-generated links to content-
+    addressed blobs outside the snapshot directory.  The chosen explicit
+    policy is to reject them and require materialization as real files.
+    """
+    cache_root = tmp_path / "hub" / "models--org--model"
+    blobs = cache_root / "blobs"
+    snapshots = cache_root / "snapshots" / "abc123def"
+    blobs.mkdir(parents=True)
+    snapshots.mkdir(parents=True)
+
+    blob = blobs / "deadbeef"
+    blob.write_bytes(SENTINEL)
+    (snapshots / "tokenizer.json").symlink_to(
+        pathlib.Path("..") / ".." / "blobs" / "deadbeef"
+    )
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(snapshots, dst)
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_symlink_object_not_copied(tmp_path: pathlib.Path) -> None:
+    """The symlink itself must not be copied as a link into the output."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "real.txt").write_bytes(b"real")
+    (src / "tokenizer.json").symlink_to("real.txt")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError):
+        _copy_aux_files(src, dst)
+
+    # No file and no symlink should appear at the destination.
+    assert not (dst / "tokenizer.json").exists()
+    assert not (dst / "tokenizer.json").is_symlink()
+
+
+def test_symlink_to_directory_rejected(tmp_path: pathlib.Path) -> None:
+    """A symlink to a directory is refused (only *real* directories are skipped)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    target_dir = tmp_path / "subdir"
+    target_dir.mkdir()
+    (src / "tokenizer.json").symlink_to(target_dir)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        _copy_aux_files(src, dst)
+
+
+def test_fifo_rejected_with_accurate_error(tmp_path: pathlib.Path) -> None:
+    """A FIFO (named pipe) is rejected with an accurately named error.
+
+    O_NONBLOCK prevents the open from blocking; the post-open fstat then
+    identifies it as a FIFO and refuses to copy.  This test patches
+    ``_candidate_open`` with a wrapper that asserts ``O_NONBLOCK`` is present
+    in the flags before delegating to the real ``os.open`` — otherwise a
+    regression that drops ``O_NONBLOCK`` would hang pytest on the FIFO open.
+    """
+    import b12x.quantization.mxfp6.fp6_safetensors_export as mod
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").write_bytes(b"real")
+    fifo_path = src / "pipe.json"
+    os.mkfifo(fifo_path)
+
+    real_open = os.open
+
+    def nonblock_asserting_open(path, flags, *args, **kwargs):
+        assert flags & os.O_NONBLOCK, (
+            "candidate open must include O_NONBLOCK to avoid blocking on FIFO"
+        )
+        return real_open(path, flags, *args, **kwargs)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    orig = mod._candidate_open
+    mod._candidate_open = nonblock_asserting_open
+    try:
+        with pytest.raises(UnsafeAuxiliaryFileError, match="FIFO"):
+            _copy_aux_files(src, dst)
+    finally:
+        mod._candidate_open = orig
+
+
+def test_source_root_symlink_rejected(tmp_path: pathlib.Path) -> None:
+    """A symlinked source directory root is rejected by O_NOFOLLOW on the root."""
+    real_dir = tmp_path / "real_model"
+    real_dir.mkdir()
+    (real_dir / "tokenizer.json").write_bytes(b"benign")
+    link = tmp_path / "linked_model"
+    link.symlink_to(real_dir)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises((UnsafeAuxiliaryFileError, OSError), match="linked_model"):
+        _copy_aux_files(link, dst)
+    assert not (dst / "tokenizer.json").exists()
+
+
+def test_mix_regular_and_symlink_aborts_on_symlink(tmp_path: pathlib.Path) -> None:
+    """If any auxiliary entry is a symlink, the copy aborts with an error."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer_config.json").write_bytes(b"ok")
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_bytes(SENTINEL)
+    (src / "tokenizer.json").symlink_to(sentinel)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    with pytest.raises(UnsafeAuxiliaryFileError):
+        _copy_aux_files(src, dst)
+
+    # The symlink target must never appear in output.
+    if (dst / "tokenizer.json").exists():
+        assert dst.joinpath("tokenizer.json").read_bytes() != SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# Race resistance: monkeypatched open that swaps regular file to symlink.
+# ---------------------------------------------------------------------------
+
+def test_swap_race_regular_to_symlink_rejected(tmp_path: pathlib.Path) -> None:
+    """A regular file swapped to a symlink *during* the open is rejected.
+
+    The implementation opens each candidate with ``O_NOFOLLOW`` relative to the
+    source directory descriptor — there is no separate ``lstat`` before the
+    open, so there is no TOCTOU window.  This test monkeypatches the
+    module-local ``_candidate_open`` seam to swap the target file to an
+    external symlink immediately before the real ``os.open`` runs, proving
+    the O_NOFOLLOW open rejects it atomically.  The capability check and
+    source-root open continue to use the real ``os.open`` undisturbed.
+    """
+    import b12x.quantization.mxfp6.fp6_safetensors_export as mod
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "tokenizer.json").write_bytes(b"benign")
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_bytes(SENTINEL)
+
+    real_open = os.open
+    swapped: list[bool] = []
+
+    def swapping_open(path, flags, *args, **kwargs):
+        # Assert the production code passes the expected safety flags and
+        # a source-directory descriptor — not a bare CWD-relative open.
+        assert kwargs.get("dir_fd") is not None, (
+            "candidate open must use dir_fd (source-directory descriptor)"
+        )
+        assert flags & os.O_NOFOLLOW, "candidate open must include O_NOFOLLOW"
+        # Swap the regular file to a symlink right before the real open.
+        if isinstance(path, str) and path == "tokenizer.json" and not swapped:
+            swapped.append(True)
+            os.unlink(src / "tokenizer.json")
+            (src / "tokenizer.json").symlink_to(sentinel)
+        return real_open(path, flags, *args, **kwargs)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    orig = mod._candidate_open
+    mod._candidate_open = swapping_open
+    try:
+        with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+            _copy_aux_files(src, dst)
+    finally:
+        mod._candidate_open = orig
+
+    assert swapped, "monkeypatched open was never called for tokenizer.json"
+    assert not (dst / "tokenizer.json").exists()
+    # Sentinel must never appear in output.
+    if (dst / "tokenizer.json").exists():
+        assert (dst / "tokenizer.json").read_bytes() != SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the public dense exporter enforces the same policy.
+# ---------------------------------------------------------------------------
+
+def test_dense_export_rejects_symlinked_aux(tmp_path: pathlib.Path) -> None:
+    """export_dense_model_to_fp6_safetensors refuses a symlinked auxiliary file."""
+    src = tmp_path / "d"
+    _fake_dense(src, layers=1, k=64, n=64)
+    sentinel = tmp_path / "secret.txt"
+    sentinel.write_bytes(SENTINEL)
+    (src / "tokenizer.json").symlink_to(sentinel)
+
+    out = tmp_path / "outd"
+    with pytest.raises(UnsafeAuxiliaryFileError, match="tokenizer.json"):
+        export_dense_model_to_fp6_safetensors(
+            src, out, device="cpu", use_gpu=False, verbose=False
+        )
+
+    # Sentinel bytes must not be anywhere in the output directory.
+    if out.exists():
+        for f in out.rglob("*"):
+            if f.is_file():
+                assert SENTINEL not in f.read_bytes(), (
+                    f"sentinel bytes leaked into {f}"
+                )
+
+
+def test_dense_export_regular_aux_preserved(tmp_path: pathlib.Path) -> None:
+    """A regular (non-symlink) auxiliary file is copied through the exporter."""
+    src = tmp_path / "d"
+    _fake_dense(src, layers=1, k=64, n=64)
+    (src / "tokenizer.json").write_bytes(b'{"model": "test"}')
+    (src / "generation_config.json").write_bytes(b'{"temp": 1}')
+
+    out = tmp_path / "outd"
+    export_dense_model_to_fp6_safetensors(
+        src, out, device="cpu", use_gpu=False, verbose=False
+    )
+
+    assert (out / "tokenizer.json").read_bytes() == b'{"model": "test"}'
+    assert (out / "generation_config.json").read_bytes() == b'{"temp": 1}'
+    # The exporter writes its own config.json — the source one must not clobber it.
+    cfg = json.loads((out / "config.json").read_text())
+    assert cfg["quantization_config"]["quant_algo"] == "W6A6"


### PR DESCRIPTION
## Problem

The FP6 full-checkpoint exporters copied top-level auxiliary entries via path-following filesystem helpers. An attacker-controlled checkpoint could use an absolute, relative, broken, same-repository, or Hugging Face cache symlink to disclose external bytes into a published output bundle.

## Change

- enumerate source entries through a pinned directory descriptor
- open eligible candidates relative to that descriptor with `O_NOFOLLOW` and `O_NONBLOCK`
- verify regular-file type after open, then copy from the already-open descriptor
- reject every eligible symlink and unsafe non-regular entry fail-closed
- fail closed when required POSIX descriptor-relative capabilities are unavailable
- preserve real regular-file copying, skipped subdirectories/extensions, quantized shard/index/config behavior, and destination semantics
- expose `UnsafeAuxiliaryFileError`
- document HF cache materialization guidance and the source/destination race boundaries

## Verification

- Linux/Python 3.12: `python -m pytest tests/quantization/test_aux_symlink_security.py -q` — 19 passed
- macOS/Python 3.12: same command — 19 passed
- behavioral smoke includes byte-exact real-file copy, every symlink topology, source-swap/vanish seams, FIFO nonblocking rejection, capability failure, skipped-name noninspection, and full exporter outputs
- `ruff check` and `python -m py_compile` on changed source/test

Destination clobbering is tracked independently in #173 and is intentionally not mixed into this source-disclosure fix.

Closes #172