### PR TITLE
security: bound dense MLA page-table and cache addresses

### DIFF
--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -100,6 +100,8 @@ class DenseMlaForwardKernel:
         page_stride_bytes: Int64,
         cache_record_stride_bytes: Int64,
         page_table_stride: Int64,
+        page_table_width: Int32,
+        num_cache_pages: Int32,
         total_q: Int32,
         batch: Int32,
         active_splits: Int32,
@@ -124,6 +126,8 @@ class DenseMlaForwardKernel:
             page_stride_bytes,
             cache_record_stride_bytes,
             page_table_stride,
+            page_table_width,
+            num_cache_pages,
             total_q,
             batch,
             active_splits,
@@ -416,6 +420,8 @@ class DenseMlaForwardKernel:
         page_stride_bytes: Int64,
         cache_record_stride_bytes: Int64,
         page_table_stride: Int64,
+        page_table_width: Int32,
+        num_cache_pages: Int32,
         total_q: Int32,
         batch: Int32,
         active_splits: Int32,
@@ -445,6 +451,38 @@ class DenseMlaForwardKernel:
         query_end = Int32(cu_seqlens_q[request + Int32(1)])
         query_length = query_end - query_begin
         cache_length = Int32(cache_seqlens[request])
+
+        # Bound graph-live metadata by the actual table and cache capacities.
+        max_table_tokens = page_table_width * Int32(self.page_size)
+        if cache_length > max_table_tokens:
+            cache_length = max_table_tokens
+
+        first_page = Int32(page_table[request.to(Int64) * page_table_stride])
+        if first_page < Int32(0) or first_page >= num_cache_pages:
+            cache_length = Int32(0)
+
+        valid_pages = Int32(0)
+        required_pages = (cache_length + Int32(self.page_size) - Int32(1)) // Int32(
+            self.page_size
+        )
+        still_valid = Int32(1)
+        page_idx = Int32(0)
+        while page_idx < required_pages:
+            pid = Int32(
+                page_table[
+                    request.to(Int64) * page_table_stride + page_idx.to(Int64)
+                ]
+            )
+            page_is_valid = Int32(0)
+            if pid >= Int32(0) and pid < num_cache_pages:
+                page_is_valid = Int32(1)
+            valid_pages += still_valid * page_is_valid
+            if page_is_valid == Int32(0):
+                still_valid = Int32(0)
+            page_idx += Int32(1)
+        valid_cache_length = valid_pages * Int32(self.page_size)
+        if valid_cache_length < cache_length:
+            cache_length = valid_cache_length
 
         first_valid_chunk = Int32(0)
         visible_chunks_end = cache_length
@@ -499,6 +537,32 @@ class DenseMlaForwardKernel:
                             head_base + local_head,
                         ] = Float32(-Float32.inf)
                 entry += Int32(self.block_threads)
+
+            # Issue #157: Zero output for non-merge paths.  The merge
+            # kernel already produces zero when all split LSEs are -inf,
+            # but the direct (non-split or active_splits==1) path writes
+            # only LSE.  Without this, a dead request's output retains
+            # stale/NaN data from before replay.
+            if active_splits <= Int32(1):
+                total_qh = Int32(self.query_tile * HEADS_PER_TILE)
+                flat = tid
+                while flat < total_qh * Int32(self.value_dim):
+                    qh = flat // Int32(self.value_dim)
+                    v_idx = flat - qh * Int32(self.value_dim)
+                    q_slot = qh // Int32(HEADS_PER_TILE)
+                    l_head = qh - q_slot * Int32(HEADS_PER_TILE)
+                    q_row = query_start + q_slot
+                    if (
+                        q_row < total_q
+                        and head_base + l_head < Int32(self.num_heads)
+                    ):
+                        output[
+                            q_row,
+                            head_base + l_head,
+                            v_idx,
+                        ] = (Float32(0.0)).to(output.element_type)
+                    flat += Int32(self.block_threads)
+
             _exit_thread()
 
         smem = cutlass_utils.SmemAllocator()
@@ -548,6 +612,8 @@ class DenseMlaForwardKernel:
                     page_stride_bytes,
                     cache_record_stride_bytes,
                     page_table_stride,
+                    page_table_width,
+                    num_cache_pages,
                     page_size=self.page_size,
                     record_bytes=self.layout.record_bytes,
                     record_stride_bytes=self.layout.record_stride_bytes,

--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -241,14 +241,17 @@ class DenseMlaForwardKernel:
                         record_stride_bytes=self.layout.record_stride_bytes,
                         qk_dim=self.qk_dim,
                     )
-                qk = mask_and_scale(
+                qk, valid0, valid1 = mask_and_scale(
                     qk,
+                    kv_buffer_addr,
                     chunk_begin,
                     visible_begin,
                     visible_end,
                     score_scale_log2,
                     local_warp,
                     lane,
+                    record_bytes=self.layout.record_bytes,
+                    record_stride_bytes=self.layout.record_stride_bytes,
                 )
                 probability = [
                     Float32(0.0),
@@ -258,6 +261,8 @@ class DenseMlaForwardKernel:
                 ]
                 probability, warp_scale0, warp_scale1 = online_softmax(
                     qk,
+                    valid0,
+                    valid1,
                     probability,
                     accumulator,
                     global_max,
@@ -452,7 +457,8 @@ class DenseMlaForwardKernel:
         query_length = query_end - query_begin
         cache_length = Int32(cache_seqlens[request])
 
-        # Bound graph-live metadata by the actual table and cache capacities.
+        # Bound graph-live metadata by the actual table capacity. A valid first
+        # page provides the request-local source for masked bulk-copy records.
         max_table_tokens = page_table_width * Int32(self.page_size)
         if cache_length > max_table_tokens:
             cache_length = max_table_tokens
@@ -460,29 +466,6 @@ class DenseMlaForwardKernel:
         first_page = Int32(page_table[request.to(Int64) * page_table_stride])
         if first_page < Int32(0) or first_page >= num_cache_pages:
             cache_length = Int32(0)
-
-        valid_pages = Int32(0)
-        required_pages = (cache_length + Int32(self.page_size) - Int32(1)) // Int32(
-            self.page_size
-        )
-        still_valid = Int32(1)
-        page_idx = Int32(0)
-        while page_idx < required_pages:
-            pid = Int32(
-                page_table[
-                    request.to(Int64) * page_table_stride + page_idx.to(Int64)
-                ]
-            )
-            page_is_valid = Int32(0)
-            if pid >= Int32(0) and pid < num_cache_pages:
-                page_is_valid = Int32(1)
-            valid_pages += still_valid * page_is_valid
-            if page_is_valid == Int32(0):
-                still_valid = Int32(0)
-            page_idx += Int32(1)
-        valid_cache_length = valid_pages * Int32(self.page_size)
-        if valid_cache_length < cache_length:
-            cache_length = valid_cache_length
 
         first_valid_chunk = Int32(0)
         visible_chunks_end = cache_length
@@ -538,11 +521,8 @@ class DenseMlaForwardKernel:
                         ] = Float32(-Float32.inf)
                 entry += Int32(self.block_threads)
 
