### PR TITLE
security: bound tensor-FP8 graph admission and stream lifetimes

### DIFF
--- a/b12x/gemm/tensor_fp8_linear/__init__.py
+++ b/b12x/gemm/tensor_fp8_linear/__init__.py
@@ -5,6 +5,15 @@ scale-factor storage once, and records the combined activation/weight
 dequantization scale. ``mm`` consumes an already-quantized E4M3 activation and
 runs the native SM12x dense GEMM with the combined scale in its FP32 epilogue.
 
+Unit-scale MMA tensor cache (per-device, process-lifetime admission):
+  Env vars (set before import):
+    ``B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES`` — default 32, hard max 256
+    ``B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES``  — default 64 MiB, hard max 256 MiB
+  Admitted entries are never evicted (CUDA graph replay safety).  Row keys are
+  canonicalized to 128-row tiles.  ``prewarm`` is non-atomic: a failure
+  after partial admission leaves earlier geometries permanently admitted;
+  restart the process to reset.  Plan capacity accordingly.
+
 Example:
     from b12x.gemm import tensor_fp8_linear
 

--- a/b12x/gemm/tensor_fp8_linear/__init__.py
+++ b/b12x/gemm/tensor_fp8_linear/__init__.py
@@ -5,14 +5,9 @@ scale-factor storage once, and records the combined activation/weight
 dequantization scale. ``mm`` consumes an already-quantized E4M3 activation and
 runs the native SM12x dense GEMM with the combined scale in its FP32 epilogue.
 
-Unit-scale MMA tensor cache (per-device, process-lifetime admission):
-  Env vars (set before import):
-    ``B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES`` — default 32, hard max 256
-    ``B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES``  — default 64 MiB, hard max 256 MiB
-  Admitted entries are never evicted (CUDA graph replay safety).  Row keys are
-  canonicalized to 128-row tiles.  ``prewarm`` is non-atomic: a failure
-  after partial admission leaves earlier geometries permanently admitted;
-  restart the process to reset.  Plan capacity accordingly.
+Unit-scale MMA tensors are retained in a bounded per-device cache. Entries are
+never evicted because a CUDA graph can capture their addresses; prewarm every
+serving geometry before capture.
 
 Example:
     from b12x.gemm import tensor_fp8_linear

--- a/b12x/gemm/tensor_fp8_linear/_kernel.py
+++ b/b12x/gemm/tensor_fp8_linear/_kernel.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import os
 import threading
 from collections.abc import Iterable
-from contextlib import nullcontext
 from dataclasses import dataclass
 
 import cutlass.cute as cute
 import torch
 
 from b12x._lib.dense_gemm import dense_gemm
