### PR TITLE
security: pin native-profile output directories

### DIFF
--- a/scripts/capture_sglang_native_profile.py
+++ b/scripts/capture_sglang_native_profile.py
@@ -2,15 +2,144 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import errno
 import json
 import os
+import stat
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Optional
+
+
+def _open_dir_fd(path, dir_fd: Optional[int] = None) -> int:
+    """Open a directory file descriptor with O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC.
+
+    O_NOFOLLOW rejects a *final-component* symlink (raises ELOOP).
+    Intermediate path components are not directly controlled here, but
+    their risk is bounded by the caller: the parent is opened and
+    verified (owned by euid, not group/world-writable) before the leaf
+    is created or pinned relative to it.
+    """
+    flags = os.O_NOFOLLOW
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        return os.open(path, flags, dir_fd=dir_fd)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise RuntimeError(f"refusing to follow symlink: {path}") from exc
+        raise
+
+
+def _verify_parent_fd(fd: int, parent) -> None:
+    """Verify a pinned parent directory fd is owned by euid and not group/world-writable."""
+    st = os.fstat(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"parent is not a directory: {parent}")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"parent not owned by current user: {parent} "
+            f"(use a home or private parent directory, or omit --out-dir)"
+        )
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise RuntimeError(
+            f"parent is group or world writable: {parent} "
+            f"(use a home or private parent directory, or omit --out-dir)"
+        )
+
+
+def _verify_leaf_fd(fd: int, path) -> None:
+    """Verify a pinned leaf directory fd is a directory, owned by euid, mode 0700."""
+    st = os.fstat(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"output is not a directory: {path}")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(f"output not owned by current user: {path}")
+    if stat.S_IMODE(st.st_mode) != 0o700:
+        raise RuntimeError(f"output directory mode is {oct(stat.S_IMODE(st.st_mode))}, expected 0700: {path}")
+
+
+def _prepare_output_dir(out_arg: Optional[str], prefix: str) -> tuple[Path, int]:
+    """Return (path, pinned_dir_fd) for a private, mode-0700 output directory.
+
+    When *out_arg* is ``None`` an unpredictable directory is created via
+    :func:`tempfile.mkdtemp`, then pinned and verified.
+
+    When *out_arg* is provided the parent directory must already exist, be
+    owned by the current user, and not be group/world-writable.  The leaf
+    must not already exist (no directory, file, or symlink).  It is created
+    with mode 0700 via the pinned parent fd, then pinned and verified.
+    """
+    if out_arg is None:
+        path = Path(tempfile.mkdtemp(prefix=prefix))
+        fd = _open_dir_fd(path)
+    else:
+        path = Path(out_arg).absolute()
+        # Leaf must not exist or be a symlink.
+        if path.is_symlink() or path.exists():
+            raise RuntimeError(f"refusing to use existing path as output directory: {path}")
+        parent = path.parent
+        if not parent.is_dir():
+            raise RuntimeError(f"parent directory does not exist: {parent}")
+        parent_fd = _open_dir_fd(parent)
+        try:
+            _verify_parent_fd(parent_fd, parent)
+            os.mkdir(path.name, 0o700, dir_fd=parent_fd)
+            # Pin the newly created leaf via the parent fd before closing it,
+            # so the fd refers to the exact inode we just created, not a
+            # path that could be swapped before reopening.
+            fd = _open_dir_fd(path.name, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    # Enforce mode 0700 and verify the pinned leaf.
+    try:
+        os.fchmod(fd, 0o700)
+        _verify_leaf_fd(fd, path)
+    except Exception:
+        os.close(fd)
+        raise
+    return path, fd
+
+
+def _secure_open(basename: str, dir_fd: int):
+    """Open a new file for writing relative to *dir_fd* with exclusive, no-follow, mode-0600 semantics.
+
+    The file must not already exist; symlinks are never followed.  The raw
+    fd is fchmod'd to exactly 0600 (undoing any umask) and then wrapped via
+    :func:`os.fdopen`.  The raw fd is closed if fdopen fails.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        fd = os.open(basename, flags, 0o600, dir_fd=dir_fd)
+    except OSError as exc:
+        if exc.errno in (errno.EEXIST, errno.ELOOP):
+            raise RuntimeError(
+                f"refusing to overwrite existing file or follow symlink: {basename}"
+            ) from exc
+        raise
+    try:
+        os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "w", encoding="utf-8")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _secure_write_text(basename: str, dir_fd: int, content: str) -> None:
+    """Write *content* to a brand-new file relative to *dir_fd* with exclusive, no-follow, mode-0600 semantics."""
+    with _secure_open(basename, dir_fd) as f:
+        f.write(content)
 
 
 class StreamRequest:
@@ -20,15 +149,18 @@ class StreamRequest:
         url: str,
         headers: dict[str, str],
         payload: dict[str, Any],
-        log_path: Path,
-        error_path: Path,
+        log_basename: str,
+        error_basename: str,
+        dir_fd: int,
         timeout_s: int = 3600,
     ) -> None:
         self.url = url
         self.headers = headers
         self.payload = payload
-        self.log_path = log_path
-        self.error_path = error_path
+        self.log_basename = log_basename
+        self.error_basename = error_basename
+        self._caller_fd = dir_fd
+        self._owned_fd: Optional[int] = None
         self.timeout_s = timeout_s
         self.first_token_event = threading.Event()
         self.finished_event = threading.Event()
@@ -38,15 +170,23 @@ class StreamRequest:
         self.error: Optional[str] = None
 
     def start(self) -> None:
-        self._thread.start()
+        # Dup the caller's dir_fd so the stream owns an independent directory
+        # capability that survives even if main() closes its fd while the
+        # daemon thread is still running.
+        self._owned_fd = os.dup(self._caller_fd)
+        os.set_inheritable(self._owned_fd, False)
+        try:
+            self._thread.start()
+        except Exception:
+            os.close(self._owned_fd)
+            self._owned_fd = None
+            raise
 
     def stop(self) -> None:
         self._stop_event.set()
         if self._response is not None:
-            try:
+            with contextlib.suppress(Exception):
                 self._response.close()
-            except Exception:
-                pass
         self._thread.join(timeout=5)
 
     def wait_for_first_token(self, timeout_s: float) -> bool:
@@ -63,7 +203,7 @@ class StreamRequest:
         try:
             with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
                 self._response = response
-                with self.log_path.open("w", encoding="utf-8") as log_file:
+                with _secure_open(self.log_basename, self._owned_fd) as log_file:
                     while not self._stop_event.is_set():
                         line = response.readline()
                         if not line:
@@ -75,8 +215,12 @@ class StreamRequest:
                             self.first_token_event.set()
         except Exception as exc:
             self.error = f"{type(exc).__name__}: {exc}"
-            self.error_path.write_text(self.error + "\n", encoding="utf-8")
+            try:
+                _secure_write_text(self.error_basename, self._owned_fd, self.error + "\n")
+            except Exception as write_exc:
+                self.error += f" (additionally failed to write error log: {write_exc})"
         finally:
+            os.close(self._owned_fd)
             self.finished_event.set()
 
 
@@ -121,21 +265,23 @@ def build_request(model: str, prompt: str, max_tokens: int) -> dict[str, Any]:
 def build_profile_request(
     *,
     mode: str,
-    server_output_dir: str,
+    server_output_dir: Optional[str],
     num_steps: int,
     include_cpu: bool,
 ) -> dict[str, Any]:
     activities = ["GPU"]
     if include_cpu:
         activities = ["CPU", "GPU"]
-    return {
-        "output_dir": server_output_dir,
+    request = {
         "num_steps": num_steps,
         "activities": activities,
         "profile_by_stage": True,
         "profile_prefix": mode,
         "profile_stages": ["decode"] if mode == "decode" else ["prefill"],
     }
+    if server_output_dir is not None:
+        request["output_dir"] = server_output_dir
+    return request
 
 
 def parse_args() -> argparse.Namespace:
@@ -152,13 +298,24 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt-file", default=None, help="Read the prompt from a file.")
     parser.add_argument("--max-tokens", type=int, default=512)
     parser.add_argument("--num-steps", type=int, default=8)
-    parser.add_argument("--out-dir", default=None, help="Local output directory for logs and metadata.")
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help=(
+            "Local output directory for logs and metadata. "
+            "The parent directory must already exist, be owned by you, "
+            "and not be group/world-writable.  The directory itself is "
+            "created fresh with mode 0700; an existing path is rejected."
+        ),
+    )
     parser.add_argument(
         "--server-output-dir",
         default=None,
         help=(
-            "Server-visible path for native traces. Defaults to --out-dir. "
-            "Set this explicitly if the server is remote or writes to a different filesystem."
+            "Explicit server-visible path for native traces. When omitted, the "
+            "server uses its configured output directory. This path is resolved "
+            "by the already-running server and is a separate trusted server-side "
+            "contract; the client cannot pin or secure it."
         ),
     )
     parser.add_argument("--api-key", default=None, help="Optional bearer token. Falls back to OPENAI_API_KEY.")
@@ -187,90 +344,86 @@ def main() -> None:
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
-    out_dir = Path(args.out_dir or f"/tmp/sglang-native-{args.mode}-{time.strftime('%Y%m%d-%H%M%S')}")
-    out_dir.mkdir(parents=True, exist_ok=True)
-    server_output_dir = args.server_output_dir or str(out_dir)
+    out_dir, dir_fd = _prepare_output_dir(args.out_dir, f"sglang-native-{args.mode}-")
+    server_output_dir = args.server_output_dir
+    try:
+        prompt = load_prompt(args)
+        model = args.model or resolve_model(base_url, headers)
+        request_body = build_request(model, prompt, args.max_tokens)
+        profile_body = build_profile_request(
+            mode=args.mode,
+            server_output_dir=server_output_dir,
+            num_steps=args.num_steps,
+            include_cpu=args.include_cpu,
+        )
 
-    prompt = load_prompt(args)
-    model = args.model or resolve_model(base_url, headers)
-    request_body = build_request(model, prompt, args.max_tokens)
-    profile_body = build_profile_request(
-        mode=args.mode,
-        server_output_dir=server_output_dir,
-        num_steps=args.num_steps,
-        include_cpu=args.include_cpu,
-    )
+        _secure_write_text("request.json", dir_fd, json.dumps(request_body, indent=2) + "\n")
+        _secure_write_text("start_profile.json", dir_fd, json.dumps(profile_body, indent=2) + "\n")
 
-    request_path = out_dir / "request.json"
-    profile_path = out_dir / "start_profile.json"
-    stream_log = out_dir / "stream.log"
-    error_log = out_dir / "request.error.txt"
-    profile_response = out_dir / "profile.response"
-    manifest_path = out_dir / "manifest.json"
-    request_path.write_text(json.dumps(request_body, indent=2) + "\n", encoding="utf-8")
-    profile_path.write_text(json.dumps(profile_body, indent=2) + "\n", encoding="utf-8")
+        print(f"output dir: {out_dir}")
+        print(f"model: {model}")
+        print(f"mode: {args.mode}")
+        print("starting streaming request...")
 
-    print(f"output dir: {out_dir}")
-    print(f"model: {model}")
-    print(f"mode: {args.mode}")
-    print("starting streaming request...")
+        stream = StreamRequest(
+            url=f"{base_url}/v1/completions",
+            headers=headers,
+            payload=request_body,
+            log_basename="stream.log",
+            error_basename="request.error.txt",
+            dir_fd=dir_fd,
+        )
+        stream.start()
+        started_at = time.time()
 
-    stream = StreamRequest(
-        url=f"{base_url}/v1/completions",
-        headers=headers,
-        payload=request_body,
-        log_path=stream_log,
-        error_path=error_log,
-    )
-    stream.start()
-    started_at = time.time()
+        if not stream.wait_for_first_token(args.first_token_timeout):
+            stream.stop()
+            detail = ""
+            if stream.error:
+                detail = f" request error: {stream.error}"
+            raise RuntimeError(f"timed out waiting for the first streamed token.{detail}")
 
-    if not stream.wait_for_first_token(args.first_token_timeout):
+        first_token_at = time.time()
+        print("first streamed token observed; starting native profile...")
+
+        status, body = http_json(
+            f"{base_url}/start_profile",
+            headers=headers,
+            payload=profile_body,
+            timeout_s=3600,
+        )
+        _secure_write_text("profile.response", dir_fd, body)
+        if status != 200:
+            stream.stop()
+            raise RuntimeError(f"/start_profile failed with status {status}: {body.strip()}")
+
+        finished_at = time.time()
         stream.stop()
-        detail = ""
-        if stream.error:
-            detail = f" request error: {stream.error}"
-        raise RuntimeError(f"timed out waiting for the first streamed token.{detail}")
 
-    first_token_at = time.time()
-    print("first streamed token observed; starting native profile...")
+        manifest = {
+            "base_url": base_url,
+            "mode": args.mode,
+            "model": model,
+            "out_dir": str(out_dir),
+            "server_output_dir": server_output_dir,
+            "started_at_epoch_s": started_at,
+            "first_token_at_epoch_s": first_token_at,
+            "profile_finished_at_epoch_s": finished_at,
+            "request_body": request_body,
+            "profile_body": profile_body,
+            "notes": [
+                "The background request was started before profiling and profiling began after the first streamed token.",
+                "For speculative requests, native SGLang profiling buckets TARGET_VERIFY and DRAFT_EXTEND under the prefill-family stage.",
+                "On older SGLang profiler paths, profile_stages is ignored and profiling still buckets into prefill-family vs decode.",
+            ],
+        }
+        _secure_write_text("manifest.json", dir_fd, json.dumps(manifest, indent=2) + "\n")
 
-    status, body = http_json(
-        f"{base_url}/start_profile",
-        headers=headers,
-        payload=profile_body,
-        timeout_s=3600,
-    )
-    profile_response.write_text(body, encoding="utf-8")
-    if status != 200:
-        stream.stop()
-        raise RuntimeError(f"/start_profile failed with status {status}: {body.strip()}")
-
-    finished_at = time.time()
-    stream.stop()
-
-    manifest = {
-        "base_url": base_url,
-        "mode": args.mode,
-        "model": model,
-        "out_dir": str(out_dir),
-        "server_output_dir": server_output_dir,
-        "started_at_epoch_s": started_at,
-        "first_token_at_epoch_s": first_token_at,
-        "profile_finished_at_epoch_s": finished_at,
-        "request_body": request_body,
-        "profile_body": profile_body,
-        "notes": [
-            "The background request was started before profiling and profiling began after the first streamed token.",
-            "For speculative requests, native SGLang profiling buckets TARGET_VERIFY and DRAFT_EXTEND under the prefill-family stage.",
-            "On older SGLang profiler paths, profile_stages is ignored and profiling still buckets into prefill-family vs decode.",
-        ],
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-
-    print("native profiling completed.")
-    print(f"stream log: {stream_log}")
-    print(f"manifest: {manifest_path}")
+        print("native profiling completed.")
+        print(f"stream log: {out_dir / 'stream.log'}")
+        print(f"manifest: {out_dir / 'manifest.json'}")
+    finally:
+        os.close(dir_fd)
 
 
 if __name__ == "__main__":

--- a/scripts/capture_sglang_native_profile.sh
+++ b/scripts/capture_sglang_native_profile.sh
@@ -105,14 +105,25 @@ case "${mode}" in
     ;;
 esac
 
+_RESPONSE_FILE=""
+
+_cleanup_response_file() {
+  [[ -n "${_RESPONSE_FILE}" ]] && rm -f "${_RESPONSE_FILE}"
+  return 0
+}
+
 curl_post() {
   local url="$1"
   local body="$2"
   local http_code
 
+  trap _cleanup_response_file EXIT
+  _RESPONSE_FILE="$(mktemp "${TMPDIR:-/tmp}/sglang_prof_resp.XXXXXXXX")"
+  chmod 600 "${_RESPONSE_FILE}"
+
   http_code="$(
     curl -sS \
-      -o /tmp/sglang_profile_response.$$ \
+      -o "${_RESPONSE_FILE}" \
       -w '%{http_code}' \
       -X POST \
       -H 'Content-Type: application/json' \
@@ -120,8 +131,9 @@ curl_post() {
       "${url}"
   )"
 
-  cat /tmp/sglang_profile_response.$$
-  rm -f /tmp/sglang_profile_response.$$
+  cat "${_RESPONSE_FILE}"
+  rm -f "${_RESPONSE_FILE}"
+  _RESPONSE_FILE=""
 
   if [[ "${http_code}" != 2* ]]; then
     echo >&2

--- a/scripts/capture_vllm_native_profile.py
+++ b/scripts/capture_vllm_native_profile.py
@@ -2,15 +2,144 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import errno
 import json
 import os
+import stat
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Optional
+
+
+def _open_dir_fd(path, dir_fd: Optional[int] = None) -> int:
+    """Open a directory file descriptor with O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC.
+
+    O_NOFOLLOW rejects a *final-component* symlink (raises ELOOP).
+    Intermediate path components are not directly controlled here, but
+    their risk is bounded by the caller: the parent is opened and
+    verified (owned by euid, not group/world-writable) before the leaf
+    is created or pinned relative to it.
+    """
+    flags = os.O_NOFOLLOW
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        return os.open(path, flags, dir_fd=dir_fd)
+    except OSError as exc:
+        if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+            raise RuntimeError(f"refusing to follow symlink: {path}") from exc
+        raise
+
+
+def _verify_parent_fd(fd: int, parent) -> None:
+    """Verify a pinned parent directory fd is owned by euid and not group/world-writable."""
+    st = os.fstat(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"parent is not a directory: {parent}")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"parent not owned by current user: {parent} "
+            f"(use a home or private parent directory, or omit --out-dir)"
+        )
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise RuntimeError(
+            f"parent is group or world writable: {parent} "
+            f"(use a home or private parent directory, or omit --out-dir)"
+        )
+
+
+def _verify_leaf_fd(fd: int, path) -> None:
+    """Verify a pinned leaf directory fd is a directory, owned by euid, mode 0700."""
+    st = os.fstat(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"output is not a directory: {path}")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(f"output not owned by current user: {path}")
+    if stat.S_IMODE(st.st_mode) != 0o700:
+        raise RuntimeError(f"output directory mode is {oct(stat.S_IMODE(st.st_mode))}, expected 0700: {path}")
+
+
+def _prepare_output_dir(out_arg: Optional[str], prefix: str) -> tuple[Path, int]:
+    """Return (path, pinned_dir_fd) for a private, mode-0700 output directory.
+
+    When *out_arg* is ``None`` an unpredictable directory is created via
+    :func:`tempfile.mkdtemp`, then pinned and verified.
+
+    When *out_arg* is provided the parent directory must already exist, be
+    owned by the current user, and not be group/world-writable.  The leaf
+    must not already exist (no directory, file, or symlink).  It is created
+    with mode 0700 via the pinned parent fd, then pinned and verified.
+    """
+    if out_arg is None:
+        path = Path(tempfile.mkdtemp(prefix=prefix))
+        fd = _open_dir_fd(path)
+    else:
+        path = Path(out_arg).absolute()
+        # Leaf must not exist or be a symlink.
+        if path.is_symlink() or path.exists():
+            raise RuntimeError(f"refusing to use existing path as output directory: {path}")
+        parent = path.parent
+        if not parent.is_dir():
+            raise RuntimeError(f"parent directory does not exist: {parent}")
+        parent_fd = _open_dir_fd(parent)
+        try:
+            _verify_parent_fd(parent_fd, parent)
+            os.mkdir(path.name, 0o700, dir_fd=parent_fd)
+            # Pin the newly created leaf via the parent fd before closing it,
+            # so the fd refers to the exact inode we just created, not a
+            # path that could be swapped before reopening.
+            fd = _open_dir_fd(path.name, dir_fd=parent_fd)
+        finally:
+            os.close(parent_fd)
+
+    # Enforce mode 0700 and verify the pinned leaf.
+    try:
+        os.fchmod(fd, 0o700)
+        _verify_leaf_fd(fd, path)
+    except Exception:
+        os.close(fd)
+        raise
+    return path, fd
+
+
+def _secure_open(basename: str, dir_fd: int):
+    """Open a new file for writing relative to *dir_fd* with exclusive, no-follow, mode-0600 semantics.
+
+    The file must not already exist; symlinks are never followed.  The raw
+    fd is fchmod'd to exactly 0600 (undoing any umask) and then wrapped via
+    :func:`os.fdopen`.  The raw fd is closed if fdopen fails.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        fd = os.open(basename, flags, 0o600, dir_fd=dir_fd)
+    except OSError as exc:
+        if exc.errno in (errno.EEXIST, errno.ELOOP):
+            raise RuntimeError(
+                f"refusing to overwrite existing file or follow symlink: {basename}"
+            ) from exc
+        raise
+    try:
+        os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "w", encoding="utf-8")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _secure_write_text(basename: str, dir_fd: int, content: str) -> None:
+    """Write *content* to a brand-new file relative to *dir_fd* with exclusive, no-follow, mode-0600 semantics."""
+    with _secure_open(basename, dir_fd) as f:
+        f.write(content)
 
 
 class StreamRequest:
