### PR TITLE
security: bound NSA paged-indexer cache addresses

### DIFF
--- a/b12x/attention/nsa_indexer/fused_indexer.py
+++ b/b12x/attention/nsa_indexer/fused_indexer.py
@@ -1521,7 +1521,11 @@ class SparseNSAFusedIndexerKernel:
                         pid = Int32(real_page_table[q_idx, pcol])
                 t0 = Float32(0.0)
                 t1 = Float32(0.0)
-                if pid >= Int32(0):
+                if (
+                    (pid >= Int32(0))
+                    & (pid < Int32(k_quant_bytes.shape[0]))
+                    & (pid < Int32(k_scales.shape[0]))
+                ):
                     k_off = Int64(pid) * Int64(self.k_quant_page_stride) + Int64(
                         (tip0 + lane // Int32(4)) * Int32(_INDEX_HEAD_DIM)
                         + lane4 * Int32(4)
@@ -1542,7 +1546,11 @@ class SparseNSAFusedIndexerKernel:
                         if tok_rel < span:
                             val = Float32(-3.4028235e38)
                             gidx = Int32(-1)
-                            if pid >= Int32(0):
+                            if (
+                                (pid >= Int32(0))
+                                & (pid < Int32(k_quant_bytes.shape[0]))
+                                & (pid < Int32(k_scales.shape[0]))
+                            ):
                                 if cutlass.const_expr(cc == 0):
                                     tsel = t0
                                 else:
@@ -1557,7 +1565,12 @@ class SparseNSAFusedIndexerKernel:
                                     tsel * ld_global_nc_f32(scale_addr)
                                 )
                                 if cutlass.const_expr(self.paged_output):
-                                    gidx = pid * Int32(_PAGE_SIZE) + tip0 + col
+                                    physical_idx = (
+                                        Int64(pid) * Int64(_PAGE_SIZE)
+                                        + Int64(tip0 + col)
+                                    )
+                                    if physical_idx <= Int64(2147483647):
+                                        gidx = Int32(physical_idx)
                                 else:
                                     gidx = span_first + tok_rel
                             s_c0_values[carry_count + tok_rel - round_base] = val
@@ -1611,7 +1624,7 @@ class SparseNSAFusedIndexerKernel:
             cur_scale_addr = scales_base_addr
             prev_do = Int32(0)
             prev_valid = Int32(0)
-            prev_out_base = Int32(0)
+            prev_out_base = Int64(0)
             prev_scale_addr = scales_base_addr
             prev_pl2 = Int32(0)
             cur_pl2 = Int32(0)
@@ -1620,7 +1633,11 @@ class SparseNSAFusedIndexerKernel:
                     pid0 = Int32(-1)
                     if page_start < Int32(real_page_table.shape[1]):
                         pid0 = Int32(real_page_table[q_idx, page_start])
-                    if pid0 >= Int32(0):
+                    if (
+                        (pid0 >= Int32(0))
+                        & (pid0 < Int32(k_quant_bytes.shape[0]))
+                        & (pid0 < Int32(k_scales.shape[0]))
+                    ):
                         _stream_issue_k_page_cp_async(
                             k_quant_bytes,
                             k_scales,
@@ -1647,7 +1664,12 @@ class SparseNSAFusedIndexerKernel:
                     page_id = Int32(-1)
                     if page_col < Int32(real_page_table.shape[1]):
                         page_id = Int32(real_page_table[q_idx, page_col])
-                    if (page_id >= Int32(0)) & (valid_slots > Int32(0)):
+                    if (
+                        (page_id >= Int32(0))
+                        & (page_id < Int32(k_quant_bytes.shape[0]))
+                        & (page_id < Int32(k_scales.shape[0]))
+                        & (valid_slots > Int32(0))
+                    ):
                         do_page = Int32(1)
                 else:
                     if valid_slots > Int32(0):
@@ -1670,7 +1692,12 @@ class SparseNSAFusedIndexerKernel:
                     if nxt < page_end:
                         if nxt < Int32(real_page_table.shape[1]):
                             pid_n = Int32(real_page_table[q_idx, nxt])
-                        if (pid_n >= Int32(0)) & (nxt * Int32(_PAGE_SIZE) < seq_len):
+                        if (
+                            (pid_n >= Int32(0))
+                            & (pid_n < Int32(k_quant_bytes.shape[0]))
+                            & (pid_n < Int32(k_scales.shape[0]))
+                            & (nxt * Int32(_PAGE_SIZE) < seq_len)
+                        ):
                             nxt_valid = Int32(1)
                     # stage((p+1) % 3): perm -> k_page -> k_page3 -> perm
                     nk = k_page_base_addr
@@ -1736,9 +1763,13 @@ class SparseNSAFusedIndexerKernel:
                                                 prev_scale_addr + slot_idx * Int32(4)
                                             )
                                         )