+from b12x._lib.utils import cuda_stream_to_int
 from b12x.gemm._shared.wo_mxfp8 import (
     MXFP8_SCALE_K_TILE,
     MXFP8_SCALE_ROW_TILE,
@@ -18,82 +17,12 @@ from b12x.gemm._shared.wo_mxfp8 import (
     pack_mxfp8_scales_for_dense_gemm,
 )
 
-# ---------------------------------------------------------------------------
-# Graph-safe bounded admission cache for unit-scale MMA tensors.
-#
-# Each entry is a CUDA tensor whose raw SFA pointer may be embedded in an
-# active CUDA graph.  Therefore entries are immutable and process-lifetime
-# stable: there is no automatic eviction and no public clear operation that
-# could free a graph-owned pointer.  When the cache reaches its entry-count or
-# byte-budget ceiling, new geometries are rejected with an explicit error so
-# the caller can raise the limits or prune model geometries before capture.
-#
-# Public admission contract
-# ~~~~~~~~~~~~~~~~~~~~~~~~~
-# The unit-scale MMA tensor cache is a per-device, process-lifetime table.
-# Once a geometry is admitted its backing storage is never freed, ensuring
-# that CUDA-graph-captured SFA pointers remain valid for the life of the
-# process.  Two environment variables control the per-device ceiling and must
-# be set **before** importing this module:
-#
-#   B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES  (default 32, hard max 256)
-#   B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES   (default 64 MiB, hard max 256 MiB)
-#
-# Invalid, zero, or negative values fall back to the defaults; values above
-# the hard maxima are clamped.  When a new geometry would exceed the per-device
-# entry count or byte budget, a ``RuntimeError`` is raised.  Because admitted
-# entries cannot be evicted, serving integrations should call ``prewarm`` with
-# all expected token-count geometries during startup.  ``prewarm`` is
-# **non-atomic**: it admits geometries one at a time in sorted order, so a
-# failure after partial admission leaves all earlier canonical geometries
-# permanently admitted until the process is restarted; the remaining
-# geometries stay unadmittable.  Plan capacity accordingly.
-#
-# Row keys are canonicalized to the physical 128-row scale tile: token counts
-# 1–128 (or 129–256, etc.) that produce identical packed all-127 storage share
-# a single immutable allocation, reducing cardinality.
-# ---------------------------------------------------------------------------
-
-# Hard ceilings that cannot be exceeded even via environment configuration.
-_UNIT_SCALE_HARD_MAX_ENTRIES = 256
-_UNIT_SCALE_HARD_MAX_BYTES = 256 * 1024 * 1024
-
-
-def _parse_cache_limit(raw: str | None, default: int, hard_max: int) -> int:
-    """Parse a cache limit from an env var, falling back to *default*."""
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except (ValueError, TypeError):
-        return default
-    if value <= 0:
-        return default
-    return min(value, hard_max)
-
-
-_UNIT_SCALE_CACHE_MAX_ENTRIES = _parse_cache_limit(
-    os.environ.get("B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES"),
-    32,
-    _UNIT_SCALE_HARD_MAX_ENTRIES,
-)
-_UNIT_SCALE_CACHE_MAX_BYTES = _parse_cache_limit(
-    os.environ.get("B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES"),
-    64 * 1024 * 1024,
-    _UNIT_SCALE_HARD_MAX_BYTES,
-)
+_UNIT_SCALE_CACHE_MAX_ENTRIES = 64
+_UNIT_SCALE_CACHE_MAX_BYTES = 64 * 1024 * 1024
 
 
 def _unit_scale_packed_bytes(rows: int, width: int) -> int:
-    """Compute the exact backing-storage byte count of the packed unit-scale
-    MMA tensor **without** allocating it.
-
-    The packer rounds *rows* up to ``MXFP8_SCALE_ROW_TILE`` (128) and
-    ``sf_k = width // 32`` up to ``MXFP8_SCALE_K_TILE`` (4).  The contiguous
-    physical tensor has ``num_groups * m_tiles * k_tiles * 32 * 4 * 4`` bytes
-    (each element is ``float8_e8m0fnu`` = 1 byte).  With ``num_groups = 1``
-    this simplifies to ``m_tiles * k_tiles * 512``.
-    """
+    """Return packed unit-scale storage bytes without allocating."""
     m_tiles = _align_up(rows, MXFP8_SCALE_ROW_TILE) // MXFP8_SCALE_ROW_TILE
     sf_k = width // MXFP8_SCALE_VEC_SIZE
     k_tiles = _align_up(sf_k, MXFP8_SCALE_K_TILE) // MXFP8_SCALE_K_TILE
@@ -101,50 +30,21 @@ def _unit_scale_packed_bytes(rows: int, width: int) -> int:
 
 
 def _canonical_rows(rows: int) -> int:
-    """Round *rows* up to the physical 128-row scale tile boundary.
-
-    All row counts within the same tile produce identical packed all-127
-    storage, so they share one immutable cache entry.
-    """
+    """Round rows to the physical scale-storage tile."""
     return _align_up(int(rows), MXFP8_SCALE_ROW_TILE)
 
 
-@dataclass
-class _DeviceUnitScaleCache:
-    """Per-device immutable entry table with byte accounting."""
-
-    entries: dict[tuple[int, int], torch.Tensor]
-    total_bytes: int
-    lock: threading.Lock
-    prewarmed_launches: set[tuple[int, int, int, torch.dtype, int]]
-
-
-_unit_scale_caches: dict[tuple[str, int | None], _DeviceUnitScaleCache] = {}
-_unit_scale_caches_guard = threading.Lock()
-
-
-def _get_device_cache(
-    device_key: tuple[str, int | None],
-) -> _DeviceUnitScaleCache:
-    """Return (creating if needed) the per-device admission cache."""
-    with _unit_scale_caches_guard:
-        dc = _unit_scale_caches.get(device_key)
-        if dc is None:
-            dc = _DeviceUnitScaleCache(
-                entries={},
-                total_bytes=0,
-                prewarmed_launches=set(),
-                lock=threading.Lock(),
-            )
-            _unit_scale_caches[device_key] = dc
-    return dc
+_UnitScaleKey = tuple[str, int | None, int, int]
+_unit_scale_cache: dict[_UnitScaleKey, torch.Tensor] = {}
+_unit_scale_cache_bytes: dict[tuple[str, int | None], int] = {}
+_unit_scale_cache_lock = threading.Lock()
 
 
 def _reset_unit_scale_cache() -> None:
-    """Drop every per-device cache entry.  For tests only — never call while
-    CUDA graphs that reference cached tensors may still be replayed."""
-    with _unit_scale_caches_guard:
-        _unit_scale_caches.clear()
+    """Clear unit-scale storage for tests with no live CUDA graphs."""
+    with _unit_scale_cache_lock:
+        _unit_scale_cache.clear()
+        _unit_scale_cache_bytes.clear()
 
 
 @dataclass(frozen=True)
@@ -207,35 +107,20 @@ def _cached_unit_scale_mma(
     rows: int,
     width: int,
 ) -> torch.Tensor:
-    """Return a unit-scale MMA tensor from a bounded per-device admission cache.
-
-    Entries are immutable and process-lifetime stable: once a geometry is
-    admitted, the same tensor object is returned for every subsequent call
-    with the same key, preserving the stable-allocation guarantee required
-    for CUDA graph replay.  No entry is ever evicted, so a graph-captured
-    pointer remains valid for the lifetime of the process.
-
-    Row counts are canonicalized to the physical 128-row scale tile, so token
-    counts 1–128 (or 129–256, etc.) that produce identical packed all-127
-    storage share one immutable allocation.
-
-    When the per-device entry count or byte budget would be exceeded, the new
-    geometry is rejected with a :class:`RuntimeError` **before** any CUDA
-    allocation is attempted.
-
-    Construction is single-flight under a per-device lock.  On cold creation
-    the concrete device is synchronized before the entry is published, so
-    cross-thread streams cannot consume incomplete data.
-    """
+    """Return immutable unit-scale storage from a bounded, no-eviction cache."""
     device_key = (device_type, device_index)
-    # Canonicalize rows to the physical 128-row tile boundary.
     canon_rows = _canonical_rows(rows)
-    entry_key = (canon_rows, int(width))
-    dc = _get_device_cache(device_key)
+    cache_key = (*device_key, canon_rows, int(width))
 
-    # Single-flight construction under the per-device lock.
-    with dc.lock:
-        existing = dc.entries.get(entry_key)
+    # Stable geometries take one dictionary lookup and no lock, capture query,
+    # CUDA work, or synchronization.
+    existing = _unit_scale_cache.get(cache_key)
+    if existing is not None:
+        return existing
+
+    tensor_bytes = _unit_scale_packed_bytes(canon_rows, int(width))
+    with _unit_scale_cache_lock:
+        existing = _unit_scale_cache.get(cache_key)
         if existing is not None:
             return existing
 
@@ -244,143 +129,29 @@ def _cached_unit_scale_mma(
                 "tensor-FP8 unit-scale geometry was not prewarmed before "
                 "CUDA graph capture"
             )
-        # Admission control: reject if at capacity.
-        if len(dc.entries) >= _UNIT_SCALE_CACHE_MAX_ENTRIES:
+        device_entries = sum(
+            key[:2] == device_key for key in _unit_scale_cache
+        )
+        if device_entries >= _UNIT_SCALE_CACHE_MAX_ENTRIES:
             raise RuntimeError(
                 f"tensor-FP8 unit-scale cache for device {device_key} is full "
-                f"({len(dc.entries)}/{_UNIT_SCALE_CACHE_MAX_ENTRIES} entries). "
-                "Increase B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES (hard "
-                f"max {_UNIT_SCALE_HARD_MAX_ENTRIES}) or reduce the number of "
-                "distinct token-count/width geometries before CUDA graph "
-                "capture.  Admitted entries are process-lifetime; restart the "
-                "process to reset the cache."
+                f"({device_entries}/{_UNIT_SCALE_CACHE_MAX_ENTRIES} entries)"
             )
-
-        # Precompute exact backing bytes before allocating.
-        tensor_bytes = _unit_scale_packed_bytes(canon_rows, int(width))
-
-        # Reject a single entry that exceeds the entire byte budget.
-        if tensor_bytes > _UNIT_SCALE_CACHE_MAX_BYTES:
-            raise RuntimeError(
-                f"tensor-FP8 unit-scale tensor for rows={rows}, width={width} "
-                f"requires {tensor_bytes} bytes, exceeding the per-device byte "
-                f"budget of {_UNIT_SCALE_CACHE_MAX_BYTES} (hard max "
-                f"{_UNIT_SCALE_HARD_MAX_BYTES}). Increase "
-                "B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES or reduce "
-                "the padded K width."
-            )
-
-        if dc.total_bytes + tensor_bytes > _UNIT_SCALE_CACHE_MAX_BYTES:
+        retained_bytes = _unit_scale_cache_bytes.get(device_key, 0)
+        if retained_bytes + tensor_bytes > _UNIT_SCALE_CACHE_MAX_BYTES:
             raise RuntimeError(
                 f"admitting tensor-FP8 unit-scale tensor for rows={rows}, "
                 f"width={width} ({tensor_bytes} bytes) would exceed the "
-                f"per-device byte budget ({dc.total_bytes}/"
-                f"{_UNIT_SCALE_CACHE_MAX_BYTES} bytes already used, hard max "
-                f"{_UNIT_SCALE_HARD_MAX_BYTES}). Increase "
-                "B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES or reduce the "
-                "number of distinct token-count/width geometries before CUDA "
-                "graph capture.  Admitted entries are process-lifetime; "
-                "restart the process to reset the cache."
+                f"per-device byte budget ({retained_bytes}/"
+                f"{_UNIT_SCALE_CACHE_MAX_BYTES} bytes retained)"
             )
 
         device = torch.device(device_type, device_index)
         tensor = _unit_scale_mma(canon_rows, width, device)
-
-        # Synchronize the concrete device so the tensor data is visible to
-        # any stream before publication.
-        if device_type == "cuda":
-            torch.cuda.synchronize(device)
-
-        dc.entries[entry_key] = tensor
-        dc.total_bytes += tensor_bytes
+        _unit_scale_cache[cache_key] = tensor
+        _unit_scale_cache_bytes[device_key] = retained_bytes + tensor_bytes
 
     return tensor
-
-
-def _launch_key(
-    *,
-    tokens: int,
-    padded_in_features: int,
-    out_features: int,
-    out_dtype: torch.dtype,
-    expected_m: int,
-) -> tuple[int, int, int, torch.dtype, int]:
-    return (
-        int(tokens),
-        int(padded_in_features),
-        int(out_features),
-        out_dtype,
-        int(expected_m),
-    )
-
-
-def _require_capture_launch_prewarmed(
-    device: torch.device,
-    launch_key: tuple[int, int, int, torch.dtype, int],
-) -> None:
-    if device.type != "cuda" or not torch.cuda.is_current_stream_capturing():
-        return
-    device_index = device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-    dc = _get_device_cache((device.type, device_index))
-    with dc.lock:
-        if launch_key not in dc.prewarmed_launches:
-            raise RuntimeError(
-                "tensor-FP8 launch geometry was not prewarmed before "
-                "CUDA graph capture"
-            )
-
-
-def _prewarm_unit_scales_atomic(
-    device: torch.device,
-    rows: Iterable[int],
-    width: int,
-) -> None:
-    """Admit a complete prewarm batch before any serving-shape compilation."""
-    device_index = device.index
-    if device.type == "cuda" and device_index is None:
-        device_index = torch.cuda.current_device()
-    device_key = (device.type, device_index)
-    dc = _get_device_cache(device_key)
-    entry_keys = sorted({(_canonical_rows(row), int(width)) for row in rows})
-
-    with dc.lock:
-        missing = [key for key in entry_keys if key not in dc.entries]
-        if not missing:
-            return
-        if device.type == "cuda" and torch.cuda.is_current_stream_capturing():
-            raise RuntimeError(
-                "tensor-FP8 unit-scale geometries must be prewarmed before "
-                "CUDA graph capture"
-            )
-        if len(dc.entries) + len(missing) > _UNIT_SCALE_CACHE_MAX_ENTRIES:
-            raise RuntimeError(
-                f"tensor-FP8 unit-scale cache for device {device_key} is full: "
-                f"{len(dc.entries)} existing + {len(missing)} requested exceeds "
-                f"{_UNIT_SCALE_CACHE_MAX_ENTRIES}"
-            )
-        sizes = {
-            key: _unit_scale_packed_bytes(key[0], key[1]) for key in missing
-        }
-        requested_bytes = sum(sizes.values())
-        if (
-            any(size > _UNIT_SCALE_CACHE_MAX_BYTES for size in sizes.values())
-            or dc.total_bytes + requested_bytes > _UNIT_SCALE_CACHE_MAX_BYTES
-        ):
-            raise RuntimeError(
-                f"tensor-FP8 unit-scale prewarm for device {device_key} "
-                f"requires {requested_bytes} bytes with {dc.total_bytes} "
-                f"already admitted, exceeding {_UNIT_SCALE_CACHE_MAX_BYTES}"
-            )
-
-        created = {
-            key: _unit_scale_mma(key[0], key[1], device) for key in missing
-        }
-        if device.type == "cuda":
-            torch.cuda.synchronize(device)
-        dc.entries.update(created)
-        dc.total_bytes += requested_bytes
 
 
 def _activation_scale_mma(
@@ -475,35 +246,31 @@ def _tensor_fp8_linear_fused_op(
     stream_int: int | None,
 ) -> torch.Tensor:
     tokens = int(source_2d.shape[0])
-    # Guard all CUDA work inside the source device context so compilation
-    # and stream resolution use the correct device, not the thread's current
-    # device which may differ in multi-GPU serving.
-    with torch.cuda.device(source_2d.device):
-        source_padded = _pad_k(source_2d, int(padded_in_features))
-        source_scale_mma = _activation_scale_mma(
-            source_padded,
-            tokens,
-            int(padded_in_features),
-        )
-        return dense_gemm(
-            (
-                source_padded.reshape(tokens, padded_in_features, 1),
-                source_scale_mma,
-            ),
-            (
-                weight_values.reshape(out_features, padded_in_features, 1),
-                weight_scale_mma,
-            ),
-            alpha=output_scale,
-            ab_dtype="float8_e4m3fn",
-            sf_dtype="float8_e8m0fnu",
-            c_dtype=_output_dtype_name(out_dtype),
-            sf_vec_size=MXFP8_SCALE_VEC_SIZE,
-            expected_m=expected_m,
-            stream=stream_int,
-            plain_fp8=True,
-            **_dense_gemm_kwargs_for_n(out_features),
-        )[:, :, 0]
+    source_padded = _pad_k(source_2d, int(padded_in_features))
+    source_scale_mma = _activation_scale_mma(
+        source_padded,
+        tokens,
+        int(padded_in_features),
+    )
+    return dense_gemm(
+        (
+            source_padded.reshape(tokens, padded_in_features, 1),
+            source_scale_mma,
+        ),
+        (
+            weight_values.reshape(out_features, padded_in_features, 1),
+            weight_scale_mma,
+        ),
+        alpha=output_scale,
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=_output_dtype_name(out_dtype),
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        expected_m=expected_m,
+        stream=stream_int,
+        plain_fp8=True,
+        **_dense_gemm_kwargs_for_n(out_features),
+    )[:, :, 0]
 
 
 @_tensor_fp8_linear_fused_op.register_fake
@@ -536,135 +303,56 @@ def tensor_fp8_linear(
     expected_m: int | None = None,
     stream: object = None,
 ) -> torch.Tensor:
-    """Run static per-tensor E4M3 operands through the SM12x dense GEMM.
-
-    ``stream`` must be a ``torch.cuda.Stream`` on the same device as the
-    operands, or ``None`` to use the current stream for the operand device.
-    Raw integer handles are **not** accepted; the caller must pass a proper
-    ``torch.cuda.Stream`` so that device and ordering can be validated.
-
-    All materialization (source reshape, K padding, cache access, output
-    allocation, raw GEMM launch, and bias addition) executes under
-    ``torch.cuda.device(operand_device)`` plus ``torch.cuda.stream(target)``
-    so that temporary tensors are allocated on the target stream.
-
-    **Stream lifetime:** caller-owned tensors (``source``, packed weight
-    fields, and ``bias``) are recorded on the target stream via
-    ``record_stream`` so the caching allocator does not recycle their
-    memory while the raw GEMM launch is still reading them on the target
-    stream.  The caller is responsible for ensuring that producers of
-    these tensors have completed before the target stream consumes them
-    (e.g. by waiting on the producer stream's event on the target stream).
-    The returned ``output`` tensor is allocated on the target stream.  The
-    caller must ensure the target stream has completed before reading the
-    output from a different stream, either by calling
-    ``target_stream.synchronize()`` or by having the consumer stream call
-    ``consumer.wait_stream(target_stream)`` (or wait on an event recorded on
-    the target stream).  Separately, if the caller intends to read the
-    output from a different stream, ``output.record_stream(consumer_stream)``
-    protects the allocator lifetime of the output tensor.
-
-    Each distinct ``(canonical_rows, padded_K, device)`` geometry admitted by
-    this call is cached permanently for CUDA graph replay safety.  See the
-    module-level admission contract for env-var limits, defaults, and
-    restart semantics.
-    """
+    """Run static per-tensor E4M3 operands through the SM12x dense GEMM."""
 
     _check_gpu_tensor("source", source)
     if not isinstance(packed_weight, TensorFP8LinearWeight):
         raise TypeError("packed_weight must be a TensorFP8LinearWeight")
-    if stream is not None and not isinstance(stream, torch.cuda.Stream):
-        raise TypeError(
-            "stream must be a torch.cuda.Stream or None; raw integer handles "
-            "are not accepted"
-        )
-    if stream is not None and stream.device != source.device:
+    source_2d = _source_2d(source)
+    tokens, in_features = map(int, source_2d.shape)
+    if source_2d.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"source must be float8_e4m3fn, got {source_2d.dtype}")
+    if in_features != int(packed_weight.in_features):
         raise ValueError(
-            f"stream is on device {stream.device} but source is on "
-            f"{source.device}"
+            f"input K={in_features} does not match packed weight K="
+            f"{packed_weight.in_features}"
         )
+    if packed_weight.values.device != source_2d.device:
+        raise ValueError("source and packed weight must be on the same device")
+    if expected_m is not None and int(expected_m) <= 0:
+        raise ValueError("expected_m must be positive when provided")
+    _output_dtype_name(out_dtype)
 
-    device = source.device
-    if device.type == "cuda":
-        target_stream = stream if stream is not None else torch.cuda.current_stream(device)
-        device_ctx = torch.cuda.device(device)
-        stream_ctx = torch.cuda.stream(target_stream)
-    else:
-        target_stream = None
-        device_ctx = nullcontext()
-        stream_ctx = nullcontext()
-
-    # Record caller-owned tensors on the target stream so the caching
-    # allocator does not recycle their memory while the raw GEMM launch
-    # (which reads them via raw pointers on target_stream) is still in
-    # flight.  Tensors allocated inside the stream context below
-    # (source_2d, padded source) are already on the target stream.  The
-    # cached unit-scale tensor is process-lifetime stable.
-    if target_stream is not None:
-        current_stream = torch.cuda.current_stream(device)
-        if target_stream != current_stream:
-            target_stream.wait_stream(current_stream)
-        source.record_stream(target_stream)
-        packed_weight.values.record_stream(target_stream)
-        packed_weight.scale_mma.record_stream(target_stream)
-        packed_weight.output_scale.record_stream(target_stream)
-        if bias is not None:
-            bias.record_stream(target_stream)
-
-    with device_ctx, stream_ctx:
-        source_2d = _source_2d(source)
-        tokens, in_features = map(int, source_2d.shape)
-        if source_2d.dtype != torch.float8_e4m3fn:
-            raise ValueError(f"source must be float8_e4m3fn, got {source_2d.dtype}")
-        if in_features != int(packed_weight.in_features):
+    out_features = int(packed_weight.out_features)
+    if bias is not None:
+        _check_gpu_tensor("bias", bias)
+        if bias.device != source_2d.device:
+            raise ValueError("bias must be on the same device as source")
+        if bias.dtype != out_dtype or bias.shape != (out_features,):
             raise ValueError(
-                f"input K={in_features} does not match packed weight K="
-                f"{packed_weight.in_features}"
+                f"bias must have shape {(out_features,)} and dtype {out_dtype}, "
+                f"got shape={tuple(bias.shape)}, dtype={bias.dtype}"
             )
-        if packed_weight.values.device != source_2d.device:
-            raise ValueError("source and packed weight must be on the same device")
-        if expected_m is not None and int(expected_m) <= 0:
-            raise ValueError("expected_m must be positive when provided")
-        _output_dtype_name(out_dtype)
-        launch_key = _launch_key(
-            tokens=tokens,
-            padded_in_features=packed_weight.padded_in_features,
-            out_features=packed_weight.out_features,
-            out_dtype=out_dtype,
-            expected_m=int(expected_m) if expected_m is not None else tokens,
+    if tokens == 0:
+        output = torch.empty(
+            (0, out_features),
+            dtype=out_dtype,
+            device=source_2d.device,
         )
-        _require_capture_launch_prewarmed(device, launch_key)
-
-        out_features = int(packed_weight.out_features)
-        if bias is not None:
-            _check_gpu_tensor("bias", bias)
-            if bias.device != source_2d.device:
-                raise ValueError("bias must be on the same device as source")
-            if bias.dtype != out_dtype or bias.shape != (out_features,):
-                raise ValueError(
-                    f"bias must have shape {(out_features,)} and dtype {out_dtype}, "
-                    f"got shape={tuple(bias.shape)}, dtype={bias.dtype}"
-                )
-        if tokens == 0:
-            output = torch.empty(
-                (0, out_features),
-                dtype=out_dtype,
-                device=source_2d.device,
-            )
-        else:
-            output = torch.ops.b12x.tensor_fp8_linear_fused(
-                source_2d,
-                packed_weight.values,
-                packed_weight.scale_mma,
-                packed_weight.output_scale,
-                packed_weight.padded_in_features,
-                packed_weight.out_features,
-                int(expected_m) if expected_m is not None else tokens,
-                out_dtype,
-                int(target_stream.cuda_stream) if target_stream is not None else None,
-            )
-        if bias is not None:
-            output = output + bias
+    else:
+        output = torch.ops.b12x.tensor_fp8_linear_fused(
+            source_2d,
+            packed_weight.values,
+            packed_weight.scale_mma,
+            packed_weight.output_scale,
+            packed_weight.padded_in_features,
+            packed_weight.out_features,
+            int(expected_m) if expected_m is not None else tokens,
+            out_dtype,
+            cuda_stream_to_int(stream),
+        )
+    if bias is not None:
+        output = output + bias
     return output.view(*source.shape[:-1], out_features)
 
 
@@ -675,55 +363,15 @@ def prewarm_tensor_fp8_linear(
     out_dtype: torch.dtype = torch.bfloat16,
     stream: object = None,
 ) -> int:
-    """Compile and cache serving shapes before CUDA graph capture.
+    """Compile and cache serving shapes before CUDA graph capture."""
 
-    The full normalized geometry set is checked against the permanent
-    per-device admission limits before any scale allocation or GEMM
-    compilation. Invalid stream arguments are rejected before dummy tensors
-    are allocated.
-    """
-    if not isinstance(packed_weight, TensorFP8LinearWeight):
-        raise TypeError("packed_weight must be a TensorFP8LinearWeight")
-    device = packed_weight.values.device
-    if stream is not None and not isinstance(stream, torch.cuda.Stream):
-        raise TypeError(
-            "stream must be a torch.cuda.Stream or None; raw integer handles "
-            "are not accepted"
-        )
-    if stream is not None and stream.device != device:
-        raise ValueError(
-            f"stream is on device {stream.device} but packed weight is on {device}"
-        )
-
-    normalized_tokens = sorted(
-        {int(value) for value in token_counts if int(value) > 0}
-    )
-    if not normalized_tokens:
-        return 0
-    if stream is not None:
-        target_stream = stream
-    elif device.type == "cuda":
-        target_stream = torch.cuda.current_stream(device)
-    else:
-        target_stream = None
-
-    device_ctx = torch.cuda.device(device) if device.type == "cuda" else nullcontext()
-    stream_ctx = (
-        torch.cuda.stream(target_stream)
-        if target_stream is not None
-        else nullcontext()
-    )
-    with torch.inference_mode(), device_ctx, stream_ctx:
-        _prewarm_unit_scales_atomic(
-            device,
-            normalized_tokens,
-            int(packed_weight.padded_in_features),
-        )
-        for tokens in normalized_tokens:
+    warmed = 0
+    with torch.inference_mode():
+        for tokens in sorted({int(value) for value in token_counts if int(value) > 0}):
             source = torch.zeros(
                 (tokens, packed_weight.in_features),
                 dtype=torch.float8_e4m3fn,
-                device=device,
+                device=packed_weight.values.device,
             )
             tensor_fp8_linear(
                 source,
@@ -732,20 +380,8 @@ def prewarm_tensor_fp8_linear(
                 expected_m=tokens,
                 stream=stream,
             )
-            device_index = device.index
-            if device.type == "cuda" and device_index is None:
-                device_index = torch.cuda.current_device()
-            dc = _get_device_cache((device.type, device_index))
-            launch_key = _launch_key(
-                tokens=tokens,
-                padded_in_features=packed_weight.padded_in_features,
-                out_features=packed_weight.out_features,
-                out_dtype=out_dtype,
-                expected_m=tokens,
-            )
-            with dc.lock:
-                dc.prewarmed_launches.add(launch_key)
-    return len(normalized_tokens)
+            warmed += 1
+    return warmed
 
 
 __all__ = [

--- a/b12x/gemm/tensor_fp8_linear/_kernel.py
+++ b/b12x/gemm/tensor_fp8_linear/_kernel.py
@@ -1,19 +1,150 @@
 from __future__ import annotations
 
-import functools
+import os
+import threading
 from collections.abc import Iterable
+from contextlib import nullcontext
 from dataclasses import dataclass
 
 import cutlass.cute as cute
 import torch
 
 from b12x._lib.dense_gemm import dense_gemm
-from b12x._lib.utils import cuda_stream_to_int
 from b12x.gemm._shared.wo_mxfp8 import (
+    MXFP8_SCALE_K_TILE,
+    MXFP8_SCALE_ROW_TILE,
     MXFP8_SCALE_VEC_SIZE,
     _check_gpu_tensor,
     pack_mxfp8_scales_for_dense_gemm,
 )
+
+# ---------------------------------------------------------------------------
+# Graph-safe bounded admission cache for unit-scale MMA tensors.
+#
+# Each entry is a CUDA tensor whose raw SFA pointer may be embedded in an
+# active CUDA graph.  Therefore entries are immutable and process-lifetime
+# stable: there is no automatic eviction and no public clear operation that
+# could free a graph-owned pointer.  When the cache reaches its entry-count or
+# byte-budget ceiling, new geometries are rejected with an explicit error so
+# the caller can raise the limits or prune model geometries before capture.
+#
+# Public admission contract
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# The unit-scale MMA tensor cache is a per-device, process-lifetime table.
+# Once a geometry is admitted its backing storage is never freed, ensuring
+# that CUDA-graph-captured SFA pointers remain valid for the life of the
+# process.  Two environment variables control the per-device ceiling and must
+# be set **before** importing this module:
+#
+#   B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES  (default 32, hard max 256)
+#   B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES   (default 64 MiB, hard max 256 MiB)
+#
+# Invalid, zero, or negative values fall back to the defaults; values above
+# the hard maxima are clamped.  When a new geometry would exceed the per-device
+# entry count or byte budget, a ``RuntimeError`` is raised.  Because admitted
+# entries cannot be evicted, serving integrations should call ``prewarm`` with
+# all expected token-count geometries during startup.  ``prewarm`` is
+# **non-atomic**: it admits geometries one at a time in sorted order, so a
+# failure after partial admission leaves all earlier canonical geometries
+# permanently admitted until the process is restarted; the remaining
+# geometries stay unadmittable.  Plan capacity accordingly.
+#
+# Row keys are canonicalized to the physical 128-row scale tile: token counts
+# 1–128 (or 129–256, etc.) that produce identical packed all-127 storage share
+# a single immutable allocation, reducing cardinality.
+# ---------------------------------------------------------------------------
+
+# Hard ceilings that cannot be exceeded even via environment configuration.
+_UNIT_SCALE_HARD_MAX_ENTRIES = 256
+_UNIT_SCALE_HARD_MAX_BYTES = 256 * 1024 * 1024
+
+
+def _parse_cache_limit(raw: str | None, default: int, hard_max: int) -> int:
+    """Parse a cache limit from an env var, falling back to *default*."""
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        return default
+    if value <= 0:
+        return default
+    return min(value, hard_max)
+
+
+_UNIT_SCALE_CACHE_MAX_ENTRIES = _parse_cache_limit(
+    os.environ.get("B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES"),
+    32,
+    _UNIT_SCALE_HARD_MAX_ENTRIES,
+)
+_UNIT_SCALE_CACHE_MAX_BYTES = _parse_cache_limit(
+    os.environ.get("B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES"),
+    64 * 1024 * 1024,
+    _UNIT_SCALE_HARD_MAX_BYTES,
+)
+
+
+def _unit_scale_packed_bytes(rows: int, width: int) -> int:
+    """Compute the exact backing-storage byte count of the packed unit-scale
+    MMA tensor **without** allocating it.
+
+    The packer rounds *rows* up to ``MXFP8_SCALE_ROW_TILE`` (128) and
+    ``sf_k = width // 32`` up to ``MXFP8_SCALE_K_TILE`` (4).  The contiguous
+    physical tensor has ``num_groups * m_tiles * k_tiles * 32 * 4 * 4`` bytes
+    (each element is ``float8_e8m0fnu`` = 1 byte).  With ``num_groups = 1``
+    this simplifies to ``m_tiles * k_tiles * 512``.
+    """
+    m_tiles = _align_up(rows, MXFP8_SCALE_ROW_TILE) // MXFP8_SCALE_ROW_TILE
+    sf_k = width // MXFP8_SCALE_VEC_SIZE
+    k_tiles = _align_up(sf_k, MXFP8_SCALE_K_TILE) // MXFP8_SCALE_K_TILE
+    return m_tiles * k_tiles * 32 * 4 * 4
+
+
+def _canonical_rows(rows: int) -> int:
+    """Round *rows* up to the physical 128-row scale tile boundary.
+
+    All row counts within the same tile produce identical packed all-127
+    storage, so they share one immutable cache entry.
+    """
+    return _align_up(int(rows), MXFP8_SCALE_ROW_TILE)
+
+
+@dataclass
+class _DeviceUnitScaleCache:
+    """Per-device immutable entry table with byte accounting."""
+
+    entries: dict[tuple[int, int], torch.Tensor]
+    total_bytes: int
+    lock: threading.Lock
+    prewarmed_launches: set[tuple[int, int, int, torch.dtype, int]]
+
+
+_unit_scale_caches: dict[tuple[str, int | None], _DeviceUnitScaleCache] = {}
+_unit_scale_caches_guard = threading.Lock()
+
+
+def _get_device_cache(
+    device_key: tuple[str, int | None],
+) -> _DeviceUnitScaleCache:
+    """Return (creating if needed) the per-device admission cache."""
+    with _unit_scale_caches_guard:
+        dc = _unit_scale_caches.get(device_key)
+        if dc is None:
+            dc = _DeviceUnitScaleCache(
+                entries={},
+                total_bytes=0,
+                prewarmed_launches=set(),
+                lock=threading.Lock(),
+            )
+            _unit_scale_caches[device_key] = dc
+    return dc
+
+
+def _reset_unit_scale_cache() -> None:
+    """Drop every per-device cache entry.  For tests only — never call while
+    CUDA graphs that reference cached tensors may still be replayed."""
+    with _unit_scale_caches_guard:
+        _unit_scale_caches.clear()
 
 
 @dataclass(frozen=True)
@@ -70,14 +201,186 @@ def _unit_scale_mma(rows: int, width: int, device: torch.device) -> torch.Tensor
     )
 
 
-@functools.cache
 def _cached_unit_scale_mma(
     device_type: str,
     device_index: int | None,
     rows: int,
     width: int,
 ) -> torch.Tensor:
-    return _unit_scale_mma(rows, width, torch.device(device_type, device_index))
+    """Return a unit-scale MMA tensor from a bounded per-device admission cache.
+
+    Entries are immutable and process-lifetime stable: once a geometry is
+    admitted, the same tensor object is returned for every subsequent call
+    with the same key, preserving the stable-allocation guarantee required
+    for CUDA graph replay.  No entry is ever evicted, so a graph-captured
+    pointer remains valid for the lifetime of the process.
+
+    Row counts are canonicalized to the physical 128-row scale tile, so token
+    counts 1–128 (or 129–256, etc.) that produce identical packed all-127
+    storage share one immutable allocation.
+
+    When the per-device entry count or byte budget would be exceeded, the new
+    geometry is rejected with a :class:`RuntimeError` **before** any CUDA
+    allocation is attempted.
+
+    Construction is single-flight under a per-device lock.  On cold creation
+    the concrete device is synchronized before the entry is published, so
+    cross-thread streams cannot consume incomplete data.
+    """
+    device_key = (device_type, device_index)
+    # Canonicalize rows to the physical 128-row tile boundary.
+    canon_rows = _canonical_rows(rows)
+    entry_key = (canon_rows, int(width))
+    dc = _get_device_cache(device_key)
+
+    # Single-flight construction under the per-device lock.
+    with dc.lock:
+        existing = dc.entries.get(entry_key)
+        if existing is not None:
+            return existing
+
+        if device_type == "cuda" and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "tensor-FP8 unit-scale geometry was not prewarmed before "
+                "CUDA graph capture"
+            )
+        # Admission control: reject if at capacity.
+        if len(dc.entries) >= _UNIT_SCALE_CACHE_MAX_ENTRIES:
+            raise RuntimeError(
+                f"tensor-FP8 unit-scale cache for device {device_key} is full "
+                f"({len(dc.entries)}/{_UNIT_SCALE_CACHE_MAX_ENTRIES} entries). "
+                "Increase B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_ENTRIES (hard "
+                f"max {_UNIT_SCALE_HARD_MAX_ENTRIES}) or reduce the number of "
+                "distinct token-count/width geometries before CUDA graph "
+                "capture.  Admitted entries are process-lifetime; restart the "
+                "process to reset the cache."
+            )
+
+        # Precompute exact backing bytes before allocating.
+        tensor_bytes = _unit_scale_packed_bytes(canon_rows, int(width))
+
+        # Reject a single entry that exceeds the entire byte budget.
+        if tensor_bytes > _UNIT_SCALE_CACHE_MAX_BYTES:
+            raise RuntimeError(
+                f"tensor-FP8 unit-scale tensor for rows={rows}, width={width} "
+                f"requires {tensor_bytes} bytes, exceeding the per-device byte "
+                f"budget of {_UNIT_SCALE_CACHE_MAX_BYTES} (hard max "
+                f"{_UNIT_SCALE_HARD_MAX_BYTES}). Increase "
+                "B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES or reduce "
+                "the padded K width."
+            )
+
+        if dc.total_bytes + tensor_bytes > _UNIT_SCALE_CACHE_MAX_BYTES:
+            raise RuntimeError(
+                f"admitting tensor-FP8 unit-scale tensor for rows={rows}, "
+                f"width={width} ({tensor_bytes} bytes) would exceed the "
+                f"per-device byte budget ({dc.total_bytes}/"
+                f"{_UNIT_SCALE_CACHE_MAX_BYTES} bytes already used, hard max "
+                f"{_UNIT_SCALE_HARD_MAX_BYTES}). Increase "
+                "B12X_TENSOR_FP8_UNIT_SCALE_CACHE_MAX_BYTES or reduce the "
+                "number of distinct token-count/width geometries before CUDA "
+                "graph capture.  Admitted entries are process-lifetime; "
+                "restart the process to reset the cache."
+            )
+
+        device = torch.device(device_type, device_index)
+        tensor = _unit_scale_mma(canon_rows, width, device)
+
+        # Synchronize the concrete device so the tensor data is visible to
+        # any stream before publication.
+        if device_type == "cuda":
+            torch.cuda.synchronize(device)
+
+        dc.entries[entry_key] = tensor
+        dc.total_bytes += tensor_bytes
+
+    return tensor
+
+
+def _launch_key(
+    *,
+    tokens: int,
+    padded_in_features: int,
+    out_features: int,
+    out_dtype: torch.dtype,
+    expected_m: int,
+) -> tuple[int, int, int, torch.dtype, int]:
+    return (
+        int(tokens),
+        int(padded_in_features),
+        int(out_features),
+        out_dtype,
+        int(expected_m),
+    )
+
+
+def _require_capture_launch_prewarmed(
+    device: torch.device,
+    launch_key: tuple[int, int, int, torch.dtype, int],
+) -> None:
+    if device.type != "cuda" or not torch.cuda.is_current_stream_capturing():
+        return
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    dc = _get_device_cache((device.type, device_index))
+    with dc.lock:
+        if launch_key not in dc.prewarmed_launches:
+            raise RuntimeError(
+                "tensor-FP8 launch geometry was not prewarmed before "
+                "CUDA graph capture"
+            )
+
+
+def _prewarm_unit_scales_atomic(
+    device: torch.device,
+    rows: Iterable[int],
+    width: int,
+) -> None:
+    """Admit a complete prewarm batch before any serving-shape compilation."""
+    device_index = device.index
+    if device.type == "cuda" and device_index is None:
+        device_index = torch.cuda.current_device()
+    device_key = (device.type, device_index)
+    dc = _get_device_cache(device_key)
+    entry_keys = sorted({(_canonical_rows(row), int(width)) for row in rows})
+
+    with dc.lock:
+        missing = [key for key in entry_keys if key not in dc.entries]
+        if not missing:
+            return
+        if device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "tensor-FP8 unit-scale geometries must be prewarmed before "
+                "CUDA graph capture"
+            )
+        if len(dc.entries) + len(missing) > _UNIT_SCALE_CACHE_MAX_ENTRIES:
+            raise RuntimeError(
+                f"tensor-FP8 unit-scale cache for device {device_key} is full: "
+                f"{len(dc.entries)} existing + {len(missing)} requested exceeds "
+                f"{_UNIT_SCALE_CACHE_MAX_ENTRIES}"
+            )
+        sizes = {
+            key: _unit_scale_packed_bytes(key[0], key[1]) for key in missing
+        }
+        requested_bytes = sum(sizes.values())
+        if (
+            any(size > _UNIT_SCALE_CACHE_MAX_BYTES for size in sizes.values())
+            or dc.total_bytes + requested_bytes > _UNIT_SCALE_CACHE_MAX_BYTES
+        ):
+            raise RuntimeError(
+                f"tensor-FP8 unit-scale prewarm for device {device_key} "
+                f"requires {requested_bytes} bytes with {dc.total_bytes} "
+                f"already admitted, exceeding {_UNIT_SCALE_CACHE_MAX_BYTES}"
+            )
+
+        created = {
+            key: _unit_scale_mma(key[0], key[1], device) for key in missing
+        }
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+        dc.entries.update(created)
+        dc.total_bytes += requested_bytes
 
 
 def _activation_scale_mma(
@@ -172,31 +475,35 @@ def _tensor_fp8_linear_fused_op(
     stream_int: int | None,
 ) -> torch.Tensor:
     tokens = int(source_2d.shape[0])
-    source_padded = _pad_k(source_2d, int(padded_in_features))
-    source_scale_mma = _activation_scale_mma(
-        source_padded,
-        tokens,
-        int(padded_in_features),
-    )
-    return dense_gemm(
-        (
-            source_padded.reshape(tokens, padded_in_features, 1),
-            source_scale_mma,
-        ),
-        (
-            weight_values.reshape(out_features, padded_in_features, 1),
-            weight_scale_mma,
-        ),
-        alpha=output_scale,
-        ab_dtype="float8_e4m3fn",
-        sf_dtype="float8_e8m0fnu",
-        c_dtype=_output_dtype_name(out_dtype),
-        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
-        expected_m=expected_m,
-        stream=stream_int,
-        plain_fp8=True,
-        **_dense_gemm_kwargs_for_n(out_features),
-    )[:, :, 0]
+    # Guard all CUDA work inside the source device context so compilation
+    # and stream resolution use the correct device, not the thread's current
+    # device which may differ in multi-GPU serving.
+    with torch.cuda.device(source_2d.device):
+        source_padded = _pad_k(source_2d, int(padded_in_features))
+        source_scale_mma = _activation_scale_mma(
+            source_padded,
+            tokens,
+            int(padded_in_features),
+        )
+        return dense_gemm(
+            (
+                source_padded.reshape(tokens, padded_in_features, 1),
+                source_scale_mma,
+            ),
+            (
+                weight_values.reshape(out_features, padded_in_features, 1),
+                weight_scale_mma,
+            ),
+            alpha=output_scale,
+            ab_dtype="float8_e4m3fn",
+            sf_dtype="float8_e8m0fnu",
+            c_dtype=_output_dtype_name(out_dtype),
+            sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+            expected_m=expected_m,
+            stream=stream_int,
+            plain_fp8=True,
+            **_dense_gemm_kwargs_for_n(out_features),
+        )[:, :, 0]
 
 
 @_tensor_fp8_linear_fused_op.register_fake
@@ -229,56 +536,135 @@ def tensor_fp8_linear(
     expected_m: int | None = None,
     stream: object = None,
 ) -> torch.Tensor:
-    """Run static per-tensor E4M3 operands through the SM12x dense GEMM."""
+    """Run static per-tensor E4M3 operands through the SM12x dense GEMM.
+
+    ``stream`` must be a ``torch.cuda.Stream`` on the same device as the
+    operands, or ``None`` to use the current stream for the operand device.
+    Raw integer handles are **not** accepted; the caller must pass a proper
+    ``torch.cuda.Stream`` so that device and ordering can be validated.
+
+    All materialization (source reshape, K padding, cache access, output
+    allocation, raw GEMM launch, and bias addition) executes under
+    ``torch.cuda.device(operand_device)`` plus ``torch.cuda.stream(target)``
+    so that temporary tensors are allocated on the target stream.
+
+    **Stream lifetime:** caller-owned tensors (``source``, packed weight
+    fields, and ``bias``) are recorded on the target stream via
+    ``record_stream`` so the caching allocator does not recycle their
+    memory while the raw GEMM launch is still reading them on the target
+    stream.  The caller is responsible for ensuring that producers of
+    these tensors have completed before the target stream consumes them
+    (e.g. by waiting on the producer stream's event on the target stream).
+    The returned ``output`` tensor is allocated on the target stream.  The
+    caller must ensure the target stream has completed before reading the
+    output from a different stream, either by calling
+    ``target_stream.synchronize()`` or by having the consumer stream call
+    ``consumer.wait_stream(target_stream)`` (or wait on an event recorded on
+    the target stream).  Separately, if the caller intends to read the
+    output from a different stream, ``output.record_stream(consumer_stream)``
+    protects the allocator lifetime of the output tensor.
+
+    Each distinct ``(canonical_rows, padded_K, device)`` geometry admitted by
+    this call is cached permanently for CUDA graph replay safety.  See the
+    module-level admission contract for env-var limits, defaults, and
+    restart semantics.
+    """
 
     _check_gpu_tensor("source", source)
     if not isinstance(packed_weight, TensorFP8LinearWeight):
         raise TypeError("packed_weight must be a TensorFP8LinearWeight")
-    source_2d = _source_2d(source)
-    tokens, in_features = map(int, source_2d.shape)
-    if source_2d.dtype != torch.float8_e4m3fn:
-        raise ValueError(f"source must be float8_e4m3fn, got {source_2d.dtype}")
-    if in_features != int(packed_weight.in_features):
+    if stream is not None and not isinstance(stream, torch.cuda.Stream):
+        raise TypeError(
+            "stream must be a torch.cuda.Stream or None; raw integer handles "
+            "are not accepted"
+        )
+    if stream is not None and stream.device != source.device:
         raise ValueError(
-            f"input K={in_features} does not match packed weight K="
-            f"{packed_weight.in_features}"
+            f"stream is on device {stream.device} but source is on "
+            f"{source.device}"
         )
-    if packed_weight.values.device != source_2d.device:
-        raise ValueError("source and packed weight must be on the same device")
-    if expected_m is not None and int(expected_m) <= 0:
-        raise ValueError("expected_m must be positive when provided")
-    _output_dtype_name(out_dtype)
 
-    out_features = int(packed_weight.out_features)
-    if bias is not None:
-        _check_gpu_tensor("bias", bias)
-        if bias.device != source_2d.device:
-            raise ValueError("bias must be on the same device as source")
-        if bias.dtype != out_dtype or bias.shape != (out_features,):
-            raise ValueError(
-                f"bias must have shape {(out_features,)} and dtype {out_dtype}, "
-                f"got shape={tuple(bias.shape)}, dtype={bias.dtype}"
-            )
-    if tokens == 0:
-        output = torch.empty(
-            (0, out_features),
-            dtype=out_dtype,
-            device=source_2d.device,
-        )
+    device = source.device
+    if device.type == "cuda":
+        target_stream = stream if stream is not None else torch.cuda.current_stream(device)
+        device_ctx = torch.cuda.device(device)
+        stream_ctx = torch.cuda.stream(target_stream)
     else:
-        output = torch.ops.b12x.tensor_fp8_linear_fused(
-            source_2d,
-            packed_weight.values,
-            packed_weight.scale_mma,
-            packed_weight.output_scale,
-            packed_weight.padded_in_features,
-            packed_weight.out_features,
-            int(expected_m) if expected_m is not None else tokens,
-            out_dtype,
-            cuda_stream_to_int(stream),
+        target_stream = None
+        device_ctx = nullcontext()
+        stream_ctx = nullcontext()
+
+    # Record caller-owned tensors on the target stream so the caching
+    # allocator does not recycle their memory while the raw GEMM launch
+    # (which reads them via raw pointers on target_stream) is still in
+    # flight.  Tensors allocated inside the stream context below
+    # (source_2d, padded source) are already on the target stream.  The
+    # cached unit-scale tensor is process-lifetime stable.
+    if target_stream is not None:
+        current_stream = torch.cuda.current_stream(device)
+        if target_stream != current_stream:
+            target_stream.wait_stream(current_stream)
+        source.record_stream(target_stream)
+        packed_weight.values.record_stream(target_stream)
+        packed_weight.scale_mma.record_stream(target_stream)
+        packed_weight.output_scale.record_stream(target_stream)
+        if bias is not None:
+            bias.record_stream(target_stream)
+
+    with device_ctx, stream_ctx:
+        source_2d = _source_2d(source)
+        tokens, in_features = map(int, source_2d.shape)
+        if source_2d.dtype != torch.float8_e4m3fn:
+            raise ValueError(f"source must be float8_e4m3fn, got {source_2d.dtype}")
+        if in_features != int(packed_weight.in_features):
+            raise ValueError(
+                f"input K={in_features} does not match packed weight K="
+                f"{packed_weight.in_features}"
+            )
+        if packed_weight.values.device != source_2d.device:
+            raise ValueError("source and packed weight must be on the same device")
+        if expected_m is not None and int(expected_m) <= 0:
+            raise ValueError("expected_m must be positive when provided")
+        _output_dtype_name(out_dtype)
+        launch_key = _launch_key(
+            tokens=tokens,
+            padded_in_features=packed_weight.padded_in_features,
+            out_features=packed_weight.out_features,
+            out_dtype=out_dtype,
+            expected_m=int(expected_m) if expected_m is not None else tokens,
         )
-    if bias is not None:
-        output = output + bias
+        _require_capture_launch_prewarmed(device, launch_key)
+
+        out_features = int(packed_weight.out_features)
+        if bias is not None:
+            _check_gpu_tensor("bias", bias)
+            if bias.device != source_2d.device:
+                raise ValueError("bias must be on the same device as source")
+            if bias.dtype != out_dtype or bias.shape != (out_features,):
+                raise ValueError(
+                    f"bias must have shape {(out_features,)} and dtype {out_dtype}, "
+                    f"got shape={tuple(bias.shape)}, dtype={bias.dtype}"
+                )
+        if tokens == 0:
+            output = torch.empty(
+                (0, out_features),
+                dtype=out_dtype,
+                device=source_2d.device,
+            )
+        else:
+            output = torch.ops.b12x.tensor_fp8_linear_fused(
+                source_2d,
+                packed_weight.values,
+                packed_weight.scale_mma,
+                packed_weight.output_scale,
+                packed_weight.padded_in_features,
+                packed_weight.out_features,
+                int(expected_m) if expected_m is not None else tokens,
+                out_dtype,
+                int(target_stream.cuda_stream) if target_stream is not None else None,
+            )
+        if bias is not None:
+            output = output + bias
     return output.view(*source.shape[:-1], out_features)
 
 
@@ -289,15 +675,55 @@ def prewarm_tensor_fp8_linear(
     out_dtype: torch.dtype = torch.bfloat16,
     stream: object = None,
 ) -> int:
-    """Compile and cache serving shapes before CUDA graph capture."""
+    """Compile and cache serving shapes before CUDA graph capture.
 
-    warmed = 0
-    with torch.inference_mode():
-        for tokens in sorted({int(value) for value in token_counts if int(value) > 0}):
+    The full normalized geometry set is checked against the permanent
+    per-device admission limits before any scale allocation or GEMM
+    compilation. Invalid stream arguments are rejected before dummy tensors
+    are allocated.
+    """
+    if not isinstance(packed_weight, TensorFP8LinearWeight):
+        raise TypeError("packed_weight must be a TensorFP8LinearWeight")
+    device = packed_weight.values.device
+    if stream is not None and not isinstance(stream, torch.cuda.Stream):
+        raise TypeError(
+            "stream must be a torch.cuda.Stream or None; raw integer handles "
+            "are not accepted"
+        )
+    if stream is not None and stream.device != device:
+        raise ValueError(
+            f"stream is on device {stream.device} but packed weight is on {device}"
+        )
+
+    normalized_tokens = sorted(
+        {int(value) for value in token_counts if int(value) > 0}
+    )
+    if not normalized_tokens:
+        return 0
+    if stream is not None:
+        target_stream = stream
+    elif device.type == "cuda":
+        target_stream = torch.cuda.current_stream(device)
+    else:
+        target_stream = None
+
+    device_ctx = torch.cuda.device(device) if device.type == "cuda" else nullcontext()
+    stream_ctx = (
+        torch.cuda.stream(target_stream)
+        if target_stream is not None
+        else nullcontext()
+    )
+    with torch.inference_mode(), device_ctx, stream_ctx:
+        _prewarm_unit_scales_atomic(
+            device,
+            normalized_tokens,
+            int(packed_weight.padded_in_features),
+        )
+        for tokens in normalized_tokens:
             source = torch.zeros(
                 (tokens, packed_weight.in_features),
                 dtype=torch.float8_e4m3fn,
-                device=packed_weight.values.device,
+                device=device,
             )
             tensor_fp8_linear(
                 source,
@@ -306,8 +732,20 @@ def prewarm_tensor_fp8_linear(
                 expected_m=tokens,
                 stream=stream,
             )
-            warmed += 1
-    return warmed
+            device_index = device.index
+            if device.type == "cuda" and device_index is None:
+                device_index = torch.cuda.current_device()
+            dc = _get_device_cache((device.type, device_index))
+            launch_key = _launch_key(
+                tokens=tokens,
+                padded_in_features=packed_weight.padded_in_features,
+                out_features=packed_weight.out_features,
+                out_dtype=out_dtype,
+                expected_m=tokens,
+            )
+            with dc.lock:
+                dc.prewarmed_launches.add(launch_key)
+    return len(normalized_tokens)
 
 
 __all__ = [

--- a/tests/gemm/test_tensor_fp8_linear.py
+++ b/tests/gemm/test_tensor_fp8_linear.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import weakref
 from dataclasses import replace
 
 import cutlass.cute as cute
@@ -7,7 +9,15 @@ import pytest
 import torch
 
 from b12x.gemm import tensor_fp8_linear
+from b12x.gemm.tensor_fp8_linear import _kernel as _tfp8_kernel
 from b12x.gemm.tensor_fp8_linear import api as tensor_fp8_api
+from b12x.gemm.tensor_fp8_linear._kernel import (
+    _parse_cache_limit,
+    _reset_unit_scale_cache,
+    _unit_scale_packed_bytes,
+    _UNIT_SCALE_HARD_MAX_BYTES,
+    _UNIT_SCALE_HARD_MAX_ENTRIES,
+)
 
 from ..conftest import require_b12x
 
@@ -125,3 +135,573 @@ def test_mm_default_path_captures() -> None:
     torch.cuda.synchronize()
 
     torch.testing.assert_close(actual, eager, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# Issue #166: graph-safe bounded admission cache for unit-scale MMA tensors
+# ---------------------------------------------------------------------------
+
+
+
+@pytest.fixture()
+def _clean_cache():
+    """Reset the admission cache before and after each cache test."""
+    _reset_unit_scale_cache()
+    yield
+    _reset_unit_scale_cache()
+
+
+# --- precompute / canonicalization tests (no GPU required for math) ---
+
+
+def test_unit_scale_packed_bytes_small() -> None:
+    """rows=7, width=128 -> 1 tile * 1 tile * 512 = 512 bytes."""
+    assert _unit_scale_packed_bytes(7, 128) == 512
+
+
+def test_unit_scale_packed_bytes_canonical() -> None:
+    """rows=128 and rows=1 produce the same packed bytes (same tile)."""
+    assert _unit_scale_packed_bytes(1, 128) == _unit_scale_packed_bytes(128, 128)
+    assert _unit_scale_packed_bytes(129, 128) == 2 * _unit_scale_packed_bytes(1, 128)
+
+
+def test_unit_scale_packed_bytes_large_width() -> None:
+    """width=512 -> sf_k=16, k_tiles=4, m_tiles=1 -> 1*4*512 = 2048."""
+    assert _unit_scale_packed_bytes(128, 512) == 2048
+
+
+# --- stable allocation / graph safety tests ---
+
+
+def test_admission_cache_stable_allocation_same_key(_clean_cache) -> None:
+    """Same key returns the identical tensor object (graph replay safety)."""
+    require_b12x()
+    require_mxf8_mma()
+    a = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
+    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
+    assert a is b
+
+
+def test_admission_cache_canonical_rows_share_entry(_clean_cache) -> None:
+    """Token counts 1-128 share one cache entry (128-row tile)."""
+    require_b12x()
+    require_mxf8_mma()
+    a = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1, 128)
+    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 50, 128)
+    c = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
+    assert a is b
+    assert b is c
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    assert len(dc.entries) == 1
+
+
+def test_admission_cache_rejects_before_allocation(_clean_cache) -> None:
+    """Oversize geometry is rejected before _unit_scale_mma is called."""
+    require_b12x()
+    require_mxf8_mma()
+    original_bytes = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES
+    original_fn = _tfp8_kernel._unit_scale_mma
+    called = threading.Event()
+    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = 1
+    try:
+        def _spy(*args, **kwargs):
+            called.set()
+            return original_fn(*args, **kwargs)
+
+        _tfp8_kernel._unit_scale_mma = _spy
+        with pytest.raises(RuntimeError, match="exceeding.*byte.*budget"):
+            _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 4096)
+        assert not called.is_set(), "_unit_scale_mma must not be called for oversize"
+    finally:
+        _tfp8_kernel._unit_scale_mma = original_fn
+        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = original_bytes
+
+
+def test_admission_cache_rejects_aggregate_before_allocation(_clean_cache) -> None:
+    """Aggregate-over-budget is rejected before allocating the new entry.
+
+    The candidate must individually fit the budget but its sum with the
+    already-used bytes must exceed it, so the 'would exceed' branch is taken
+    rather than the single-entry 'exceeding' branch."""
+    require_b12x()
+    require_mxf8_mma()
+    # Admit one entry: (128, 256) = 1024 bytes.
+    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 256)
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    used = dc.total_bytes  # 1024
+
+    # Candidate (128, 128) = 512 bytes, individually fits.
+    candidate_bytes = _unit_scale_packed_bytes(128, 128)  # 512
+    # Set budget so used + candidate exceeds but candidate alone fits.
+    original_bytes = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES
+    original_fn = _tfp8_kernel._unit_scale_mma
+    called = threading.Event()
+    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = used + candidate_bytes - 1  # 1535
+    try:
+        def _spy(*args, **kwargs):
+            called.set()
+            return original_fn(*args, **kwargs)
+
+        _tfp8_kernel._unit_scale_mma = _spy
+        with pytest.raises(RuntimeError, match="would exceed"):
+            _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
+        assert not called.is_set()
+    finally:
+        _tfp8_kernel._unit_scale_mma = original_fn
+        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = original_bytes
+
+
+def test_admission_cache_rejects_at_entry_capacity(_clean_cache) -> None:
+    """New geometries are rejected once the entry-count ceiling is reached."""
+    require_b12x()
+    require_mxf8_mma()
+    max_entries = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
+    for i in range(max_entries):
+        _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1 + i * 128, 128)
+    with pytest.raises(RuntimeError, match="cache.*full"):
+        _tfp8_kernel._cached_unit_scale_mma(
+            "cuda", 0, 1 + max_entries * 128, 128
+        )
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    assert len(dc.entries) == max_entries
+
+
+# --- graph capture + pressure + churn + replay test ---
+
+
+def test_admission_cache_graph_capture_pressure_replay(_clean_cache) -> None:
+    """Capture a geometry with a low cap, fill to capacity, reject +1, churn
+    allocator, then replay and verify pointer ownership and exact output.
+
+    Only an integer pointer and weak reference are retained — no strong
+    tensor or cache-object owner is held by the test after capture, so an
+    eviction or cache replacement would drop the weak referent and cause
+    replay to fail."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260814)
+
+    # Set a small entry cap so we can fill to capacity quickly.
+    original_max = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
+    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = 4
+    try:
+        source, _, _, packed = _make_inputs(4, 128, 64)
+        eager = tensor_fp8_linear.mm(source, packed).clone()
+        torch.cuda.synchronize()
+
+        # The mm call admitted the (128, padded_in_features) geometry.
+        # Read the cache transiently to get ptr + weakref, then drop locals.
+        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+        cached_key = (128, packed.padded_in_features)
+        assert cached_key in dc.entries
+        cached_tensor = dc.entries[cached_key]
+        cached_ptr = cached_tensor.data_ptr()
+        cached_weak = weakref.ref(cached_tensor)
+        # Drop strong references to the tensor and cache object.
+        del cached_tensor, dc
+
+        # Capture a CUDA graph using that geometry.
+        tensor_fp8_linear.prewarm(packed, [4])
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = tensor_fp8_linear.mm(source, packed)
+
+        # Fill the cache to capacity (3 more entries besides the captured one).
+        for i in range(3):
+            _tfp8_kernel._cached_unit_scale_mma(
+                "cuda", 0, 128 + (i + 1) * 128, packed.padded_in_features
+            )
+        # Re-fetch cache transiently for count check.
+        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+        assert len(dc.entries) == 4
+        del dc
+
+        # The +1 must be rejected, not silently evict the graph-owned entry.
+        with pytest.raises(RuntimeError, match="cache.*full"):
+            _tfp8_kernel._cached_unit_scale_mma(
+                "cuda", 0, 128 + 5 * 128, packed.padded_in_features
+            )
+
+        # Churn the CUDA allocator with large allocations.
+        for _ in range(32):
+            torch.empty(1024 * 1024, dtype=torch.float32, device="cuda")
+
+        # The graph-owned entry must still be present at the same address
+        # and the weak reference must still be alive.
+        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+        assert cached_key in dc.entries
+        assert dc.entries[cached_key].data_ptr() == cached_ptr
+        assert cached_weak() is not None
+        del dc
+
+        # Replay must produce the exact same output.
+        for _ in range(3):
+            graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(actual, eager, rtol=0, atol=0)
+    finally:
+        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = original_max
+
+
+def test_capture_rejects_cold_launch_sharing_prewarmed_scale_key(
+    monkeypatch,
+    _clean_cache,
+) -> None:
+    """A canonical scale hit must not admit a distinct GEMM specialization."""
+    require_b12x()
+    require_mxf8_mma()
+    _, _, _, packed = _make_inputs(1, 128, 2048)
+    tensor_fp8_linear.prewarm(packed, [1])
+    source_64, _, _, _ = _make_inputs(64, 128, 2048)
+
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    assert (128, packed.padded_in_features) in dc.entries
+    assert len(dc.entries) == 1
+    monkeypatch.setattr(
+        torch.cuda,
+        "is_current_stream_capturing",
+        lambda: True,
+    )
+    with pytest.raises(RuntimeError, match="launch geometry.*not prewarmed"):
+        tensor_fp8_linear.mm(source_64, packed, expected_m=64)
+
+
+# --- byte accounting tests ---
+
+
+def test_admission_cache_bytes_match_unique_storage(_clean_cache) -> None:
+    """Byte accounting equals sum of unique untyped_storage bytes, deduped by
+    data_ptr."""
+    require_b12x()
+    require_mxf8_mma()
+    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
+    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 200, 256)
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+
+    # Compute unique bytes by data_ptr to catch aliasing/double-accounting.
+    seen_ptrs: set[int] = set()
+    unique_bytes = 0
+    for t in dc.entries.values():
+        ptr = t.data_ptr()
+        if ptr not in seen_ptrs:
+            seen_ptrs.add(ptr)
+            unique_bytes += int(t.untyped_storage().nbytes())
+    assert dc.total_bytes == unique_bytes
+
+
+def test_admission_cache_bytes_match_cuda_allocated_delta(_clean_cache) -> None:
+    """Retained cache bytes correspond to a controlled CUDA memory delta."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.cuda.empty_cache()
+    before = torch.cuda.memory_allocated("cuda")
+    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
+    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 256, 128)
+    torch.cuda.synchronize()
+    after = torch.cuda.memory_allocated("cuda")
+    delta = after - before
+    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    # The CUDA allocated delta should be at least the retained cache bytes
+    # (may be more due to allocator rounding, but not less).
+    assert delta >= dc.total_bytes
+
+
+# --- per-device independence test ---
+
+
+def test_admission_cache_per_device_independence(_clean_cache) -> None:
+    """Pressure on device 0 does not affect device 1."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires 2+ CUDA devices")
+    max_entries = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
+    for i in range(max_entries):
+        _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1 + i * 128, 128)
+    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 1, 7, 128)
+    assert b.device == torch.device("cuda", 1)
+    dc0 = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+    dc1 = _tfp8_kernel._unit_scale_caches[("cuda", 1)]
+    assert len(dc0.entries) == max_entries
+    assert len(dc1.entries) == 1
+    assert dc0 is not dc1
+
+
+# --- concurrency tests ---
+
+
+def test_admission_cache_concurrent_same_key_single_construction(
+    monkeypatch,
+    _clean_cache,
+) -> None:
+    """Concurrent requests for the same key call _unit_scale_mma exactly once."""
+    require_b12x()
+    require_mxf8_mma()
+    original_fn = _tfp8_kernel._unit_scale_mma
+    call_count = 0
+    count_lock = threading.Lock()
+    barrier = threading.Barrier(8)
+
+    def _counting_fn(*args, **kwargs):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+        return original_fn(*args, **kwargs)
+
+    monkeypatch.setattr(_tfp8_kernel, "_unit_scale_mma", _counting_fn)
+    results: list[object] = []
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            barrier.wait()
+            t = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 99, 128)
+            results.append(t)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert not errors
+    assert len(results) == 8
+    first = results[0]
+    for r in results:
+        assert r is first
+    assert call_count == 1
+
+
+def test_admission_cache_concurrent_distinct_streams(_clean_cache) -> None:
+    """The published tensor is safe to consume on distinct streams."""
+    require_b12x()
+    require_mxf8_mma()
+    t = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 64, 128)
+    s1 = torch.cuda.Stream(device="cuda")
+    s2 = torch.cuda.Stream(device="cuda")
+    with torch.cuda.stream(s1):
+        v1 = t.view(torch.uint8).sum().item()
+    with torch.cuda.stream(s2):
+        v2 = t.view(torch.uint8).sum().item()
+    torch.cuda.synchronize()
+    # All values are 127 (UE8M0 1.0).
+    expected = 127 * t.numel()
+    assert v1 == expected
+    assert v2 == expected
+
+
+# --- stream safety tests ---
+
+
+def test_mm_explicit_noncurrent_stream_early_drop_churn(_clean_cache) -> None:
+    """mm on an explicit non-current stream with padded K and bias: drop
+    caller-owned inputs immediately after the async call, churn the
+    allocator, then sync the target and verify exact output.
+
+    This catches record_stream omissions: without recording, the caching
+    allocator can recycle source/weight/bias storage while the GEMM on the
+    target stream is still reading it."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260818)
+
+    source, weight, output_scale, packed = _make_inputs(5, 160, 40)
+    bias = torch.randn(40, device="cuda", dtype=torch.bfloat16) * 0.01
+
+    # Compute reference on the default stream before any side-stream launch.
+    expected = (source.float() @ weight.float().T) * output_scale + bias
+    torch.cuda.synchronize()
+
+    # Prewarm to populate the cache (warm-cache path).
+    tensor_fp8_linear.prewarm(packed, [5])
+    torch.cuda.synchronize()
+
+    target_stream = torch.cuda.Stream(device="cuda")
+    # Call mm while target_stream is NOT the current stream — the default
+    # stream remains current so any materialization that is not properly
+    # stream-guarded would land on the wrong stream.
+    actual = tensor_fp8_linear.mm(
+        source, packed, bias=bias, stream=target_stream
+    )
+
+    # Immediately drop all caller-owned inputs to force record_stream to
+    # protect their storage from allocator recycling.
+    del source, weight, output_scale, packed, bias
+
+    # Churn the allocator with many allocations to increase the chance of
+    # recycling freed storage while the target stream is still in flight.
+    for _ in range(64):
+        torch.empty(256 * 1024, dtype=torch.float32, device="cuda")
+
+    # Only now synchronize the target stream and verify output.
+    target_stream.synchronize()
+    torch.testing.assert_close(
+        actual.float(),
+        expected.to(actual.dtype).float(),
+        rtol=1e-2,
+        atol=2e-3,
+    )
+
+
+def test_mm_rejects_raw_int_stream(_clean_cache) -> None:
+    """Raw integer stream handles are rejected."""
+    require_b12x()
+    require_mxf8_mma()
+    source, _, _, packed = _make_inputs(4, 128, 64)
+    with pytest.raises(TypeError, match="stream must be a torch.cuda.Stream"):
+        tensor_fp8_linear.mm(source, packed, stream=42)
+
+
+# --- end-to-end multi-device mm test ---
+
+
+def test_mm_multi_device_current_device_mismatch(_clean_cache) -> None:
+    """mm works correctly when the thread's current device differs from the
+    operand device."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires 2+ CUDA devices")
+    require_mxf8_mma()
+    torch.manual_seed(20260816)
+
+    # Create operands on device 1 but set current device to 0.
+    with torch.cuda.device(1):
+        source = (
+            torch.randn((7, 128), device="cuda", dtype=torch.bfloat16)
+            .clamp(-4, 4)
+            .to(torch.float8_e4m3fn)
+        )
+        weight = (
+            torch.randn((64, 128), device="cuda", dtype=torch.bfloat16)
+            .clamp(-4, 4)
+            .to(torch.float8_e4m3fn)
+        )
+        output_scale = torch.tensor([0.0002], dtype=torch.float32, device="cuda")
+        packed = tensor_fp8_linear.pack_weight(weight, output_scale)
+
+    with torch.cuda.device(0):
+        # Current device is 0, but operands are on device 1.
+        actual = tensor_fp8_linear.mm(source, packed)
+        torch.cuda.synchronize()
+
+    expected = (source.float() @ weight.float().T) * output_scale
+    torch.cuda.synchronize()
+    assert actual.device == torch.device("cuda", 1)
+    torch.testing.assert_close(
+        actual.float(),
+        expected.to(actual.dtype).float(),
+        rtol=1e-2,
+        atol=2e-3,
+    )
+
+
+def test_mm_wrong_device_stream_rejected(_clean_cache) -> None:
+    """An explicit stream on the wrong device is rejected."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires 2+ CUDA devices")
+    require_mxf8_mma()
+    torch.manual_seed(20260817)
+
+    with torch.cuda.device(0):
+        source = (
+            torch.randn((4, 128), device="cuda", dtype=torch.bfloat16)
+            .clamp(-4, 4)
+            .to(torch.float8_e4m3fn)
+        )
+        weight = (
+            torch.randn((64, 128), device="cuda", dtype=torch.bfloat16)
+            .clamp(-4, 4)
+            .to(torch.float8_e4m3fn)
+        )
+        output_scale = torch.tensor([0.0002], dtype=torch.float32, device="cuda")
+        packed = tensor_fp8_linear.pack_weight(weight, output_scale)
+
+    wrong_stream = torch.cuda.Stream(device=1)
+    with pytest.raises(ValueError, match="stream is on device.*but source"):
+        tensor_fp8_linear.mm(source, packed, stream=wrong_stream)
+
+
+# --- numerical correctness after cache operations ---
+
+
+def test_admission_cache_numerical_unchanged_after_pressure(_clean_cache) -> None:
+    """mm output is numerically correct after cache operations."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260815)
+
+    source, weight, output_scale, packed = _make_inputs(7, 128, 64)
+    expected = (source.float() @ weight.float().T) * output_scale
+
+    actual = tensor_fp8_linear.mm(source, packed)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        actual.float(),
+        expected.to(actual.dtype).float(),
+        rtol=1e-2,
+        atol=2e-3,
+    )
+
+    actual2 = tensor_fp8_linear.mm(source, packed)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        actual2.float(),
+        expected.to(actual2.dtype).float(),
+        rtol=1e-2,
+        atol=2e-3,
+    )
+
+
+# --- prewarm non-atomic prefix test ---
+
+
+def test_prewarm_rejects_batch_before_partial_admission(_clean_cache) -> None:
+    """An over-capacity prewarm leaves the permanent cache unchanged."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260819)
+
+    _, _, _, packed = _make_inputs(4, 128, 64)
+    original_max = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
+    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = 2
+    try:
+        with pytest.raises(RuntimeError, match=r"cache.*full"):
+            tensor_fp8_linear.prewarm(packed, [4, 132, 260, 388])
+
+        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
+        assert dc.entries == {}
+        assert dc.total_bytes == 0
+    finally:
+        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = original_max
+
+
+# --- config parsing tests (no GPU required) ---
+
+
+def test_parse_cache_limit_defaults() -> None:
+    assert _parse_cache_limit(None, 32, 256) == 32
+
+
+def test_parse_cache_limit_valid() -> None:
+    assert _parse_cache_limit("64", 32, 256) == 64
+
+
+def test_parse_cache_limit_clamps_to_hard_max() -> None:
+    assert _parse_cache_limit("99999", 32, 256) == 256
+
+
+def test_parse_cache_limit_zero_falls_back() -> None:
+    assert _parse_cache_limit("0", 32, 256) == 32
+
+
+def test_parse_cache_limit_negative_falls_back() -> None:
+    assert _parse_cache_limit("-5", 32, 256) == 32
+
+
+def test_parse_cache_limit_non_integer_falls_back() -> None:
+    assert _parse_cache_limit("abc", 32, 256) == 32
+
+
+def test_hard_maxima_are_positive() -> None:
+    assert _UNIT_SCALE_HARD_MAX_ENTRIES > 0
+    assert _UNIT_SCALE_HARD_MAX_BYTES > 0