-            # Issue #157: Zero output for non-merge paths.  The merge
-            # kernel already produces zero when all split LSEs are -inf,
-            # but the direct (non-split or active_splits==1) path writes
-            # only LSE.  Without this, a dead request's output retains
-            # stale/NaN data from before replay.
+            # The merge kernel zeroes empty splits. Direct paths must clear
+            # output here so graph replay cannot retain stale values.
             if active_splits <= Int32(1):
                 total_qh = Int32(self.query_tile * HEADS_PER_TILE)
                 flat = tid

--- a/b12x/attention/dense_mla/_io.py
+++ b/b12x/attention/dense_mla/_io.py
@@ -28,6 +28,8 @@ def issue_dense_page_gather(
     page_stride_bytes: Int64,
     record_stride_bytes_global: Int64,
     page_table_stride: Int64,
+    page_table_width: Int32,
+    num_cache_pages: Int32,
     *,
     page_size: cutlass.Constexpr,
     record_bytes: cutlass.Constexpr,
@@ -35,10 +37,27 @@ def issue_dense_page_gather(
 ):
     """Stage one 64-record dense window with an mbarrier transaction.
 
-    Every pool-scaled product is promoted before multiplication. Invalid tail
-    rows copy physical record zero and are masked by the consumer; issuing a
+    Every pool-scaled product is promoted before multiplication. Invalid
+    tail rows copy a request-local page (``page_table[request, 0]``, clamped
+    to ``[0, num_cache_pages-1]``) and are masked by the consumer; issuing a
     fixed byte count keeps the full-barrier protocol independent of live
     sequence length and therefore graph-replay stable.
+
+    The page-table lookup is executed only for tokens within the live
+    sequence length whose logical page fits the actual table width
+    (``page_table_width``, a capture-static shape constant).  Physical page
+    IDs from the table are clamped to ``[0, num_cache_pages-1]`` (also
+    capture-static).  Every other entry falls back to the request-local
+    page, record zero — preventing out-of-bounds table or cache addresses
+    even when ``cache_seqlens`` or ``page_table`` values are mutated after
+    CUDA graph capture.
+
+    The kernel additionally caps ``cache_length`` at the table capacity and
+    zeroes the request when ``page_table[request, 0]`` is invalid, so the
+    request-local fallback here is only reached for requests whose first
+    page is valid.  Masked PV MMA therefore multiplies zero probability by
+    finite data from a real request-local page, not by NaN/Inf from an
+    uninitialized global page.
     """
     full_mbar_addr = shared_ptr_to_u32(full_mbar_ptr)
     if io_lane == Int32(0):
@@ -47,20 +66,45 @@ def issue_dense_page_gather(
             Int32(CANDIDATES_PER_CHUNK * record_bytes),
         )
 
+    # Request-local safe page: load page_table[request, 0] once and
+    # validate against the actual cache extent.  This is the fallback
+    # source for tail / out-of-range / corrupted entries.  It is
+    # guaranteed to be a real, initialized page belonging to this
+    # request (the caller maps the first active page at slot 0).
+    # page_table_width >= 1 and num_cache_pages >= 1 are enforced at
+    # bind by shape-only checks, so the table load and fallback are
+    # always safe.
+    request_local_page = Int32(
+        page_table[request.to(Int64) * page_table_stride]
+    )
+    if request_local_page < Int32(0):
+        request_local_page = Int32(0)
+    elif request_local_page >= num_cache_pages:
+        request_local_page = num_cache_pages - Int32(1)
+
     entry = io_lane
     for _ in cutlass.range_constexpr(CANDIDATES_PER_CHUNK // 32):
         logical_token = token_begin + entry
-        safe_token = logical_token
-        if logical_token >= token_end:
-            safe_token = Int32(0)
-        logical_page = safe_token // Int32(page_size)
-        in_page = safe_token - logical_page * Int32(page_size)
-        physical_page = Int32(
-            page_table[request.to(Int64) * page_table_stride + logical_page.to(Int64)]
-        )
 
-        # Load-bearing Int64 conversions. Neither multiplication is allowed to
-        # occur in Int32, even when benchmark page ids happen to be small.
+        # Default to the validated request-local page and record zero. Masked
+        # records still issue a fixed byte count for the barrier protocol.
+        physical_page = request_local_page
+        in_page = Int32(0)
+        if logical_token < token_end:
+            logical_page = logical_token // Int32(page_size)
+            if logical_page < page_table_width:
+                in_page = logical_token - logical_page * Int32(page_size)
+                physical_page = Int32(
+                    page_table[
+                        request.to(Int64) * page_table_stride
+                        + logical_page.to(Int64)
+                    ]
+                )
+                if physical_page < Int32(0) or physical_page >= num_cache_pages:
+                    physical_page = request_local_page
+
+        # Load-bearing Int64 conversions. Neither multiplication may occur in
+        # Int32, even when benchmark page ids happen to be small.
         source_offset = (
             physical_page.to(Int64) * page_stride_bytes
             + in_page.to(Int64) * record_stride_bytes_global

--- a/b12x/attention/dense_mla/_io.py
+++ b/b12x/attention/dense_mla/_io.py
@@ -9,7 +9,9 @@ from cutlass import Int32, Int64
 from b12x._lib.intrinsics import (
     cp_async_bulk_g2s_mbar,
     get_ptr_as_int64,
+    ld_shared_i32,
     shared_ptr_to_u32,
+    st_shared_i32,
 )
 
 from ._layout import CANDIDATES_PER_CHUNK
@@ -37,71 +39,79 @@ def issue_dense_page_gather(
 ):
     """Stage one 64-record dense window with an mbarrier transaction.
 
-    Every pool-scaled product is promoted before multiplication. Invalid
-    tail rows copy a request-local page (``page_table[request, 0]``, clamped
-    to ``[0, num_cache_pages-1]``) and are masked by the consumer; issuing a
-    fixed byte count keeps the full-barrier protocol independent of live
-    sequence length and therefore graph-replay stable.
+    The producer validates each page id at the point where it forms the cache
+    address. It stages a signed page marker in the record's existing padding:
+    nonnegative markers are live page ids and negative markers encode the
+    request-local fallback page. The consumer uses the same marker to exclude
+    invalid records from softmax.
 
-    The page-table lookup is executed only for tokens within the live
-    sequence length whose logical page fits the actual table width
-    (``page_table_width``, a capture-static shape constant).  Physical page
-    IDs from the table are clamped to ``[0, num_cache_pages-1]`` (also
-    capture-static).  Every other entry falls back to the request-local
-    page, record zero — preventing out-of-bounds table or cache addresses
-    even when ``cache_seqlens`` or ``page_table`` values are mutated after
-    CUDA graph capture.
-
-    The kernel additionally caps ``cache_length`` at the table capacity and
-    zeroes the request when ``page_table[request, 0]`` is invalid, so the
-    request-local fallback here is only reached for requests whose first
-    page is valid.  Masked PV MMA therefore multiplies zero probability by
-    finite data from a real request-local page, not by NaN/Inf from an
-    uninitialized global page.
+    Markers are published before the bulk-copy transaction begins. The fixed
+    transaction byte count therefore retains graph-stable barrier behavior,
+    including for invalid and tail records.
     """
     full_mbar_addr = shared_ptr_to_u32(full_mbar_ptr)
+    request_local_page = Int32(
+        page_table[request.to(Int64) * page_table_stride]
+    )
+
+    # Resolve page-table entries once. The encoded markers occupy four of the
+    # sixteen padding bytes already present after every staged record.
+    entry = io_lane
+    for _ in cutlass.range_constexpr(CANDIDATES_PER_CHUNK // 32):
+        logical_token = token_begin + entry
+        physical_page = request_local_page
+        record_valid = Int32(0)
+        if logical_token < token_end:
+            logical_page = logical_token // Int32(page_size)
+            if logical_page < page_table_width:
+                candidate_page = Int32(
+                    page_table[
+                        request.to(Int64) * page_table_stride
+                        + logical_page.to(Int64)
+                    ]
+                )
+                if (
+                    candidate_page >= Int32(0)
+                    and candidate_page < num_cache_pages
+                ):
+                    physical_page = candidate_page
+                    record_valid = Int32(1)
+
+        marker = physical_page
+        if record_valid == Int32(0):
+            marker = Int32(-1) - physical_page
+        st_shared_i32(
+            kv_dst_addr
+            + entry * Int32(record_stride_bytes)
+            + Int32(record_bytes),
+            marker,
+        )
+        entry += Int32(32)
+
+    # mbarrier.try_wait.parity is not a shared-memory fence. Publish the page
+    # markers before the transaction whose completion releases the consumers.
+    cute.arch.fence_acq_rel_cta()
     if io_lane == Int32(0):
         cute.arch.mbarrier_arrive_and_expect_tx(
             full_mbar_ptr,
             Int32(CANDIDATES_PER_CHUNK * record_bytes),
         )
 
-    # Request-local safe page: load page_table[request, 0] once and
-    # validate against the actual cache extent.  This is the fallback
-    # source for tail / out-of-range / corrupted entries.  It is
-    # guaranteed to be a real, initialized page belonging to this
-    # request (the caller maps the first active page at slot 0).
-    # page_table_width >= 1 and num_cache_pages >= 1 are enforced at
-    # bind by shape-only checks, so the table load and fallback are
-    # always safe.
-    request_local_page = Int32(
-        page_table[request.to(Int64) * page_table_stride]
-    )
-    if request_local_page < Int32(0):
-        request_local_page = Int32(0)
-    elif request_local_page >= num_cache_pages:
-        request_local_page = num_cache_pages - Int32(1)
-
     entry = io_lane
     for _ in cutlass.range_constexpr(CANDIDATES_PER_CHUNK // 32):
         logical_token = token_begin + entry
-
-        # Default to the validated request-local page and record zero. Masked
-        # records still issue a fixed byte count for the barrier protocol.
-        physical_page = request_local_page
-        in_page = Int32(0)
-        if logical_token < token_end:
-            logical_page = logical_token // Int32(page_size)
-            if logical_page < page_table_width:
-                in_page = logical_token - logical_page * Int32(page_size)
-                physical_page = Int32(
-                    page_table[
-                        request.to(Int64) * page_table_stride
-                        + logical_page.to(Int64)
-                    ]
-                )
-                if physical_page < Int32(0) or physical_page >= num_cache_pages:
-                    physical_page = request_local_page
+        marker = ld_shared_i32(
+            kv_dst_addr
+            + entry * Int32(record_stride_bytes)
+            + Int32(record_bytes)
+        )
+        physical_page = marker
+        if marker < Int32(0):
+            physical_page = Int32(-1) - marker
+        logical_page = logical_token // Int32(page_size)
+        in_page = logical_token - logical_page * Int32(page_size)
+        if logical_token >= token_end:
+            in_page = Int32(0)
 
         # Load-bearing Int64 conversions. Neither multiplication may occur in
         # Int32, even when benchmark page ids happen to be small.

--- a/b12x/attention/dense_mla/_kernel.py
+++ b/b12x/attention/dense_mla/_kernel.py
@@ -196,6 +196,8 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         Int64(int(binding.kv_cache.stride(0)) * binding.kv_cache.element_size()),
         Int64(int(binding.kv_cache.stride(1)) * binding.kv_cache.element_size()),
         Int64(int(binding.page_table.stride(0))),
+        Int32(int(binding.page_table.shape[1])),
+        Int32(int(binding.kv_cache.shape[0])),
         Int32(int(binding.q.shape[0])),
         Int32(int(binding.cache_seqlens.shape[0])),
         Int32(binding.active_splits),

--- a/b12x/attention/dense_mla/_math.py
+++ b/b12x/attention/dense_mla/_math.py
@@ -26,6 +26,7 @@ from b12x._lib.intrinsics import (
     fp8_e4m3_to_f32,
     get_ptr_as_int64,
     ld_shared_f32,
+    ld_shared_i32,
     ld_shared_u32,
     ldmatrix_m8n8x2_b16,
     ldmatrix_m8n8x4_b16,
@@ -237,31 +238,61 @@ def qk_bf16(
 @cute.jit
 def mask_and_scale(
     qk,
+    kv_smem_addr: Int32,
     chunk_begin: Int32,
     visible_begin: Int32,
     visible_end: Int32,
     scale_log2: Float32,
     local_warp: Int32,
     lane: Int32,
+    *,
+    record_bytes: cutlass.Constexpr,
+    record_stride_bytes: cutlass.Constexpr,
 ):
-    """Apply K3 causal bounds and convert scores to the base-2 domain."""
+    """Apply page validity and causal bounds, then convert to base 2."""
     gid = lane >> Int32(2)
-    candidate0 = chunk_begin + local_warp * Int32(16) + gid
-    candidate1 = candidate0 + Int32(8)
-    if candidate0 < visible_begin or candidate0 >= visible_end:
+    local_candidate0 = local_warp * Int32(16) + gid
+    local_candidate1 = local_candidate0 + Int32(8)
+    candidate0 = chunk_begin + local_candidate0
+    candidate1 = chunk_begin + local_candidate1
+    marker0 = ld_shared_i32(
+        kv_smem_addr
+        + local_candidate0 * Int32(record_stride_bytes)
+        + Int32(record_bytes)
+    )
+    marker1 = ld_shared_i32(
+        kv_smem_addr
+        + local_candidate1 * Int32(record_stride_bytes)
+        + Int32(record_bytes)
+    )
+    valid0 = Int32(1)
+    valid1 = Int32(1)
+    if (
+        candidate0 < visible_begin
+        or candidate0 >= visible_end
+        or marker0 < Int32(0)
+    ):
+        valid0 = Int32(0)
         qk[0] = Float32(_MASK)
         qk[1] = Float32(_MASK)
-    if candidate1 < visible_begin or candidate1 >= visible_end:
+    if (
+        candidate1 < visible_begin
+        or candidate1 >= visible_end
+        or marker1 < Int32(0)
+    ):
+        valid1 = Int32(0)
         qk[2] = Float32(_MASK)
         qk[3] = Float32(_MASK)
     for idx in cutlass.range_constexpr(4):
         qk[idx] = qk[idx] * scale_log2
-    return qk
+    return qk, valid0, valid1
 
 
 @cute.jit
 def online_softmax(
     qk,
+    valid0: Int32,
+    valid1: Int32,
     p,
     acc,
     global_max,
@@ -297,6 +328,12 @@ def online_softmax(
     p[1] = exp2_approx(qk[1] - local_max1)
     p[2] = exp2_approx(qk[2] - local_max0)
     p[3] = exp2_approx(qk[3] - local_max1)
+    if valid0 == Int32(0):
+        p[0] = Float32(0.0)
+        p[1] = Float32(0.0)
+    if valid1 == Int32(0):
+        p[2] = Float32(0.0)
+        p[3] = Float32(0.0)
     local_sum0 = p[0] + p[2]
     local_sum1 = p[1] + p[3]
     for offset in (4, 8, 16):

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -473,10 +473,28 @@ def _validate_binding(
         raise ValueError(
             "page_table must have shape [batch, width<=max_page_table_width]"
         )
+    if int(page_table.shape[1]) < 1:
+        raise ValueError("page_table must have at least one column")
     if page_table.dtype != torch.int32:
         raise TypeError("page_table must be torch.int32")
     if page_table.device != scratch.device or not page_table.is_contiguous():
         raise ValueError("page_table must be contiguous on the plan device")
+
+    # --- Issue #157: shape-only capacity floor (no host sync) ---------------
+    # The actual kv_cache must contain at least one physical page because the
+    # device predicate in ``issue_dense_page_gather`` uses the validated
+    # request-local first page as the barrier-safe fallback for masked records.
+    # An invalid first page marks the request dead. This is a shape check (int
+    # on .shape), not a value read, so it honors the views-only / no-allocation
+    # / no-sync bind contract.
+    if int(cache.shape[0]) < 1:
+        raise ValueError("kv_cache must contain at least one physical page")
+
+    # Live *values* (cache_seqlens, page_table entries) are NOT validated here.
+    # They are mutable across CUDA-graph replay and reading them would require
+    # host synchronisation, violating the bind contract. Device-side predicates
+    # cap visible cache_length at the first invalid page and use only the
+    # validated page_table[request, 0] fallback for masked gather records.
 
     kv_scale = _validate_scalar(
         kv_scale,

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -480,21 +480,9 @@ def _validate_binding(
     if page_table.device != scratch.device or not page_table.is_contiguous():
         raise ValueError("page_table must be contiguous on the plan device")
 
-    # --- Issue #157: shape-only capacity floor (no host sync) ---------------
-    # The actual kv_cache must contain at least one physical page because the
-    # device predicate in ``issue_dense_page_gather`` uses the validated
-    # request-local first page as the barrier-safe fallback for masked records.
-    # An invalid first page marks the request dead. This is a shape check (int
-    # on .shape), not a value read, so it honors the views-only / no-allocation
-    # / no-sync bind contract.
+    # Masked bulk-copy records use the request's first page as a safe source.
     if int(cache.shape[0]) < 1:
         raise ValueError("kv_cache must contain at least one physical page")
-
-    # Live *values* (cache_seqlens, page_table entries) are NOT validated here.
-    # They are mutable across CUDA-graph replay and reading them would require
-    # host synchronisation, violating the bind contract. Device-side predicates
-    # cap visible cache_length at the first invalid page and use only the
-    # validated page_table[request, 0] fallback for masked gather records.
 
     kv_scale = _validate_scalar(
         kv_scale,

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -932,3 +932,1231 @@ def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
         expected_output,
         expected_lse,
     )
+
+# ---------------------------------------------------------------------------
+# Issue #157: adversarial metadata-safety gates for dense MLA.
+#
+# These tests prove that no live dense-MLA metadata can produce an OOB
+# table or cache address. Bind performs shape checks only (no host
+# synchronisation, no allocation). Device-side predicates cap visible
+# cache_length at the first invalid page and use the validated request-local
+# page_table[request, 0] fallback for masked gather records on every invocation,
+# protecting CUDA graph replay after metadata mutation.
+#
+# Discrimination strategy: sentinel pages filled with NaN (BF16) or a
+# maximally distinct value (FP8) are placed where the old unguarded kernel
+# would read. The guarded kernel excludes the invalid suffix and the output
+# stays finite / matches the capped safe reference.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_plan(
+    device,
+    *,
+    pages: int = 4,
+    page_size: int = 16,
+    width: int = 4,
+    kv_dtype=torch.bfloat16,
+    num_q_heads: int = HEADS,
+    use_cuda_graph: bool = False,
+) -> dense_mla.Plan:
+    return dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=kv_dtype,
+            num_q_heads=num_q_heads,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=page_size * width,
+            max_page_table_width=width,
+            num_cache_pages=pages,
+            use_cuda_graph=use_cuda_graph,
+        )
+    )
+
+
+@torch.inference_mode()
+def test_bind_rejects_zero_cache_pages() -> None:
+    """A kv_cache with zero physical pages must raise (no safe fallback)."""
+    device = require_b12x()
+    plan = _tiny_plan(device, pages=4, page_size=16, width=4)
+    q = torch.zeros(1, HEADS, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache = torch.empty(0, 16, QK_DIM, dtype=torch.bfloat16, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    page_table = torch.zeros(1, 4, dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([16], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    with pytest.raises(ValueError, match="at least one physical page"):
+        dense_mla.bind(
+            plan,
+            scratch=_scratch(plan),
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+
+
+@torch.inference_mode()
+def test_bind_rejects_zero_page_table_width() -> None:
+    """A page_table with zero columns must raise (no slot for fallback)."""
+    device = require_b12x()
+    plan = _tiny_plan(device, pages=4, page_size=16, width=4)
+    q = torch.zeros(1, HEADS, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache = torch.zeros(4, 16, QK_DIM, dtype=torch.bfloat16, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    page_table = torch.empty(1, 0, dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([16], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    with pytest.raises(ValueError, match="at least one column"):
+        dense_mla.bind(
+            plan,
+            scratch=_scratch(plan),
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+
+
+@torch.inference_mode()
+def test_inactive_padding_negative_ids_binds_and_runs() -> None:
+    """Inactive page-table slots with -1 must bind and run; only the active
+    prefix (determined by cache_seqlens) is accessed by the device."""
+    device = require_b12x()
+    torch.manual_seed(20260813)
+    page_size = 16
+    pages = 8
+    width = 8
+    plan = _tiny_plan(device, pages=pages, page_size=page_size, width=width)
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = (torch.randn(pages, page_size, QK_DIM, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    page_table = torch.full((1, width), -1, dtype=torch.int32, device=device)
+    page_table[0, :2] = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([32], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_inactive_padding_high_ids_binds_and_runs() -> None:
+    """Inactive page-table slots with arbitrary high IDs must bind and run."""
+    device = require_b12x()
+    torch.manual_seed(20260814)
+    page_size = 16
+    pages = 8
+    width = 8
+    plan = _tiny_plan(device, pages=pages, page_size=page_size, width=width)
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = (torch.randn(pages, page_size, QK_DIM, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    page_table = torch.full((1, width), 999, dtype=torch.int32, device=device)
+    page_table[0, :2] = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([32], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_post_capture_logical_bound_mutation_does_not_oob() -> None:
+    """After CUDA graph capture, mutating cache_seqlens so a second logical
+    page is live must not cause an OOB table read.
+
+    Plans a wide capacity (8 pages, width 8) but binds a 1-column page-table
+    view backed by a [1, 8] tensor.  Sentinel page ID 7 in columns 1-7
+    points at a page filled with NaN.  After capture, cache_seqlens is
+    mutated to 32, but the kernel caps cache_length at page_table_width(1) *
+    page_size(16) = 16.  The old kernel reads backing column 1 (page ID 7)
+    and produces NaN output.  The guarded kernel never reads the OOB column
+    and the output matches the capped reference (cache_seqlens=16).
+    """
+    device = require_b12x()
+    torch.manual_seed(20260815)
+    page_size = 16
+    backing_pages = 8
+    plan = _tiny_plan(
+        device,
+        pages=backing_pages,
+        page_size=page_size,
+        width=backing_pages,
+        use_cuda_graph=True,
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = (torch.randn(backing_pages, page_size, QK_DIM, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    cache[7] = float("nan")  # sentinel
+    page_table_backing = torch.full(
+        (1, backing_pages), 7, dtype=torch.int32, device=device
+    )
+    page_table_backing[0, 0] = 0
+    page_table = page_table_backing[:, :1]  # 1-column view, stride(0)=8
+    assert page_table.is_contiguous()
+    cache_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    # Mutate cache_seqlens so logical page 1 *would* be live.  The kernel
+    # caps cache_length at page_table_width(1) * page_size(16) = 16, so
+    # only page 0 is processed.  Old kernel reads page_table_backing[0, 1]
+    # = 7 -> cache page 7 (NaN) -> NaN output.
+    cache_seqlens.fill_(2 * page_size)
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "output must be finite — sentinel NaN page was read (logical bound failed)"
+    )
+    # The capped behavior matches a reference with cache_seqlens = page_size.
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_post_capture_physical_bound_mutation_does_not_oob() -> None:
+    """After CUDA graph capture, mutating a page-table entry to point past
+    the actual cache view must not cause an OOB cache read.
+
+    Plans 8 pages but binds a 2-page cache view of an 8-page backing.
+    Sentinel NaN data fills backing pages 2-7.  After capture, slot 1
+    is mutated to page ID 5 (below planned capacity but above the
+    actual 2-page view).  The kernel detects the invalid page, caps
+    cache_length to 1*page_size=16 (only slot 0 is valid), and masks
+    tokens 16..31.  The old kernel reads backing page 5 (NaN).  The
+    guarded kernel matches the capped reference.
+    """
+    device = require_b12x()
+    torch.manual_seed(20260816)
+    page_size = 16
+    backing_pages = 8
+    plan = _tiny_plan(
+        device,
+        pages=backing_pages,
+        page_size=page_size,
+        width=2,
+        use_cuda_graph=True,
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache_backing = (
+        torch.randn(backing_pages, page_size, QK_DIM, device=device) * 0.1
+    ).to(torch.bfloat16)
+    cache_backing[2:] = float("nan")  # sentinel pages
+    cache = cache_backing[:2]  # 2-page view
+    assert cache.is_contiguous()
+    page_table = torch.tensor([[0, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    # Mutate slot 1 to page ID 5 (OOB for 2-page view).  The kernel
+    # detects the invalid page and caps cache_length to page_size (only
+    # slot 0 is valid).  Tokens 16..31 are masked.
+    page_table[0, 1] = 5
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "output must be finite — sentinel NaN page was read (physical bound failed)"
+    )
+    # The capped behavior matches a reference with cache_seqlens=page_size
+    # and the original page_table (only page 0's tokens are visible).
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    safe_pt = torch.tensor([[0, 1]], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, safe_pt, capped_seqlens, cu_seqlens_q
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_post_capture_negative_page_id_does_not_oob() -> None:
+    """After CUDA graph capture, mutating a page-table entry to -1 must not
+    cause an OOB cache read.  Uses nonzero data to discriminate.
+
+    Slot 1 is mutated to -1.  The kernel detects the invalid page and
+    caps cache_length to 1*page_size=16 (only slot 0 is valid).
+    Tokens 16..31 are masked.  The reference uses the capped seqlens."""
+    device = require_b12x()
+    torch.manual_seed(20260817)
+    page_size = 16
+    pages = 4
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=4, use_cuda_graph=True
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = (torch.randn(pages, page_size, QK_DIM, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    page_table = torch.arange(pages, dtype=torch.int32, device=device).reshape(1, pages)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    # Mutate slot 1 to -1.  Kernel caps cache_length to page_size.
+    page_table[0, 1] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item())
+    # Capped to cache_seqlens=page_size — only page 0's tokens visible.
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_fp8_post_capture_physical_bound_mutation_does_not_oob() -> None:
+    """FP8 path: after CUDA graph capture, mutating an active page-table
+    entry past the actual cache view must not OOB.  Sentinel pages use
+    max FP8 value (448) to make OOB reads produce visibly different output."""
+    device = require_b12x()
+    torch.manual_seed(20260818)
+    page_size = 16
+    backing_pages = 8
+    plan = _tiny_plan(
+        device,
+        pages=backing_pages,
+        page_size=page_size,
+        width=2,
+        kv_dtype=FP8,
+        use_cuda_graph=True,
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    cache_float = torch.randn(backing_pages, page_size, QK_DIM, device=device) * 0.1
+    cache_float[2:] = 448.0  # sentinel: max E4M3 value
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[:2].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache_backing = (cache_float / kv_scale).to(FP8)
+    cache = cache_backing[:2]  # 2-page view
+    assert cache.is_contiguous()
+    page_table = torch.tensor([[0, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 1] = 5  # OOB for 2-page view
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "FP8 output must be finite — sentinel page was read (physical bound failed)"
+    )
+    # Kernel caps cache_length to page_size (only slot 0 valid).
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    safe_pt = torch.tensor([[0, 1]], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, safe_pt, capped_seqlens, cu_seqlens_q,
+        q_scale=q_scale, kv_scale=kv_scale,
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_bind_does_not_allocate_or_synchronize() -> None:
+    """bind must honor the views-only / no-allocation / no-sync contract."""
+    device = require_b12x()
+    page_size = 16
+    pages = 4
+    plan = _tiny_plan(device, pages=pages, page_size=page_size, width=4)
+    q = torch.randn(1, HEADS, QK_DIM, device=device).to(torch.bfloat16)
+    cache = torch.randn(pages, page_size, QK_DIM, device=device).to(torch.bfloat16)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    page_table = torch.arange(pages, dtype=torch.int32, device=device).reshape(1, pages)
+    cache_seqlens = torch.tensor([32], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    scratch = _scratch(plan)
+
+    torch.cuda.synchronize()
+    alloc_before = torch.cuda.memory_allocated(device)
+
+    binding = dense_mla.bind(
+        plan,
+        scratch=scratch,
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+
+    alloc_after = torch.cuda.memory_allocated(device)
+    assert alloc_after == alloc_before, (
+        f"bind allocated {alloc_after - alloc_before} bytes; "
+        "bind must be allocation-free"
+    )
+    assert binding.q.data_ptr() == q.data_ptr()
+    assert binding.page_table.data_ptr() == page_table.data_ptr()
+    assert binding.cache_seqlens.data_ptr() == cache_seqlens.data_ptr()
+    assert binding.kv_cache.data_ptr() == cache.data_ptr()
+
+
+@torch.inference_mode()
+def test_bf16_poisoned_page0_with_padded_table_matches_reference() -> None:
+    """BF16: global page 0 is NaN poison, live prefix maps to page 1+,
+    inactive padding is -1.  Output must be finite and match the
+    active-prefix reference."""
+    device = require_b12x()
+    torch.manual_seed(20260820)
+    page_size = 16
+    pages = 4
+    width = 8
+    plan = _tiny_plan(device, pages=pages, page_size=page_size, width=width)
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache[2] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.full((1, width), -1, dtype=torch.int32, device=device)
+    page_table[0, 0] = 1
+    page_table[0, 1] = 2
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(actual_output).all().item()), (
+        "output must be finite — poisoned page 0 was used as fallback"
+    )
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_fp8_poisoned_page0_with_padded_table_matches_reference() -> None:
+    """FP8: global page 0 is 448 (max E4M3) poison, live prefix maps to
+    page 1+, inactive padding is -1."""
+    device = require_b12x()
+    torch.manual_seed(20260821)
+    page_size = 16
+    pages = 4
+    width = 8
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, kv_dtype=FP8
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    cache_float = torch.zeros(pages, page_size, QK_DIM, device=device)
+    cache_float[0] = 448.0  # poison global page 0
+    cache_float[1] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    cache_float[2] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[1:3].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.full((1, width), -1, dtype=torch.int32, device=device)
+    page_table[0, 0] = 1
+    page_table[0, 1] = 2
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(actual_output).all().item()), (
+        "FP8 output must be finite — poisoned page 0 was used as fallback"
+    )
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q,
+        q_scale=q_scale, kv_scale=kv_scale,
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_bf16_poisoned_page0_high_pid_live_prefix_matches_reference() -> None:
+    """BF16: global page 0 is NaN, live prefix maps to high page IDs near
+    the tail, inactive padding is -1."""
+    device = require_b12x()
+    torch.manual_seed(20260822)
+    page_size = 16
+    pages = 4
+    width = 8
+    plan = _tiny_plan(device, pages=pages, page_size=page_size, width=width)
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[2] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache[3] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.full((1, width), -1, dtype=torch.int32, device=device)
+    page_table[0, 0] = 2
+    page_table[0, 1] = 3
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(actual_output).all().item()), (
+        "output must be finite — poisoned page 0 was used as fallback"
+    )
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_fp8_poisoned_page0_high_pid_live_prefix_matches_reference() -> None:
+    """FP8: global page 0 is 448, live prefix maps to high page IDs,
+    inactive padding is -1."""
+    device = require_b12x()
+    torch.manual_seed(20260823)
+    page_size = 16
+    pages = 4
+    width = 8
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, kv_dtype=FP8
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    cache_float = torch.zeros(pages, page_size, QK_DIM, device=device)
+    cache_float[0] = 448.0  # poison global page 0
+    cache_float[2] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    cache_float[3] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[2:4].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.full((1, width), -1, dtype=torch.int32, device=device)
+    page_table[0, 0] = 2
+    page_table[0, 1] = 3
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(actual_output).all().item()), (
+        "FP8 output must be finite — poisoned page 0 was used as fallback"
+    )
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q,
+        q_scale=q_scale, kv_scale=kv_scale,
+    )
+    _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_fp8_post_capture_logical_bound_mutation_does_not_oob() -> None:
+    """FP8 path: after CUDA graph capture, mutating cache_seqlens so a
+    second logical page is live must not cause an OOB table read.
+
+    The kernel caps cache_length at page_table_width(1) * page_size(16) =
+    16, so only page 0 is processed.  Old kernel reads backing col 1
+    (page 7, sentinel 448) and produces divergent output.  Guarded
+    kernel matches the capped reference (cache_seqlens=16)."""
+    device = require_b12x()
+    torch.manual_seed(20260824)
+    page_size = 16
+    backing_pages = 8
+    plan = _tiny_plan(
+        device,
+        pages=backing_pages,
+        page_size=page_size,
+        width=backing_pages,
+        kv_dtype=FP8,
+        use_cuda_graph=True,
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    cache_float = torch.randn(backing_pages, page_size, QK_DIM, device=device) * 0.1
+    cache_float[7] = 448.0  # sentinel
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[:2].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table_backing = torch.full(
+        (1, backing_pages), 7, dtype=torch.int32, device=device
+    )
+    page_table_backing[0, 0] = 0
+    page_table = page_table_backing[:, :1]  # 1-column view
+    assert page_table.is_contiguous()
+    cache_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    cache_seqlens.fill_(2 * page_size)
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "FP8 output must be finite — sentinel page was read (logical bound failed)"
+    )
+    # Capped to cache_seqlens=page_size — matches capped reference.
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q,
+        q_scale=q_scale, kv_scale=kv_scale,
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_bf16_post_capture_dead_request_zeroes_output() -> None:
+    """BF16: capture with valid slot 0, then mutate slot 0 to -1 and
+    cache_seqlens to positive.  The kernel detects the invalid first
+    page, sets cache_length=0, takes the early exit, and zeroes the
+    output.  Global page 0 is poisoned with NaN to prove the zeroing
+    is real, not a stale read."""
+    device = require_b12x()
+    torch.manual_seed(20260825)
+    page_size = 16
+    pages = 4
+    width = 4
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, use_cuda_graph=True
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor([[1, 1, 1, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([0], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, _ = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    # Mutate slot 0 to -1 (invalid) and cache_seqlens to positive.
+    page_table[0, 0] = -1
+    cache_seqlens.fill_(page_size)
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "output must be finite — dead request was not zeroed"
+    )
+    assert bool((captured_output == 0).all().item()), (
+        "dead request output must be zero, not stale data"
+    )
+
+
+@torch.inference_mode()
+def test_fp8_post_capture_dead_request_zeroes_output() -> None:
+    """Wide FP8: capture with valid slot 0, then mutate slot 0 high.
+
+    The physical 1088-wide record yields a 1024-wide value output, covering
+    the full dead-request zeroing loop rather than only its first 512 lanes.
+    """
+    device = require_b12x()
+    torch.manual_seed(20260826)
+    page_size = 16
+    pages = 4
+    width = 4
+    physical_width = 1088
+    value_dim = 1024
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=FP8,
+            num_q_heads=HEADS,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=page_size * width,
+            max_page_table_width=width,
+            num_cache_pages=pages,
+            head_dim=physical_width,
+            v_head_dim=value_dim,
+            physical_record_width=physical_width,
+            use_cuda_graph=True,
+        )
+    )
+    q_float = torch.randn(1, HEADS, physical_width, device=device) * 0.1
+    cache_float = torch.zeros(pages, page_size, physical_width, device=device)
+    cache_float[0] = 448.0  # poison global page 0
+    cache_float[1] = torch.randn(page_size, physical_width, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[1:2].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.tensor([[1, 1, 1, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([0], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, value_dim, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, _ = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 0] = 999999
+    cache_seqlens.fill_(page_size)
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "FP8 output must be finite — dead request was not zeroed"
+    )
+    assert bool((captured_output == 0).all().item()), (
+        "dead request output must be zero, not stale data"
+    )
+
+
+@torch.inference_mode()
+def test_bf16_slot1_invalid_with_poisoned_page0_matches_capped_reference() -> None:
+    """BF16: slot 0 valid (page 1), slot 1 mutated to -1 after capture.
+    Global page 0 is NaN poison.  Kernel caps cache_length to page_size
+    (only slot 0 valid), masks tokens 16..31.  Output matches the
+    capped reference and is finite despite poisoned page 0."""
+    device = require_b12x()
+    torch.manual_seed(20260827)
+    page_size = 16
+    pages = 4
+    width = 4
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, use_cuda_graph=True
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache[2] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor([[1, 2, 1, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 1] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "output must be finite — poisoned page 0 was used"
+    )
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_fp8_slot1_invalid_with_poisoned_page0_matches_capped_reference() -> None:
+    """FP8: slot 0 valid (page 1), slot 1 mutated to 999999 after capture.
+    Global page 0 is 448 poison.  Kernel caps cache_length to page_size,
+    masks tokens 16..31.  Output matches the capped reference."""
+    device = require_b12x()
+    torch.manual_seed(20260828)
+    page_size = 16
+    pages = 4
+    width = 4
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width,
+        kv_dtype=FP8, use_cuda_graph=True,
+    )
+    q_float = torch.randn(1, HEADS, QK_DIM, device=device) * 0.1
+    cache_float = torch.zeros(pages, page_size, QK_DIM, device=device)
+    cache_float[0] = 448.0  # poison global page 0
+    cache_float[1] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    cache_float[2] = torch.randn(page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float[1:3].abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.tensor([[1, 2, 1, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan, scratch=_scratch(plan),
+        q=q, kv_cache=cache, output=output,
+        page_table=page_table, cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q, q_scale=q_scale, kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 1] = 999999
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "FP8 output must be finite — poisoned page 0 was used"
+    )
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q,
+        q_scale=q_scale, kv_scale=kv_scale,
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_bf16_high_valid_pid_slot1_invalid_matches_capped_reference() -> None:
+    """BF16: slot 0 maps to a high valid PID (last page), slot 1 mutated
+    to -1.  Global page 0 is NaN.  Kernel caps to page_size; output
+    matches capped reference with the high PID page."""
+    device = require_b12x()
+    torch.manual_seed(20260829)
+    page_size = 16
+    pages = 4
+    width = 4
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, use_cuda_graph=True
+    )
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[3] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor([[3, 0, 0, 0]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan, scratch=_scratch(plan),
+        q=q, kv_cache=cache, output=output,
+        page_table=page_table, cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 1] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item()), (
+        "output must be finite — poisoned page 0 was used"
+    )
+    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, capped_seqlens, cu_seqlens_q
+    )
+    _assert_matches(
+        captured_output, captured_lse, expected_output, expected_lse
+    )
+
+
+@torch.inference_mode()
+def test_bf16_dead_request_lse_neg_inf_direct() -> None:
+    """BF16 direct path (num_splits==1): slot 0 mutated to -1 after
+    capture.  Output must be zero and LSE must be -inf."""
+    device = require_b12x()
+    torch.manual_seed(20260830)
+    page_size = 16
+    pages = 4
+    width = 4
+    # num_splits == 1 for a small plan → direct path
+    plan = _tiny_plan(
+        device, pages=pages, page_size=page_size, width=width, use_cuda_graph=True
+    )
+    assert plan.num_splits == 1
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor([[1, 1, 1, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan, scratch=_scratch(plan),
+        q=q, kv_cache=cache, output=output,
+        page_table=page_table, cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 0] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item())
+    assert bool((captured_output == 0).all().item())
+    assert bool((captured_lse == float("-inf")).all().item())
+
+
+@torch.inference_mode()
+def test_bf16_dead_request_lse_neg_inf_merged() -> None:
+    """BF16 merged path (num_splits>1, active_splits>1): slot 0 mutated
+    to -1 after capture.  Output must be zero and LSE must be -inf."""
+    device = require_b12x()
+    torch.manual_seed(20260831)
+    page_size = 16
+    pages = 4
+    width = 8
+    # Wide enough to force multiple splits
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=torch.bfloat16,
+            num_q_heads=HEADS,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=page_size * width,
+            max_page_table_width=width,
+            num_cache_pages=pages,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits > 1
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor(
+        [[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.int32, device=device
+    )
+    cache_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    binding = dense_mla.bind(
+        plan, scratch=_scratch(plan),
+        q=q, kv_cache=cache, output=output,
+        page_table=page_table, cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+    dense_mla.compile(binding=binding)
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    page_table[0, 0] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item())
+    assert bool((captured_output == 0).all().item())
+    assert bool((captured_lse == float("-inf")).all().item())
+
+
+@torch.inference_mode()
+def test_bf16_dead_request_lse_neg_inf_active_splits1() -> None:
+    """BF16 active_splits=1 path with plan.num_splits>1: slot 0 mutated
+    to -1 after capture.  This exercises the distinct early-exit branch
+    at _forward.py where num_splits>1 but active_splits==1 writes
+    final_lse (not partial_lse).  Output must be zero and LSE=-inf."""
+    device = require_b12x()
+    torch.manual_seed(20260832)
+    page_size = 16
+    pages = 4
+    width = 8
+    # Wide enough to force multiple splits
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=torch.bfloat16,
+            num_q_heads=HEADS,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=page_size * width,
+            max_page_table_width=width,
+            num_cache_pages=pages,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits > 1
+    q = (torch.randn(1, HEADS, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    cache = torch.zeros(pages, page_size, QK_DIM, dtype=torch.bfloat16, device=device)
+    cache[0] = float("nan")  # poison global page 0
+    cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor(
+        [[1, 1, 1, 1, 1, 1, 1, 1]], dtype=torch.int32, device=device
+    )
+    cache_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    # Bind with active_splits=1 — distinct from both direct (num_splits=1)
+    # and merged (active_splits>1) paths.
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        active_splits=1,
+    )
+    assert binding.active_splits == 1
+    dense_mla.compile(binding=binding)
+    # Run once to produce finite output/LSE before capture.
+    dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output, captured_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+
+    # Poison output and mutate slot 0 to invalid.
+    page_table[0, 0] = -1
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured_output).all().item())
+    assert bool((captured_output == 0).all().item())
+    assert bool((captured_lse == float("-inf")).all().item())

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -933,23 +933,6 @@ def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
         expected_lse,
     )
 
-# ---------------------------------------------------------------------------
-# Issue #157: adversarial metadata-safety gates for dense MLA.
-#
-# These tests prove that no live dense-MLA metadata can produce an OOB
-# table or cache address. Bind performs shape checks only (no host
-# synchronisation, no allocation). Device-side predicates cap visible
-# cache_length at the first invalid page and use the validated request-local
-# page_table[request, 0] fallback for masked gather records on every invocation,
-# protecting CUDA graph replay after metadata mutation.
-#
-# Discrimination strategy: sentinel pages filled with NaN (BF16) or a
-# maximally distinct value (FP8) are placed where the old unguarded kernel
-# would read. The guarded kernel excludes the invalid suffix and the output
-# stays finite / matches the capped safe reference.
-# ---------------------------------------------------------------------------
-
-
 def _tiny_plan(
     device,
     *,
@@ -1816,11 +1799,8 @@ def test_fp8_post_capture_dead_request_zeroes_output() -> None:
 
 
 @torch.inference_mode()
-def test_bf16_slot1_invalid_with_poisoned_page0_matches_capped_reference() -> None:
-    """BF16: slot 0 valid (page 1), slot 1 mutated to -1 after capture.
-    Global page 0 is NaN poison.  Kernel caps cache_length to page_size
-    (only slot 0 valid), masks tokens 16..31.  Output matches the
-    capped reference and is finite despite poisoned page 0."""
+def test_bf16_invalid_page_is_excluded_without_dropping_later_pages() -> None:
+    """Graph replay excludes a bad page while retaining later valid pages."""
     device = require_b12x()
     torch.manual_seed(20260827)
     page_size = 16
@@ -1834,8 +1814,9 @@ def test_bf16_slot1_invalid_with_poisoned_page0_matches_capped_reference() -> No
     cache[0] = float("nan")  # poison global page 0
     cache[1] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
     cache[2] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
-    page_table = torch.tensor([[1, 2, 1, 1]], dtype=torch.int32, device=device)
-    cache_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
+    cache[3] = (torch.randn(page_size, QK_DIM, device=device) * 0.1).to(torch.bfloat16)
+    page_table = torch.tensor([[1, 2, 3, 1]], dtype=torch.int32, device=device)
+    cache_seqlens = torch.tensor([3 * page_size], dtype=torch.int32, device=device)
     cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
     output = torch.empty(1, HEADS, VALUE_DIM, dtype=torch.bfloat16, device=device)
     binding = dense_mla.bind(
@@ -1864,9 +1845,10 @@ def test_bf16_slot1_invalid_with_poisoned_page0_matches_capped_reference() -> No
     assert bool(torch.isfinite(captured_output).all().item()), (
         "output must be finite — poisoned page 0 was used"
     )
-    capped_seqlens = torch.tensor([page_size], dtype=torch.int32, device=device)
+    packed_page_table = torch.tensor([[1, 3]], dtype=torch.int32, device=device)
+    packed_seqlens = torch.tensor([2 * page_size], dtype=torch.int32, device=device)
     expected_output, expected_lse = dense_mla.reference(
-        q, cache, page_table, capped_seqlens, cu_seqlens_q
+        q, cache, packed_page_table, packed_seqlens, cu_seqlens_q
     )
     _assert_matches(
         captured_output, captured_lse, expected_output, expected_lse


### PR DESCRIPTION
## Problem
Dense MLA page-table metadata could select out-of-range logical or physical pages, including after CUDA graph capture, causing GPU OOB access or cross-request cache reads.

## Fix
- bind live page-table width and physical cache capacity through the kernel ABI
- validate active page IDs on-device at replay time and truncate at the first invalid page
- use only a validated request-local staging fallback; invalid pages remain score-masked
- preserve Int64 pool-scaled address arithmetic
- zero output and write `-inf` LSE for dead requests across direct and split/merge modes
- reject impossible bindings without host value synchronization

## Verification
- `py_compile`, Ruff, and `git diff --check` passed for all changed files
- SM121: `python -m pytest -q tests/attention/test_dense_mla.py` → 35 passed
- independent source review: APPROVE at `e80208a`

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attention handling for incomplete, invalid, or out-of-range cache page metadata.
  - Prevented invalid page references from causing unsafe cache access.
  - Correctly limits visibility to valid cache pages and handles empty-cache scenarios.
  - Dead or invalid requests now produce zeroed outputs with consistent negative-infinity likelihood values.

- **Tests**
  - Added extensive coverage for boundary conditions, metadata changes, CUDA graph replay, and BF16/FP8 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->