-                                        s_c0_gindex[carry_count + slot_idx] = (
-                                            prev_out_base + slot_idx
+                                        output_candidate = (
+                                            prev_out_base + Int64(slot_idx)
                                         )
+                                        output_idx = Int32(-1)
+                                        if output_candidate <= Int64(2147483647):
+                                            output_idx = Int32(output_candidate)
+                                        s_c0_gindex[carry_count + slot_idx] = output_idx
                             carry_count = carry_count + prev_valid
                             prev_do = Int32(0)
                 if do_page != Int32(0):
@@ -1813,9 +1844,9 @@ class SparseNSAFusedIndexerKernel:
                         prev_scale_addr = cur_scale_addr
                         prev_pl2 = cur_pl2
                         cur_pl2 = cur_pl2 ^ Int32(1)
-                        prev_out_base = abs_start + page_base
+                        prev_out_base = Int64(abs_start) + Int64(page_base)
                         if cutlass.const_expr(self.paged_output):
-                            prev_out_base = page_id * Int32(_PAGE_SIZE)
+                            prev_out_base = Int64(page_id) * Int64(_PAGE_SIZE)
                     else:
                         split_idx = Int32(0)
                         while split_idx < Int32(self.page_splits):
@@ -1874,9 +1905,13 @@ class SparseNSAFusedIndexerKernel:
                                             self.kv_layout == KV_LAYOUT_PAGED
                                             and self.paged_output
                                         ):
-                                            output_idx = (
-                                                page_id * Int32(_PAGE_SIZE) + slot_idx
+                                            output_candidate = (
+                                                Int64(page_id) * Int64(_PAGE_SIZE)
+                                                + Int64(slot_idx)
                                             )
+                                            output_idx = Int32(-1)
+                                            if output_candidate <= Int64(2147483647):
+                                                output_idx = Int32(output_candidate)
                                         s_c0_gindex[carry_count + slot_idx] = output_idx
                             # page_splits==1 (always for 1/2/4 head tiles): no post-reduce
                             # barrier — the next page's load barrier (or the trim's leading
@@ -1981,9 +2016,13 @@ class SparseNSAFusedIndexerKernel:
                                         prev_scale_addr + slot_idx * Int32(4)
                                     )
                                 )
-                                s_c0_gindex[carry_count + slot_idx] = (
-                                    prev_out_base + slot_idx
+                                output_candidate = (
+                                    prev_out_base + Int64(slot_idx)
                                 )
+                                output_idx = Int32(-1)
+                                if output_candidate <= Int64(2147483647):
+                                    output_idx = Int32(output_candidate)
+                                s_c0_gindex[carry_count + slot_idx] = output_idx
                     carry_count = carry_count + prev_valid
                 if carry_count > topk_static:
                     cute.arch.sync_threads()

--- a/b12x/attention/nsa_indexer/kernel.py
+++ b/b12x/attention/nsa_indexer/kernel.py
@@ -980,7 +980,11 @@ class SparseNSAPagedLogitsKernel:
                     source_page_col < Int32(real_page_table.shape[1])
                 ):
                     page_id = Int32(real_page_table[q_idx, source_page_col])