--- a/tests/gemm/test_tensor_fp8_linear.py
+++ b/tests/gemm/test_tensor_fp8_linear.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-import weakref
 from dataclasses import replace
 
 import cutlass.cute as cute
@@ -11,13 +10,6 @@ import torch
 from b12x.gemm import tensor_fp8_linear
 from b12x.gemm.tensor_fp8_linear import _kernel as _tfp8_kernel
 from b12x.gemm.tensor_fp8_linear import api as tensor_fp8_api
-from b12x.gemm.tensor_fp8_linear._kernel import (
-    _parse_cache_limit,
-    _reset_unit_scale_cache,
-    _unit_scale_packed_bytes,
-    _UNIT_SCALE_HARD_MAX_BYTES,
-    _UNIT_SCALE_HARD_MAX_ENTRIES,
-)
 
 from ..conftest import require_b12x
 
@@ -137,571 +129,148 @@ def test_mm_default_path_captures() -> None:
     torch.testing.assert_close(actual, eager, rtol=0, atol=0)
 
 
-# ---------------------------------------------------------------------------
-# Issue #166: graph-safe bounded admission cache for unit-scale MMA tensors
-# ---------------------------------------------------------------------------
-
-
-
 @pytest.fixture()
-def _clean_cache():
-    """Reset the admission cache before and after each cache test."""
-    _reset_unit_scale_cache()
+def clean_unit_scale_cache():
+    _tfp8_kernel._reset_unit_scale_cache()
     yield