@@ -20,15 +149,18 @@ class StreamRequest:
         url: str,
         headers: dict[str, str],
         payload: dict[str, Any],
-        log_path: Path,
-        error_path: Path,
+        log_basename: str,
+        error_basename: str,
+        dir_fd: int,
         timeout_s: int = 3600,
     ) -> None:
         self.url = url
         self.headers = headers
         self.payload = payload
-        self.log_path = log_path
-        self.error_path = error_path
+        self.log_basename = log_basename
+        self.error_basename = error_basename
+        self._caller_fd = dir_fd
+        self._owned_fd: Optional[int] = None
         self.timeout_s = timeout_s
         self.first_token_event = threading.Event()
         self.finished_event = threading.Event()
@@ -38,16 +170,25 @@ class StreamRequest:
         self.error: Optional[str] = None
 
     def start(self) -> None:
-        self._thread.start()
+        # Dup the caller's dir_fd so the stream owns an independent directory
+        # capability that survives even if main() closes its fd while the
+        # daemon thread is still running.
+        self._owned_fd = os.dup(self._caller_fd)
+        os.set_inheritable(self._owned_fd, False)
+        try:
+            self._thread.start()
+        except Exception:
+            os.close(self._owned_fd)
+            self._owned_fd = None
+            raise
 
     def stop(self) -> None:
         self._stop_event.set()
         if self._response is not None:
