### PR TITLE
security: validate FP6 dense artifacts before launch

### DIFF
--- a/b12x/quantization/mxfp6/fp6_dense_weights.py
+++ b/b12x/quantization/mxfp6/fp6_dense_weights.py
@@ -37,6 +37,7 @@ from b12x._lib.fp6 import (
     mx_gs_numerator,
 )
 from b12x._lib.utils import mxfp6_packed_k_bytes
+from b12x._lib.intrinsics import align_up
 from b12x._lib.dense_gemm import dense_gemm, _DENSE_FUSED_QUANT
 
 _TILE = 128  # MX-FP6 GPU quantizer tile (M and K must be multiples of this)
@@ -316,6 +317,141 @@ def _quantize_matrix_fp6_bytes_small_m(
         return codes, out.scale_storage, alpha, inv_gs[:m].view(m, 1)
     return codes, out.scale_storage, alpha
 
+# Standalone FP6 dense-weight safetensors schema id (see save_fp6_dense_weight).
+# Existing artifacts carry this tag; the loader rejects anything else.
+_FP6_DENSE_FORMAT_TAG = "b12x_fp6_dense_weight_v1"
+_FP6_WEIGHT_FMTS = ("e3m2", "e2m3")
+_FP6_ACT_FMTS = ("e3m2", "e2m3", "e4m3")
+_FP6_DENSE_TENSOR_KEYS = frozenset({"packed", "scale_storage", "global_scale"})
+_FP6_DENSE_META_KEYS = frozenset(
+    {"out_features", "in_features", "fmt", "act_fmt", "out_features_unsharded"}
+)
+_FP6_DENSE_REQUIRED_META_KEYS = frozenset({"out_features", "in_features", "fmt"})
+
+
+def _validate_fp6_dense_artifact(weight: "FP6DenseWeight") -> None:
+    """Validate the standalone FP6 dense-weight artifact schema and geometry.
+
+    Enforces the exact ``b12x_fp6_dense_weight_v1`` contract that the saver
+    emits and the producer (``quantize_dense_weight_to_fp6``) guarantees:
+
+    * ``out_features`` is a positive integer (the MX-FP6 GEMM imposes no N
+      alignment constraint; the scale producer pads N to 128 internally);
+    * ``in_features`` is a positive integer and a multiple of
+      ``SF_VEC_SIZE_FP6`` (32) — the minimum the FP6 packing and scale layout
+      require (``%32`` implies the ``%4`` that ``mxfp6_packed_k_bytes`` needs);
+    * ``packed`` is a contiguous rank-2 ``uint8`` tensor of shape exactly
+      ``(out_features, 3*in_features//4)`` — i.e. its leading dimension *is*
+      ``out_features`` (this is the security-critical check that defeats both
+      PoCs in issue #152);
+    * ``scale_storage`` is a contiguous ``uint8`` buffer of the exact padded
+      swizzled-block size ``align_up(out_features, 128) *
+      align_up(in_features//32, 4)`` (128-row scale padding is what lets a
+      too-small ``out_features`` hide inside an oversized scale buffer);
+    * ``global_scale`` is a ``float32`` tensor with shape exactly ``(1,)``;
+    * ``fmt`` / ``act_fmt`` are on the FP6 sub-format allowlist;
+    * ``out_features_unsharded`` is a non-negative int (a routing hint only;
+      it never scales into an offset, so it cannot by itself corrupt memory);
+    * ``packed``, ``scale_storage``, and ``global_scale`` share one device.
+
+    Raises ``ValueError`` on any violation. Called from
+    :meth:`FP6DenseWeight.__post_init__`, so it gates every construction path:
+    the standalone loader builds the dataclass on CPU *before* any CUDA
+    transfer, and ``.to(device)`` reconstructs a fresh instance *after*
+    transfer; trusted in-memory producers always emit schema-valid objects.
+
+    Note: the dataclass is mutable; the vLLM plugin releases ``packed`` to
+    ``torch.empty(0)`` after materializing ``gemm_weight()`` (plugin.py:258).
+    That post-construction mutation is outside the validator's scope; callers
+    must not invoke ``to()`` or ``save`` on a released instance.
+    """
+    of = weight.out_features
+    inf = weight.in_features
+    if not isinstance(of, int) or isinstance(of, bool):
+        raise ValueError(f"FP6DenseWeight: out_features must be int, got {type(of).__name__}")
+    if not isinstance(inf, int) or isinstance(inf, bool):
+        raise ValueError(f"FP6DenseWeight: in_features must be int, got {type(inf).__name__}")
+    if of <= 0:
+        raise ValueError(f"FP6DenseWeight: out_features must be positive, got {of}")
+    if inf <= 0 or inf % SF_VEC_SIZE_FP6 != 0:
+        raise ValueError(
+            f"FP6DenseWeight: in_features must be a positive multiple of "
+            f"{SF_VEC_SIZE_FP6}, got {inf}"
+        )
+    ofu = weight.out_features_unsharded
+    if not isinstance(ofu, int) or isinstance(ofu, bool):
+        raise ValueError(
+            f"FP6DenseWeight: out_features_unsharded must be int, got {type(ofu).__name__}"
+        )
+    if ofu < 0:
+        raise ValueError(f"FP6DenseWeight: out_features_unsharded must be >= 0, got {ofu}")
+
+    if weight.fmt not in _FP6_WEIGHT_FMTS:
+        raise ValueError(
+            f"FP6DenseWeight: fmt must be one of {_FP6_WEIGHT_FMTS}, got {weight.fmt!r}"
+        )
+    if weight.act_fmt not in _FP6_ACT_FMTS:
+        raise ValueError(
+            f"FP6DenseWeight: act_fmt must be one of {_FP6_ACT_FMTS}, got {weight.act_fmt!r}"
+        )
+
+    packed = weight.packed
+    if not isinstance(packed, torch.Tensor):
+        raise ValueError(
+            f"FP6DenseWeight: packed must be a torch.Tensor, got {type(packed).__name__}"
+        )
+    if packed.dtype != torch.uint8:
+        raise ValueError(f"FP6DenseWeight: packed must be uint8, got {packed.dtype}")
+    if packed.ndim != 2:
+        raise ValueError(
+            f"FP6DenseWeight: packed must be rank-2 (out_features, 3*in_features//4), "
+            f"got {tuple(packed.shape)}"
+        )
+    if not packed.is_contiguous():
+        raise ValueError("FP6DenseWeight: packed must be contiguous")
+    exp_packed_k = mxfp6_packed_k_bytes(inf)
+    if tuple(packed.shape) != (of, exp_packed_k):
+        raise ValueError(
+            f"FP6DenseWeight: packed shape must be ({of}, {exp_packed_k}), "
+            f"got {tuple(packed.shape)}"
+        )
+
+    scale = weight.scale_storage
+    if not isinstance(scale, torch.Tensor):
+        raise ValueError(
+            f"FP6DenseWeight: scale_storage must be a torch.Tensor, got {type(scale).__name__}"
+        )
+    if scale.dtype != torch.uint8:
+        raise ValueError(f"FP6DenseWeight: scale_storage must be uint8, got {scale.dtype}")
+    if not scale.is_contiguous():
+        raise ValueError("FP6DenseWeight: scale_storage must be contiguous")
+    exp_scale_numel = align_up(of, _TILE) * align_up(inf // SF_VEC_SIZE_FP6, 4)
+    if scale.numel() != exp_scale_numel:
+        raise ValueError(
+            f"FP6DenseWeight: scale_storage must hold {exp_scale_numel} padded uint8 elements "
+            f"(align_up(out_features,128) * align_up(in_features//32,4)), "
+            f"got {scale.numel()}"
+        )
+
+    gs = weight.global_scale
+    if not isinstance(gs, torch.Tensor):
+        raise ValueError(
+            f"FP6DenseWeight: global_scale must be a torch.Tensor, got {type(gs).__name__}"
+        )
+    if gs.dtype != torch.float32:
+        raise ValueError(f"FP6DenseWeight: global_scale must be float32, got {gs.dtype}")
+    if tuple(gs.shape) != (1,):
+        raise ValueError(
+            f"FP6DenseWeight: global_scale must have shape (1,), got {tuple(gs.shape)}"
+        )
+
+    if packed.device != scale.device or packed.device != gs.device:
+        raise ValueError(
+            f"FP6DenseWeight: packed/scale_storage/global_scale must share one device, "
+            f"got packed={packed.device}, scale_storage={scale.device}, "
+            f"global_scale={gs.device}"
+        )
+
 
 @dataclass
 class FP6DenseWeight:
@@ -346,8 +482,12 @@ class FP6DenseWeight:
         # Not a dataclass field so it is excluded from ``fields()``/save and is
         # rebuilt lazily after ``to()`` (which constructs a fresh instance).
         self._packed_expanded: Optional[torch.Tensor] = None
-        if not self.act_fmt:
+        if isinstance(self.act_fmt, str) and not self.act_fmt:
             self.act_fmt = self.fmt
+        # Enforce the standalone artifact schema/geometry on every construction
+        # path: the loader builds on CPU before any CUDA transfer, ``.to()``
+        # reconstructs after transfer, and trusted producers emit valid objects.
+        _validate_fp6_dense_artifact(self)
 
     @property
     def ab_dtype(self) -> str:
@@ -481,6 +621,18 @@ def dense_fp6_linear_expanded(
     if k != in_features:
         raise ValueError(
             f"in_features mismatch: x K={k}, weight in_features={in_features}"
+        )
+    # Defense in depth: the raw weight's leading dimension (the GEMM's RHS-derived
+    # N) must equal the metadata out_features the caller used to size the output.
+    # The dataclass loader already enforces this for FP6DenseWeight, but this
+    # tensor-level wrapper (and the opaque custom op on top of it) accept loose
+    # tensors, so reject a mismatch before any quantization, allocation, or
+    # kernel resolution. ``shape[0]`` is the row count for both the 2-D packed
+    # ``(N, 3K/4)`` and 3-D expanded ``(N, K, 1)`` layouts.
+    if weight.shape[0] != out_features:
+        raise ValueError(
+            f"out_features mismatch: weight has {weight.shape[0]} rows but "
+            f"out_features={out_features}"
         )
     w_k = weight.shape[1]
     if w_k == in_features:
@@ -705,7 +857,7 @@ def save_fp6_dense_weight(weight: FP6DenseWeight, path: str) -> None:
 
     tensors: dict[str, torch.Tensor] = {}
     # historical schema id; do not rename (existing artifacts carry it)
-    metadata = {"__format__": "b12x_fp6_dense_weight_v1"}
+    metadata = {"__format__": _FP6_DENSE_FORMAT_TAG}
     # fields()+getattr instead of asdict(): asdict deep-copies every field,
     # cloning the (potentially on-GPU) packed tensors before the .cpu() move.
     for f in fields(weight):
@@ -720,18 +872,48 @@ def save_fp6_dense_weight(weight: FP6DenseWeight, path: str) -> None:
 def load_fp6_dense_weight(
     path: str, *, device: torch.device | str = "cuda"
 ) -> FP6DenseWeight:
-    """Load a weight saved by :func:`save_fp6_dense_weight` onto ``device``."""
+    """Load a weight saved by :func:`save_fp6_dense_weight` onto ``device``.
+
+    Untrusted artifacts are validated against the standalone
+    ``b12x_fp6_dense_weight_v1`` schema before any CUDA transfer: metadata and
+    tensor key sets are checked before tensor materialization, and
+    :meth:`FP6DenseWeight.__post_init__` enforces the full geometry (dimensions,
+    packed/scale shapes, scalar global scale, formats) on the CPU-built
+    dataclass, ahead of the ``.to(device)`` move.
+    """
     import json
 
     from safetensors.torch import safe_open
 
-    fields: dict[str, object] = {}
+    kwargs: dict[str, object] = {}
     with safe_open(path, framework="pt", device="cpu") as f:
         metadata = f.metadata() or {}
-        for key in f.keys():
-            fields[key] = f.get_tensor(key)
-    for key, value in metadata.items():
-        if key == "__format__":
-            continue
-        fields[key] = json.loads(value)
-    return FP6DenseWeight(**fields).to(device)
+        fmt_tag = metadata.get("__format__")
+        if fmt_tag != _FP6_DENSE_FORMAT_TAG:
+            raise ValueError(
+                f"unsupported FP6 dense artifact format: expected "
+                f"{_FP6_DENSE_FORMAT_TAG!r}, got {fmt_tag!r}"
+            )
+        meta_keys = set(metadata) - {"__format__"}
+        unexpected = meta_keys - _FP6_DENSE_META_KEYS
+        if unexpected:
+            raise ValueError(
+                f"FP6 dense artifact has unexpected metadata keys: {sorted(unexpected)}"
+            )
+        missing = _FP6_DENSE_REQUIRED_META_KEYS - meta_keys
+        if missing:
+            raise ValueError(
+                f"FP6 dense artifact missing required metadata keys: {sorted(missing)}"
+            )
+        for key in _FP6_DENSE_META_KEYS & meta_keys:
+            kwargs[key] = json.loads(metadata[key])
+
+        tensor_keys = set(f.keys())
+        if tensor_keys != _FP6_DENSE_TENSOR_KEYS:
+            raise ValueError(
+                f"FP6 dense artifact tensor keys must be exactly "
+                f"{sorted(_FP6_DENSE_TENSOR_KEYS)}, got {sorted(tensor_keys)}"
+            )
+        for key in tensor_keys:
+            kwargs[key] = f.get_tensor(key)
+    return FP6DenseWeight(**kwargs).to(device)

--- a/tests/quantization/test_fp6_dense_artifact_validation.py
+++ b/tests/quantization/test_fp6_dense_artifact_validation.py
@@ -1,0 +1,624 @@
+"""Focused regression tests for FP6 dense artifact validation (#152).
+
+Primarily CPU-only: these tests exercise validation/rejection paths without a
+kernel launch; one mixed-device contract test is CUDA-gated. The pre-fix code
+had no geometry validation in ``FP6DenseWeight.__post_init__``, no N-equality
+check in ``dense_fp6_linear_expanded``, and no format-tag check in the loader.
+The reusable validator and wrapper guard cover those paths.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from b12x.quantization.mxfp6.fp6_dense_weights import (
+    FP6DenseWeight,
+    dense_fp6_linear_expanded,
+    load_fp6_dense_weight,
+    save_fp6_dense_weight,
+)
+
+_TILE = 128
+_SF_VEC = 32
+_FMT_TAG = "b12x_fp6_dense_weight_v1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _scale_numel(out_features: int, in_features: int) -> int:
+    """Padded swizzled UE8M0 scale storage size (matches ``align_up``)."""
+    rows_pad = ((out_features + _TILE - 1) // _TILE) * _TILE
+    cols_pad = ((in_features // _SF_VEC + 3) // 4) * 4
+    return rows_pad * cols_pad
+
+
+def _make_valid_tensors(n: int, k: int, *, device: str = "cpu"):
+    """Create schema-valid CPU tensors for an ``(N, K)`` FP6 dense weight."""
+    packed = torch.zeros(n, 3 * k // 4, dtype=torch.uint8, device=device)
+    scale = torch.zeros(_scale_numel(n, k), dtype=torch.uint8, device=device)
+    gs = torch.ones(1, dtype=torch.float32, device=device)
+    return packed, scale, gs
+
+
+def _make_valid_weight(n: int = 128, k: int = 128, **kw) -> FP6DenseWeight:
+    """Construct a schema-valid ``FP6DenseWeight`` on CPU (no CUDA needed)."""
+    packed, scale, gs = _make_valid_tensors(n, k)
+    defaults = dict(fmt="e2m3", act_fmt="e4m3", out_features_unsharded=0)
+    defaults.update(kw)
+    return FP6DenseWeight(
+        packed=packed,
+        scale_storage=scale,
+        global_scale=gs,
+        out_features=n,
+        in_features=k,
+        **defaults,
+    )
+
+
+def _write_artifact(
+    path,
+    *,
+    out_features: int,
+    in_features: int,
+    packed: torch.Tensor | None = None,
+    scale: torch.Tensor | None = None,
+    gs: torch.Tensor | None = None,
+    fmt: str = "e2m3",
+    act_fmt: str = "e4m3",
+    out_features_unsharded: int = 0,
+    format_tag: str = _FMT_TAG,
+):
+    """Write a standalone FP6 dense-weight safetensors artifact directly."""
+    if packed is None:
+        packed = torch.zeros(out_features, 3 * in_features // 4, dtype=torch.uint8)
+    if scale is None:
+        scale = torch.zeros(_scale_numel(out_features, in_features), dtype=torch.uint8)
+    if gs is None:
+        gs = torch.ones(1, dtype=torch.float32)
+    tensors = {"packed": packed, "scale_storage": scale, "global_scale": gs}
+    metadata = {
+        "__format__": format_tag,
+        "out_features": json.dumps(out_features),
+        "in_features": json.dumps(in_features),
+        "fmt": json.dumps(fmt),
+        "act_fmt": json.dumps(act_fmt),
+        "out_features_unsharded": json.dumps(out_features_unsharded),
+    }
+    save_file(tensors, str(path), metadata=metadata)
+
+
+# ---------------------------------------------------------------------------
+# Loader: malformed artifacts reject before device transfer
+# ---------------------------------------------------------------------------
+
+def test_loader_rejects_metadata_n_below_packed_rows(tmp_path):
+    """Packed has more rows than metadata ``out_features`` → reject on CPU.
+
+    A valid N=256,K=128 artifact's packed tensor has 256 rows, but the JSON
+    metadata claims ``out_features=128``. The validator's packed-shape check
+    catches the mismatch at dataclass construction — before ``.to(device)``.
+    """
+    packed, scale, gs = _make_valid_tensors(256, 128)
+    path = tmp_path / "below.safetensors"
+    _write_artifact(
+        path,
+        out_features=128,  # metadata claims 128
+        in_features=128,
+        packed=packed,
+        scale=scale,
+        gs=gs,
+    )
+    with pytest.raises(ValueError, match="packed shape"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_metadata_n_above_packed_rows(tmp_path):
+    """Packed has fewer rows than metadata ``out_features`` → reject on CPU.
+
+    A valid N=128,K=128 artifact's packed tensor has 128 rows, but the JSON
+    metadata claims ``out_features=256``. The validator's packed-shape check
+    catches the mismatch at dataclass construction — before ``.to(device)``.
+    """
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    path = tmp_path / "above.safetensors"
+    _write_artifact(
+        path,
+        out_features=256,  # metadata claims 256
+        in_features=128,
+        packed=packed,
+        scale=scale,
+        gs=gs,
+    )
+    with pytest.raises(ValueError, match="packed shape"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_wrong_format_tag(tmp_path):
+    """An artifact without the ``b12x_fp6_dense_weight_v1`` tag is rejected."""
+    path = tmp_path / "badtag.safetensors"
+    _write_artifact(path, out_features=128, in_features=128, format_tag="evil")
+    with pytest.raises(ValueError, match="unsupported FP6 dense artifact format"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_unexpected_tensor_key(tmp_path):
+    """Only the three tensors in the standalone schema are accepted."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    path = tmp_path / "extra-tensor.safetensors"
+    save_file(
+        {
+            "packed": packed,
+            "scale_storage": scale,
+            "global_scale": gs,
+            "act_fmt": torch.zeros(1, dtype=torch.uint8),
+        },
+        str(path),
+        metadata={
+            "__format__": _FMT_TAG,
+            "out_features": "128",
+            "in_features": "128",
+            "fmt": json.dumps("e2m3"),
+        },
+    )
+    with pytest.raises(ValueError, match="tensor keys must be exactly"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_missing_tensor_key(tmp_path):
+    """A missing tensor is reported as a schema error, not a constructor error."""
+    packed, scale, _ = _make_valid_tensors(128, 128)
+    path = tmp_path / "missing-tensor.safetensors"
+    save_file(
+        {"packed": packed, "scale_storage": scale},
+        str(path),
+        metadata={
+            "__format__": _FMT_TAG,
+            "out_features": "128",
+            "in_features": "128",
+            "fmt": json.dumps("e2m3"),
+        },
+    )
+    with pytest.raises(ValueError, match="tensor keys must be exactly"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_unexpected_metadata_key(tmp_path):
+    """Application metadata is allowlisted before dataclass construction."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    path = tmp_path / "extra-metadata.safetensors"
+    save_file(
+        {"packed": packed, "scale_storage": scale, "global_scale": gs},
+        str(path),
+        metadata={
+            "__format__": _FMT_TAG,
+            "out_features": "128",
+            "in_features": "128",
+            "fmt": json.dumps("e2m3"),
+            "evil": json.dumps("value"),
+        },
+    )
+    with pytest.raises(ValueError, match="unexpected metadata keys"):
+        load_fp6_dense_weight(str(path), device="cpu")
+
+
+def test_loader_rejects_metadata_before_reading_tensors(monkeypatch):
+    """Metadata schema failure occurs before safetensor materialization."""
+    class MetadataOnlyArtifact:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def metadata(self):
+            return {
+                "__format__": _FMT_TAG,
+                "out_features": "128",
+                "in_features": "128",
+                "fmt": json.dumps("e2m3"),
+                "evil": json.dumps("value"),
+            }
+
+        def keys(self):
+            raise AssertionError("tensor keys inspected before metadata rejection")
+
+    monkeypatch.setattr(
+        "safetensors.torch.safe_open",
+        lambda *_args, **_kwargs: MetadataOnlyArtifact(),
+    )
+    with pytest.raises(ValueError, match="unexpected metadata keys"):
+        load_fp6_dense_weight("unused.safetensors", device="cpu")
+
+
+def test_loader_rejects_before_device_transfer(tmp_path, monkeypatch):
+    """Malformed geometry is rejected before ``FP6DenseWeight.to`` can run."""
+    packed, scale, gs = _make_valid_tensors(256, 128)
+    path = tmp_path / "pre-transfer.safetensors"
+    _write_artifact(
+        path,
+        out_features=128,
+        in_features=128,
+        packed=packed,
+        scale=scale,
+        gs=gs,
+    )
+    called = False
+
+    def fail_to(self, device):
+        nonlocal called
+        called = True
+        raise AssertionError("malformed artifact reached device transfer")
+
+    monkeypatch.setattr(FP6DenseWeight, "to", fail_to)
+    with pytest.raises(ValueError, match="packed shape"):
+        load_fp6_dense_weight(str(path), device="cuda")
+    assert not called
+
+
+# ---------------------------------------------------------------------------
+# Dataclass: geometry validation on every construction path
+# ---------------------------------------------------------------------------
+
+def test_dataclass_rejects_packed_row_mismatch():
+    """Direct construction with packed.shape[0] != out_features is rejected."""
+    packed, scale, gs = _make_valid_tensors(256, 128)
+    with pytest.raises(ValueError, match="packed shape"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,  # mismatch with 256 packed rows
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_in_features_not_multiple_of_32():
+    """The format requires K to be a positive multiple of the scale group."""
+    packed = torch.zeros(64, 36, dtype=torch.uint8)
+    scale = torch.zeros(_scale_numel(64, 48), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="in_features must be a positive multiple of 32"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=64,
+            in_features=48,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_wrong_scale_size():
+    """Scale storage must match the exact padded size for the declared geometry."""
+    packed = torch.zeros(128, 96, dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    # Too few scale elements
+    with pytest.raises(ValueError, match="scale_storage must hold"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=torch.zeros(100, dtype=torch.uint8),
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_non_scalar_global_scale():
+    """``global_scale`` must have the producer's exact one-element shape."""
+    packed, scale, _ = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match=r"global_scale must have shape \(1,\)"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=torch.ones(2, dtype=torch.float32),
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_bool_dimension():
+    """A JSON boolean must not pass Python's ``bool``-is-an-``int`` quirk."""
+    packed, scale, gs = _make_valid_tensors(1, 128)
+    with pytest.raises(ValueError, match="out_features must be int"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=True,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+@pytest.mark.parametrize("bad_dtype", [torch.int8, torch.float32])
+def test_dataclass_rejects_wrong_packed_dtype(bad_dtype):
+    """Packed code storage is byte-exact uint8."""
+    _, scale, gs = _make_valid_tensors(128, 128)
+    packed = torch.zeros(128, 96, dtype=bad_dtype)
+    with pytest.raises(ValueError, match="packed must be uint8"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_noncontiguous_packed():
+    """A shape-compatible strided view cannot be passed to the raw layout."""
+    packed = torch.zeros(128, 192, dtype=torch.uint8)[:, ::2]
+    assert packed.shape == (128, 96)
+    assert not packed.is_contiguous()
+    _, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="packed must be contiguous"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_oversized_scale_storage():
+    """Scale storage must be exact; extra bytes cannot hide metadata drift."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="scale_storage must hold"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=torch.zeros(scale.numel() + 1, dtype=torch.uint8),
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_bad_fmt():
+    """``fmt`` must be on the FP6 sub-format allowlist."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="fmt must be one of"):
+        FP6DenseWeight(
+            packed=packed, scale_storage=scale, global_scale=gs,
+            out_features=128, in_features=128, fmt="e5m2",
+        )
+
+
+def test_dataclass_rejects_bad_act_fmt():
+    """``act_fmt`` must be on the activation sub-format allowlist."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="act_fmt must be one of"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+            act_fmt="e5m2",
+        )
+
+
+def test_dataclass_rejects_global_scale_dtype():
+    """``global_scale`` must use the producer's float32 representation."""
+    packed, scale, _ = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="global_scale must be float32"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=torch.ones(1, dtype=torch.float64),
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_noncontiguous_scale_storage():
+    """An exact-size strided scale view is not a canonical kernel buffer."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    strided_scale = torch.zeros(scale.numel() * 2, dtype=torch.uint8)[::2]
+    assert strided_scale.numel() == scale.numel()
+    assert not strided_scale.is_contiguous()
+    with pytest.raises(ValueError, match="scale_storage must be contiguous"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=strided_scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_packed_rank():
+    """Packed storage must have the producer's rank-2 layout."""
+    _, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="packed must be rank-2"):
+        FP6DenseWeight(
+            packed=torch.zeros(128, 96, 1, dtype=torch.uint8),
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+def test_dataclass_rejects_negative_out_features_unsharded():
+    """The routing hint cannot encode a negative width."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="out_features_unsharded must be >= 0"):
+        FP6DenseWeight(
+            packed=packed,
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+            out_features_unsharded=-1,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_dataclass_rejects_mixed_tensor_devices():
+    """All raw buffers must name storage on the same device."""
+    packed, scale, gs = _make_valid_tensors(128, 128)
+    with pytest.raises(ValueError, match="must share one device"):
+        FP6DenseWeight(
+            packed=packed.to("cuda"),
+            scale_storage=scale,
+            global_scale=gs,
+            out_features=128,
+            in_features=128,
+            fmt="e2m3",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Raw wrapper / custom-op: N-equality before launch
+# ---------------------------------------------------------------------------
+
+def test_expanded_wrapper_rejects_weight_rows_below_out_features():
+    """``dense_fp6_linear_expanded`` rejects weight.shape[0] < out_features."""
+    x = torch.zeros(4, 128, dtype=torch.bfloat16)
+    weight = torch.zeros(128, 96, dtype=torch.uint8)  # 128 rows
+    scale = torch.zeros(_scale_numel(128, 128), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="out_features mismatch"):
+        dense_fp6_linear_expanded(
+            x, weight, scale, gs, fmt="e2m3",
+            out_features=256,  # metadata claims 256, weight has 128
+            in_features=128,
+        )
+
+
+def test_expanded_wrapper_rejects_weight_rows_above_out_features():
+    """``dense_fp6_linear_expanded`` rejects weight.shape[0] > out_features."""
+    x = torch.zeros(4, 128, dtype=torch.bfloat16)
+    weight = torch.zeros(256, 96, dtype=torch.uint8)  # 256 rows
+    scale = torch.zeros(_scale_numel(128, 128), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="out_features mismatch"):
+        dense_fp6_linear_expanded(
+            x, weight, scale, gs, fmt="e2m3",
+            out_features=128,  # metadata claims 128, weight has 256
+            in_features=128,
+        )
+
+
+def test_expanded_wrapper_rejects_expanded_weight_mismatch():
+    """N-equality also holds for the 3-D expanded ``(N, K, 1)`` layout."""
+    x = torch.zeros(4, 128, dtype=torch.bfloat16)
+    weight = torch.zeros(256, 128, 1, dtype=torch.uint8)  # expanded, 256 rows
+    scale = torch.zeros(_scale_numel(128, 128), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="out_features mismatch"):
+        dense_fp6_linear_expanded(
+            x, weight, scale, gs, fmt="e2m3",
+            out_features=128,
+            in_features=128,
+        )
+
+
+def test_custom_op_rejects_weight_rows_mismatch():
+    """The opaque custom op propagates the N-equality rejection."""
+    import b12x.quantization.mxfp6.fp6_dense_op  # noqa: F401
+
+    x = torch.zeros(4, 128, dtype=torch.bfloat16)
+    weight = torch.zeros(128, 96, dtype=torch.uint8)
+    scale = torch.zeros(_scale_numel(128, 128), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with pytest.raises(ValueError, match="out_features mismatch"):
+        torch.ops.b12x.fp6_dense_linear(
+            x, weight, scale, gs, "e2m3",
+            256,  # out_features mismatch
+            128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Valid artifacts: behavior retained
+# ---------------------------------------------------------------------------
+
+def test_valid_artifact_roundtrip_cpu(tmp_path):
+    """A valid saver-produced artifact round-trips on CPU validation."""
+    w = _make_valid_weight(256, 128, fmt="e2m3", act_fmt="e4m3")
+    path = tmp_path / "valid.safetensors"
+    save_fp6_dense_weight(w, path)
+
+    loaded = load_fp6_dense_weight(str(path), device="cpu")
+    assert isinstance(loaded, FP6DenseWeight)
+    assert loaded.out_features == 256
+    assert loaded.in_features == 128
+    assert loaded.fmt == "e2m3"
+    assert loaded.act_fmt == "e4m3"
+    torch.testing.assert_close(loaded.packed, w.packed, rtol=0, atol=0)
+    torch.testing.assert_close(loaded.scale_storage, w.scale_storage, rtol=0, atol=0)
+    torch.testing.assert_close(loaded.global_scale, w.global_scale, rtol=0, atol=0)
+
+
+def test_valid_w6a6_dataclass_construction():
+    """W6A6 (act_fmt == fmt) dataclass construction passes validation."""
+    w = _make_valid_weight(128, 128, fmt="e3m2", act_fmt="e3m2")
+    assert w.act_fmt == "e3m2"
+    assert w.packed.shape == (128, 96)
+
+
+def test_valid_w6a8_dataclass_construction():
+    """W6A8 (act_fmt == e4m3) dataclass construction passes validation."""
+    w = _make_valid_weight(128, 128, fmt="e2m3", act_fmt="e4m3")
+    assert w.act_fmt == "e4m3"
+
+
+def test_valid_unaligned_output_width_preserved():
+    """N need not be 128-aligned because scale storage pads its row extent."""
+    w = _make_valid_weight(64, 128, fmt="e2m3", act_fmt="e4m3")
+    assert w.packed.shape == (64, 96)
+    assert w.scale_storage.numel() == _scale_numel(64, 128)
+
+
+
+
+def test_to_preserves_geometry():
+    """``.to('cpu')`` reconstructs a valid validated dataclass."""
+    w = _make_valid_weight(256, 128, fmt="e2m3", act_fmt="e4m3", out_features_unsharded=512)
+    w2 = w.to("cpu")
+    assert w2.out_features == 256
+    assert w2.out_features_unsharded == 512
+    assert w2.packed.shape == (256, 96)
+
+
+# ---------------------------------------------------------------------------
+# Custom-op fake shapes: preserved
+# ---------------------------------------------------------------------------
+
+def test_custom_op_fake_shape_preserved():
+    """Fake and real paths agree on valid metadata/weight geometry."""
+    import b12x.quantization.mxfp6.fp6_dense_op  # noqa: F401
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    x = torch.zeros(7, 128, dtype=torch.bfloat16)
+    weight = torch.zeros(128, 96, dtype=torch.uint8)
+    scale = torch.zeros(_scale_numel(128, 128), dtype=torch.uint8)
+    gs = torch.ones(1, dtype=torch.float32)
+    with FakeTensorMode() as mode:
+        fx = mode.from_tensor(x)
+        fweight = mode.from_tensor(weight)
+        fscale = mode.from_tensor(scale)
+        fgs = mode.from_tensor(gs)
+        out = torch.ops.b12x.fp6_dense_linear(
+            fx, fweight, fscale, fgs, "e2m3", 128, 128
+        )
+        assert tuple(out.shape) == (7, 128)
+        assert out.dtype == torch.bfloat16


### PR DESCRIPTION
## Problem

The standalone FP6 dense loader trusted safetensors metadata independently from packed tensor geometry. A malformed artifact could declare output dimensions inconsistent with its packed rows and scale storage, then reach raw CUDA launch geometry.

## Fix

- validate the exact `b12x_fp6_dense_weight_v1` tensor and metadata schema on CPU before tensor materialization
- require packed rows/columns, padded scale bytes, scalar scale, formats, contiguity, and device coherence to match producer contracts
- reject inconsistent raw expanded-weight output geometry before launch
- preserve valid non-128-aligned output widths; only K must satisfy the 32-element FP6 scale group

## Verification

- Linux/CUDA: `pytest tests/quantization/test_fp6_dense_artifact_validation.py -q` — 34 passed
- `ruff check` on source and focused tests
- `python -m py_compile` on source and focused tests
- independent adversarial peer review approved the implementation and follow-up schema/materialization-order tests; current head adds only its requested docstring correction

Closes #152