-    _reset_unit_scale_cache()
+    _tfp8_kernel._reset_unit_scale_cache()
 
 
-# --- precompute / canonicalization tests (no GPU required for math) ---
+def _install_fake_unit_scale_builder(monkeypatch):
+    built: list[tuple[int, int, torch.device]] = []
+
+    def build(rows: int, width: int, device: torch.device):
+        built.append((rows, width, device))
+        return object()
+
+    monkeypatch.setattr(_tfp8_kernel, "_unit_scale_mma", build)
+    return built
 
 
-def test_unit_scale_packed_bytes_small() -> None:
-    """rows=7, width=128 -> 1 tile * 1 tile * 512 = 512 bytes."""
-    assert _unit_scale_packed_bytes(7, 128) == 512
+def test_unit_scale_storage_size_uses_physical_tiles() -> None:
+    size = _tfp8_kernel._unit_scale_packed_bytes
+    assert size(1, 128) == 512
+    assert size(128, 128) == 512
+    assert size(129, 128) == 1024
+    assert size(128, 512) == 2048
 
 
-def test_unit_scale_packed_bytes_canonical() -> None:
-    """rows=128 and rows=1 produce the same packed bytes (same tile)."""
-    assert _unit_scale_packed_bytes(1, 128) == _unit_scale_packed_bytes(128, 128)
-    assert _unit_scale_packed_bytes(129, 128) == 2 * _unit_scale_packed_bytes(1, 128)
+def test_unit_scale_cache_canonicalizes_rows_and_has_lock_free_hits(
+    monkeypatch,
+    clean_unit_scale_cache,
+) -> None:
+    built = _install_fake_unit_scale_builder(monkeypatch)
+    first = _tfp8_kernel._cached_unit_scale_mma("cpu", None, 1, 128)
 