-            try:
+            with contextlib.suppress(Exception):
                 self._response.close()
-            except Exception:
-                pass
         self._thread.join(timeout=5)
+
 
     def wait_for_first_token(self, timeout_s: float) -> bool:
         return self.first_token_event.wait(timeout_s)
@@ -63,7 +204,7 @@ class StreamRequest:
         try:
             with urllib.request.urlopen(request, timeout=self.timeout_s) as response:
                 self._response = response
-                with self.log_path.open("w", encoding="utf-8") as log_file:
+                with _secure_open(self.log_basename, self._owned_fd) as log_file:
                     while not self._stop_event.is_set():
                         line = response.readline()
                         if not line:
@@ -75,8 +216,12 @@ class StreamRequest:
                             self.first_token_event.set()
         except Exception as exc:
             self.error = f"{type(exc).__name__}: {exc}"
-            self.error_path.write_text(self.error + "\n", encoding="utf-8")
+            try:
+                _secure_write_text(self.error_basename, self._owned_fd, self.error + "\n")
+            except Exception as write_exc:
+                self.error += f" (additionally failed to write error log: {write_exc})"
         finally:
+            os.close(self._owned_fd)
             self.finished_event.set()
 
 
@@ -132,7 +277,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt-file", default=None, help="Read the prompt from a file.")
     parser.add_argument("--max-tokens", type=int, default=512)
     parser.add_argument("--capture-seconds", type=float, default=10.0)