-                    if page_id >= Int32(0):
+                    if (
+                        (page_id >= Int32(0))
+                        & (page_id < Int32(k_quant_bytes.shape[0]))
+                        & (page_id < Int32(k_scales.shape[0]))
+                    ):
                         if use_scalar_k_load_flag != Int32(0):
                             _load_index_k_page_scalar(
                                 k_quant_bytes,
@@ -1418,7 +1422,11 @@ class SparseNSAScheduledSingleRowLogitsKernel:
                 page_base = page_col * Int32(_PAGE_SIZE)
                 if page_base < seq_len:
                     page_id = Int32(real_page_table[Int32(0), page_col])
-                    if page_id >= Int32(0):
+                    if (
+                        (page_id >= Int32(0))
+                        & (page_id < Int32(k_quant_bytes.shape[0]))
+                        & (page_id < Int32(k_scales.shape[0]))
+                    ):
                         if use_scalar_k_load_flag != Int32(0):
                             _load_index_k_page_scalar(
                                 k_quant_bytes,
@@ -1806,7 +1814,11 @@ class SparseNSAScheduledMultiRowLogitsKernel:
                         page_base = page_col * Int32(_PAGE_SIZE)
                         if page_base < seq_len:
                             page_id = Int32(real_page_table[current_q_idx, page_col])
-                            if page_id >= Int32(0):
+                            if (
+                                (page_id >= Int32(0))
+                                & (page_id < Int32(k_quant_bytes.shape[0]))
+                                & (page_id < Int32(k_scales.shape[0]))
+                            ):
                                 if use_scalar_k_load_flag != Int32(0):
                                     _load_index_k_page_scalar(
                                         k_quant_bytes,
@@ -3453,7 +3465,11 @@ class SparseNSAPagedStreamLogitsKernel:
                     src_col0 < Int32(real_page_table.shape[1])
                 ):
                     page_id0 = Int32(real_page_table[q_idx, src_col0])
-                    if page_id0 >= Int32(0):
+                    if (
+                        (page_id0 >= Int32(0))
+                        & (page_id0 < Int32(k_quant_bytes.shape[0]))
+                        & (page_id0 < Int32(k_scales.shape[0]))
+                    ):
                         _stream_issue_k_page_cp_async(
                             k_quant_bytes,
                             k_scales,
@@ -3487,7 +3503,11 @@ class SparseNSAPagedStreamLogitsKernel:
                         src_col_n < Int32(real_page_table.shape[1])
                     ):
                         page_id_n = Int32(real_page_table[q_idx, src_col_n])
-                        if page_id_n >= Int32(0):
+                        if (
+                            (page_id_n >= Int32(0))
+                            & (page_id_n < Int32(k_quant_bytes.shape[0]))
+                            & (page_id_n < Int32(k_scales.shape[0]))
+                        ):
                             _stream_issue_k_page_cp_async(
                                 k_quant_bytes,
                                 k_scales,
@@ -3513,7 +3533,12 @@ class SparseNSAPagedStreamLogitsKernel:
                     if (page_base < seq_len) & (
                         src_col < Int32(real_page_table.shape[1])
                     ):
-                        if Int32(real_page_table[q_idx, src_col]) >= Int32(0):
+                        page_id = Int32(real_page_table[q_idx, src_col])
+                        if (
+                            (page_id >= Int32(0))
+                            & (page_id < Int32(k_quant_bytes.shape[0]))
+                            & (page_id < Int32(k_scales.shape[0]))
+                        ):
                             consume = Int32(1)
                 if consume != Int32(0):
                     valid_slots = seq_len - page_base

--- a/b12x/attention/nsa_indexer/paged.py
+++ b/b12x/attention/nsa_indexer/paged.py
@@ -217,6 +217,7 @@ def _plan_two_level_fold(
         "page_table_width",
         "source_page_offset",
         "cache_row_stride_bytes",
+        "num_cache_pages",
     ]
 )
 def _gather_shared_paged_supertile_kernel(
@@ -235,6 +236,7 @@ def _gather_shared_paged_supertile_kernel(
     page_size: tl.constexpr,
     index_head_dim: tl.constexpr,
     cache_row_stride_bytes,
+    num_cache_pages,
     cache_data_bytes: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -248,7 +250,7 @@ def _gather_shared_paged_supertile_kernel(
         mask=token_mask & (page_cols < page_table_width),
         other=-1,
     )
-    valid_tokens = token_mask & (page_ids >= 0)
+    valid_tokens = token_mask & (page_ids >= 0) & (page_ids < num_cache_pages)
     # Packed multi-group allocations can span more than 4 GiB. Keep address
     # math 64-bit even though the logical page IDs themselves are int32.
     page_byte_offsets = page_ids.to(tl.int64) * cache_row_stride_bytes
@@ -631,6 +633,7 @@ def _prepare_shared_paged_supertile(
         PAGED_INDEX_PAGE_SIZE,
         INDEX_HEAD_DIM,
         int(index_k_cache.stride(0)),
+        int(index_k_cache.shape[0]),
         _PAGED_INDEX_CACHE_DATA_BYTES,
         num_warps=4,
     )
@@ -1083,7 +1086,7 @@ def index_topk_fp8(
                 page_size=page_size,
                 tile_block_q=_PAGED_INDEX_TILE_BLOCK_Q,
                 tile_block_k=_PAGED_INDEX_TILE_BLOCK_K,
-                preinitialize_tile_logits=False,
+                preinitialize_tile_logits=True,
             )
             topk_lengths = lengths_for_kernel
         if not logits.is_contiguous():
@@ -1162,6 +1165,7 @@ def index_topk_fp8(
                     else None
                 ),
                 output_page_size=page_size,
+                output_page_capacity=int(index_k_cache.shape[0]),
             )
 
     return final_raw_indices

--- a/b12x/attention/nsa_indexer/tiled_topk.py
+++ b/b12x/attention/nsa_indexer/tiled_topk.py
@@ -188,6 +188,7 @@ def _emit_global_index_virtual(
     vidx: Int32,
     row_idx: Int32,
     page_size: Int32,
+    output_page_capacity: Int32,
     is_first: cutlass.Constexpr[bool],
     output_physical_slots: cutlass.Constexpr[bool],
 ) -> Int32:
@@ -207,18 +208,30 @@ def _emit_global_index_virtual(
         else:
             gidx = Int32(carry_indices[carry_base + (vidx - chunk_len)])
     if cutlass.const_expr(output_physical_slots):
-        physical_idx = Int32(-1)
-        if gidx >= Int32(0):
-            page_col = gidx // page_size
-            page_offset = gidx - page_col * page_size
-            page_table_index = (
-                Int64(row_idx) * Int64(output_page_table_row_stride)
-                + Int64(page_col)
-            )
-            page_id = Int32(output_page_table[page_table_index])
-            if page_id >= Int32(0):
-                physical_idx = page_id * page_size + page_offset
-        gidx = physical_idx
+        if output_page_capacity <= Int32(0):
+            # Row-fold gather tables contain final indices directly rather
+            # than page IDs; gidx is already bounded by the input extent.
+            if gidx >= Int32(0):
+                table_index = (
+                    Int64(row_idx) * Int64(output_page_table_row_stride)
+                    + Int64(gidx)
+                )
+                gidx = Int32(output_page_table[table_index])
+        else:
+            physical_idx = Int64(-1)
+            if gidx >= Int32(0):
+                page_col = gidx // page_size
+                page_offset = gidx - page_col * page_size
+                page_table_index = (
+                    Int64(row_idx) * Int64(output_page_table_row_stride)
+                    + Int64(page_col)
+                )
+                page_id = Int32(output_page_table[page_table_index])
+                if (page_id >= Int32(0)) & (page_id < output_page_capacity):
+                    candidate = Int64(page_id) * Int64(page_size) + Int64(page_offset)
+                    if candidate <= Int64(2147483647):
+                        physical_idx = candidate
+            gidx = Int32(physical_idx)
     return gidx
 
 
@@ -568,6 +581,7 @@ class SparseNSATiledTopkKernel:
         input_extent,
         output_index_offset,
         output_page_size,
+        output_page_capacity,
         out_row_stride,
         out_row_base,
         stream,
@@ -593,6 +607,7 @@ class SparseNSATiledTopkKernel:
             input_extent,
             output_index_offset,
             output_page_size,
+            output_page_capacity,
             out_row_stride,
             out_row_base,
         ).launch(
@@ -624,6 +639,7 @@ class SparseNSATiledTopkKernel:
         input_extent: Int32,
         output_index_offset: Int32,
         output_page_size: Int32,
+        output_page_capacity: Int32,
         out_row_stride: Int32,
         out_row_base: Int32,
     ):
@@ -783,6 +799,7 @@ class SparseNSATiledTopkKernel:
                         i,
                         bid,
                         output_page_size,
+                        output_page_capacity,
                         self.is_first,
                         self.output_physical_slots,
                     )
@@ -1205,6 +1222,7 @@ class SparseNSATiledTopkKernel:
                     selected0,
                     bid,
                     output_page_size,
+                    output_page_capacity,
                     self.is_first,
                     self.output_physical_slots,
                 )
@@ -1235,6 +1253,7 @@ class SparseNSATiledTopkKernel:
                     selected1,
                     bid,
                     output_page_size,
+                    output_page_capacity,
                     self.is_first,
                     self.output_physical_slots,
                 )