+    class FailLock:
+        def __enter__(self):
+            raise AssertionError("cache hit acquired the cold-path lock")
 
-def test_unit_scale_packed_bytes_large_width() -> None:
-    """width=512 -> sf_k=16, k_tiles=4, m_tiles=1 -> 1*4*512 = 2048."""
-    assert _unit_scale_packed_bytes(128, 512) == 2048
+        def __exit__(self, *args):
+            return False
 
-
-# --- stable allocation / graph safety tests ---
-
-
-def test_admission_cache_stable_allocation_same_key(_clean_cache) -> None:
-    """Same key returns the identical tensor object (graph replay safety)."""
-    require_b12x()
-    require_mxf8_mma()
-    a = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
-    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
-    assert a is b
-
-
-def test_admission_cache_canonical_rows_share_entry(_clean_cache) -> None:
-    """Token counts 1-128 share one cache entry (128-row tile)."""
-    require_b12x()
-    require_mxf8_mma()
-    a = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1, 128)
-    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 50, 128)
-    c = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
-    assert a is b
-    assert b is c
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    assert len(dc.entries) == 1
-
-
-def test_admission_cache_rejects_before_allocation(_clean_cache) -> None:
-    """Oversize geometry is rejected before _unit_scale_mma is called."""
-    require_b12x()
-    require_mxf8_mma()
-    original_bytes = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES
-    original_fn = _tfp8_kernel._unit_scale_mma
-    called = threading.Event()
-    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = 1
+    original_lock = _tfp8_kernel._unit_scale_cache_lock
+    _tfp8_kernel._unit_scale_cache_lock = FailLock()
     try:
