### PR TITLE
security: validate MXFP8 quantizer destinations

### DIFF
--- a/b12x/_lib/quant/mxfp8_rows.py
+++ b/b12x/_lib/quant/mxfp8_rows.py
@@ -33,6 +33,16 @@ _THREADS = 256
 _GRID_CTAS_PER_SM = 4
 _WARP_SUBGROUP_WIDTH = 4
 
+_SCALE_VEC_SIZE = 32
+_SCALE_ROW_TILE = 128
+_SCALE_K_TILE = 4
+_KERNEL_ALIGN_BYTES = 16
+# Guard the kernel's explicit Int32 offset arithmetic (scale_mma offset =
+# row32*16 + row4*4 + tile_m*T*512 + k4 + tile_k*512, where T=ceil(G/4)).
+# 2^31 - 1 is the max positive Int32; keep a safety margin for intermediate
+# products before the final addition.
+_INT32_MAX = 2 ** 31 - 1
+
 
 class _MXFP8RowsQuantLaunch:
     def __init__(
@@ -276,8 +286,16 @@ def _get_compiled_mxfp8_rows_quant(
     subgroup_width: int,
     threads: int,
     value_order: str,
+    device: torch.device,
 ) -> Callable:
     k = int(k)
+    if device.type != "cuda":
+        raise ValueError(f"MXFP8 CuTe quantizer requires a CUDA device, got {device}")
+    device_index = (
+        torch.cuda.current_device()
+        if device.index is None
+        else int(device.index)
+    )
     if k <= 0 or k % 32 != 0:
         raise ValueError(f"MXFP8 CuTe quantizer requires K divisible by 32, got {k}")
     if source_dtype == torch.bfloat16:
@@ -320,6 +338,7 @@ def _get_compiled_mxfp8_rows_quant(
         int(subgroup_width),
         int(threads),
         value_order,
+        device_index,
     )
     raise_if_kernel_resolution_frozen(
         "cute.compile",
@@ -337,7 +356,7 @@ def _get_compiled_mxfp8_rows_quant(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "gemm.mxfp8_quant_cute",
-            3,
+            4,
             cache_key,
         ),
     )
@@ -395,6 +414,313 @@ def _get_compiled_mxfp8_rows_quant(
     return launch_tensors
 
 
+def _backing_span(tensor: torch.Tensor) -> int:
+    """Bytes from ``tensor.data_ptr()`` to the end of its untyped storage.
+
+    Uses ``storage_offset`` + ``nbytes`` of the *storage* (not ``numel``,
+    which zero-stride expansions spoof) so a one-element backing allocation
+    expanded to a large logical shape is correctly detected as too short.
+    """
+    untyped = tensor.untyped_storage()
+    # storage_offset is in elements of the tensor's current dtype; convert
+    # to bytes using the element size.
+    elem_size = tensor.element_size()
+    offset_bytes = tensor.storage_offset() * elem_size
+    return len(untyped) - offset_bytes
+
+
+def _check_alignment(name: str, tensor: torch.Tensor) -> None:
+    ptr = tensor.data_ptr()
+    if ptr % _KERNEL_ALIGN_BYTES != 0:
+        raise ValueError(
+            f"{name} base pointer must be {_KERNEL_ALIGN_BYTES}-byte aligned "
+            f"for the CuTe kernel, got data_ptr()=0x{ptr:x} "
+            f"(offset {ptr % _KERNEL_ALIGN_BYTES})"
+        )
+
+
+def _check_device(name: str, tensor: torch.Tensor, ref_device: torch.device) -> None:
+    if tensor.device != ref_device:
+        raise ValueError(
+            f"{name} must be on the source/launch device {ref_device}, "
+            f"got {tensor.device}"
+        )
+
+
+def _check_no_alias(
+    name_a: str, ptr_a: int, span_a: int,
+    name_b: str, ptr_b: int, span_b: int,
+) -> None:
+    """Reject overlapping byte ranges ``[ptr, ptr+span)``."""
+    if ptr_a < ptr_b + span_b and ptr_b < ptr_a + span_a:
+        raise ValueError(
+            f"{name_a} and {name_b} have overlapping storage "
+            f"(0x{ptr_a:x}+{span_a} vs 0x{ptr_b:x}+{span_b})"
+        )
+
+
+def validate_mxfp8_rows_source(source: torch.Tensor) -> None:
+    """Validate the complete raw-pointer contract for an MXFP8 source."""
+    if not isinstance(source, torch.Tensor):
+        raise TypeError(
+            f"source must be a torch.Tensor, got {type(source).__name__}"
+        )
+    if source.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(
+            f"CuTe MXFP8 quantizer requires BF16 or FP16 input, got {source.dtype}"
+        )
+    if source.ndim != 2 or not source.is_contiguous():
+        raise ValueError("CuTe MXFP8 quantizer requires contiguous [M,K] input")
+    if not source.is_cuda:
+        raise ValueError("source must be on CUDA")
+    m, k = (int(dim) for dim in source.shape)
+    _compute_mxfp8_rows_geometry(m, k)
+    _check_alignment("source", source)
+    required_bytes = m * k * source.element_size()
+    span = _backing_span(source)
+    if span < required_bytes:
+        raise ValueError(
+            f"source backing storage is {span} bytes from data_ptr() but the "
+            f"kernel reads {required_bytes} bytes"
+        )
+
+
+def _compute_mxfp8_rows_geometry(
+    m: int,
+    k: int,
+) -> dict[str, int]:
+    """Compute exact destination spans and prove every Int32 kernel index."""
+    if m <= 0:
+        raise ValueError(f"MXFP8 row quantizer requires positive M, got {m}")
+    if k <= 0 or k % _SCALE_VEC_SIZE != 0:
+        raise ValueError(
+            f"MXFP8 row quantizer requires K divisible by {_SCALE_VEC_SIZE}, got {k}"
+        )
+
+    g = k // _SCALE_VEC_SIZE
+    m_tiles = (m + _SCALE_ROW_TILE - 1) // _SCALE_ROW_TILE
+    k_tiles = (g + _SCALE_K_TILE - 1) // _SCALE_K_TILE
+    values_bytes = m * k
+    scale_rows_bytes = m * g
+    scale_mma_bytes = m_tiles * k_tiles * 512
+
+    # The row permutation is not monotonic within a 128-row tile. Compute its
+    # exact maximum over the live rows in the final tile rather than assuming
+    # the final logical row has the largest address.
+    live_rows_in_last_tile = (m - 1) % _SCALE_ROW_TILE + 1
+    max_row_offset = max(
+        (row % 32) * 16 + (row // 32) * 4
+        for row in range(live_rows_in_last_tile)
+    )
+    last_group = g - 1
+    scale_mma_max_offset = (
+        ((m - 1) // _SCALE_ROW_TILE) * k_tiles * 512
+        + (last_group // _SCALE_K_TILE) * 512
+        + max_row_offset
+        + last_group % _SCALE_K_TILE
+    )
+
+    # All dynamic coordinates, task counters, and explicit scale offsets in
+    # the kernel are Int32. Python integers make these products overflow-safe.
+    int32_maxima = {
+        "M": m,
+        "source element index": values_bytes - 1,
+        "values word index": m * (k // 4) - 1,
+        "scale_rows element index": scale_rows_bytes - 1,
+        "task count": m * g,
+        "scale_mma byte offset": scale_mma_max_offset,
+    }
+    overflow = {
+        name: value for name, value in int32_maxima.items() if value > _INT32_MAX
+    }
+    if overflow:
+        details = ", ".join(f"{name}={value}" for name, value in overflow.items())
+        raise ValueError(
+            f"MXFP8 row quantizer Int32 index range exceeded for M={m}, K={k}: "
+            f"{details}"
+        )
+    if scale_mma_max_offset >= scale_mma_bytes:
+        raise RuntimeError(
+            "internal MXFP8 scale geometry exceeds its canonical backing span"
+        )
+    return {
+        "g": g,
+        "m_tiles": m_tiles,
+        "k_tiles": k_tiles,
+        "values_bytes": values_bytes,
+        "scale_rows_bytes": scale_rows_bytes,
+        "scale_mma_bytes": scale_mma_bytes,
+        "scale_mma_max_offset": scale_mma_max_offset,
+    }
+
+
+def _validate_mxfp8_rows_destination(
+    *,
+    name: str,
+    tensor: torch.Tensor,
+    ref_device: torch.device,
+    expected_dtype: torch.dtype,
+    expected_shape: tuple[int, ...],
+    expected_strides: tuple[int, ...] | None,
+    required_bytes: int,
+    is_scale_mma: bool = False,
+) -> int:
+    """Validate one caller-owned MXFP8 row-quantizer destination tensor.
+
+    Enforces dtype, CUDA device equality, canonical contiguous layout/stride,
+    exact capacity measured against untyped backing storage (not ``numel``),
+    16-byte ``data_ptr()`` alignment, and returns the base ``data_ptr()`` for
+    alias checking.
+
+    ``expected_strides`` is the exact required stride tuple; ``None`` means
+    "contiguous for this shape" (computed from shape).
+    ``is_scale_mma`` enables the canonical permuted-stride contract instead
+    of plain contiguity.
+    """
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor).__name__}")
+    if tensor.dtype != expected_dtype:
+        raise TypeError(
+            f"{name} must have dtype {expected_dtype}, got {tensor.dtype}"
+        )
+    _check_device(name, tensor, ref_device)
+    if tuple(tensor.shape) != expected_shape:
+        raise ValueError(
+            f"{name} must have shape {expected_shape}, got {tuple(tensor.shape)}"
+        )
+    # Stride contract
+    if is_scale_mma:
+        # scale_mma is a permuted view of physical [1, m_tiles, k_tiles, 32, 4, 4].
+        # Canonical strides: (16, 4, k_tiles*512, 1, 512, m_tiles*k_tiles*512).
+        # Verify exact stride match.
+        actual_strides = tuple(tensor.stride())
+        m_tiles = expected_shape[2]
+        k_tiles = expected_shape[4]
+        canonical_strides = (
+            16, 4, k_tiles * 512, 1, 512, m_tiles * k_tiles * 512,
+        )
+        if actual_strides != canonical_strides:
+            raise ValueError(
+                f"{name} has noncanonical strides {actual_strides}; "
+                f"expected the canonical MMA-swizzled strides {canonical_strides}"
+            )
+    else:
+        if expected_strides is not None:
+            actual_strides = tuple(tensor.stride())
+            if actual_strides != expected_strides:
+                raise ValueError(
+                    f"{name} has strides {actual_strides}, "
+                    f"expected {expected_strides}"
+                )
+        else:
+            if not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous")
+    # Reject zero-stride expansions: any stride of 0 in a non-singleton dim
+    # means the logical shape is larger than the physical backing.
+    for i, (s, dim) in enumerate(zip(tensor.stride(), tensor.shape, strict=True)):
+        if dim > 1 and s == 0:
+            raise ValueError(
+                f"{name} has a zero stride at dim {i} (dim size {dim}), "
+                "which indicates a noncanonical expansion"
+            )
+    # Alignment
+    _check_alignment(name, tensor)
+    # Backing span: bytes from data_ptr() to end of storage.  This catches
+    # one-byte allocations expanded to exact logical shapes.
+    span = _backing_span(tensor)
+    if span < required_bytes:
+        raise ValueError(
+            f"{name} backing storage is {span} bytes from data_ptr() but the "
+            f"kernel writes {required_bytes} bytes"
+        )
+    return tensor.data_ptr()
+
+
+def validate_mxfp8_rows_destinations(
+    source: torch.Tensor,
+    values: torch.Tensor,
+    scale_rows: torch.Tensor,
+    scale_mma: torch.Tensor,
+) -> None:
+    """Validate every caller-owned MXFP8 row-quantizer destination before launch.
+
+    This is the single reusable exact destination contract for the row
+    quantizer.  It checks:
+      - Source is CUDA (the launch device).
+      - Each destination's dtype, shape, device equality, canonical stride/
+        contiguity, 16-byte alignment, and sufficient backing bytes from
+        ``data_ptr()`` to the end of untyped storage.
+      - No pairwise overlap among source, values, scale_rows, scale_mma
+        write regions (rejects aliases).
+      - Int32 safety of the scale_mma offset arithmetic.
+
+    Canonical producer behavior is preserved: allocator-produced tensors
+    from ``empty_mxfp8_rows_for_dense_gemm`` and disjoint aligned slices of
+    a shared scratch arena remain accepted.
+    """
+    validate_mxfp8_rows_source(source)
+    ref_device = source.device
+
+    m = int(source.shape[0])
+    k = int(source.shape[1])
+    geom = _compute_mxfp8_rows_geometry(m, k)
+    g = geom["g"]
+    m_tiles = geom["m_tiles"]
+    k_tiles = geom["k_tiles"]
+
+    # values: [M, K] float8_e4m3fn, contiguous, M*K bytes
+    values_ptr = _validate_mxfp8_rows_destination(
+        name="values",
+        tensor=values,
+        ref_device=ref_device,
+        expected_dtype=torch.float8_e4m3fn,
+        expected_shape=(m, k),
+        expected_strides=(k, 1),
+        required_bytes=geom["values_bytes"],
+    )
+
+    # scale_rows: [1, M, G] float8_e8m0fnu, contiguous, M*G bytes
+    scale_rows_ptr = _validate_mxfp8_rows_destination(
+        name="scale_rows",
+        tensor=scale_rows,
+        ref_device=ref_device,
+        expected_dtype=torch.float8_e8m0fnu,
+        expected_shape=(1, m, g),
+        expected_strides=(m * g, g, 1),
+        required_bytes=geom["scale_rows_bytes"],
+    )
+
+    # scale_mma: [32, 4, ceil(M/128), 4, ceil(G/4), 1] float8_e8m0fnu,
+    # canonical permuted strides, ceil(M/128)*ceil(G/4)*512 bytes
+    expected_scale_mma_shape = (32, 4, m_tiles, 4, k_tiles, 1)
+    scale_mma_ptr = _validate_mxfp8_rows_destination(
+        name="scale_mma",
+        tensor=scale_mma,
+        ref_device=ref_device,
+        expected_dtype=torch.float8_e8m0fnu,
+        expected_shape=expected_scale_mma_shape,
+        expected_strides=None,
+        required_bytes=geom["scale_mma_bytes"],
+        is_scale_mma=True,
+    )
+
+    # Alias checks: reject overlapping write regions.
+    source_ptr = source.data_ptr()
+    source_bytes = source.element_size() * source.numel()
+    _check_no_alias("source", source_ptr, source_bytes,
+                     "values", values_ptr, geom["values_bytes"])
+    _check_no_alias("source", source_ptr, source_bytes,
+                     "scale_rows", scale_rows_ptr, geom["scale_rows_bytes"])
+    _check_no_alias("source", source_ptr, source_bytes,
+                     "scale_mma", scale_mma_ptr, geom["scale_mma_bytes"])
+    _check_no_alias("values", values_ptr, geom["values_bytes"],
+                     "scale_rows", scale_rows_ptr, geom["scale_rows_bytes"])
+    _check_no_alias("values", values_ptr, geom["values_bytes"],
+                     "scale_mma", scale_mma_ptr, geom["scale_mma_bytes"])
+    _check_no_alias("scale_rows", scale_rows_ptr, geom["scale_rows_bytes"],
+                     "scale_mma", scale_mma_ptr, geom["scale_mma_bytes"])
+
+
 def quantize_mxfp8_rows_cute(
     source: torch.Tensor,
     values: torch.Tensor,
@@ -410,25 +736,22 @@ def quantize_mxfp8_rows_cute(
     scale groups and avoids a separate activation transpose kernel.
     """
 
-    if source.dtype not in (torch.bfloat16, torch.float16):
-        raise TypeError(
-            f"CuTe MXFP8 quantizer requires BF16 or FP16 input, got {source.dtype}"
-        )
-    if source.ndim != 2 or not source.is_contiguous():
-        raise ValueError("CuTe MXFP8 quantizer requires contiguous [M,K] input")
+    validate_mxfp8_rows_destinations(source, values, scale_rows, scale_mma)
     if value_order == "trellis_native_mma":
         subgroup_width = 8
     else:
         subgroup_width = _WARP_SUBGROUP_WIDTH if int(source.shape[0]) > 8 else 0
-    _get_compiled_mxfp8_rows_quant(
-        int(source.shape[1]),
-        source.dtype,
-        subgroup_width,
-        _THREADS,
-        value_order,
-    )(
-        source,
-        values,
-        scale_rows,
-        scale_mma,
-    )
+    with torch.cuda.device(source.device):
+        _get_compiled_mxfp8_rows_quant(
+            int(source.shape[1]),
+            source.dtype,
+            subgroup_width,
+            _THREADS,
+            value_order,
+            source.device,
+        )(
+            source,
+            values,
+            scale_rows,
+            scale_mma,
+        )

--- a/b12x/_lib/quant/mxfp8_rows.py
+++ b/b12x/_lib/quant/mxfp8_rows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import cuda.bindings.driver as cuda
 import cutlass
@@ -42,6 +43,16 @@ _KERNEL_ALIGN_BYTES = 16
 # 2^31 - 1 is the max positive Int32; keep a safety margin for intermediate
 # products before the final addition.
 _INT32_MAX = 2 ** 31 - 1
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedMXFP8RowsQuantization:
+    """Validated tensors for one fixed raw-pointer quantizer launch contract."""
+
+    source: torch.Tensor
+    values: torch.Tensor
+    scale_rows: torch.Tensor
+    scale_mma: torch.Tensor
 
 
 class _MXFP8RowsQuantLaunch:
@@ -641,7 +652,7 @@ def validate_mxfp8_rows_destinations(
     values: torch.Tensor,
     scale_rows: torch.Tensor,
     scale_mma: torch.Tensor,
-) -> None:
+) -> _PreparedMXFP8RowsQuantization:
     """Validate every caller-owned MXFP8 row-quantizer destination before launch.
 
     This is the single reusable exact destination contract for the row
@@ -720,8 +731,31 @@ def validate_mxfp8_rows_destinations(
     _check_no_alias("scale_rows", scale_rows_ptr, geom["scale_rows_bytes"],
                      "scale_mma", scale_mma_ptr, geom["scale_mma_bytes"])
 
+    return _PreparedMXFP8RowsQuantization(
+        source=source,
+        values=values,
+        scale_rows=scale_rows,
+        scale_mma=scale_mma,
+    )
 
-def quantize_mxfp8_rows_cute(
+
+def quantize_prepared_mxfp8_rows_cute(
+    prepared: _PreparedMXFP8RowsQuantization,
+    *,
+    value_order: str = "linear",
+) -> None:
+    """Launch a destination contract validated during preparation."""
+
+    _quantize_mxfp8_rows_cute_unchecked(
+        prepared.source,
+        prepared.values,
+        prepared.scale_rows,
+        prepared.scale_mma,
+        value_order=value_order,
+    )
+
+
+def _quantize_mxfp8_rows_cute_unchecked(
     source: torch.Tensor,
     values: torch.Tensor,
     scale_rows: torch.Tensor,
@@ -729,14 +763,8 @@ def quantize_mxfp8_rows_cute(
     *,
     value_order: str = "linear",
 ) -> None:
-    """Quantize contiguous BF16 rows into dense-GEMM MXFP8 layouts.
+    """Launch tensors whose raw-pointer contract is already established."""
 
-    ``trellis_native_mma`` applies the fixed within-K32 byte permutation used
-    by direct native-trellis E4M3 B fragments.  It changes neither values nor
-    scale groups and avoids a separate activation transpose kernel.
-    """
-
-    validate_mxfp8_rows_destinations(source, values, scale_rows, scale_mma)
     if value_order == "trellis_native_mma":
         subgroup_width = 8
     else:
@@ -755,3 +783,27 @@ def quantize_mxfp8_rows_cute(
             scale_rows,
             scale_mma,
         )
+
+
+def quantize_mxfp8_rows_cute(
+    source: torch.Tensor,
+    values: torch.Tensor,
+    scale_rows: torch.Tensor,
+    scale_mma: torch.Tensor,
+    *,
+    value_order: str = "linear",
+) -> None:
+    """Quantize contiguous BF16 rows into dense-GEMM MXFP8 layouts.
+
+    ``trellis_native_mma`` applies the fixed within-K32 byte permutation used
+    by direct native-trellis E4M3 B fragments.  It changes neither values nor
+    scale groups and avoids a separate activation transpose kernel.
+    """
+
+    prepared = validate_mxfp8_rows_destinations(
+        source,
+        values,
+        scale_rows,
+        scale_mma,
+    )
+    quantize_prepared_mxfp8_rows_cute(prepared, value_order=value_order)

--- a/b12x/gemm/_shared/block_fp8.py
+++ b/b12x/gemm/_shared/block_fp8.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterable, Sequence
 
 import torch
@@ -34,7 +34,11 @@ from b12x._lib.scratch import (
     scratch_tensor,
 )
 from b12x._lib.quant.mxfp8_rows import (
+    _PreparedMXFP8RowsQuantization,
+    _quantize_mxfp8_rows_cute_unchecked,
+    quantize_prepared_mxfp8_rows_cute,
     quantize_mxfp8_rows_cute,
+    validate_mxfp8_rows_destinations,
     validate_mxfp8_rows_source,
 )
 
@@ -67,6 +71,7 @@ class BlockFP8LinearBinding:
     packed_weight: BlockFP8LinearWeight
     x_q: MXFP8Rows
     output: torch.Tensor
+    _quantization: _PreparedMXFP8RowsQuantization | None = field(repr=False)
     bias: torch.Tensor | None = None
     # DeepGEMM-style regime hint forwarded to dense_gemm (decode vs prefill tile).
     # None keeps the M-independent default; set it at bind time so the warmed
@@ -330,20 +335,13 @@ def _source_2d(source: torch.Tensor) -> torch.Tensor:
     return source.view(-1, source.shape[-1])
 
 
-def _check_block_fp8_linear_tensors(
-    x_q: MXFP8Rows,
+def _check_block_fp8_linear_output(
     output: torch.Tensor,
     *,
     tokens: int,
     packed_weight: BlockFP8LinearWeight,
     output_dtype: torch.dtype,
 ) -> None:
-    _check_mxfp8_rows_storage(
-        x_q,
-        m=tokens,
-        k=packed_weight.in_features,
-        num_groups=1,
-    )
     if output.shape != (tokens, packed_weight.out_features, 1):
         raise ValueError(
             "output must have shape "
@@ -374,18 +372,26 @@ def build_block_fp8_linear_binding(
         )
     if source_2d.dtype not in (torch.bfloat16, torch.float16):
         raise ValueError(f"source dtype must be bf16/fp16, got {source_2d.dtype}")
-    _check_block_fp8_linear_tensors(
-        x_q,
+    _check_block_fp8_linear_output(
         output,
         tokens=tokens,
         packed_weight=packed_weight,
         output_dtype=source_2d.dtype,
     )
+    quantization = None
+    if tokens > 8 or source_2d.dtype != torch.bfloat16:
+        quantization = validate_mxfp8_rows_destinations(
+            source_2d,
+            x_q.values,
+            x_q.scale_rows,
+            x_q.scale_mma,
+        )
     return BlockFP8LinearBinding(
         source=source,
         packed_weight=packed_weight,
         x_q=x_q,
         output=output,
+        _quantization=quantization,
         bias=bias,
         expected_m=expected_m,
     )
@@ -457,7 +463,7 @@ def _run_block_fp8_quant_kernel(
     in_features: int,
 ) -> None:
     del tokens, in_features
-    quantize_mxfp8_rows_cute(
+    _quantize_mxfp8_rows_cute_unchecked(
         source_tk,
         out_values,
         out_scale_rows,
@@ -547,9 +553,11 @@ def quantize_block_fp8_linear_input_mxfp8(
             num_groups=1,
         )
 
-    _check_mxfp8_rows_storage(out, m=tokens, k=in_features, num_groups=1)
-    _run_block_fp8_quant_kernel(
-        source_tk, out.values, out.scale_rows, out.scale_mma, tokens, in_features
+    quantize_mxfp8_rows_cute(
+        source_tk,
+        out.values,
+        out.scale_rows,
+        out.scale_mma,
     )
     return out
 
@@ -654,11 +662,13 @@ def block_fp8_linear_mxfp8(
         packed_weight = binding.packed_weight
         x_q_storage = binding.x_q
         output_storage = binding.output
+        quantization = binding._quantization
         bias = binding.bias
         expected_m = binding.expected_m
     else:
         x_q_storage = None
         output_storage = None
+        quantization = None
     if source is None or packed_weight is None:
         raise TypeError(
             "block_fp8_linear_mxfp8 requires source and packed_weight or binding"
@@ -699,14 +709,6 @@ def block_fp8_linear_mxfp8(
         raise TypeError(
             "block_fp8_linear_mxfp8 requires binding for caller-owned scratch"
         )
-    _check_block_fp8_linear_tensors(
-        x_q_storage,
-        output_storage,
-        tokens=tokens,
-        packed_weight=packed_weight,
-        output_dtype=source_2d.dtype,
-    )
-
     assert x_q_storage is not None
     assert output_storage is not None
     t0 = time.perf_counter() if _B12X_TIMING else 0.0
@@ -727,7 +729,9 @@ def block_fp8_linear_mxfp8(
         if bias is not None:
             output += bias
         return output.view(*source.shape[:-1], packed_weight.out_features)
-    x_q = quantize_block_fp8_linear_input_mxfp8(source_2d, out=x_q_storage)
+    assert quantization is not None
+    quantize_prepared_mxfp8_rows_cute(quantization)
+    x_q = x_q_storage
     t_quant = time.perf_counter() if _B12X_TIMING else 0.0
     output = dense_gemm(
         (x_q.values.reshape(tokens, packed_weight.in_features, 1), x_q.scale_mma),

--- a/b12x/gemm/_shared/block_fp8.py
+++ b/b12x/gemm/_shared/block_fp8.py
@@ -33,7 +33,10 @@ from b12x._lib.scratch import (
     scratch_buffer_spec,
     scratch_tensor,
 )
-from b12x._lib.quant.mxfp8_rows import quantize_mxfp8_rows_cute
+from b12x._lib.quant.mxfp8_rows import (
+    quantize_mxfp8_rows_cute,
+    validate_mxfp8_rows_source,
+)
 
 logger = logging.getLogger(__name__)
 _B12X_TIMING = (
@@ -471,6 +474,14 @@ def _quantize_block_fp8_linear_input_mxfp8_alloc_op(
     tokens: int,
     in_features: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    validate_mxfp8_rows_source(source_tk)
+    source_tokens, source_in_features = source_tk.shape
+    if tokens != source_tokens or in_features != source_in_features:
+        raise ValueError(
+            "quantize_block_fp8_linear_input_mxfp8_alloc dimensions must "
+            f"match source shape {tuple(source_tk.shape)}, got "
+            f"tokens={tokens}, in_features={in_features}"
+        )
     # Functional (allocate + return) quantizer: the raw CuTe kernel writes the
     # MXFP8 output views INSIDE this opaque op, so torch.compile never sees a
     # low-level mutation on 3 caller-visible views. Returns the

--- a/tests/gemm/test_block_fp8_linear_scratch_bindings.py
+++ b/tests/gemm/test_block_fp8_linear_scratch_bindings.py
@@ -32,6 +32,18 @@ def _packed_weight(*, in_features: int = 128, out_features: int = 256) -> BlockF
     )
 
 
+def _stub_destination_validation(monkeypatch):
+    prepared = object()
+    calls = []
+
+    def validate(source, values, scale_rows, scale_mma):
+        calls.append((source, values, scale_rows, scale_mma))
+        return prepared
+
+    monkeypatch.setattr(block_impl, "validate_mxfp8_rows_destinations", validate)
+    return prepared, calls
+
+
 def test_block_fp8_linear_scratch_plan_exposes_one_opaque_scratch_spec() -> None:
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
@@ -51,7 +63,7 @@ def test_block_fp8_linear_scratch_plan_exposes_one_opaque_scratch_spec() -> None
 
 
 def test_block_fp8_linear_scratch_plan_binds_live_shape(monkeypatch) -> None:
-    monkeypatch.setattr(block_impl, "_check_mxfp8_rows_storage", lambda *args, **kwargs: None)
+    _, validation_calls = _stub_destination_validation(monkeypatch)
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
             device="cpu",
@@ -79,10 +91,12 @@ def test_block_fp8_linear_scratch_plan_binds_live_shape(monkeypatch) -> None:
     assert not hasattr(binding, "workspace")
     assert binding.x_q.values.shape == (3, 128)
     assert binding.output is output
+    assert binding._quantization is None
+    assert validation_calls == []
 
 
 def test_block_fp8_linear_plan_binding_maps_scratch_views(monkeypatch) -> None:
-    monkeypatch.setattr(block_impl, "_check_mxfp8_rows_storage", lambda *args, **kwargs: None)
+    _, validation_calls = _stub_destination_validation(monkeypatch)
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
             device="cpu",
@@ -110,23 +124,25 @@ def test_block_fp8_linear_plan_binding_maps_scratch_views(monkeypatch) -> None:
     assert binding.output is output
     assert binding.source is source
     assert binding.packed_weight is packed
+    assert binding._quantization is None
+    assert validation_calls == []
 
 
 def test_block_fp8_linear_binding_supplies_runtime_tensors(monkeypatch) -> None:
     monkeypatch.setattr(block_impl, "_check_gpu_tensor", lambda *args, **kwargs: None)
-    monkeypatch.setattr(block_impl, "_check_mxfp8_rows_storage", lambda *args, **kwargs: None)
+    prepared, validation_calls = _stub_destination_validation(monkeypatch)
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
             device="cpu",
-            max_tokens=4,
+            max_tokens=9,
             in_features=128,
             out_features=256,
         )
     )
     spec = plan.scratch_specs()[0]
     scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
-    source = torch.empty((3, 128), dtype=torch.bfloat16)
-    output = torch.empty((3, 256, 1), dtype=torch.bfloat16)
+    source = torch.empty((9, 128), dtype=torch.bfloat16)
+    output = torch.empty((9, 256, 1), dtype=torch.bfloat16)
     packed = _packed_weight()
     binding = plan.bind(
         scratch=scratch,
@@ -136,10 +152,8 @@ def test_block_fp8_linear_binding_supplies_runtime_tensors(monkeypatch) -> None:
     )
     calls = {}
 
-    def fake_quantize(source_tk, *, out=None):
-        calls["source_tk"] = source_tk
-        calls["x_q_out"] = out
-        return out
+    def fake_quantize(prepared_quantization):
+        calls["quantization"] = prepared_quantization
 
     def fake_dense_gemm(a, b, **kwargs):
         calls["a"] = a
@@ -148,19 +162,19 @@ def test_block_fp8_linear_binding_supplies_runtime_tensors(monkeypatch) -> None:
         kwargs["out"].zero_()
         return kwargs["out"]
 
-    monkeypatch.setattr(block_impl, "quantize_block_fp8_linear_input_mxfp8", fake_quantize)
+    monkeypatch.setattr(block_impl, "quantize_prepared_mxfp8_rows_cute", fake_quantize)
     monkeypatch.setattr(block_impl, "dense_gemm", fake_dense_gemm)
 
     out = block_impl.block_fp8_linear_mxfp8(binding=binding)
 
-    assert calls["source_tk"].data_ptr() == source.data_ptr()
-    assert calls["x_q_out"] is binding.x_q
+    assert calls["quantization"] is prepared
     assert calls["dense_out"] is output
-    assert out.shape == (3, 256)
+    assert out.shape == (9, 256)
+    assert len(validation_calls) == 1
 
 
 def test_block_fp8_linear_binding_owns_runtime_tensors(monkeypatch) -> None:
-    monkeypatch.setattr(block_impl, "_check_mxfp8_rows_storage", lambda *args, **kwargs: None)
+    _stub_destination_validation(monkeypatch)
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
             device="cpu",

--- a/tests/quantization/test_mxfp8_rows_destination_contract.py
+++ b/tests/quantization/test_mxfp8_rows_destination_contract.py
@@ -1,0 +1,593 @@
+"""Adversarial destination-contract tests for the raw MXFP8 row quantizer."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+import b12x._lib.quant.mxfp8_rows as rows_impl
+import b12x.gemm._shared.block_fp8 as block_fp8
+from b12x.gemm._shared.wo_mxfp8 import empty_mxfp8_rows_for_dense_gemm
+
+from ..conftest import require_b12x
+
+_M = 4
+_K = 128
+_G = _K // 32
+_M_TILES = 1
+_K_TILES = 1
+_VALUES_BYTES = _M * _K
+_SCALE_ROWS_BYTES = _M * _G
+_SCALE_MMA_BYTES = _M_TILES * _K_TILES * 512
+
+
+def _scale_mma_from_u8(storage: torch.Tensor) -> torch.Tensor:
+    physical = storage.narrow(0, 0, _SCALE_MMA_BYTES).view(
+        1, _M_TILES, _K_TILES, 32, 4, 4
+    )
+    return physical.view(torch.float8_e8m0fnu).permute(3, 4, 1, 5, 2, 0)
+
+
+def _valid_case() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = require_b12x()
+    source = torch.randn((_M, _K), dtype=torch.bfloat16, device=device)
+    out = empty_mxfp8_rows_for_dense_gemm(_M, _K, device=device)
+    return source, out.values, out.scale_rows, out.scale_mma
+
+
+def _assert_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    tensors: tuple[torch.Tensor, object, object, object],
+    *,
+    error: type[BaseException],
+    match: str,
+) -> None:
+    compiled = False
+
+    def forbid_compile(*_args, **_kwargs):
+        nonlocal compiled
+        compiled = True
+        raise AssertionError("destination validation reached kernel resolution")
+
+    monkeypatch.setattr(rows_impl, "_get_compiled_mxfp8_rows_quant", forbid_compile)
+    source, values, scale_rows, scale_mma = tensors
+    with pytest.raises(error, match=match):
+        rows_impl.quantize_mxfp8_rows_cute(
+            source,
+            values,  # type: ignore[arg-type]
+            scale_rows,  # type: ignore[arg-type]
+            scale_mma,  # type: ignore[arg-type]
+        )
+    assert not compiled
+
+
+def test_canonical_destinations_pass_exact_contract() -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    rows_impl.validate_mxfp8_rows_destinations(
+        source, values, scale_rows, scale_mma
+    )
+
+
+def _misaligned_source(device: torch.device) -> torch.Tensor:
+    storage = torch.empty(_M * _K * 2 + 2, dtype=torch.uint8, device=device)
+    return storage.narrow(0, 2, _M * _K * 2).view(torch.bfloat16).view(_M, _K)
+
+
+def test_misaligned_source_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (_misaligned_source(source.device), values, scale_rows, scale_mma),
+        error=ValueError,
+        match="source base pointer must be 16-byte aligned",
+    )
+
+
+def test_public_alloc_quantizer_is_fullgraph_traceable() -> None:
+    device = require_b12x()
+    source = torch.randn((_M, _K), dtype=torch.bfloat16, device=device)
+
+    def quantize_values(x: torch.Tensor) -> torch.Tensor:
+        return block_fp8.quantize_block_fp8_linear_input_mxfp8(x).values
+
+    compiled = torch.compile(quantize_values, backend="eager", fullgraph=True)
+    result = compiled(source)
+    assert result.shape == source.shape
+    assert result.dtype == torch.float8_e4m3fn
+
+
+
+@pytest.mark.parametrize(
+    ("tokens", "in_features"),
+    [(_M + 1, _K), (_M, _K + 32)],
+)
+def test_direct_alloc_op_rejects_dimensions_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+    tokens: int,
+    in_features: int,
+) -> None:
+    source, _, _, _ = _valid_case()
+
+    def forbid_allocation(*_args, **_kwargs):
+        raise AssertionError("dimension validation reached output allocation")
+
+    monkeypatch.setattr(block_fp8, "empty_mxfp8_rows_bases", forbid_allocation)
+    with pytest.raises(ValueError, match="dimensions must match source shape"):
+        torch.ops.b12x.quantize_block_fp8_linear_input_mxfp8_alloc(
+            source, tokens, in_features
+        )
+
+
+def test_direct_alloc_op_rejects_misalignment_before_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = require_b12x()
+    source = _misaligned_source(device)
+
+    def forbid_allocation(*_args, **_kwargs):
+        raise AssertionError("source validation reached output allocation")
+
+    monkeypatch.setattr(block_fp8, "empty_mxfp8_rows_bases", forbid_allocation)
+    with pytest.raises(
+        ValueError, match="source base pointer must be 16-byte aligned"
+    ):
+        torch.ops.b12x.quantize_block_fp8_linear_input_mxfp8_alloc(
+            source, _M, _K
+        )
+
+def test_aligned_disjoint_arena_slices_are_accepted() -> None:
+    source, _, _, _ = _valid_case()
+    scale_rows_offset = _VALUES_BYTES
+    scale_mma_offset = scale_rows_offset + _SCALE_ROWS_BYTES
+    arena = torch.empty(
+        scale_mma_offset + _SCALE_MMA_BYTES,
+        dtype=torch.uint8,
+        device=source.device,
+    )
+    values = (
+        arena.narrow(0, 0, _VALUES_BYTES)
+        .view(torch.float8_e4m3fn)
+        .view(_M, _K)
+    )
+    scale_rows = (
+        arena.narrow(0, scale_rows_offset, _SCALE_ROWS_BYTES)
+        .view(torch.float8_e8m0fnu)
+        .view(1, _M, _G)
+    )
+    scale_mma = _scale_mma_from_u8(
+        arena.narrow(0, scale_mma_offset, _SCALE_MMA_BYTES)
+    )
+
+    assert scale_rows.storage_offset() != 0
+    assert scale_mma.storage_offset() != 0
+    rows_impl.validate_mxfp8_rows_destinations(
+        source, values, scale_rows, scale_mma
+    )
+
+
+@pytest.mark.parametrize(
+    ("destination", "replacement", "match"),
+    [
+        (
+            "values",
+            lambda device: torch.empty(
+                (_M, _K), dtype=torch.uint8, device=device
+            ),
+            "values must have dtype",
+        ),
+        (
+            "scale_rows",
+            lambda device: torch.empty(
+                (1, _M, _G), dtype=torch.uint8, device=device
+            ),
+            "scale_rows must have dtype",
+        ),
+        (
+            "scale_mma",
+            lambda device: torch.empty(
+                (32, 4, 1, 4, 1, 1), dtype=torch.uint8, device=device
+            ),
+            "scale_mma must have dtype",
+        ),
+    ],
+)
+def test_wrong_destination_dtype_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    destination: str,
+    replacement: Callable[[torch.device], torch.Tensor],
+    match: str,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    tensors = {
+        "values": values,
+        "scale_rows": scale_rows,
+        "scale_mma": scale_mma,
+    }
+    tensors[destination] = replacement(source.device)
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, tensors["values"], tensors["scale_rows"], tensors["scale_mma"]),
+        error=TypeError,
+        match=match,
+    )
+
+
+@pytest.mark.parametrize(
+    ("destination", "replacement", "match"),
+    [
+        (
+            "values",
+            lambda device: torch.empty(
+                (_M, _K + 32), dtype=torch.float8_e4m3fn, device=device
+            ),
+            "values must have shape",
+        ),
+        (
+            "scale_rows",
+            lambda device: torch.empty(
+                (1, _M, _G + 1), dtype=torch.float8_e8m0fnu, device=device
+            ),
+            "scale_rows must have shape",
+        ),
+        (
+            "scale_mma",
+            lambda device: torch.empty(
+                (32, 4, 1, 4, 2, 1),
+                dtype=torch.float8_e8m0fnu,
+                device=device,
+            ),
+            "scale_mma must have shape",
+        ),
+    ],
+)
+def test_wrong_destination_shape_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    destination: str,
+    replacement: Callable[[torch.device], torch.Tensor],
+    match: str,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    tensors = {
+        "values": values,
+        "scale_rows": scale_rows,
+        "scale_mma": scale_mma,
+    }
+    tensors[destination] = replacement(source.device)
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, tensors["values"], tensors["scale_rows"], tensors["scale_mma"]),
+        error=ValueError,
+        match=match,
+    )
+
+
+@pytest.mark.parametrize("destination", ["values", "scale_rows", "scale_mma"])
+def test_wrong_destination_device_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    destination: str,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    replacements = {
+        "values": torch.empty((_M, _K), dtype=torch.float8_e4m3fn),
+        "scale_rows": torch.empty(
+            (1, _M, _G), dtype=torch.float8_e8m0fnu
+        ),
+        "scale_mma": _scale_mma_from_u8(
+            torch.empty(_SCALE_MMA_BYTES, dtype=torch.uint8)
+        ),
+    }
+    tensors = {
+        "values": values,
+        "scale_rows": scale_rows,
+        "scale_mma": scale_mma,
+    }
+    tensors[destination] = replacements[destination]
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, tensors["values"], tensors["scale_rows"], tensors["scale_mma"]),
+        error=ValueError,
+        match="must be on the source/launch device",
+    )
+
+
+@pytest.mark.parametrize(
+    ("destination", "replacement", "match"),
+    [
+        (
+            "values",
+            lambda device: torch.empty(
+                (_K, _M), dtype=torch.float8_e4m3fn, device=device
+            ).t(),
+            "values has strides",
+        ),
+        (
+            "scale_rows",
+            lambda device: torch.empty(
+                (1, _G, _M), dtype=torch.float8_e8m0fnu, device=device
+            ).transpose(1, 2),
+            "scale_rows has strides",
+        ),
+        (
+            "scale_mma",
+            lambda device: torch.empty(
+                (32, 4, 1, 4, 1, 1),
+                dtype=torch.float8_e8m0fnu,
+                device=device,
+            ),
+            "scale_mma has noncanonical strides",
+        ),
+    ],
+)
+def test_noncanonical_destination_layout_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    destination: str,
+    replacement: Callable[[torch.device], torch.Tensor],
+    match: str,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    tensors = {
+        "values": values,
+        "scale_rows": scale_rows,
+        "scale_mma": scale_mma,
+    }
+    tensors[destination] = replacement(source.device)
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, tensors["values"], tensors["scale_rows"], tensors["scale_mma"]),
+        error=ValueError,
+        match=match,
+    )
+
+
+def _misaligned_values(device: torch.device) -> torch.Tensor:
+    storage = torch.empty(_VALUES_BYTES + 1, dtype=torch.uint8, device=device)
+    return (
+        storage.narrow(0, 1, _VALUES_BYTES)
+        .view(torch.float8_e4m3fn)
+        .view(_M, _K)
+    )
+
+
+def _misaligned_scale_rows(device: torch.device) -> torch.Tensor:
+    storage = torch.empty(_SCALE_ROWS_BYTES + 1, dtype=torch.uint8, device=device)
+    return (
+        storage.narrow(0, 1, _SCALE_ROWS_BYTES)
+        .view(torch.float8_e8m0fnu)
+        .view(1, _M, _G)
+    )
+
+
+def _misaligned_scale_mma(device: torch.device) -> torch.Tensor:
+    storage = torch.empty(_SCALE_MMA_BYTES + 1, dtype=torch.uint8, device=device)
+    return _scale_mma_from_u8(storage.narrow(0, 1, _SCALE_MMA_BYTES))
+
+
+@pytest.mark.parametrize(
+    ("destination", "replacement"),
+    [
+        ("values", _misaligned_values),
+        ("scale_rows", _misaligned_scale_rows),
+        ("scale_mma", _misaligned_scale_mma),
+    ],
+)
+def test_misaligned_destination_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    destination: str,
+    replacement: Callable[[torch.device], torch.Tensor],
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    tensors = {
+        "values": values,
+        "scale_rows": scale_rows,
+        "scale_mma": scale_mma,
+    }
+    tensors[destination] = replacement(source.device)
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, tensors["values"], tensors["scale_rows"], tensors["scale_mma"]),
+        error=ValueError,
+        match="base pointer must be 16-byte aligned",
+    )
+
+
+def test_short_backing_span_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    real_backing_span = rows_impl._backing_span
+
+    def short_values_span(tensor: torch.Tensor) -> int:
+        if tensor is values:
+            return _VALUES_BYTES - 1
+        return real_backing_span(tensor)
+
+    monkeypatch.setattr(rows_impl, "_backing_span", short_values_span)
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, values, scale_rows, scale_mma),
+        error=ValueError,
+        match="values backing storage is",
+    )
+
+
+def _alias_case(
+    pair: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    source, values, scale_rows, scale_mma = _valid_case()
+    if pair == "source-values":
+        values = (
+            source.view(torch.uint8)
+            .reshape(-1)
+            .narrow(0, 0, _VALUES_BYTES)
+            .view(torch.float8_e4m3fn)
+            .view(_M, _K)
+        )
+    elif pair == "source-scale_rows":
+        scale_rows = (
+            source.view(torch.uint8)
+            .reshape(-1)
+            .narrow(0, 0, _SCALE_ROWS_BYTES)
+            .view(torch.float8_e8m0fnu)
+            .view(1, _M, _G)
+        )
+    elif pair == "source-scale_mma":
+        scale_mma = _scale_mma_from_u8(source.view(torch.uint8).reshape(-1))
+    else:
+        arena = torch.empty(
+            _SCALE_MMA_BYTES, dtype=torch.uint8, device=source.device
+        )
+        if pair in {"values-scale_rows", "values-scale_mma"}:
+            values = (
+                arena.narrow(0, 0, _VALUES_BYTES)
+                .view(torch.float8_e4m3fn)
+                .view(_M, _K)
+            )
+        if pair in {"values-scale_rows", "scale_rows-scale_mma"}:
+            scale_rows = (
+                arena.narrow(0, 0, _SCALE_ROWS_BYTES)
+                .view(torch.float8_e8m0fnu)
+                .view(1, _M, _G)
+            )
+        if pair in {"values-scale_mma", "scale_rows-scale_mma"}:
+            scale_mma = _scale_mma_from_u8(arena)
+    return source, values, scale_rows, scale_mma
+
+
+@pytest.mark.parametrize(
+    "pair",
+    [
+        "source-values",
+        "source-scale_rows",
+        "source-scale_mma",
+        "values-scale_rows",
+        "values-scale_mma",
+        "scale_rows-scale_mma",
+    ],
+)
+def test_every_overlapping_storage_pair_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+    pair: str,
+) -> None:
+    _assert_rejected_before_compile(
+        monkeypatch,
+        _alias_case(pair),
+        error=ValueError,
+        match="overlapping storage",
+    )
+
+
+def test_non_tensor_destination_is_rejected_before_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, _, scale_rows, scale_mma = _valid_case()
+    _assert_rejected_before_compile(
+        monkeypatch,
+        (source, object(), scale_rows, scale_mma),
+        error=TypeError,
+        match="values must be a torch.Tensor",
+    )
+
+
+def test_partial_row_tile_reports_true_maximum_scale_offset() -> None:
+    geometry = rows_impl._compute_mxfp8_rows_geometry(33, _K)
+    assert geometry["scale_mma_max_offset"] == 499
+    assert geometry["scale_mma_max_offset"] < geometry["scale_mma_bytes"]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source element index",
+        "values word index",
+        "scale_rows element index",
+        "task count",
+        "scale_mma byte offset",
+    ],
+)
+def test_every_int32_index_family_is_guarded(field: str) -> None:
+    with pytest.raises(ValueError, match=field):
+        rows_impl._compute_mxfp8_rows_geometry(1 << 30, _K)
+
+
+def test_launch_resolves_stream_inside_source_device_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, values, scale_rows, scale_mma = _valid_case()
+    raw_calls: list[tuple[object, ...]] = []
+
+    def fake_compile(*_args, **_kwargs):
+        def fake_raw(*args):
+            raw_calls.append(args)
+
+        return fake_raw
+
+    rows_impl._get_compiled_mxfp8_rows_quant.cache_clear()
+    monkeypatch.setattr(rows_impl, "b12x_compile", fake_compile)
+
+    entered: list[torch.device] = []
+    active: list[torch.device] = []
+
+    @contextmanager
+    def record_device(device):
+        resolved = torch.device(device)
+        entered.append(resolved)
+        active.append(resolved)
+        try:
+            yield
+        finally:
+            active.pop()
+
+    def checked_current_stream():
+        assert active == [source.device]
+        return object()
+
+    monkeypatch.setattr(torch.cuda, "device", record_device)
+    monkeypatch.setattr(rows_impl, "current_cuda_stream", checked_current_stream)
+    try:
+        rows_impl.quantize_mxfp8_rows_cute(
+            source, values, scale_rows, scale_mma
+        )
+    finally:
+        rows_impl._get_compiled_mxfp8_rows_quant.cache_clear()
+
+    assert entered == [source.device]
+    assert len(raw_calls) == 1
+
+
+def test_compile_cache_separates_device_identities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compile_devices: list[torch.device] = []
+    compile_specs = []
+
+    def fake_compile(*_args, **kwargs):
+        compile_devices.append(requested_device)
+        compile_specs.append(kwargs["compile_spec"])
+        return lambda *_launch_args: None
+
+    monkeypatch.setattr(rows_impl, "b12x_compile", fake_compile)
+    monkeypatch.setattr(rows_impl, "current_cuda_stream", object)
+    rows_impl._get_compiled_mxfp8_rows_quant.cache_clear()
+    try:
+        for requested_device in (
+            torch.device("cuda:0"),
+            torch.device("cuda:1"),
+            torch.device("cuda:0"),
+        ):
+            rows_impl._get_compiled_mxfp8_rows_quant(
+                _K,
+                torch.bfloat16,
+                0,
+                rows_impl._THREADS,
+                "linear",
+                requested_device,
+            )
+    finally:
+        rows_impl._get_compiled_mxfp8_rows_quant.cache_clear()
+
+    assert compile_devices == [torch.device("cuda:0"), torch.device("cuda:1")]
+    assert compile_specs[0].json_key != compile_specs[1].json_key


### PR DESCRIPTION
## Problem

The raw MXFP8 row quantizer accepted caller-owned destinations and converted their pointers without proving exact geometry, dtype, device, physical layout, alignment, backing capacity, or non-overlap. Its dynamic Int32 index products and device-specific compile cache were also not bounded/keyed at this boundary.

## Fix

- validate exact values, row-scale, and MMA-scale destination shapes, dtypes, devices, canonical strides, alignment, and remaining backing bytes before kernel resolution
- reject every source/destination and destination/destination overlap while preserving aligned disjoint views into a shared scratch arena
- compute destination spans and the exact non-monotonic partial-row-tile MMA-scale maximum using Python integers
- reject overflow in every Int32 kernel coordinate/task family: M, source elements, value words, row scales, task count, and MMA-scale offset
- resolve compilation and launch inside the source CUDA-device context and include device identity in the outer compile cache key
- add safe launch spies plus adversarial coverage for every destination property and alias pair

## Verification

- Linux/CUDA: `pytest tests/quantization/test_mxfp8_rows_destination_contract.py tests/gemm/test_cute_migration_gemm_corpus.py::test_cute_migration_mxfp8_quant_gpu_oracle_and_graph tests/gemm/test_cute_migration_gemm_corpus.py::test_cute_migration_mxfp8_quant_trellis_native_mma_order -q` — 36 passed
- local: `py_compile`, focused Ruff, and `git diff --check` passed
- independent security review approved head `2509852`

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added robust MXFP8 row quantization with CUDA-aware validation and device-specific compilation handling.
  - Added prepared quantization support for more efficient execution with caller-provided output buffers.

- **Bug Fixes**
  - Improved block-FP8 quantization reliability by validating inputs and output buffers before processing.
  - Prevented invalid tensor geometry, unsupported layouts, unsafe memory overlap, and oversized configurations.
  - Ensured operations execute on the correct CUDA device and stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->