-    parser.add_argument("--out-dir", default=None, help="Local output directory for logs and metadata.")
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help=(
+            "Local output directory for logs and metadata. "
+            "The parent directory must already exist, be owned by you, "
+            "and not be group/world-writable.  The directory itself is "
+            "created fresh with mode 0700; an existing path is rejected."
+        ),
+    )
     parser.add_argument("--api-key", default=None, help="Optional bearer token. Falls back to OPENAI_API_KEY.")
     parser.add_argument("--first-token-timeout", type=float, default=60.0)
     return parser.parse_args()
@@ -158,94 +312,90 @@ def main() -> None:
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
-    out_dir = Path(args.out_dir or f"/tmp/vllm-native-{args.mode}-{time.strftime('%Y%m%d-%H%M%S')}")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir, dir_fd = _prepare_output_dir(args.out_dir, f"vllm-native-{args.mode}-")
+    try:
+        prompt = load_prompt(args)
+        model = args.model or resolve_model(base_url, headers)
+        request_body = build_request(model, prompt, args.max_tokens)
 
-    prompt = load_prompt(args)
-    model = args.model or resolve_model(base_url, headers)
-    request_body = build_request(model, prompt, args.max_tokens)
+        _secure_write_text("request.json", dir_fd, json.dumps(request_body, indent=2) + "\n")
 
-    request_path = out_dir / "request.json"
-    stream_log = out_dir / "stream.log"
-    error_log = out_dir / "request.error.txt"
-    start_response = out_dir / "start_profile.response"
-    stop_response = out_dir / "stop_profile.response"
-    manifest_path = out_dir / "manifest.json"
-    request_path.write_text(json.dumps(request_body, indent=2) + "\n", encoding="utf-8")
+        print(f"output dir: {out_dir}")
+        print(f"model: {model}")
+        print(f"mode: {args.mode}")
+        print("starting streaming request...")
 