@@ -1310,6 +1329,7 @@ def run_tiled_topk(
     is_first: bool = True,
     output_page_table: torch.Tensor | None = None,
     output_page_size: int = 64,
+    output_page_capacity: int | None = None,
     extent_splits: int = 1,
     output_row_stride: int | None = None,
     output_row_base: int = 0,
@@ -1388,6 +1408,11 @@ def run_tiled_topk(
             raise ValueError(
                 f"output_page_size must be positive, got {output_page_size}"
             )
+        if output_page_capacity is None or int(output_page_capacity) <= 0:
+            raise ValueError(
+                "output_page_capacity must be positive when output_page_table is set"
+            )
+        output_page_capacity = int(output_page_capacity)
         output_page_table_row_stride = int(output_page_table.stride(0))
         if output_page_table_row_stride == 0:
             # A row-shared expanded table has no flattenable multi-row view.
@@ -1401,6 +1426,7 @@ def run_tiled_topk(
         output_page_table_for_kernel = lengths
         output_page_table_row_stride = 0
         output_page_size = 1
+        output_page_capacity = 0
     num_q_tiles = (num_q_rows + block_q - 1) // block_q
     tile_size = block_q * block_k
     total_elements = int(tile_logits.shape[0])
@@ -1535,6 +1561,7 @@ def run_tiled_topk(
         Int32(input_extent),
         Int32(output_index_offset),
         Int32(output_page_size),
+        Int32(output_page_capacity),
         Int32(output_row_stride),
         Int32(output_row_base),
         current_cuda_stream(),
@@ -1556,7 +1583,7 @@ def run_tiled_topk(
             "output_page_table", output_page_table_key_tensor, dynamic=True
         ),
         (
-            "tiled_topk_v27_runtime_page_stride",
+            "tiled_topk_v28_runtime_page_capacity",
             topk,
             block_q,
             block_k,
@@ -1568,7 +1595,7 @@ def run_tiled_topk(
     )
     compile_spec = KernelCompileSpec.from_key(
         "attention.indexer.tiled_topk",
-        4,
+        5,
         cache_key,
         labels=(
             "input",
@@ -1718,6 +1745,7 @@ def run_row_topk(
         Int32(width),
         Int32(output_index_offset),
         Int32(1),
+        Int32(0),
         Int32(1),
         Int32(0),
         current_cuda_stream(),

--- a/tests/attention/test_fused_indexer.py
+++ b/tests/attention/test_fused_indexer.py
@@ -510,6 +510,67 @@ def test_fused_indexer_preinitialized_state_graph_replay_switches_merge_mode():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+@pytest.mark.parametrize("ctas_per_group", [8, 32])
+def test_fused_indexer_graph_replay_masks_page_ids_at_capacity(ctas_per_group):
+    """Live invalid page IDs never form value or scale addresses."""
+    device = torch.device("cuda")
+    rows, heads, topk, seqlen = 4, 64, 512, _PS
+    q_fp8, weights, k_fp8, k_scales, page_table, seqlens = _build_case(
+        rows, heads, seqlen, topk, seed=43, device=device
+    )
+    pack_capacity, _ = fused_indexer_scratch_capacity(
+        rows, topk, torch.cuda.get_device_properties(device).multi_processor_count
+    )
+    pack_capacity = max(pack_capacity, rows * ctas_per_group * topk)
+    kwargs = {
+        "q_bytes": q_fp8.view(torch.uint8),
+        "weights": weights,
+        "k_quant_bytes": k_fp8.view(torch.uint8).contiguous(),
+        "k_scales": k_scales,
+        "real_page_table": page_table,
+        "seqlens": seqlens,
+        "num_heads": heads,
+        "topk": topk,
+        "out_indices": torch.empty(
+            (rows, topk), dtype=torch.int32, device=device
+        ),
+        "out_values": torch.empty(
+            (rows, topk), dtype=torch.float32, device=device
+        ),
+        "ctas_per_group": ctas_per_group,
+        "pack_values": torch.empty(
+            pack_capacity, dtype=torch.float32, device=device
+        ),
+        "pack_indices": torch.empty(
+            pack_capacity, dtype=torch.int32, device=device
+        ),
+        "merge_state": torch.zeros(
+            rows * _COOP_STATE_WORDS, dtype=torch.int32, device=device
+        ),
+        "merge_state_preinitialized": True,
+    }
+    run_fused_paged_indexer(**kwargs)
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_fused_paged_indexer(**kwargs)
+
+    page_table.fill_(int(k_fp8.shape[0]))
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.all(kwargs["out_indices"] == -1)
+    assert torch.all(kwargs["out_values"] <= torch.finfo(torch.float32).min)
+
+    page_table.zero_()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    for row in range(rows):
+        valid = kwargs["out_indices"][row]
+        valid = valid[valid >= 0]
+        assert set(valid.tolist()) == set(range(seqlen))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
 @pytest.mark.parametrize("rows", [1, 2, 4])
 def test_fused_indexer_mla_matches_reference(rows):
     # FLAT/MLA: contiguous K, per-row [k_start, k_end) windows -> absolute indices.
@@ -537,6 +598,48 @@ def test_fused_indexer_mla_matches_reference(rows):
         logit = (torch.relu(torch.einsum("hd,td->ht", qf[r], kf[a:b])) * weights[r].unsqueeze(1)).sum(0) * k_scales[a:b]
         gset = set((torch.topk(logit, topk).indices + a).tolist())  # absolute index
         assert set(idx[r].tolist()) == gset
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")
+def test_fused_indexer_staged_physical_slot_overflow_returns_sentinel():
+    """Staged physical output never wraps a valid high PID into slot zero."""
+    device = torch.device("cuda")
+    rows, heads, topk = 1, 32, 512
+    high_page_id = 1 << 26
+    q_fp8 = torch.randn(
+        (rows, heads, 128), device=device
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn((rows, heads), dtype=torch.float32, device=device)
+    one_page = torch.randn(
+        (1, _PS, 128), device=device
+    ).to(torch.float8_e4m3fn)
+    one_scale_page = torch.ones((1, _PS), dtype=torch.float32, device=device)
+    pages_used = topk // _PS
+    k_quant = one_page.expand(high_page_id + pages_used, -1, -1)
+    k_scales = one_scale_page.expand(high_page_id + pages_used, -1)
+    page_table = torch.arange(
+        high_page_id,
+        high_page_id + pages_used,
+        dtype=torch.int32,
+        device=device,
+    ).reshape(1, -1)
+    seqlens = torch.tensor([topk], dtype=torch.int32, device=device)
+
+    idx, val = run_fused_paged_indexer(
+        q_bytes=q_fp8.view(torch.uint8),
+        weights=weights,
+        k_quant_bytes=k_quant.view(torch.uint8),
+        k_scales=k_scales,
+        real_page_table=page_table,
+        seqlens=seqlens,
+        num_heads=heads,
+        topk=topk,
+        ctas_per_group=8,
+        output_physical_slots=True,
+    )
+    torch.cuda.synchronize(device)
+    assert torch.all(idx == -1)
+    assert torch.isfinite(val).all()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for fused indexer")

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -400,10 +400,13 @@ def test_index_topk_fp8_graph_matches_reference(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for graph capture")
+@pytest.mark.parametrize("stream_scorer", [False, True])
 def test_paged_tiled_indexer_emits_physical_slots_in_final_fold(
     monkeypatch,
+    stream_scorer: bool,
 ) -> None:
     monkeypatch.setenv("B12X_PAGED_INDEX_SUPERTILE_K", "512")
+    monkeypatch.setenv("B12X_INDEXER_STREAM_SCORER", "1" if stream_scorer else "0")
 
     device = torch.device("cuda")
     gen = torch.Generator(device="cpu").manual_seed(91_009)
@@ -485,6 +488,11 @@ def test_paged_tiled_indexer_emits_physical_slots_in_final_fold(
         torch.sort(expected, dim=1).values,
     )
 
+    shared_storage[0, :25].fill_(int(index_k_cache.shape[0]))
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.all(actual == -1)
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
@@ -507,7 +515,9 @@ def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
         device=device,
     )
 
-    def select(width: int, *, shared: bool = False) -> tuple[torch.Tensor, torch.Tensor]:
+    def select(
+        width: int, *, shared: bool = False, capacity: int = 4096
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         selected_page_ids = page_ids
         if shared:
             selected_page_ids = torch.full_like(page_ids, 2000)
@@ -532,6 +542,7 @@ def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
             zero_row_start=True,
             output_page_table=page_table,
             output_page_size=64,
+            output_page_capacity=capacity,
         )
         torch.cuda.synchronize(device)
         return indices, selected_page_ids
@@ -540,6 +551,7 @@ def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
     misses_after_narrow = compile_cache_info()["compile_misses"]
     wide, wide_page_ids = select(8192)
     shared, shared_page_ids = select(8192, shared=True)
+    invalid, _ = select(1, capacity=1000)
     misses_after_reuse = compile_cache_info()["compile_misses"]
 
     def expected(selected_page_ids: torch.Tensor) -> torch.Tensor:
@@ -552,6 +564,7 @@ def test_tiled_topk_physical_slots_use_runtime_page_table_row_stride(
     assert torch.equal(torch.sort(narrow, dim=1).values, expected(narrow_page_ids))
     assert torch.equal(torch.sort(wide, dim=1).values, expected(wide_page_ids))
     assert torch.equal(torch.sort(shared, dim=1).values, expected(shared_page_ids))
+    assert torch.all(invalid == -1)
     assert misses_after_reuse == misses_after_narrow
 
 
@@ -604,6 +617,7 @@ def test_paged_index_shared_supertile_prefill_graph_matches_reference(
     )
     assert not index_k_cache.is_contiguous()
     actual = torch.empty((rows, topk), dtype=torch.int32, device=device)
+    actual_scores = torch.empty((rows, topk), dtype=torch.float32, device=device)
     expected = torch.empty((rows, topk), dtype=torch.int32, device=device)
     shared_table_binding = graph_shared_page_table.expand(rows, -1)
     binding = _bind_paged_indexer(
@@ -675,6 +689,7 @@ def test_paged_index_shared_supertile_prefill_graph_matches_reference(
         expected_num_q_heads=num_heads,
         binding=binding,
         out_indices=actual,
+        out_scores=actual_scores,
         supertile_k=supertile_k,
     )
     torch.cuda.synchronize(device)
@@ -689,6 +704,7 @@ def test_paged_index_shared_supertile_prefill_graph_matches_reference(
             expected_num_q_heads=num_heads,
             binding=binding,
             out_indices=actual,
+            out_scores=actual_scores,
             supertile_k=supertile_k,
         )
     graph.replay()
@@ -716,6 +732,13 @@ def test_paged_index_shared_supertile_prefill_graph_matches_reference(
         torch.sort(actual, dim=1).values,
         torch.sort(expected, dim=1).values,
     )
+
+    prepare(int(index_k_cache.shape[0]), 64, shared_page_table=True)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    valid = actual >= 0
+    assert torch.all(valid.sum(dim=1) == 64)
+    assert torch.all(actual_scores[valid] == 0)
 
 
 def test_paged_index_supertile_scratch_sizes_candidate_carry_buffer() -> None:


### PR DESCRIPTION
## Problem

NSA paged-indexer kernels accepted non-negative page-table IDs without proving the physical page existed in the packed K/value and scale cache. CUDA graph replay keeps page-table values device-live, so host-only validation could not make the launch safe.

## Fix

- bound every direct fused, legacy scalar/tiled, and streamed scorer page ID against both live cache tensors before address formation
- pass runtime cache capacity into the packed-contiguous gather and mask invalid pages before loading
- pass runtime cache capacity into final logical-to-physical top-k emission and emit `-1` for invalid physical pages
- preserve graph replay, runtime row-stride reuse, compile-cache identity, and valid-page behavior
- add invalid-page graph-replay coverage for fused CTA policies, legacy/stream tiled paths, packed-contiguous gather, and physical-slot mapping

Closes #160

## Verification

- SM121: 12 targeted GPU tests passed at final head `f7d51b7`, including graph replay and the existing live high-page-ID Int64-offset regression
- focused `py_compile`, Ruff (excluding pre-existing diagnostics), and `git diff --check` passed
- independent peer review: APPROVE; all scoped sinks are bounded by live value/scale capacity before access or physical emission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or out-of-range paged cache IDs are now safely rejected across attention indexing and scoring paths.
  - Prevented invalid cache entries from producing out-of-bounds accesses, incorrect scores, or physical slots.
  - Improved handling of invalid entries during tiled top-k processing and CUDA graph replay.

- **Tests**
  - Added regression and integration coverage for invalid page IDs, cache boundaries, physical-slot output, and streaming scorer modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->