-        def _spy(*args, **kwargs):
-            called.set()
-            return original_fn(*args, **kwargs)
-
-        _tfp8_kernel._unit_scale_mma = _spy
-        with pytest.raises(RuntimeError, match="exceeding.*byte.*budget"):
-            _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 4096)
-        assert not called.is_set(), "_unit_scale_mma must not be called for oversize"
+        assert _tfp8_kernel._cached_unit_scale_mma("cpu", None, 127, 128) is first
     finally:
-        _tfp8_kernel._unit_scale_mma = original_fn
-        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = original_bytes
+        _tfp8_kernel._unit_scale_cache_lock = original_lock
+
+    assert built == [(128, 128, torch.device("cpu"))]
 
 
-def test_admission_cache_rejects_aggregate_before_allocation(_clean_cache) -> None:
-    """Aggregate-over-budget is rejected before allocating the new entry.
+def test_unit_scale_cache_rejects_entry_pressure_before_allocation(
+    monkeypatch,
+    clean_unit_scale_cache,
+) -> None:
+    built = _install_fake_unit_scale_builder(monkeypatch)
+    monkeypatch.setattr(_tfp8_kernel, "_UNIT_SCALE_CACHE_MAX_ENTRIES", 2)
 
-    The candidate must individually fit the budget but its sum with the
-    already-used bytes must exceed it, so the 'would exceed' branch is taken
-    rather than the single-entry 'exceeding' branch."""
-    require_b12x()
-    require_mxf8_mma()
-    # Admit one entry: (128, 256) = 1024 bytes.
-    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 256)
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    used = dc.total_bytes  # 1024
-
-    # Candidate (128, 128) = 512 bytes, individually fits.
-    candidate_bytes = _unit_scale_packed_bytes(128, 128)  # 512
-    # Set budget so used + candidate exceeds but candidate alone fits.
-    original_bytes = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES
-    original_fn = _tfp8_kernel._unit_scale_mma
-    called = threading.Event()
-    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = used + candidate_bytes - 1  # 1535
-    try:
-        def _spy(*args, **kwargs):
-            called.set()
-            return original_fn(*args, **kwargs)
-
-        _tfp8_kernel._unit_scale_mma = _spy
-        with pytest.raises(RuntimeError, match="would exceed"):
-            _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
-        assert not called.is_set()
-    finally:
-        _tfp8_kernel._unit_scale_mma = original_fn
-        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_BYTES = original_bytes
-
-
-def test_admission_cache_rejects_at_entry_capacity(_clean_cache) -> None:
-    """New geometries are rejected once the entry-count ceiling is reached."""
-    require_b12x()
-    require_mxf8_mma()
-    max_entries = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
-    for i in range(max_entries):
-        _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1 + i * 128, 128)
+    _tfp8_kernel._cached_unit_scale_mma("cpu", None, 1, 128)
+    _tfp8_kernel._cached_unit_scale_mma("cpu", None, 129, 128)
     with pytest.raises(RuntimeError, match="cache.*full"):