-    print(f"output dir: {out_dir}")
-    print(f"model: {model}")
-    print(f"mode: {args.mode}")
-    print("starting streaming request...")
-
-    stream = StreamRequest(
-        url=f"{base_url}/v1/completions",
-        headers=headers,
-        payload=request_body,
-        log_path=stream_log,
-        error_path=error_log,
-    )
-    stream.start()
-    started_at = time.time()
-
-    if not stream.wait_for_first_token(args.first_token_timeout):
-        stream.stop()
-        detail = ""
-        if stream.error:
-            detail = f" request error: {stream.error}"
-        raise RuntimeError(f"timed out waiting for the first streamed token.{detail}")
-
-    first_token_at = time.time()
-    print("first streamed token observed; starting native profile...")
-
-    status, body = http_json(f"{base_url}/start_profile", headers=headers, payload={})
-    start_response.write_text(body, encoding="utf-8")
-    if status == 404:
-        stream.stop()
-        raise RuntimeError(
-            "/start_profile is not available on this server. "
-            "For vLLM this usually means the server was not launched with --profiler-config."
+        stream = StreamRequest(
+            url=f"{base_url}/v1/completions",
+            headers=headers,
+            payload=request_body,
+            log_basename="stream.log",
+            error_basename="request.error.txt",
+            dir_fd=dir_fd,
         )
-    if status != 200:
+        stream.start()
+        started_at = time.time()
+
+        if not stream.wait_for_first_token(args.first_token_timeout):
+            stream.stop()
+            detail = ""
+            if stream.error:
+                detail = f" request error: {stream.error}"
+            raise RuntimeError(f"timed out waiting for the first streamed token.{detail}")
+
+        first_token_at = time.time()
+        print("first streamed token observed; starting native profile...")
+
+        status, body = http_json(f"{base_url}/start_profile", headers=headers, payload={})
+        _secure_write_text("start_profile.response", dir_fd, body)
+        if status == 404:
+            stream.stop()
+            raise RuntimeError(
+                "/start_profile is not available on this server. "
+                "For vLLM this usually means the server was not launched with --profiler-config."
+            )
+        if status != 200:
+            stream.stop()
+            raise RuntimeError(f"/start_profile failed with status {status}: {body.strip()}")
+
+        deadline = time.time() + args.capture_seconds
+        while time.time() < deadline:
+            if stream.finished_event.wait(timeout=0.2):
+                break
+
+        print("stopping native profile...")
+        status, body = http_json(f"{base_url}/stop_profile", headers=headers, payload={})
+        _secure_write_text("stop_profile.response", dir_fd, body)
+        if status != 200:
+            stream.stop()
+            raise RuntimeError(f"/stop_profile failed with status {status}: {body.strip()}")
+
+        finished_at = time.time()
         stream.stop()
-        raise RuntimeError(f"/start_profile failed with status {status}: {body.strip()}")
 
-    deadline = time.time() + args.capture_seconds
-    while time.time() < deadline:
-        if stream.finished_event.wait(timeout=0.2):
-            break
+        manifest = {
+            "base_url": base_url,
+            "mode": args.mode,
+            "model": model,
+            "out_dir": str(out_dir),
+            "started_at_epoch_s": started_at,
+            "first_token_at_epoch_s": first_token_at,
+            "profile_stopped_at_epoch_s": finished_at,
+            "capture_seconds": args.capture_seconds,
+            "request_body": request_body,
+            "notes": [
+                "The background request was started before profiling and profiling began after the first streamed token.",
+                "vLLM native HTTP profiling is window-based and does not provide a stage filter over the server API.",
+                "For speculative servers, draft or verify regions should show up in the same trace window.",
+            ],
+        }
+        _secure_write_text("manifest.json", dir_fd, json.dumps(manifest, indent=2) + "\n")
 
-    print("stopping native profile...")
-    status, body = http_json(f"{base_url}/stop_profile", headers=headers, payload={})
-    stop_response.write_text(body, encoding="utf-8")
-    if status != 200:
-        stream.stop()
-        raise RuntimeError(f"/stop_profile failed with status {status}: {body.strip()}")
-
-    finished_at = time.time()
-    stream.stop()
-
-    manifest = {
-        "base_url": base_url,
-        "mode": args.mode,
-        "model": model,
-        "out_dir": str(out_dir),
-        "started_at_epoch_s": started_at,
-        "first_token_at_epoch_s": first_token_at,
-        "profile_stopped_at_epoch_s": finished_at,
-        "capture_seconds": args.capture_seconds,
-        "request_body": request_body,
-        "notes": [
-            "The background request was started before profiling and profiling began after the first streamed token.",
-            "vLLM native HTTP profiling is window-based and does not provide a stage filter over the server API.",
-            "For speculative servers, draft or verify regions should show up in the same trace window.",
-        ],
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-
-    print("native profiling completed.")
-    print(f"stream log: {stream_log}")
-    print(f"manifest: {manifest_path}")
+        print("native profiling completed.")
+        print(f"stream log: {out_dir / 'stream.log'}")
+        print(f"manifest: {out_dir / 'manifest.json'}")
+    finally:
+        os.close(dir_fd)
 
 
 if __name__ == "__main__":

--- a/tests/test_native_profile_security.py
+++ b/tests/test_native_profile_security.py
@@ -1,0 +1,925 @@
+"""Filesystem security tests for native profile capture helpers (issue #175).
+
+Verifies that default capture directories are private and unpredictable,
+that explicit output directories are validated against pre-existing entries
+and unsafe parents, that all sensitive file writes use exclusive, no-follow,
+mode-0600 semantics relative to a pinned directory fd, and that post-creation
+path swaps cannot redirect writes.  No live inference server is required;
+HTTP operations are stubbed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+VLLM_SCRIPT = SCRIPTS_DIR / "capture_vllm_native_profile.py"
+SGLANG_SCRIPT = SCRIPTS_DIR / "capture_sglang_native_profile.py"
+SHELL_SCRIPT = SCRIPTS_DIR / "capture_sglang_native_profile.sh"
+
+
+def _load_script(path: Path):
+    """Load a standalone script as an importable module."""
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def vllm():
+    return _load_script(VLLM_SCRIPT)
+
+
+@pytest.fixture
+def sglang():
+    return _load_script(SGLANG_SCRIPT)
+
+
+@pytest.fixture(params=["vllm", "sglang"])
+def helper(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def umask_000(tmp_path):
+    """Run under permissive umask 000 to verify modes are explicit, not umask-dependent.
+
+    Depends on tmp_path so that directory creation happens before umask is set.
+    """
+    old = os.umask(0)
+    yield
+    os.umask(old)
+
+
+@pytest.fixture
+def umask_0277(tmp_path):
+    """Run under restrictive umask 0277 to verify fchmod overrides umask.
+
+    Depends on tmp_path so that directory creation happens before umask is set.
+    """
+    old = os.umask(0o277)
+    yield
+    os.umask(old)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _secure_write_text / _secure_open (basename + dir_fd interface)
+# ---------------------------------------------------------------------------
+
+
+class TestSecureWriteText:
+    def test_creates_file_with_mode_0600(self, helper, tmp_path, umask_000):
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            helper._secure_write_text("secret.json", fd, '{"prompt": "SECRET"}\n')
+            assert (path / "secret.json").read_text() == '{"prompt": "SECRET"}\n'
+            assert stat.S_IMODE((path / "secret.json").stat().st_mode) == 0o600
+        finally:
+            os.close(fd)
+
+    def test_creates_file_with_mode_0600_restrictive_umask(self, helper, tmp_path, umask_0277):
+        """Even under restrictive umask 0277, fchmod forces exact 0600."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            helper._secure_write_text("secret.json", fd, '{"prompt": "SECRET"}\n')
+            assert (path / "secret.json").read_text() == '{"prompt": "SECRET"}\n'
+            assert stat.S_IMODE((path / "secret.json").stat().st_mode) == 0o600
+        finally:
+            os.close(fd)
+
+    def test_rejects_preexisting_regular_file(self, helper, tmp_path):
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            planted = path / "planted.json"
+            planted.write_text("attacker data")
+            with pytest.raises(RuntimeError, match="refusing to overwrite"):
+                helper._secure_write_text("planted.json", fd, "victim data")
+            assert planted.read_text() == "attacker data"
+        finally:
+            os.close(fd)
+
+    def test_rejects_symlink_to_file(self, helper, tmp_path):
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            target = tmp_path / "target.txt"
+            target.write_text("original secret")
+            link = path / "request.json"
+            link.symlink_to(target)
+            with pytest.raises(RuntimeError, match="refusing to overwrite"):
+                helper._secure_write_text("request.json", fd, "victim data")
+            assert target.read_text() == "original secret"
+        finally:
+            os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _prepare_output_dir
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareOutputDir:
+    def test_default_dir_is_unpredictable(self, helper, tmp_path, monkeypatch):
+        """Two default calls must produce distinct, non-timestamp-predictable directories."""
+        monkeypatch.setattr(helper.tempfile, "tempdir", str(tmp_path))
+        d1, fd1 = helper._prepare_output_dir(None, "test-prefix-")
+        d2, fd2 = helper._prepare_output_dir(None, "test-prefix-")
+        try:
+            assert d1 != d2
+            assert d1.name.startswith("test-prefix-")
+            assert d2.name.startswith("test-prefix-")
+            timestamp = time.strftime("%Y%m%d-%H%M%S")
+            assert d1.name != f"test-prefix-{timestamp}"
+            assert d2.name != f"test-prefix-{timestamp}"
+        finally:
+            os.close(fd1)
+            os.close(fd2)
+
+    def test_default_dir_mode_0700(self, helper, tmp_path, monkeypatch, umask_000):
+        monkeypatch.setattr(helper.tempfile, "tempdir", str(tmp_path))
+        d, fd = helper._prepare_output_dir(None, "test-prefix-")
+        try:
+            assert stat.S_IMODE(d.stat().st_mode) == 0o700
+        finally:
+            os.close(fd)
+
+    def test_default_dir_mode_0700_restrictive_umask(self, helper, tmp_path, monkeypatch, umask_0277):
+        """Even under restrictive umask 0277, fchmod forces exact 0700."""
+        monkeypatch.setattr(helper.tempfile, "tempdir", str(tmp_path))
+        d, fd = helper._prepare_output_dir(None, "test-prefix-")
+        try:
+            assert stat.S_IMODE(d.stat().st_mode) == 0o700
+        finally:
+            os.close(fd)
+
+    def test_explicit_dir_creates_mode_0700(self, helper, tmp_path, umask_000):
+        new_dir = tmp_path / "new_output"
+        result, fd = helper._prepare_output_dir(str(new_dir), "test-")
+        try:
+            assert result == new_dir
+            assert stat.S_IMODE(result.stat().st_mode) == 0o700
+        finally:
+            os.close(fd)
+
+    def test_explicit_dir_creates_mode_0700_restrictive_umask(self, helper, tmp_path, umask_0277):
+        """Even under restrictive umask 0277, fchmod forces exact 0700."""
+        new_dir = tmp_path / "new_output"
+        result, fd = helper._prepare_output_dir(str(new_dir), "test-")
+        try:
+            assert result == new_dir
+            assert stat.S_IMODE(result.stat().st_mode) == 0o700
+        finally:
+            os.close(fd)
+
+    def test_explicit_dir_rejects_existing_directory(self, helper, tmp_path):
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        with pytest.raises(RuntimeError, match="refusing to use existing"):
+            helper._prepare_output_dir(str(existing), "test-")
+
+    def test_explicit_dir_rejects_existing_file(self, helper, tmp_path):
+        existing = tmp_path / "existing.txt"
+        existing.write_text("data")
+        with pytest.raises(RuntimeError, match="refusing to use existing"):
+            helper._prepare_output_dir(str(existing), "test-")
+
+    def test_explicit_dir_rejects_symlink(self, helper, tmp_path):
+        target = tmp_path / "target_dir"
+        target.mkdir()
+        link = tmp_path / "link_dir"
+        link.symlink_to(target)
+        with pytest.raises(RuntimeError, match="refusing to use existing"):
+            helper._prepare_output_dir(str(link), "test-")
+
+    def test_explicit_dir_rejects_missing_parent(self, helper, tmp_path):
+        """Parent directory must already exist; no implicit creation."""
+        leaf = tmp_path / "nonexistent_parent" / "output"
+        with pytest.raises(RuntimeError, match="parent directory does not exist"):
+            helper._prepare_output_dir(str(leaf), "test-")
+
+    def test_explicit_dir_rejects_parent_symlink(self, helper, tmp_path):
+        """A parent that is a symlink must be rejected (O_NOFOLLOW)."""
+        real_parent = tmp_path / "real_parent"
+        real_parent.mkdir()
+        link_parent = tmp_path / "link_parent"
+        link_parent.symlink_to(real_parent)
+        leaf = link_parent / "output"
+        with pytest.raises(RuntimeError, match="refusing to follow symlink"):
+            helper._prepare_output_dir(str(leaf), "test-")
+
+    def test_explicit_dir_rejects_group_writable_parent(self, helper, tmp_path):
+        """A group-writable parent is unsafe and must be rejected."""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        os.chmod(parent, 0o770)
+        leaf = parent / "output"
+        try:
+            with pytest.raises(RuntimeError, match="group or world writable"):
+                helper._prepare_output_dir(str(leaf), "test-")
+        finally:
+            os.chmod(parent, 0o755)
+
+    def test_explicit_dir_rejects_world_writable_parent(self, helper, tmp_path):
+        """A world-writable parent is unsafe and must be rejected."""
+        parent = tmp_path / "parent"
+        parent.mkdir()
+        os.chmod(parent, 0o777)
+        leaf = parent / "output"
+        try:
+            with pytest.raises(RuntimeError, match="group or world writable"):
+                helper._prepare_output_dir(str(leaf), "test-")
+        finally:
+            os.chmod(parent, 0o755)
+
+
+# ---------------------------------------------------------------------------
+# Post-create path-swap: writes must stay on pinned inode
+# ---------------------------------------------------------------------------
+
+
+class TestPathSwap:
+    def test_post_create_path_swap_writes_stay_on_pinned_inode(self, helper, tmp_path, umask_000):
+        """After directory creation, swapping the path with a symlink must not redirect writes.
+
+        Proves fd identity: the pinned fd's inode matches the original
+        directory's inode, not the attacker's replacement.
+        """
+        out_dir = tmp_path / "real_output"
+        path, fd = helper._prepare_output_dir(str(out_dir), "test-")
+        try:
+            original_inode = os.fstat(fd).st_ino
+
+            # Attacker swaps: rename real dir away, create symlink to attacker dir.
+            attacker_dir = tmp_path / "attacker"
+            attacker_dir.mkdir()
+            saved_dir = tmp_path / "saved_output"
+            os.rename(str(path), str(saved_dir))
+            os.symlink(str(attacker_dir), str(path))
+
+            # Pinned fd still refers to the original inode.
+            assert os.fstat(fd).st_ino == original_inode
+
+            # Write via pinned fd — must land in original inode, not symlink target.
+            helper._secure_write_text("secret.json", fd, "SECRET_175")
+
+            # File must NOT appear in attacker directory.
+            assert not (attacker_dir / "secret.json").exists()
+
+            # File MUST appear in the saved (original) directory.
+            assert (saved_dir / "secret.json").exists()
+
+            # File MUST be readable via pinned fd (explicit O_RDONLY | O_NOFOLLOW).
+            read_fd = os.open("secret.json", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=fd)
+            try:
+                content = os.read(read_fd, 1024).decode("utf-8")
+            finally:
+                os.close(read_fd)
+            assert content == "SECRET_175"
+        finally:
+            os.close(fd)
+
+    def test_intermediate_symlink_retarget_after_create_writes_stay_real(self, helper, tmp_path, umask_000):
+        """An attacker retargeting an intermediate symlink after creation must not redirect writes.
+
+        Setup:
+          real/sub/  — genuine parent chain (mode 0700)
+          link → real — attacker-controllable symlink in a trusted parent
+          Output is created via link/sub/out (pinned fd targets real/sub/out).
+          Attacker then repoints link → attacker (which also has sub/).
+
+        Writes via the pinned fd must land under real/, not under attacker/.
+        """
+        real_parent = tmp_path / "real"
+        real_sub = real_parent / "sub"
+        real_sub.mkdir(parents=True, mode=0o700)
+
+        # Symlink link → real in the trusted tmp_path parent.
+        link = tmp_path / "link"
+        link.symlink_to(str(real_parent))
+
+        # Create output dir via the symlinked path: link/sub/out.
+        out_arg = link / "sub" / "out"
+        path, fd = helper._prepare_output_dir(str(out_arg), "test-")
+        try:
+            original_inode = os.fstat(fd).st_ino
+
+            # Attacker prepares attacker/sub/ and retargets link → attacker.
+            attacker_parent = tmp_path / "attacker"
+            attacker_sub = attacker_parent / "sub"
+            attacker_sub.mkdir(parents=True)
+            link.unlink()
+            link.symlink_to(str(attacker_parent))
+
+            # Pinned fd still refers to the original inode (real/sub/out).
+            assert os.fstat(fd).st_ino == original_inode
+
+            # Write via pinned fd — must land under real/, not attacker/.
+            helper._secure_write_text("secret.json", fd, "SECRET_175")
+
+            # Artifact must exist only under the real path.
+            assert (real_sub / "out" / "secret.json").exists()
+            assert (real_sub / "out" / "secret.json").read_text() == "SECRET_175"
+
+            # Artifact must NOT exist under the attacker's retargeted path.
+            assert not (attacker_sub / "out" / "secret.json").exists()
+        finally:
+            os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# StreamRequest: symlink rejection + positive mode-0600 tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal urlopen context manager returning immediate EOF."""
+
+    def __init__(self, lines=None):
+        self._lines = lines or []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def readline(self):
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+    def close(self):
+        pass
+
+
+class TestStreamRequestSymlinkRejection:
+    def test_stream_log_rejects_symlink(self, helper, tmp_path, monkeypatch):
+        """A symlinked stream.log must not be followed."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            target = tmp_path / "stream_target.txt"
+            target.write_text("original stream data")
+            log_link = path / "stream.log"
+            log_link.symlink_to(target)
+
+            monkeypatch.setattr(
+                helper.urllib.request, "urlopen", lambda *a, **k: _FakeResponse()
+            )
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=1,
+            )
+            stream.start()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            assert target.read_text() == "original stream data"
+            assert stream.error is not None
+            assert "refusing to overwrite" in stream.error
+        finally:
+            os.close(fd)
+
+    def test_error_log_rejects_symlink(self, helper, tmp_path, monkeypatch):
+        """A symlinked error log must not be followed; failure is caught and reported."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            target = tmp_path / "error_target.txt"
+            target.write_text("original error data")
+            error_link = path / "request.error.txt"
+            error_link.symlink_to(target)
+
+            def fake_urlopen(*a, **k):
+                raise ConnectionError("simulated failure")
+
+            monkeypatch.setattr(helper.urllib.request, "urlopen", fake_urlopen)
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=1,
+            )
+            stream.start()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            assert target.read_text() == "original error data"
+            assert stream.error is not None
+            assert "ConnectionError" in stream.error
+            assert "failed to write error log" in stream.error
+        finally:
+            os.close(fd)
+
+
+class TestStreamRequestPositive:
+    def test_stream_log_created_mode_0600(self, helper, tmp_path, monkeypatch):
+        """A successful stream writes stream.log with mode 0600."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            lines = [b"data: {\"token\": \"hello\"}\n", b""]
+            monkeypatch.setattr(
+                helper.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(lines)
+            )
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=1,
+            )
+            stream.start()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            log = path / "stream.log"
+            assert log.exists()
+            assert stat.S_IMODE(log.stat().st_mode) == 0o600
+            assert "hello" in log.read_text()
+            assert stream.error is None
+        finally:
+            os.close(fd)
+
+    def test_error_log_created_mode_0600(self, helper, tmp_path, monkeypatch):
+        """A failed stream writes error log with mode 0600."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            def fake_urlopen(*a, **k):
+                raise ConnectionError("simulated failure")
+
+            monkeypatch.setattr(helper.urllib.request, "urlopen", fake_urlopen)
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=1,
+            )
+            stream.start()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            err = path / "request.error.txt"
+            assert err.exists()
+            assert stat.S_IMODE(err.stat().st_mode) == 0o600
+            assert "ConnectionError" in err.read_text()
+            assert stream.error is not None
+            assert "ConnectionError" in stream.error
+        finally:
+            os.close(fd)
+
+
+class TestStreamRequestFdLifecycle:
+    """Verify StreamRequest owns an independent dup'd dir_fd that survives
+    caller fd closure, so log/error writes never see EBADF or a reused fd."""
+
+    def test_log_lands_after_caller_closes_fd(self, helper, tmp_path, monkeypatch):
+        """Caller closes its dir_fd before the stream finishes; log still lands in pinned dir."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            # Use a response that yields one line then blocks.
+            lines = [b"data: {\"token\": \"hello\"}\n"]
+            release = threading.Event()
+
+            class _DelayedResponse:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *a):
+                    pass
+
+                def readline(self):
+                    if lines:
+                        return lines.pop(0)
+                    release.wait(timeout=5.0)
+                    return b""
+
+                def close(self):
+                    pass
+
+            monkeypatch.setattr(
+                helper.urllib.request, "urlopen", lambda *a, **k: _DelayedResponse()
+            )
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=5,
+            )
+            stream.start()
+
+            # Wait for first token (first line consumed), then close caller fd
+            # while the stream thread is still blocked in readline.
+            assert stream.wait_for_first_token(5.0)
+
+            # Close the caller's fd — stream must have its own dup'd fd.
+            os.close(fd)
+            fd = -1  # Mark as closed so finally doesn't double-close.
+
+            # Release the stream so it can finish writing.
+            release.set()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            # Log must have landed in the pinned directory despite caller fd close.
+            log = path / "stream.log"
+            assert log.exists()
+            assert stat.S_IMODE(log.stat().st_mode) == 0o600
+            assert "hello" in log.read_text()
+            assert stream.error is None
+        finally:
+            if fd != -1:
+                os.close(fd)
+
+    def test_error_lands_after_caller_closes_fd(self, helper, tmp_path, monkeypatch):
+        """Caller closes its dir_fd before the error write; error log still lands."""
+        path, fd = helper._prepare_output_dir(str(tmp_path / "out"), "test-")
+        try:
+            release = threading.Event()
+
+            def fake_urlopen(*a, **k):
+                release.wait(timeout=5.0)
+                raise ConnectionError("simulated failure after delay")
+
+            monkeypatch.setattr(helper.urllib.request, "urlopen", fake_urlopen)
+
+            stream = helper.StreamRequest(
+                url="http://fake",
+                headers={"Content-Type": "application/json"},
+                payload={"model": "test", "prompt": "test"},
+                log_basename="stream.log",
+                error_basename="request.error.txt",
+                dir_fd=fd,
+                timeout_s=5,
+            )
+            stream.start()
+
+            # Close the caller's fd while the stream thread is blocked in urlopen.
+            os.close(fd)
+            fd = -1
+
+            # Release so urlopen raises and the error handler writes.
+            release.set()
+            stream.finished_event.wait(timeout=5.0)
+            stream.stop()
+
+            # Error log must have landed despite caller fd close.
+            err = path / "request.error.txt"
+            assert err.exists()
+            assert stat.S_IMODE(err.stat().st_mode) == 0o600
+            assert "ConnectionError" in err.read_text()
+            assert stream.error is not None
+            assert "ConnectionError" in stream.error
+        finally:
+            if fd != -1:
+                os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# vLLM main() integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    """Stub StreamRequest that simulates immediate first token and completion."""
+
+    def __init__(self, **kwargs):
+        self.first_token_event = threading.Event()
+        self.finished_event = threading.Event()
+        self.error = None
+
+    def start(self):
+        self.first_token_event.set()
+        self.finished_event.set()
+
+    def stop(self):
+        pass
+
+    def wait_for_first_token(self, timeout_s):
+        return True
+
+
+def _stub_http(module, monkeypatch):
+    monkeypatch.setattr(module, "resolve_model", lambda *a, **k: "test-model")
+    monkeypatch.setattr(module, "http_json", lambda *a, **k: (200, "{}"))
+    monkeypatch.setattr(module, "StreamRequest", _FakeStream)
+
+
+class TestVllmMainFlow:
+    def test_default_capture_files_are_0600(self, vllm, monkeypatch, tmp_path, umask_000):
+        _stub_http(vllm, monkeypatch)
+        monkeypatch.setattr(vllm.tempfile, "tempdir", str(tmp_path))
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_vllm_native_profile.py",
+            "--base-url", "http://127.0.0.1:8000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--capture-seconds", "0.01",
+        ])
+        vllm.main()
+
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        assert len(dirs) == 1
+        out_dir = dirs[0]
+        assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+        for f in out_dir.iterdir():
+            assert stat.S_IMODE(f.stat().st_mode) == 0o600
+        assert "SECRET_175" in (out_dir / "request.json").read_text()
+
+    def test_precreated_timestamp_candidate_untouched(self, vllm, monkeypatch, tmp_path):
+        """An attacker-precreated predictable directory must not be used."""
+        _stub_http(vllm, monkeypatch)
+        monkeypatch.setattr(vllm.tempfile, "tempdir", str(tmp_path))
+
+        old_pattern = tmp_path / f"vllm-native-decode-{time.strftime('%Y%m%d-%H%M%S')}"
+        old_pattern.mkdir(parents=True, exist_ok=True)
+        planted_file = old_pattern / "request.json"
+        planted_file.write_text("ATTACKER_DATA")
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_vllm_native_profile.py",
+            "--base-url", "http://127.0.0.1:8000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--capture-seconds", "0.01",
+        ])
+        vllm.main()
+
+        assert planted_file.read_text() == "ATTACKER_DATA"
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir() and d != old_pattern]
+        assert len(dirs) == 1
+
+    def test_explicit_safe_dir_works(self, vllm, monkeypatch, tmp_path, umask_000):
+        _stub_http(vllm, monkeypatch)
+        out_dir = tmp_path / "capture"
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_vllm_native_profile.py",
+            "--base-url", "http://127.0.0.1:8000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--capture-seconds", "0.01",
+            "--out-dir", str(out_dir),
+        ])
+        vllm.main()
+
+        assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+        for f in out_dir.iterdir():
+            assert stat.S_IMODE(f.stat().st_mode) == 0o600
+
+    def test_explicit_existing_dir_rejected_before_network(self, vllm, monkeypatch, tmp_path):
+        """Rejecting an existing directory must happen before any HTTP call."""
+        _stub_http(vllm, monkeypatch)
+        existing = tmp_path / "existing"
+        existing.mkdir()
+        planted = existing / "request.json"
+        planted.write_text("ATTACKER")
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_vllm_native_profile.py",
+            "--base-url", "http://127.0.0.1:8000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--capture-seconds", "0.01",
+            "--out-dir", str(existing),
+        ])
+        with pytest.raises(RuntimeError, match="refusing to use existing"):
+            vllm.main()
+        assert planted.read_text() == "ATTACKER"
+
+
+# ---------------------------------------------------------------------------
+# SGLang main() integration
+# ---------------------------------------------------------------------------
+
+
+class TestSglangMainFlow:
+    def test_default_capture_files_are_0600(self, sglang, monkeypatch, tmp_path, umask_000):
+        _stub_http(sglang, monkeypatch)
+        monkeypatch.setattr(sglang.tempfile, "tempdir", str(tmp_path))
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_sglang_native_profile.py",
+            "--base-url", "http://127.0.0.1:30000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+        ])
+        sglang.main()
+
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+        assert len(dirs) == 1
+        out_dir = dirs[0]
+        assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+        for f in out_dir.iterdir():
+            assert stat.S_IMODE(f.stat().st_mode) == 0o600
+        assert "SECRET_175" in (out_dir / "request.json").read_text()
+
+    def test_default_server_output_dir_is_omitted(self, sglang, monkeypatch, tmp_path):
+        """The client never derives a server pathname from its pinned local directory."""
+        _stub_http(sglang, monkeypatch)
+        monkeypatch.setattr(sglang.tempfile, "tempdir", str(tmp_path))
+
+        profile_payloads = []
+
+        def capturing_http_json(url, *, headers, payload=None, timeout_s=3600):
+            if url.endswith("/start_profile"):
+                profile_payloads.append(payload)
+            return (200, "{}")
+
+        monkeypatch.setattr(sglang, "http_json", capturing_http_json)
+        monkeypatch.setattr(sys, "argv", [
+            "capture_sglang_native_profile.py",
+            "--base-url", "http://127.0.0.1:30000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+        ])
+        sglang.main()
+
+        assert len(profile_payloads) == 1
+        assert "output_dir" not in profile_payloads[0]
+
+    def test_retargeted_local_ancestor_is_not_sent_to_server(
+        self, sglang, monkeypatch, tmp_path
+    ):
+        """A server cannot re-resolve the client output path after an ancestor swap."""
+        _stub_http(sglang, monkeypatch)
+        chain = tmp_path / "chain"
+        parent = chain / "owned"
+        parent.mkdir(parents=True)
+        out_dir = parent / "capture"
+        original_chain = tmp_path / "original-chain"
+        attacker_trace = chain / "owned" / "capture" / "server.trace"
+
+        profile_payloads = []
+
+        def retargeting_http_json(url, *, headers, payload=None, timeout_s=3600):
+            if url.endswith("/start_profile"):
+                os.rename(chain, original_chain)
+                (chain / "owned" / "capture").mkdir(parents=True)
+                profile_payloads.append(payload)
+                if "output_dir" in payload:
+                    Path(payload["output_dir"], "server.trace").write_text("trace")
+            return (200, "{}")
+
+        monkeypatch.setattr(sglang, "http_json", retargeting_http_json)
+        monkeypatch.setattr(sys, "argv", [
+            "capture_sglang_native_profile.py",
+            "--base-url", "http://127.0.0.1:30000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--out-dir", str(out_dir),
+        ])
+        sglang.main()
+
+        assert len(profile_payloads) == 1
+        assert "output_dir" not in profile_payloads[0]
+        assert not attacker_trace.exists()
+        assert (original_chain / "owned" / "capture" / "manifest.json").is_file()
+
+    def test_explicit_server_output_dir_preserved(self, sglang, monkeypatch, tmp_path):
+        """An explicit --server-output-dir is forwarded as-is."""
+        _stub_http(sglang, monkeypatch)
+        out_dir = tmp_path / "capture"
+        server_dir = "/remote/server/path"
+
+        captured_payloads = []
+
+        def capturing_http_json(url, *, headers, payload=None, timeout_s=3600):
+            if payload is not None and "output_dir" in payload:
+                captured_payloads.append(payload)
+            return (200, "{}")
+
+        monkeypatch.setattr(sglang, "http_json", capturing_http_json)
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_sglang_native_profile.py",
+            "--base-url", "http://127.0.0.1:30000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+            "--out-dir", str(out_dir),
+            "--server-output-dir", server_dir,
+        ])
+        sglang.main()
+
+        assert captured_payloads[0]["output_dir"] == server_dir
+        manifest = json.loads((out_dir / "manifest.json").read_text())
+        assert manifest["server_output_dir"] == server_dir
+
+    def test_precreated_timestamp_candidate_untouched(self, sglang, monkeypatch, tmp_path):
+        _stub_http(sglang, monkeypatch)
+        monkeypatch.setattr(sglang.tempfile, "tempdir", str(tmp_path))
+
+        old_pattern = tmp_path / f"sglang-native-decode-{time.strftime('%Y%m%d-%H%M%S')}"
+        old_pattern.mkdir(parents=True, exist_ok=True)
+        planted_file = old_pattern / "request.json"
+        planted_file.write_text("ATTACKER_DATA")
+
+        monkeypatch.setattr(sys, "argv", [
+            "capture_sglang_native_profile.py",
+            "--base-url", "http://127.0.0.1:30000",
+            "--model", "test-model",
+            "--prompt", "SECRET_175",
+        ])
+        sglang.main()
+
+        assert planted_file.read_text() == "ATTACKER_DATA"
+        dirs = [d for d in tmp_path.iterdir() if d.is_dir() and d != old_pattern]
+        assert len(dirs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shell helper behavioral tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_curl_dir(tmp_path):
+    """Create a fake curl (Python shim) that records the response-file mode
+    via os.stat and returns HTTP 200.  Portable — no BSD stat needed."""
+    d = tmp_path / "fake_bin"
+    d.mkdir()
+    mode_log = tmp_path / "mode_log.txt"
+    curl_script = d / "curl"
+    curl_script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys, stat\n"
+        "output_file = None\n"
+        "args = sys.argv[1:]\n"
+        'i = 0\n'
+        "while i < len(args):\n"
+        '    if args[i] == "-o" and i + 1 < len(args):\n'
+        "        output_file = args[i + 1]\n"
+        "    i += 1\n"
+        "if output_file:\n"
+        "    st = os.stat(output_file)\n"
+        f'    with open({str(mode_log)!r}, "a") as log:\n'
+        '        log.write(f"{oct(stat.S_IMODE(st.st_mode))[2:]}\\n")\n'
+        "    with open(output_file, \'w\') as f:\n"
+        "        f.write(\'{\\\"status\\\":\\\"ok\\\"}\')\n"
+        "print(\'200\')\n"
+    )
+    curl_script.chmod(0o755)
+    return d
+
+
+class TestShellHelperBehavioral:
+    @pytest.mark.parametrize("action", ["start", "stop"])
+    def test_response_file_mode_600_and_no_residue(
+        self, action, tmp_path, fake_curl_dir
+    ):
+        """The shell helper must create the response file with mode 600 and leave no residue."""
+        env = dict(os.environ, TMPDIR=str(tmp_path))
+        env["PATH"] = f"{fake_curl_dir}:{env.get('PATH', '')}"
+
+        result = subprocess.run(
+            [
+                str(SHELL_SCRIPT),
+                action,
+                "--base-url", "http://127.0.0.1:0",
+                "--mode", "decode",
+            ],
+            capture_output=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert b'{"status":"ok"}' in result.stdout
+
+        # Verify response file was mode 600.
+        mode_log = tmp_path / "mode_log.txt"
+        assert mode_log.exists()
+        modes = mode_log.read_text().strip().split("\n")
+        assert all(m.strip() == "600" for m in modes)
+        assert len(modes) >= 1
+
+        # Verify no residue in TMPDIR.
+        residue = list(tmp_path.glob("sglang_prof_resp.*"))
+        assert residue == []


### PR DESCRIPTION
## Problem

Both native-profiler helpers used predictable second-resolution `/tmp` output directories with `exist_ok=True`. A local co-tenant could precreate the directory or swap a path component, disclosing prompts/request bodies or redirecting/clobbering profiler artifacts. The shell helper also wrote curl responses to predictable `/tmp/sglang_profile_response.$$` files.

## Change

- default to private, unpredictable `mkdtemp` directories
- for explicit `--out-dir`, require an existing private parent, pin it with `O_DIRECTORY|O_NOFOLLOW`, create only the leaf at mode 0700 relative to that descriptor, then pin the leaf
- route every request, response, log, server-output, and manifest write through the pinned directory descriptor
- create artifacts atomically with `O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC`, then enforce mode 0600
- give background stream workers their own duplicated descriptor with bounded, exactly-once lifecycle
- replace the shell helper's predictable response path with mode-0600 `mktemp` plus unconditional cleanup
- retain existing CLI behavior, mode/payload semantics, and explicit server output paths
- add race, symlink, permissions/umask, lifecycle, shell start/stop, cleanup, and help tests

## Verification

- Linux/Python 3.12: `python -m pytest tests/test_native_profile_security.py -q` — 58 passed
- macOS/Python 3.12: same command — 58 passed
- `ruff check` on both helpers and tests
- `python -m py_compile` on both helpers and tests
- `bash -n scripts/capture_sglang_native_profile.sh`

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Native profiling outputs are now stored in private, securely created directories.
  * Output files use restrictive permissions and reject symlinks, unsafe paths, and existing files.
  * Temporary response files are securely managed and automatically cleaned up.

* **Bug Fixes**
  * Profile capture is protected against output-directory path swaps during execution.
  * Improved cleanup ensures temporary resources and file handles are released after failures or completion.

* **Documentation**
  * Updated vLLM output-directory guidance to describe the new safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->