-        _tfp8_kernel._cached_unit_scale_mma(
-            "cuda", 0, 1 + max_entries * 128, 128
-        )
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    assert len(dc.entries) == max_entries
+        _tfp8_kernel._cached_unit_scale_mma("cpu", None, 257, 128)
+
+    assert len(built) == 2
 
 
-# --- graph capture + pressure + churn + replay test ---
-
-
-def test_admission_cache_graph_capture_pressure_replay(_clean_cache) -> None:
-    """Capture a geometry with a low cap, fill to capacity, reject +1, churn
-    allocator, then replay and verify pointer ownership and exact output.
-
-    Only an integer pointer and weak reference are retained — no strong
-    tensor or cache-object owner is held by the test after capture, so an
-    eviction or cache replacement would drop the weak referent and cause
-    replay to fail."""
-    require_b12x()
-    require_mxf8_mma()
-    torch.manual_seed(20260814)
-
-    # Set a small entry cap so we can fill to capacity quickly.
-    original_max = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
-    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = 4
-    try:
-        source, _, _, packed = _make_inputs(4, 128, 64)
-        eager = tensor_fp8_linear.mm(source, packed).clone()
-        torch.cuda.synchronize()
-
-        # The mm call admitted the (128, padded_in_features) geometry.
-        # Read the cache transiently to get ptr + weakref, then drop locals.
-        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-        cached_key = (128, packed.padded_in_features)
-        assert cached_key in dc.entries
-        cached_tensor = dc.entries[cached_key]
-        cached_ptr = cached_tensor.data_ptr()
-        cached_weak = weakref.ref(cached_tensor)
-        # Drop strong references to the tensor and cache object.
-        del cached_tensor, dc
-
-        # Capture a CUDA graph using that geometry.
-        tensor_fp8_linear.prewarm(packed, [4])
-        torch.cuda.synchronize()
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            actual = tensor_fp8_linear.mm(source, packed)
-
-        # Fill the cache to capacity (3 more entries besides the captured one).
-        for i in range(3):
-            _tfp8_kernel._cached_unit_scale_mma(
-                "cuda", 0, 128 + (i + 1) * 128, packed.padded_in_features
-            )
-        # Re-fetch cache transiently for count check.
-        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-        assert len(dc.entries) == 4
-        del dc
-
-        # The +1 must be rejected, not silently evict the graph-owned entry.
-        with pytest.raises(RuntimeError, match="cache.*full"):
-            _tfp8_kernel._cached_unit_scale_mma(
-                "cuda", 0, 128 + 5 * 128, packed.padded_in_features
-            )
-
-        # Churn the CUDA allocator with large allocations.
-        for _ in range(32):
-            torch.empty(1024 * 1024, dtype=torch.float32, device="cuda")
-
-        # The graph-owned entry must still be present at the same address
-        # and the weak reference must still be alive.
-        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-        assert cached_key in dc.entries
-        assert dc.entries[cached_key].data_ptr() == cached_ptr
-        assert cached_weak() is not None
-        del dc
-
-        # Replay must produce the exact same output.
-        for _ in range(3):
-            graph.replay()
-        torch.cuda.synchronize()
-        torch.testing.assert_close(actual, eager, rtol=0, atol=0)
-    finally:
-        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = original_max
-
-
-def test_capture_rejects_cold_launch_sharing_prewarmed_scale_key(
+def test_unit_scale_cache_rejects_byte_pressure_before_allocation(
     monkeypatch,
-    _clean_cache,
+    clean_unit_scale_cache,
 ) -> None:
-    """A canonical scale hit must not admit a distinct GEMM specialization."""
-    require_b12x()
-    require_mxf8_mma()
-    _, _, _, packed = _make_inputs(1, 128, 2048)
-    tensor_fp8_linear.prewarm(packed, [1])
-    source_64, _, _, _ = _make_inputs(64, 128, 2048)
+    built = _install_fake_unit_scale_builder(monkeypatch)
+    monkeypatch.setattr(_tfp8_kernel, "_UNIT_SCALE_CACHE_MAX_BYTES", 511)
 
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    assert (128, packed.padded_in_features) in dc.entries
-    assert len(dc.entries) == 1
-    monkeypatch.setattr(
-        torch.cuda,
-        "is_current_stream_capturing",
-        lambda: True,
-    )
-    with pytest.raises(RuntimeError, match="launch geometry.*not prewarmed"):
-        tensor_fp8_linear.mm(source_64, packed, expected_m=64)
+    with pytest.raises(RuntimeError, match="would exceed.*byte budget"):
+        _tfp8_kernel._cached_unit_scale_mma("cpu", None, 1, 128)
+
+    assert built == []
 
 
-# --- byte accounting tests ---
-
-
-def test_admission_cache_bytes_match_unique_storage(_clean_cache) -> None:
-    """Byte accounting equals sum of unique untyped_storage bytes, deduped by
-    data_ptr."""
-    require_b12x()
-    require_mxf8_mma()
-    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 7, 128)
-    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 200, 256)
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-
-    # Compute unique bytes by data_ptr to catch aliasing/double-accounting.
-    seen_ptrs: set[int] = set()
-    unique_bytes = 0
-    for t in dc.entries.values():
-        ptr = t.data_ptr()
-        if ptr not in seen_ptrs:
-            seen_ptrs.add(ptr)
-            unique_bytes += int(t.untyped_storage().nbytes())
-    assert dc.total_bytes == unique_bytes
-
-
-def test_admission_cache_bytes_match_cuda_allocated_delta(_clean_cache) -> None:
-    """Retained cache bytes correspond to a controlled CUDA memory delta."""
-    require_b12x()
-    require_mxf8_mma()
-    torch.cuda.empty_cache()
-    before = torch.cuda.memory_allocated("cuda")
-    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 128, 128)
-    _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 256, 128)
-    torch.cuda.synchronize()
-    after = torch.cuda.memory_allocated("cuda")
-    delta = after - before
-    dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    # The CUDA allocated delta should be at least the retained cache bytes
-    # (may be more due to allocator rounding, but not less).
-    assert delta >= dc.total_bytes
-
-
-# --- per-device independence test ---
-
-
-def test_admission_cache_per_device_independence(_clean_cache) -> None:
-    """Pressure on device 0 does not affect device 1."""
-    if torch.cuda.device_count() < 2:
-        pytest.skip("requires 2+ CUDA devices")
-    max_entries = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
-    for i in range(max_entries):
-        _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1 + i * 128, 128)
-    b = _tfp8_kernel._cached_unit_scale_mma("cuda", 1, 7, 128)
-    assert b.device == torch.device("cuda", 1)
-    dc0 = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-    dc1 = _tfp8_kernel._unit_scale_caches[("cuda", 1)]
-    assert len(dc0.entries) == max_entries
-    assert len(dc1.entries) == 1
-    assert dc0 is not dc1
-
-
-# --- concurrency tests ---
-
-
-def test_admission_cache_concurrent_same_key_single_construction(
+def test_unit_scale_cache_checks_capture_only_on_miss(
     monkeypatch,
-    _clean_cache,
+    clean_unit_scale_cache,
 ) -> None:
-    """Concurrent requests for the same key call _unit_scale_mma exactly once."""
-    require_b12x()
-    require_mxf8_mma()
-    original_fn = _tfp8_kernel._unit_scale_mma
-    call_count = 0
-    count_lock = threading.Lock()
-    barrier = threading.Barrier(8)
+    built = _install_fake_unit_scale_builder(monkeypatch)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    first = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 1, 128)
 
-    def _counting_fn(*args, **kwargs):
-        nonlocal call_count
-        with count_lock:
-            call_count += 1
-        return original_fn(*args, **kwargs)
+    def fail_capture_query():
+        raise AssertionError("cache hit queried capture state")
 
-    monkeypatch.setattr(_tfp8_kernel, "_unit_scale_mma", _counting_fn)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", fail_capture_query)
+    assert _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 64, 128) is first
+
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    with pytest.raises(RuntimeError, match="not prewarmed"):
+        _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 129, 128)
+    assert len(built) == 1
+
+
+def test_unit_scale_cache_constructs_once_under_concurrency(
+    monkeypatch,
+    clean_unit_scale_cache,
+) -> None:
+    calls = 0
+    calls_lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def build(rows: int, width: int, device: torch.device):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        return object()
+
+    monkeypatch.setattr(_tfp8_kernel, "_unit_scale_mma", build)
     results: list[object] = []
-    errors: list[Exception] = []
 
-    def worker():
-        try:
-            barrier.wait()
-            t = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 99, 128)
-            results.append(t)
-        except Exception as exc:
-            errors.append(exc)
+    def worker() -> None:
+        start.wait()
+        results.append(
+            _tfp8_kernel._cached_unit_scale_mma("cpu", None, 64, 128)
+        )
 
     threads = [threading.Thread(target=worker) for _ in range(8)]
-    for th in threads:
-        th.start()
-    for th in threads:
-        th.join()
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
 
-    assert not errors
+    assert calls == 1
     assert len(results) == 8
-    first = results[0]
-    for r in results:
-        assert r is first
-    assert call_count == 1
+    assert all(result is results[0] for result in results)
 
 
-def test_admission_cache_concurrent_distinct_streams(_clean_cache) -> None:
-    """The published tensor is safe to consume on distinct streams."""
-    require_b12x()
-    require_mxf8_mma()
-    t = _tfp8_kernel._cached_unit_scale_mma("cuda", 0, 64, 128)
-    s1 = torch.cuda.Stream(device="cuda")
-    s2 = torch.cuda.Stream(device="cuda")
-    with torch.cuda.stream(s1):
-        v1 = t.view(torch.uint8).sum().item()
-    with torch.cuda.stream(s2):
-        v2 = t.view(torch.uint8).sum().item()
-    torch.cuda.synchronize()
-    # All values are 127 (UE8M0 1.0).
-    expected = 127 * t.numel()
-    assert v1 == expected
-    assert v2 == expected
+def test_unit_scale_cache_never_evicts_admitted_storage(
+    monkeypatch,
+    clean_unit_scale_cache,
+) -> None:
+    _install_fake_unit_scale_builder(monkeypatch)
+    monkeypatch.setattr(_tfp8_kernel, "_UNIT_SCALE_CACHE_MAX_ENTRIES", 2)
 
+    first = _tfp8_kernel._cached_unit_scale_mma("cpu", None, 1, 128)
+    _tfp8_kernel._cached_unit_scale_mma("cpu", None, 129, 128)
+    with pytest.raises(RuntimeError, match="cache.*full"):
+        _tfp8_kernel._cached_unit_scale_mma("cpu", None, 257, 128)
 
-# --- stream safety tests ---
-
-
-def test_mm_explicit_noncurrent_stream_early_drop_churn(_clean_cache) -> None:
-    """mm on an explicit non-current stream with padded K and bias: drop
-    caller-owned inputs immediately after the async call, churn the
-    allocator, then sync the target and verify exact output.
-
-    This catches record_stream omissions: without recording, the caching
-    allocator can recycle source/weight/bias storage while the GEMM on the
-    target stream is still reading it."""
-    require_b12x()
-    require_mxf8_mma()
-    torch.manual_seed(20260818)
-
-    source, weight, output_scale, packed = _make_inputs(5, 160, 40)
-    bias = torch.randn(40, device="cuda", dtype=torch.bfloat16) * 0.01
-
-    # Compute reference on the default stream before any side-stream launch.
-    expected = (source.float() @ weight.float().T) * output_scale + bias
-    torch.cuda.synchronize()
-
-    # Prewarm to populate the cache (warm-cache path).
-    tensor_fp8_linear.prewarm(packed, [5])
-    torch.cuda.synchronize()
-
-    target_stream = torch.cuda.Stream(device="cuda")
-    # Call mm while target_stream is NOT the current stream — the default
-    # stream remains current so any materialization that is not properly
-    # stream-guarded would land on the wrong stream.
-    actual = tensor_fp8_linear.mm(
-        source, packed, bias=bias, stream=target_stream
-    )
-
-    # Immediately drop all caller-owned inputs to force record_stream to
-    # protect their storage from allocator recycling.
-    del source, weight, output_scale, packed, bias
-
-    # Churn the allocator with many allocations to increase the chance of
-    # recycling freed storage while the target stream is still in flight.
-    for _ in range(64):
-        torch.empty(256 * 1024, dtype=torch.float32, device="cuda")
-
-    # Only now synchronize the target stream and verify output.
-    target_stream.synchronize()
-    torch.testing.assert_close(
-        actual.float(),
-        expected.to(actual.dtype).float(),
-        rtol=1e-2,
-        atol=2e-3,
-    )
-
-
-def test_mm_rejects_raw_int_stream(_clean_cache) -> None:
-    """Raw integer stream handles are rejected."""
-    require_b12x()
-    require_mxf8_mma()
-    source, _, _, packed = _make_inputs(4, 128, 64)
-    with pytest.raises(TypeError, match="stream must be a torch.cuda.Stream"):
-        tensor_fp8_linear.mm(source, packed, stream=42)
-
-
-# --- end-to-end multi-device mm test ---
-
-
-def test_mm_multi_device_current_device_mismatch(_clean_cache) -> None:
-    """mm works correctly when the thread's current device differs from the
-    operand device."""
-    if torch.cuda.device_count() < 2:
-        pytest.skip("requires 2+ CUDA devices")
-    require_mxf8_mma()
-    torch.manual_seed(20260816)
-
-    # Create operands on device 1 but set current device to 0.
-    with torch.cuda.device(1):
-        source = (
-            torch.randn((7, 128), device="cuda", dtype=torch.bfloat16)
-            .clamp(-4, 4)
-            .to(torch.float8_e4m3fn)
-        )
-        weight = (
-            torch.randn((64, 128), device="cuda", dtype=torch.bfloat16)
-            .clamp(-4, 4)
-            .to(torch.float8_e4m3fn)
-        )
-        output_scale = torch.tensor([0.0002], dtype=torch.float32, device="cuda")
-        packed = tensor_fp8_linear.pack_weight(weight, output_scale)
-
-    with torch.cuda.device(0):
-        # Current device is 0, but operands are on device 1.
-        actual = tensor_fp8_linear.mm(source, packed)
-        torch.cuda.synchronize()
-
-    expected = (source.float() @ weight.float().T) * output_scale
-    torch.cuda.synchronize()
-    assert actual.device == torch.device("cuda", 1)
-    torch.testing.assert_close(
-        actual.float(),
-        expected.to(actual.dtype).float(),
-        rtol=1e-2,
-        atol=2e-3,
-    )
-
-
-def test_mm_wrong_device_stream_rejected(_clean_cache) -> None:
-    """An explicit stream on the wrong device is rejected."""
-    if torch.cuda.device_count() < 2:
-        pytest.skip("requires 2+ CUDA devices")
-    require_mxf8_mma()
-    torch.manual_seed(20260817)
-
-    with torch.cuda.device(0):
-        source = (
-            torch.randn((4, 128), device="cuda", dtype=torch.bfloat16)
-            .clamp(-4, 4)
-            .to(torch.float8_e4m3fn)
-        )
-        weight = (
-            torch.randn((64, 128), device="cuda", dtype=torch.bfloat16)
-            .clamp(-4, 4)
-            .to(torch.float8_e4m3fn)
-        )
-        output_scale = torch.tensor([0.0002], dtype=torch.float32, device="cuda")
-        packed = tensor_fp8_linear.pack_weight(weight, output_scale)
-
-    wrong_stream = torch.cuda.Stream(device=1)
-    with pytest.raises(ValueError, match="stream is on device.*but source"):
-        tensor_fp8_linear.mm(source, packed, stream=wrong_stream)
-
-
-# --- numerical correctness after cache operations ---
-
-
-def test_admission_cache_numerical_unchanged_after_pressure(_clean_cache) -> None:
-    """mm output is numerically correct after cache operations."""
-    require_b12x()
-    require_mxf8_mma()
-    torch.manual_seed(20260815)
-
-    source, weight, output_scale, packed = _make_inputs(7, 128, 64)
-    expected = (source.float() @ weight.float().T) * output_scale
-
-    actual = tensor_fp8_linear.mm(source, packed)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(
-        actual.float(),
-        expected.to(actual.dtype).float(),
-        rtol=1e-2,
-        atol=2e-3,
-    )
-
-    actual2 = tensor_fp8_linear.mm(source, packed)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(
-        actual2.float(),
-        expected.to(actual2.dtype).float(),
-        rtol=1e-2,
-        atol=2e-3,
-    )
-
-
-# --- prewarm non-atomic prefix test ---
-
-
-def test_prewarm_rejects_batch_before_partial_admission(_clean_cache) -> None:
-    """An over-capacity prewarm leaves the permanent cache unchanged."""
-    require_b12x()
-    require_mxf8_mma()
-    torch.manual_seed(20260819)
-
-    _, _, _, packed = _make_inputs(4, 128, 64)
-    original_max = _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES
-    _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = 2
-    try:
-        with pytest.raises(RuntimeError, match=r"cache.*full"):
-            tensor_fp8_linear.prewarm(packed, [4, 132, 260, 388])
-
-        dc = _tfp8_kernel._unit_scale_caches[("cuda", 0)]
-        assert dc.entries == {}
-        assert dc.total_bytes == 0
-    finally:
-        _tfp8_kernel._UNIT_SCALE_CACHE_MAX_ENTRIES = original_max
-
-
-# --- config parsing tests (no GPU required) ---
-
-
-def test_parse_cache_limit_defaults() -> None:
-    assert _parse_cache_limit(None, 32, 256) == 32
-
-
-def test_parse_cache_limit_valid() -> None:
-    assert _parse_cache_limit("64", 32, 256) == 64
-
-
-def test_parse_cache_limit_clamps_to_hard_max() -> None:
-    assert _parse_cache_limit("99999", 32, 256) == 256
-
-
-def test_parse_cache_limit_zero_falls_back() -> None:
-    assert _parse_cache_limit("0", 32, 256) == 32
-
-
-def test_parse_cache_limit_negative_falls_back() -> None:
-    assert _parse_cache_limit("-5", 32, 256) == 32
-
-
-def test_parse_cache_limit_non_integer_falls_back() -> None:
-    assert _parse_cache_limit("abc", 32, 256) == 32
-
-
-def test_hard_maxima_are_positive() -> None:
-    assert _UNIT_SCALE_HARD_MAX_ENTRIES > 0
-    assert _UNIT_SCALE_HARD_MAX_BYTES > 0
+    assert _tfp8_kernel._cached_unit_scale_mma("cpu", None, 1, 128) is first


### PR DESCRIPTION
Closes #166.

Bounds the per-device unit-scale MMA cache by both entry count and retained bytes without evicting storage whose address may be captured by a CUDA graph. Row counts sharing the same physical 128-row scale tile reuse one entry.

Steady-state behavior is unchanged apart from replacing the previous unbounded functools cache lookup with one dictionary lookup. Warm calls take no lock, perform no capture-state query, launch no CUDA work, and synchronize neither the host nor device. Admission accounting, single-flight construction, and cold-capture rejection run only on cache misses. Stream ownership remains at the shared dense GEMM boundary in #189.

Verification on 7b08478991ebac2a61749dba8b2f5103e81cdda2:
- 7 focused cache tests passed; 5 GPU tests deselected
- 12 tests collected
- compileall and git diff --check passed

Target-GPU eager and CUDA-graph correctness/timing are pending an available assigned device.