### PR TITLE
security: verify native cache ownership before loading

### DIFF
--- a/b12x/_lib/compiler.py
+++ b/b12x/_lib/compiler.py
@@ -7,9 +7,9 @@ import json
 import math
 import os
 import re
-import shutil
+import secrets
+import stat
 import sys
-import tempfile
 import time
 import traceback
 from collections import OrderedDict
@@ -673,6 +673,402 @@ def _cute_compile_cache_dir() -> Path:
     if xdg_cache_home:
         return Path(xdg_cache_home) / "b12x" / "compile"
     return Path.home() / ".cache" / "b12x" / "compile"
+
+
+def _open_secure_dir_fd(path: Path) -> int:
+    """Walk from ``/`` to *path*, opening each component with
+    ``O_DIRECTORY | O_NOFOLLOW`` and fstat-validating it.
+
+    Ancestors must be euid/root-owned and not group/world-writable.
+    The final directory must be euid-owned with no group/other permission
+    bits (mode ``0700``).  Missing components are created with ``0700``.
+
+    Returns a dirfd for the final directory.  Raises ``RuntimeError`` or
+    ``OSError`` on any violation.
+    """
+    abs_path = Path(os.path.abspath(str(path)))
+    parts = [p for p in abs_path.parts if p not in ("", "/")]
+    if not parts:
+        raise RuntimeError("b12x cache root must not be /")
+    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for i, part in enumerate(parts):
+            is_final = i == len(parts) - 1
+            try:
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            except FileNotFoundError:
+                created = False
+                try:
+                    os.mkdir(part, 0o700, dir_fd=fd)
+                    created = True
+                except FileExistsError:
+                    pass
+                if created:
+                    os.fsync(fd)
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            os.close(fd)
+            fd = next_fd
+            st = os.fstat(fd)
+            if not stat.S_ISDIR(st.st_mode):
+                raise RuntimeError(
+                    f"b12x cache path component {part!r} is not a directory"
+                )
+            if is_final:
+                _fstat_assert_private_dir(fd, str(abs_path))
+            else:
+                _fstat_assert_ancestor_dir(st, str(abs_path), part)
+        return fd
+    except BaseException:
+        with suppress(OSError):
+            os.close(fd)
+        raise
+
+
+def _open_secure_shard_fd(root_fd: int, shard_name: str) -> int:
+    """Open or create the shard directory relative to *root_fd*.
+
+    The shard must be euid-owned with no group/other permission bits.
+    """
+    try:
+        fd = os.open(
+            shard_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=root_fd,
+        )
+    except FileNotFoundError:
+        created = False
+        try:
+            os.mkdir(shard_name, 0o700, dir_fd=root_fd)
+            created = True
+        except FileExistsError:
+            pass
+        if created:
+            os.fsync(root_fd)
+        fd = os.open(
+            shard_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=root_fd,
+        )
+    try:
+        _fstat_assert_private_dir(fd, shard_name)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _fstat_assert_private_dir(fd: int, label: str) -> None:
+    """Assert fd is an euid-owned directory with no group/other bits."""
+    st = os.fstat(fd)
+    if not stat.S_ISDIR(st.st_mode):
+        raise RuntimeError(f"b12x cache dir {label} is not a directory")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"b12x cache dir {label} owned by uid {st.st_uid}, "
+            f"not euid {os.geteuid()}"
+        )
+    if st.st_mode & 0o077:
+        raise RuntimeError(
+            f"b12x cache dir {label} has group/other permission bits; "
+            f"refusing non-private cache"
+        )
+
+
+def _fstat_assert_ancestor_dir(st: os.stat_result, label: str, part: str) -> None:
+    """Assert an ancestor directory is not writable by untrusted users."""
+    if st.st_uid != os.geteuid() and st.st_uid != 0:
+        raise RuntimeError(
+            f"b12x cache ancestor {part!r} owned by uid {st.st_uid}, "
+            f"not euid {os.geteuid()} or root"
+        )
+    root_sticky = st.st_uid == 0 and bool(st.st_mode & stat.S_ISVTX)
+    if st.st_mode & stat.S_IWOTH and not root_sticky:
+        raise RuntimeError(
+            f"b12x cache ancestor {part!r} is world-writable; refusing untrusted cache"
+        )
+    if st.st_mode & stat.S_IWGRP and not root_sticky:
+        raise RuntimeError(
+            f"b12x cache ancestor {part!r} is group-writable; refusing untrusted cache"
+        )
+
+
+def _fstat_assert_regular_0600(fd: int, label: str) -> None:
+    """Assert fd is an euid-owned regular file with mode 0600 and nlink==1."""
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise RuntimeError(f"b12x cache file {label} is not a regular file")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"b12x cache file {label} owned by uid {st.st_uid}, "
+            f"not euid {os.geteuid()}"
+        )
+    if st.st_mode & 0o077:
+        raise RuntimeError(
+            f"b12x cache file {label} has group/other permission bits; "
+            f"refusing non-private artifact"
+        )
+    if st.st_nlink != 1:
+        raise RuntimeError(
+            f"b12x cache file {label} has {st.st_nlink} hard links; "
+            f"refusing non-exclusive artifact"
+        )
+
+
+def _read_fd_complete(fd: int) -> bytes:
+    """Read *fd* to EOF in a loop, returning the complete contents."""
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _openat_secure_regular(
+    dir_fd: int, name: str, flags: int = os.O_RDONLY
+) -> int:
+    """Open a leaf file relative to *dir_fd* with ``O_NOFOLLOW | O_NONBLOCK``
+    and fstat-validate as an euid-owned regular file with mode 0600.
+
+    ``O_NONBLOCK`` prevents blocking on FIFOs or special files; regular
+    files are unaffected.
+    """
+    fd = os.open(name, flags | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd)
+    try:
+        _fstat_assert_regular_0600(fd, name)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _create_secure_temp(dir_fd: int, prefix: str) -> tuple[int, str]:
+    """Create an unpredictable temp file relative to *dir_fd*.
+
+    Uses ``O_CREAT | O_EXCL | O_NOFOLLOW`` with mode ``0600`` and a
+    ``secrets``-generated name to prevent symlink preemption and name
+    guessing.
+    """
+    for _ in range(16):
+        name = f".{prefix}.{secrets.token_hex(8)}.tmp"
+        try:
+            fd = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            return fd, name
+        except FileExistsError:
+            continue
+    raise RuntimeError(f"could not create unique temp file for {prefix}")
+
+
+def _write_fd_complete(fd: int, data: bytes) -> None:
+    """Write all of *data* to *fd* in a loop, then fsync."""
+    written = 0
+    while written < len(data):
+        n = os.write(fd, data[written:])
+        if n == 0:
+            raise OSError("write returned 0 bytes")
+        written += n
+    os.fsync(fd)
+
+
+def _verify_manifest_identity(
+    manifest: object,
+    cache_key: str,
+    cache_payload: tuple[object, ...],
+    func: Any,
+    object_len: int,
+) -> str:
+    """Validate *manifest* against the expected compilation identity.
+
+    Requires exact schema v3, the exact expected field set (no extra
+    or missing keys), recomputes the cache key, and verifies every
+    payload-derived semantic field including cache_payload,
+    launch_metadata, and artifact_evidence_sha256.
+
+    Returns the ``object_sha256`` digest string on success, raises
+    ``ValueError`` on any mismatch.
+    """
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest is not a JSON object")
+
+    schema = manifest["schema"]
+    if schema != "b12x._lib.compile_manifest.v3":
+        raise ValueError(f"manifest schema {schema!r} != v3")
+
+    # Recompute cache_key from the payload representation.
+    recomputed_key = hashlib.sha256(
+        repr(cache_payload).encode("utf-8")
+    ).hexdigest()
+    if recomputed_key != cache_key:
+        raise ValueError(
+            f"recomputed cache_key {recomputed_key!r} != requested {cache_key!r}"
+        )
+
+    mk = manifest["cache_key"]
+    if mk != cache_key:
+        raise ValueError(
+            f"manifest cache_key {mk!r} != requested {cache_key!r}"
+        )
+
+    sha = manifest["object_sha256"]
+    if not isinstance(sha, str) or len(sha) != 64:
+        raise ValueError("manifest object_sha256 is not a 64-char hex string")
+
+    ob = manifest["object_bytes"]
+    if not isinstance(ob, int) or ob != object_len:
+        raise ValueError(
+            f"manifest object_bytes {ob!r} != actual {object_len}"
+        )
+    # Build the expected manifest from the payload.  Use the actual
+    # object_bytes so object_sha256 matches.  launch_metadata and
+    # artifact_evidence_sha256 depend on the compiled object (which
+    # we don't have at load time), so we verify those separately.
+    expected = _build_compile_manifest(
+        cache_key, cache_payload, func, b"\x00" * object_len, compiled=None
+    )
+
+    # Verify exact field set: no extra or missing keys.
+    expected_keys = set(expected.keys())
+    actual_keys = set(manifest.keys())
+    if actual_keys != expected_keys:
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys
+        parts = []
+        if missing:
+            parts.append(f"missing: {sorted(missing)}")
+        if extra:
+            parts.append(f"extra: {sorted(extra)}")
+        raise ValueError(f"manifest key set mismatch ({'; '.join(parts)})")
+
+    # Verify all payload-derived fields.  Skip launch_metadata and
+    # artifact_evidence_sha256 which are runtime-dependent (compiled-
+    # specific).  object_sha256 is already verified above.
+    skip_fields = {"launch_metadata", "artifact_evidence_sha256", "object_sha256"}
+    for field in sorted(expected_keys - skip_fields):
+        _assert_manifest_field(manifest, expected, field)
+
+    # Structurally validate launch_metadata (v3 canonical form).
+    _validate_launch_metadata(manifest["launch_metadata"])
+
+    # Recompute and verify artifact_evidence_sha256 from the manifest's
+    # own object_sha256 and the now-validated launch_metadata.
+    artifact_evidence = {
+        "cache_key": cache_key,
+        "object_sha256": sha,
+        "launch_metadata": manifest["launch_metadata"],
+    }
+    artifact_evidence_json = json.dumps(
+        artifact_evidence,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    expected_evidence_sha = hashlib.sha256(
+        artifact_evidence_json.encode("utf-8")
+    ).hexdigest()
+    if manifest["artifact_evidence_sha256"] != expected_evidence_sha:
+        raise ValueError(
+            f"manifest artifact_evidence_sha256 mismatch: "
+            f"{manifest['artifact_evidence_sha256']!r} != {expected_evidence_sha!r}"
+        )
+
+    return sha
+
+
+def _assert_manifest_field(
+    manifest: dict, expected: dict, field: str
+) -> None:
+    """Assert that manifest[field] matches expected[field] (required key)."""
+    actual = manifest[field]
+    wanted = expected[field]
+    if actual != wanted:
+        raise ValueError(
+            f"manifest {field} mismatch: {actual!r} != {wanted!r}"
+        )
+
+
+def _validate_launch_metadata(lm: object) -> None:
+    """Validate launch_metadata matches the v3 canonical structure.
+
+    Required keys: status, source, launch_dynamic_smem_bytes.
+    Optional key: reason (str).
+
+    status must be "exact" or "unknown".
+    source must be a non-empty string.
+    When status == "exact", launch_dynamic_smem_bytes must be a
+    non-empty dict of non-empty kernel-name strings to non-empty lists of
+    nonnegative integer SMEM byte counts.
+    When status == "unknown", launch_dynamic_smem_bytes must be empty
+    and reason must be present.
+    """
+    if not isinstance(lm, dict):
+        raise ValueError("launch_metadata is not a dict")
+    required = {"status", "source", "launch_dynamic_smem_bytes"}
+    actual_keys = set(lm.keys())
+    if not required.issubset(actual_keys):
+        raise ValueError(
+            f"launch_metadata missing keys: {sorted(required - actual_keys)}"
+        )
+    extra = actual_keys - required - {"reason"}
+    if extra:
+        raise ValueError(
+            f"launch_metadata has extra keys: {sorted(extra)}"
+        )
+    status = lm["status"]
+    if status not in ("exact", "unknown"):
+        raise ValueError(f"launch_metadata status {status!r} not valid")
+    source = lm["source"]
+    if not isinstance(source, str) or not source:
+        raise ValueError("launch_metadata source must be a non-empty string")
+    smem = lm["launch_dynamic_smem_bytes"]
+    if not isinstance(smem, dict):
+        raise ValueError("launch_dynamic_smem_bytes must be a dict")
+    if status == "exact":
+        if "reason" in lm:
+            raise ValueError(
+                "launch_metadata reason is only valid for unknown status"
+            )
+        if not smem:
+            raise ValueError(
+                "launch_dynamic_smem_bytes must be non-empty for exact status"
+            )
+        for kernel, values in smem.items():
+            if not isinstance(kernel, str) or not kernel:
+                raise ValueError(
+                    "launch_dynamic_smem_bytes keys must be non-empty strings"
+                )
+            if not isinstance(values, list) or not values:
+                raise ValueError(
+                    "launch_dynamic_smem_bytes values must be non-empty lists"
+                )
+            if any(
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 0
+                for value in values
+            ):
+                raise ValueError(
+                    "launch_dynamic_smem_bytes values must contain nonnegative ints"
+                )
+    else:
+        if smem:
+            raise ValueError("launch_dynamic_smem_bytes must be empty for unknown status")
+        if "reason" not in lm or not isinstance(lm["reason"], str) or not lm["reason"]:
+            raise ValueError("launch_metadata reason required for unknown status")
 
 
 def _cute_compile_log_enabled() -> bool:
@@ -2430,50 +2826,61 @@ def _write_compile_manifest(
     func: Any,
     object_bytes: bytes,
     compiled: Any = None,
+    *,
+    shard_fd: int | None = None,
 ) -> None:
-    manifest_path = _cache_manifest_path(cache_key)
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest = _build_compile_manifest(
         cache_key, cache_payload, func, object_bytes, compiled=compiled
     )
-    tmp_name: str | None = None
+    manifest_json = (
+        json.dumps(
+            manifest,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    own_fds = shard_fd is None
+    root_fd: int | None = None
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=manifest_path.parent,
-            prefix=f".{manifest_path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as tmp_file:
-            tmp_name = tmp_file.name
-            json.dump(
-                manifest,
-                tmp_file,
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
+        if own_fds:
+            root_fd = _open_secure_dir_fd(_cute_compile_cache_dir())
+            shard_fd = _open_secure_shard_fd(root_fd, cache_key[:2])
+        manifest_name = f"{cache_key}.json"
+        fd, tmp_name = _create_secure_temp(shard_fd, manifest_name)
+        try:
+            _write_fd_complete(fd, manifest_json)
+            pre_st = os.fstat(fd)
+            os.replace(
+                tmp_name, manifest_name,
+                src_dir_fd=shard_fd, dst_dir_fd=shard_fd,
             )
-            tmp_file.write("\n")
-        os.replace(tmp_name, manifest_path)
-        tmp_name = None
-    finally:
-        if tmp_name is not None:
+            os.fsync(shard_fd)
+            post_st = os.fstat(fd)
+            if (pre_st.st_ino, pre_st.st_dev) != (
+                post_st.st_ino, post_st.st_dev,
+            ):
+                raise RuntimeError("manifest inode changed during replace")
+            if post_st.st_nlink != 1:
+                raise RuntimeError(
+                    f"manifest has {post_st.st_nlink} links after publish"
+                )
+            os.close(fd)
+        except BaseException:
             with suppress(OSError):
-                os.unlink(tmp_name)
-
-
-def _ensure_cute_compile_manifest(
-    cache_key: str,
-    cache_payload: tuple[object, ...],
-    func: Any,
-) -> None:
-    manifest_path = _cache_manifest_path(cache_key)
-    if manifest_path.exists():
-        return
-    object_bytes = _cache_object_path(cache_key).read_bytes()
-    _write_compile_manifest(cache_key, cache_payload, func, object_bytes)
+                os.close(fd)
+            with suppress(OSError):
+                os.unlink(tmp_name, dir_fd=shard_fd)
+            raise
+    finally:
+        if own_fds:
+            with suppress(OSError):
+                os.close(shard_fd)
+            with suppress(OSError):
+                if root_fd is not None:
+                    os.close(root_fd)
 
 
 @contextmanager
@@ -2481,39 +2888,182 @@ def _disk_cache_key_lock(cache_key: str):
     try:
         import fcntl
     except ImportError:
-        yield
+        yield None
         return
 
-    lock_path = _cache_lock_path(cache_key)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_file:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
-
-def _load_cute_compile_from_disk(cache_key: str):
-    from cutlass.base_dsl.export.external_binary_module import ExternalBinaryModule
-
-    object_path = _cache_object_path(cache_key)
-    if not object_path.exists():
-        return None
+    lock_name = f"{cache_key}.lock"
+    root_fd: int | None = None
+    shard_fd: int | None = None
     try:
-        # CUTLASS may finalize or patch the ELF while loading it.  The cache
-        # object is content-addressed and its digest is recorded in the compile
-        # manifest, so never expose that canonical object to the loader.
-        with tempfile.TemporaryDirectory(
-            prefix="b12x-cute-cache-load-"
-        ) as raw_stage:
-            staged_object = Path(raw_stage) / object_path.name
-            shutil.copy2(object_path, staged_object)
-            module = ExternalBinaryModule(str(staged_object))
-            return getattr(module, _cache_prefix(cache_key))
+        root_fd = _open_secure_dir_fd(_cute_compile_cache_dir())
+        shard_fd = _open_secure_shard_fd(root_fd, cache_key[:2])
+        # Try exclusive creation first; if the lock already exists, open
+        # with O_NOFOLLOW and fstat-validate as a secure regular file.
+        try:
+            fd = os.open(
+                lock_name,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=shard_fd,
+            )
+        except FileExistsError:
+            fd = _openat_secure_regular(
+                shard_fd, lock_name, os.O_RDWR
+            )
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                yield shard_fd
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+    finally:
+        with suppress(OSError):
+            if shard_fd is not None:
+                os.close(shard_fd)
+        with suppress(OSError):
+            if root_fd is not None:
+                os.close(root_fd)
+
+
+def _load_cute_compile_from_disk(
+    cache_key: str,
+    cache_payload: tuple[object, ...] | None = None,
+    func: Any = None,
+    *,
+    shard_fd: int | None = None,
+):
+    """Load a compiled kernel from the disk cache with full integrity checks.
+
+    All path resolution is descriptor-relative.  The object is read once;
+    its SHA-256 is verified; the manifest's full semantic identity is
+    verified against *cache_payload*.  The verified buffer is staged
+    through a single O_RDWR fd that is unlinked descriptor-relative
+    (so the inode has no replaceable name), re-verified by digest on
+    that same fd, and loaded via ``/dev/fd/N`` while the fd stays open.
+
+    ``cache_payload`` and ``func`` are **required** — there is no
+    minimal-manifest fallback.
+
+    Trust contract: this verifies integrity (digest, semantic identity,
+    ownership, permissions, link count) but not provenance.  A same-euid
+    writer can produce a self-consistent malicious pair; defend against
+    that with a trusted producer/signature or process isolation.
+    """
+    if cache_payload is None or func is None:
+        return None
+    object_name = f"{cache_key}.o"
+    manifest_name = f"{cache_key}.json"
+    own_fds = shard_fd is None
+    root_fd: int | None = None
+    staging_fd: int | None = None
+    staging_dir_name: str | None = None
+    stage_fd: int | None = None
+    try:
+        if own_fds:
+            root_fd = _open_secure_dir_fd(_cute_compile_cache_dir())
+            shard_fd = _open_secure_shard_fd(root_fd, cache_key[:2])
+
+        # Open manifest descriptor-relative; fstat-validates regular 0600 nlink==1.
+        manifest_fd = _openat_secure_regular(shard_fd, manifest_name)
+        try:
+            manifest_bytes = _read_fd_complete(manifest_fd)
+        finally:
+            os.close(manifest_fd)
+
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+
+        # Open object descriptor-relative; fstat-validates regular 0600 nlink==1.
+        object_fd = _openat_secure_regular(shard_fd, object_name)
+        try:
+            object_bytes = _read_fd_complete(object_fd)
+        finally:
+            os.close(object_fd)
+
+        # Full semantic identity verification — no fallback.
+        expected_sha = _verify_manifest_identity(
+            manifest, cache_key, cache_payload, func, len(object_bytes)
+        )
+
+        # Verify the exact digest of the one buffer we will stage.
+        actual_sha = hashlib.sha256(object_bytes).hexdigest()
+        if actual_sha != expected_sha:
+            return None
+
+        # Stage the verified buffer under the validated cache shard.
+        staging_dir_name = f"._stage_{secrets.token_hex(16)}"
+        os.mkdir(staging_dir_name, 0o700, dir_fd=shard_fd)
+        staging_fd = os.open(
+            staging_dir_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=shard_fd,
+        )
+        # Use a single O_RDWR fd for staging: write, fsync, unlink
+        # descriptor-relative, then verify digest on the same fd.
+        # The unlinked inode has no name that can be swapped.
+        stage_fd = os.open(
+            object_name,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o600,
+            dir_fd=staging_fd,
+        )
+        _write_fd_complete(stage_fd, object_bytes)
+        # Unlink descriptor-relative so the inode has no replaceable name.
+        os.unlink(object_name, dir_fd=staging_fd)
+        # Re-verify digest on the same fd we wrote through.
+        os.lseek(stage_fd, 0, os.SEEK_SET)
+        staged_bytes = _read_fd_complete(stage_fd)
+        if hashlib.sha256(staged_bytes).hexdigest() != expected_sha:
+            return None
+        # Verify the staged inode is still regular/euid/0600/nlink==0 (unlinked).
+        st = os.fstat(stage_fd)
+        if not stat.S_ISREG(st.st_mode):
+            return None
+        if st.st_uid != os.geteuid():
+            return None
+        if st.st_mode & 0o077:
+            return None
+        if st.st_nlink != 0:
+            return None
+        # ExternalBinaryModule opens /dev/fd/N at the descriptor's current
+        # position on some platforms. Rewind after the digest read so the
+        # loader always sees the complete verified object.
+        os.lseek(stage_fd, 0, os.SEEK_SET)
+
+        from cutlass.base_dsl.export.external_binary_module import (
+            ExternalBinaryModule,
+        )
+
+        # Load from the exact fd we wrote and verified — no name involved.
+        inode_path = f"/dev/fd/{stage_fd}"
+        module = ExternalBinaryModule(inode_path)
+        # The CUTLASS loader may patch its private staging copy. The
+        # manifest-bound cache object remains untouched and is revalidated
+        # on every load; never publish this staging inode back to the cache.
+        result = getattr(module, _cache_prefix(cache_key))
+        return result
+    except (RuntimeError, OSError, ValueError, json.JSONDecodeError):
+        return None
     except Exception:
         return None
-
+    finally:
+        with suppress(OSError):
+            if stage_fd is not None:
+                os.close(stage_fd)
+        if staging_fd is not None:
+            with suppress(OSError):
+                os.close(staging_fd)
+        if staging_dir_name is not None and shard_fd is not None:
+            with suppress(OSError):
+                os.rmdir(staging_dir_name, dir_fd=shard_fd)
+        if own_fds:
+            with suppress(OSError):
+                if shard_fd is not None:
+                    os.close(shard_fd)
+            with suppress(OSError):
+                if root_fd is not None:
+                    os.close(root_fd)
 
 def _store_cute_compile_to_disk(
     cache_key: str,
@@ -2521,21 +3071,58 @@ def _store_cute_compile_to_disk(
     *,
     cache_payload: tuple[object, ...] | None = None,
     func: Any = None,
+    shard_fd: int | None = None,
 ) -> None:
     if not hasattr(compiled, "dump_to_object"):
         return
 
-    object_path = _cache_object_path(cache_key)
-    object_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = object_path.with_suffix(".tmp")
+    object_name = f"{cache_key}.o"
     object_bytes = compiled.dump_to_object(_cache_prefix(cache_key))
-    with open(tmp_path, "wb") as f:
-        f.write(object_bytes)
-    os.replace(tmp_path, object_path)
-    if cache_payload is not None and func is not None:
-        _write_compile_manifest(
-            cache_key, cache_payload, func, object_bytes, compiled=compiled
-        )
+    own_fds = shard_fd is None
+    root_fd: int | None = None
+    try:
+        if own_fds:
+            root_fd = _open_secure_dir_fd(_cute_compile_cache_dir())
+            shard_fd = _open_secure_shard_fd(root_fd, cache_key[:2])
+        # Publish object atomically via unpredictable O_EXCL temp.
+        # Retain fd through replace and verify post-rename inode.
+        fd, tmp_name = _create_secure_temp(shard_fd, object_name)
+        try:
+            _write_fd_complete(fd, object_bytes)
+            pre_st = os.fstat(fd)
+            os.replace(
+                tmp_name, object_name,
+                src_dir_fd=shard_fd, dst_dir_fd=shard_fd,
+            )
+            os.fsync(shard_fd)
+            post_st = os.fstat(fd)
+            if (pre_st.st_ino, pre_st.st_dev) != (
+                post_st.st_ino, post_st.st_dev,
+            ):
+                raise RuntimeError("object inode changed during replace")
+            if post_st.st_nlink != 1:
+                raise RuntimeError(
+                    f"object has {post_st.st_nlink} links after publish"
+                )
+            os.close(fd)
+        except BaseException:
+            with suppress(OSError):
+                os.close(fd)
+            with suppress(OSError):
+                os.unlink(tmp_name, dir_fd=shard_fd)
+            raise
+        if cache_payload is not None and func is not None:
+            _write_compile_manifest(
+                cache_key, cache_payload, func, object_bytes,
+                compiled=compiled, shard_fd=shard_fd,
+            )
+    finally:
+        if own_fds:
+            with suppress(OSError):
+                os.close(shard_fd)
+            with suppress(OSError):
+                if root_fd is not None:
+                    os.close(root_fd)
 
 
 def _memory_cache_get(cache_key: object) -> Any | None:
@@ -2664,10 +3251,8 @@ def compile(
     disk_cache_enabled = _cute_compile_disk_cache_enabled_for_payload(payload)
 
     if disk_cache_enabled:
-        compiled = _load_cute_compile_from_disk(cache_key)
+        compiled = _load_cute_compile_from_disk(cache_key, payload, func)
         if compiled is not None:
-            with suppress(Exception):
-                _ensure_cute_compile_manifest(cache_key, payload, func)
             with _MEMORY_CACHE_LOCK:
                 _DISK_CACHE_HITS += 1
             if post_engine_start_log:
@@ -2685,15 +3270,15 @@ def compile(
             _memory_cache_put(memory_cache_key, compiled)
             return compiled
 
-        with _disk_cache_key_lock(cache_key):
+        with _disk_cache_key_lock(cache_key) as shard_fd:
             compiled = _memory_cache_get(memory_cache_key)
             if compiled is not None:
                 return compiled
 
-            compiled = _load_cute_compile_from_disk(cache_key)
+            compiled = _load_cute_compile_from_disk(
+                cache_key, payload, func, shard_fd=shard_fd,
+            )
             if compiled is not None:
-                with suppress(Exception):
-                    _ensure_cute_compile_manifest(cache_key, payload, func)
                 with _MEMORY_CACHE_LOCK:
                     _DISK_CACHE_HITS += 1
                 if post_engine_start_log:
@@ -2744,6 +3329,7 @@ def compile(
                     compiled,
                     cache_payload=payload,
                     func=func,
+                    shard_fd=shard_fd,
                 )
             _memory_cache_put(memory_cache_key, compiled)
             return compiled

--- a/b12x/gemm/trellis_linear/_small_m.py
+++ b/b12x/gemm/trellis_linear/_small_m.py
@@ -6,9 +6,9 @@ import hashlib
 import importlib.machinery
 import importlib.util
 import os
-import secrets
 import stat
-from contextlib import suppress
+import sys
+from contextlib import contextmanager, suppress
 from functools import lru_cache
 from pathlib import Path
 
@@ -18,6 +18,15 @@ import torch
 _SOURCE_DIR = Path(__file__).resolve().parent / "csrc"
 _SOURCE = _SOURCE_DIR / "trellis_k6_small.cu"
 _VENDORED_FILES = tuple(sorted((_SOURCE_DIR / "vendor").rglob("*.[ch]*")))
+_CFLAGS = ("-O3",)
+_CUDA_CFLAGS = (
+    "-O3",
+    "--use_fast_math",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-gencode=arch=compute_120,code=sm_120",
+)
+_BUILD_COMPLETE_MARKER = ".b12x-build-complete"
 
 
 _GLM_K6_DECODE_SMS = {
@@ -45,6 +54,18 @@ def _available_sms(device_index: int) -> int:
 
 def _extension_name() -> str:
     digest = hashlib.sha256()
+    build_contract = (
+        sys.implementation.cache_tag,
+        torch.__version__,
+        torch.version.cuda,
+        bool(getattr(torch._C, "_GLIBCXX_USE_CXX11_ABI", False)),
+        os.environ.get("CC"),
+        os.environ.get("CXX"),
+        os.environ.get("CUDA_HOME"),
+        _CFLAGS,
+        _CUDA_CFLAGS,
+    )
+    digest.update(repr(build_contract).encode())
     for path in (_SOURCE, *_VENDORED_FILES):
         if path.is_file():
             digest.update(path.relative_to(_SOURCE_DIR).as_posix().encode())
@@ -191,19 +212,148 @@ def _find_and_validate_so(dir_fd: int, ext_name: str) -> tuple[int, str]:
     Accepts ``<ext_name>.so`` or ``<ext_name>_v<N>.so`` (versioned).
     Fails closed if no or multiple .so files found.
     """
-    matches = [
-        e for e in os.listdir(dir_fd)
-        if e.startswith(ext_name) and e.endswith(".so")
-    ]
+    matches = _extension_so_candidates(dir_fd, ext_name)
     if len(matches) != 1:
         raise RuntimeError(
             f"expected exactly 1 .so for {ext_name}, found {matches}"
         )
 
-
     so_name = matches[0]
     fd = _open_and_validate_so(dir_fd, so_name)
     return fd, so_name
+
+
+def _extension_so_candidates(dir_fd: int, ext_name: str) -> list[str]:
+    """List exact or Torch-versioned extension artifacts."""
+    exact_name = f"{ext_name}.so"
+    version_prefix = f"{ext_name}_v"
+    candidates = []
+    for entry in os.listdir(dir_fd):
+        if entry == exact_name:
+            candidates.append(entry)
+            continue
+        if not entry.startswith(version_prefix) or not entry.endswith(".so"):
+            continue
+        version = entry[len(version_prefix) : -len(".so")]
+        if version.isdigit():
+            candidates.append(entry)
+    return sorted(candidates)
+
+
+def _validate_private_regular(fd: int, label: str) -> None:
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        raise RuntimeError(f"trellis build file {label!r} is not regular")
+    if st.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"trellis build file {label!r} owned by uid {st.st_uid}"
+        )
+    if st.st_mode & 0o077:
+        raise RuntimeError(
+            f"trellis build file {label!r} has group/other permission bits"
+        )
+    if st.st_nlink != 1:
+        raise RuntimeError(
+            f"trellis build file {label!r} has {st.st_nlink} hard links"
+        )
+
+
+@contextmanager
+def _locked_build_dir(path: Path):
+    """Hold a process-death-safe lock on a validated build directory."""
+    import fcntl
+
+    dir_fd = _validate_secure_build_dir_fd(path)
+    lock_fd = None
+    try:
+        lock_fd = os.open(
+            ".b12x-build.lock",
+            os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        _validate_private_regular(lock_fd, ".b12x-build.lock")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield dir_fd
+    finally:
+        if lock_fd is not None:
+            with suppress(OSError):
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+        os.close(dir_fd)
+
+
+def _completed_extension_name(dir_fd: int, ext_name: str) -> str | None:
+    """Return the atomically published artifact name, or ``None``."""
+    try:
+        fd = os.open(
+            _BUILD_COMPLETE_MARKER,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC,
+            dir_fd=dir_fd,
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        _validate_private_regular(fd, _BUILD_COMPLETE_MARKER)
+        payload = os.read(fd, 4096)
+        if os.read(fd, 1):
+            raise RuntimeError("trellis build completion marker is too large")
+    finally:
+        os.close(fd)
+    try:
+        so_name = payload.decode("ascii").strip()
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("invalid trellis build completion marker") from exc
+    candidates = _extension_so_candidates(dir_fd, ext_name)
+    if candidates != [so_name]:
+        raise RuntimeError(
+            "trellis build completion marker does not match its artifact: "
+            f"marker={so_name!r}, artifacts={candidates}"
+        )
+    return so_name
+
+
+def _discard_incomplete_artifacts(dir_fd: int, ext_name: str) -> None:
+    """Remove only validated artifacts from an unpublished build attempt."""
+    for so_name in _extension_so_candidates(dir_fd, ext_name):
+        fd = _open_and_validate_so(dir_fd, so_name)
+        os.close(fd)
+        os.unlink(so_name, dir_fd=dir_fd)
+
+
+def _publish_completed_extension(dir_fd: int, so_name: str) -> None:
+    """Atomically mark one successfully imported artifact complete."""
+    tmp_name = f"{_BUILD_COMPLETE_MARKER}.tmp"
+    with suppress(FileNotFoundError):
+        os.unlink(tmp_name, dir_fd=dir_fd)
+    fd = os.open(
+        tmp_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+        0o600,
+        dir_fd=dir_fd,
+    )
+    try:
+        payload = f"{so_name}\n".encode("ascii")
+        written = 0
+        while written < len(payload):
+            count = os.write(fd, payload[written:])
+            if count == 0:
+                raise OSError("write returned zero bytes")
+            written += count
+        os.fsync(fd)
+        os.replace(
+            tmp_name,
+            _BUILD_COMPLETE_MARKER,
+            src_dir_fd=dir_fd,
+            dst_dir_fd=dir_fd,
+        )
+        os.fsync(dir_fd)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_name, dir_fd=dir_fd)
+        raise
+    finally:
+        os.close(fd)
 
 
 def _load_python_extension_from_fd(name: str, fd: int):
@@ -227,79 +377,53 @@ def _extension():
     produce a self-consistent malicious .so; defend with a trusted
     producer/signature or process isolation.
     """
-    from torch.utils.cpp_extension import (
-        _write_ninja_file_and_build_library,
-        FileBaton,
-    )
+    from torch.utils.cpp_extension import _write_ninja_file_and_build_library
     from torch.utils.cpp_extension import _is_cuda_file
 
-    build_base = _trellis_build_dir()
-    generation = f".gen_{secrets.token_hex(8)}"
-    build_directory = _validate_secure_build_dir(
-        Path(os.path.join(build_base, generation))
-    )
     ext_name = _extension_name()
-    verbose = os.environ.get("B12X_JIT_VERBOSE", "0") == "1"
-    cuda_cflags = [
-        "-O3",
-        "--use_fast_math",
-        "--expt-relaxed-constexpr",
-        "--expt-extended-lambda",
-        "-gencode=arch=compute_120,code=sm_120",
-    ]
-    cflags = ["-O3"]
-    # Build-only: call _write_ninja_file_and_build_library directly
-    # to avoid _jit_compile's _import_module_from_library which executes
-    # the .so before we can validate it.
-    with_cuda = any(_is_cuda_file(s) for s in [str(_SOURCE)])
-    baton = FileBaton(os.path.join(build_directory, "lock"))
-    if baton.try_acquire():
-        try:
+    build_directory = _validate_secure_build_dir(
+        Path(_trellis_build_dir()) / ext_name
+    )
+    with _locked_build_dir(Path(build_directory)) as build_fd:
+        completed_name = _completed_extension_name(build_fd, ext_name)
+        if completed_name is None:
+            _discard_incomplete_artifacts(build_fd, ext_name)
+            # Build-only: avoid _jit_compile's eager import so the produced
+            # library can be descriptor-validated before execution.
             old_umask = os.umask(0o077)
             try:
                 _write_ninja_file_and_build_library(
                     name=ext_name,
                     sources=[str(_SOURCE)],
-                    extra_cflags=cflags,
-                    extra_cuda_cflags=cuda_cflags,
+                    extra_cflags=list(_CFLAGS),
+                    extra_cuda_cflags=list(_CUDA_CFLAGS),
                     extra_sycl_cflags=[],
                     extra_ldflags=[],
                     extra_include_paths=[str(_SOURCE_DIR)],
                     build_directory=build_directory,
-                    verbose=verbose,
-                    with_cuda=with_cuda,
+                    verbose=os.environ.get("B12X_JIT_VERBOSE", "0") == "1",
+                    with_cuda=_is_cuda_file(str(_SOURCE)),
                     with_sycl=False,
                 )
             finally:
                 os.umask(old_umask)
-        finally:
-            baton.release()
-    else:
-        baton.wait()
 
-    # Retain the generation dirfd and open the produced .so
-    # descriptor-relative with no-follow/nlink checks.
-    gen_fd = _validate_secure_build_dir_fd(Path(build_directory))
-    try:
-        so_fd, so_name = _find_and_validate_so(gen_fd, ext_name)
+            so_fd, so_name = _find_and_validate_so(build_fd, ext_name)
+            try:
+                os.fchmod(so_fd, 0o600)
+                _validate_private_regular(so_fd, so_name)
+                module = _load_python_extension_from_fd(ext_name, so_fd)
+            finally:
+                os.close(so_fd)
+            _publish_completed_extension(build_fd, so_name)
+            return module
+
+        so_fd = _open_and_validate_so(build_fd, completed_name)
         try:
-            # Normalize mode to 0600 before any import.
-            os.fchmod(so_fd, 0o600)
-            # Verify mode after fchmod.
-            st = os.fstat(so_fd)
-            if st.st_mode & 0o077:
-                raise RuntimeError(
-                    f"trellis .so {so_name} mode not 0600 after fchmod"
-                )
-            # Execute PyInit_<ext_name> through CPython's extension loader
-            # while the validated inode fd remains open. This source exports
-            # PYBIND11_MODULE, not TORCH_LIBRARY operators.
-            module = _load_python_extension_from_fd(ext_name, so_fd)
+            _validate_private_regular(so_fd, completed_name)
+            return _load_python_extension_from_fd(ext_name, so_fd)
         finally:
             os.close(so_fd)
-    finally:
-        os.close(gen_fd)
-    return module
 
 
 def _validate_secure_build_dir_fd(path: Path) -> int:

--- a/b12x/gemm/trellis_linear/_small_m.py
+++ b/b12x/gemm/trellis_linear/_small_m.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.machinery
+import importlib.util
 import os
+import secrets
+import stat
+from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 
 import torch
-from torch.utils.cpp_extension import load
 
 
 _SOURCE_DIR = Path(__file__).resolve().parent / "csrc"
@@ -48,27 +52,321 @@ def _extension_name() -> str:
     return f"b12x_trellis_k6_{digest.hexdigest()[:12]}"
 
 
+def _trellis_build_dir() -> str:
+    """Return the exact normalized absolute path of a secure B12x-owned dir.
+
+    Never inherits an unchecked ``TORCH_EXTENSIONS_DIR``.  The default
+    lives under the same per-user cache root as the compile cache.
+    """
+    env_dir = os.environ.get("B12X_TRELLIS_BUILD_DIR")
+    if env_dir:
+        path = Path(env_dir)
+    else:
+        cache_root = os.environ.get("B12X_COMPILE_CACHE_DIR")
+        if cache_root:
+            path = Path(cache_root).parent / "trellis_build"
+        else:
+            xdg = os.environ.get("XDG_CACHE_HOME")
+            if xdg:
+                path = Path(xdg) / "b12x" / "trellis_build"
+            else:
+                path = Path.home() / ".cache" / "b12x" / "trellis_build"
+    return _validate_secure_build_dir(path)
+
+
+def _ancestor_is_root_sticky(st: os.stat_result) -> bool:
+    """Return whether a shared ancestor has root-owned sticky isolation."""
+    return st.st_uid == 0 and bool(st.st_mode & stat.S_ISVTX)
+
+
+def _validate_secure_build_dir(path: Path) -> str:
+    """Walk ancestors from ``/`` with ``O_DIRECTORY|O_NOFOLLOW`` and fstat.
+
+    Ancestors must be euid/root-owned and not group/world-writable.
+    The final directory must be euid-owned with no group/other bits
+    (mode ``0700``).  Missing components are created with ``0700``.
+
+    Returns the exact normalized absolute path string.
+    """
+    abs_path = Path(os.path.abspath(str(path)))
+    parts = [p for p in abs_path.parts if p not in ("", "/")]
+    if not parts:
+        raise RuntimeError("trellis build dir must not be /")
+    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for i, part in enumerate(parts):
+            is_final = i == len(parts) - 1
+            try:
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            except FileNotFoundError:
+                created = False
+                try:
+                    os.mkdir(part, 0o700, dir_fd=fd)
+                    created = True
+                except FileExistsError:
+                    pass
+                if created:
+                    os.fsync(fd)
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            os.close(fd)
+            fd = next_fd
+            st = os.fstat(fd)
+            if not stat.S_ISDIR(st.st_mode):
+                raise RuntimeError(
+                    f"trellis build path component {part!r} is not a directory"
+                )
+            if is_final:
+                if st.st_uid != os.geteuid():
+                    raise RuntimeError(
+                        f"trellis build dir {abs_path} owned by uid {st.st_uid}, "
+                        f"not euid {os.geteuid()}"
+                    )
+                if st.st_mode & 0o077:
+                    raise RuntimeError(
+                        f"trellis build dir {abs_path} has group/other bits; "
+                        f"refusing non-private build dir"
+                    )
+            else:
+                if st.st_uid != os.geteuid() and st.st_uid != 0:
+                    raise RuntimeError(
+                        f"trellis build ancestor {part!r} owned by uid {st.st_uid}"
+                    )
+                root_sticky = _ancestor_is_root_sticky(st)
+                if st.st_mode & stat.S_IWOTH and not root_sticky:
+                    raise RuntimeError(
+                        f"trellis build ancestor {part!r} is world-writable"
+                    )
+                if st.st_mode & stat.S_IWGRP and not root_sticky:
+                    raise RuntimeError(
+                        f"trellis build ancestor {part!r} is group-writable"
+                    )
+    finally:
+        with suppress(OSError):
+            os.close(fd)
+    return str(abs_path)
+
+def _open_and_validate_so(dir_fd: int, so_name: str) -> int:
+    """Open a .so file relative to *dir_fd* with O_NOFOLLOW|O_NONBLOCK,
+    fstat-validate as euid-owned regular nlink==1, and return the fd.
+
+    Does NOT check mode here — the linker may emit 0755; we fchmod
+    to 0600 before any import.
+    """
+    fd = os.open(
+        so_name,
+        os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC,
+        dir_fd=dir_fd,
+    )
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise RuntimeError(
+                f"trellis .so {so_name} is not a regular file"
+            )
+        if st.st_uid != os.geteuid():
+            raise RuntimeError(
+                f"trellis .so {so_name} owned by uid {st.st_uid}"
+            )
+        if st.st_nlink != 1:
+            raise RuntimeError(
+                f"trellis .so {so_name} has {st.st_nlink} hard links"
+            )
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _find_and_validate_so(dir_fd: int, ext_name: str) -> tuple[int, str]:
+    """Find exactly one produced .so in *dir_fd*, validate, return (fd, name).
+
+    Accepts ``<ext_name>.so`` or ``<ext_name>_v<N>.so`` (versioned).
+    Fails closed if no or multiple .so files found.
+    """
+    matches = [
+        e for e in os.listdir(dir_fd)
+        if e.startswith(ext_name) and e.endswith(".so")
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected exactly 1 .so for {ext_name}, found {matches}"
+        )
+
+
+    so_name = matches[0]
+    fd = _open_and_validate_so(dir_fd, so_name)
+    return fd, so_name
+
+
+def _load_python_extension_from_fd(name: str, fd: int):
+    """Execute a CPython extension from the already validated open inode."""
+    inode_path = f"/dev/fd/{fd}"
+    loader = importlib.machinery.ExtensionFileLoader(name, inode_path)
+    spec = importlib.util.spec_from_file_location(name, inode_path, loader=loader)
+    if spec is None:
+        raise ImportError(f"cannot create extension spec for {name}")
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
 @lru_cache(maxsize=1)
 def _extension():
-    build_directory = os.environ.get("B12X_TRELLIS_BUILD_DIR")
-    if build_directory:
-        Path(build_directory).mkdir(parents=True, exist_ok=True)
-    return load(
-        name=_extension_name(),
-        sources=[str(_SOURCE)],
-        extra_include_paths=[str(_SOURCE_DIR)],
-        extra_cuda_cflags=[
-            "-O3",
-            "--use_fast_math",
-            "--expt-relaxed-constexpr",
-            "--expt-extended-lambda",
-            "-gencode=arch=compute_120,code=sm_120",
-        ],
-        extra_cflags=["-O3"],
-        build_directory=build_directory,
-        verbose=os.environ.get("B12X_JIT_VERBOSE", "0") == "1",
-    )
+    """Build and load the Trellis K6 extension with full integrity checks.
 
+    Trust contract: verifies integrity (ownership, permissions, link
+    count, no-follow) but not provenance.  A same-euid writer can
+    produce a self-consistent malicious .so; defend with a trusted
+    producer/signature or process isolation.
+    """
+    from torch.utils.cpp_extension import (
+        _write_ninja_file_and_build_library,
+        FileBaton,
+    )
+    from torch.utils.cpp_extension import _is_cuda_file
+
+    build_base = _trellis_build_dir()
+    generation = f".gen_{secrets.token_hex(8)}"
+    build_directory = _validate_secure_build_dir(
+        Path(os.path.join(build_base, generation))
+    )
+    ext_name = _extension_name()
+    verbose = os.environ.get("B12X_JIT_VERBOSE", "0") == "1"
+    cuda_cflags = [
+        "-O3",
+        "--use_fast_math",
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+        "-gencode=arch=compute_120,code=sm_120",
+    ]
+    cflags = ["-O3"]
+    # Build-only: call _write_ninja_file_and_build_library directly
+    # to avoid _jit_compile's _import_module_from_library which executes
+    # the .so before we can validate it.
+    with_cuda = any(_is_cuda_file(s) for s in [str(_SOURCE)])
+    baton = FileBaton(os.path.join(build_directory, "lock"))
+    if baton.try_acquire():
+        try:
+            old_umask = os.umask(0o077)
+            try:
+                _write_ninja_file_and_build_library(
+                    name=ext_name,
+                    sources=[str(_SOURCE)],
+                    extra_cflags=cflags,
+                    extra_cuda_cflags=cuda_cflags,
+                    extra_sycl_cflags=[],
+                    extra_ldflags=[],
+                    extra_include_paths=[str(_SOURCE_DIR)],
+                    build_directory=build_directory,
+                    verbose=verbose,
+                    with_cuda=with_cuda,
+                    with_sycl=False,
+                )
+            finally:
+                os.umask(old_umask)
+        finally:
+            baton.release()
+    else:
+        baton.wait()
+
+    # Retain the generation dirfd and open the produced .so
+    # descriptor-relative with no-follow/nlink checks.
+    gen_fd = _validate_secure_build_dir_fd(Path(build_directory))
+    try:
+        so_fd, so_name = _find_and_validate_so(gen_fd, ext_name)
+        try:
+            # Normalize mode to 0600 before any import.
+            os.fchmod(so_fd, 0o600)
+            # Verify mode after fchmod.
+            st = os.fstat(so_fd)
+            if st.st_mode & 0o077:
+                raise RuntimeError(
+                    f"trellis .so {so_name} mode not 0600 after fchmod"
+                )
+            # Execute PyInit_<ext_name> through CPython's extension loader
+            # while the validated inode fd remains open. This source exports
+            # PYBIND11_MODULE, not TORCH_LIBRARY operators.
+            module = _load_python_extension_from_fd(ext_name, so_fd)
+        finally:
+            os.close(so_fd)
+    finally:
+        os.close(gen_fd)
+    return module
+
+
+def _validate_secure_build_dir_fd(path: Path) -> int:
+    """Like _validate_secure_build_dir but returns the retained fd."""
+    abs_path = Path(os.path.abspath(str(path)))
+    parts = [p for p in abs_path.parts if p not in ("", "/")]
+    if not parts:
+        raise RuntimeError("trellis build dir must not be /")
+    fd = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        for i, part in enumerate(parts):
+            is_final = i == len(parts) - 1
+            try:
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            except FileNotFoundError:
+                created = False
+                try:
+                    os.mkdir(part, 0o700, dir_fd=fd)
+                    created = True
+                except FileExistsError:
+                    pass
+                if created:
+                    os.fsync(fd)
+                next_fd = os.open(
+                    part,
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    dir_fd=fd,
+                )
+            os.close(fd)
+            fd = next_fd
+            st = os.fstat(fd)
+            if not stat.S_ISDIR(st.st_mode):
+                raise RuntimeError(
+                    f"trellis build component {part!r} not a directory"
+                )
+            if is_final:
+                if st.st_uid != os.geteuid():
+                    raise RuntimeError(
+                        f"trellis build dir owned by uid {st.st_uid}"
+                    )
+                if st.st_mode & 0o077:
+                    raise RuntimeError(
+                        "trellis build dir has group/other bits"
+                    )
+            else:
+                if st.st_uid != os.geteuid() and st.st_uid != 0:
+                    raise RuntimeError(
+                        f"trellis ancestor {part!r} owned by uid {st.st_uid}"
+                    )
+                root_sticky = _ancestor_is_root_sticky(st)
+                if st.st_mode & stat.S_IWOTH and not root_sticky:
+                    raise RuntimeError(
+                        f"trellis ancestor {part!r} is world-writable"
+                    )
+                if st.st_mode & stat.S_IWGRP and not root_sticky:
+                    raise RuntimeError(
+                        f"trellis ancestor {part!r} is group-writable"
+                    )
+        return fd
+    except BaseException:
+        with suppress(OSError):
+            os.close(fd)
+        raise
 
 def run_k6_mcg(
     x: torch.Tensor,

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -6,7 +6,10 @@ so these assertions are load-bearing.
 
 from __future__ import annotations
 
+import errno
 import importlib
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -386,3 +389,843 @@ def test_v6_semantic_payload_matches_independent_validators(monkeypatch):
         kernel_resources._semantic_payload_from_cache_payload(serialized_payload)
         == expected
     )
+
+
+
+# ---------------------------------------------------------------------------
+# Issue #168: native cache integrity / ownership / symlink hardening
+# ---------------------------------------------------------------------------
+
+import hashlib
+import json
+import multiprocessing
+import os
+import stat
+import threading
+
+
+def _open_cache_root_worker(path: str, queue) -> None:
+    try:
+        fd = compiler._open_secure_dir_fd(Path(path))
+        os.close(fd)
+        queue.put(None)
+    except BaseException as exc:
+        queue.put(f"{type(exc).__name__}: {exc}")
+
+
+_SIMPLE_PAYLOAD = (
+    "b12x_cute_compile_cache_v6",
+    ("target",),
+    "fp",
+    "tc",
+    None,
+    None,
+    None,
+    None,
+    "env",
+)
+
+
+def _simple_func():
+    pass
+
+
+def _payload_cache_key(payload):
+    return hashlib.sha256(repr(payload).encode("utf-8")).hexdigest()
+
+
+_CK = _payload_cache_key(_SIMPLE_PAYLOAD)
+
+
+def _install_fake_external_binary_module(monkeypatch, fake_cls):
+    for mod_name in (
+        "cutlass",
+        "cutlass.base_dsl",
+        "cutlass.base_dsl.export",
+        "cutlass.base_dsl.export.external_binary_module",
+    ):
+        if mod_name not in sys.modules:
+            monkeypatch.setitem(
+                sys.modules, mod_name, types.ModuleType(mod_name)
+            )
+    sys.modules[
+        "cutlass.base_dsl.export.external_binary_module"
+    ].ExternalBinaryModule = fake_cls
+
+
+def _make_full_manifest(cache_key, payload, func, object_bytes):
+    return compiler._build_compile_manifest(
+        cache_key, payload, func, object_bytes, compiled=None
+    )
+
+
+def _make_secure_cache(tmp_path, cache_key, payload=_SIMPLE_PAYLOAD, func=_simple_func):
+    cache_root = tmp_path / "cache"
+    shard_dir = cache_root / cache_key[:2]
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    object_name = f"{cache_key}.o"
+    manifest_name = f"{cache_key}.json"
+    object_path = shard_dir / object_name
+    manifest_path = shard_dir / manifest_name
+    object_bytes = b"\x7fELF\x02\x01\x01\x00fake-native-object"
+    object_path.write_bytes(object_bytes)
+    manifest = _make_full_manifest(cache_key, payload, func, object_bytes)
+    manifest_path.write_text(json.dumps(manifest) + "\n")
+    os.chmod(object_path, 0o600)
+    os.chmod(manifest_path, 0o600)
+    os.chmod(shard_dir, 0o700)
+    os.chmod(cache_root, 0o700)
+    return {
+        "root": cache_root,
+        "shard": shard_dir,
+        "object": object_path,
+        "manifest": manifest_path,
+        "bytes": object_bytes,
+        "manifest_dict": manifest,
+        "cache_key": cache_key,
+    }
+
+
+def _recompute_evidence_sha(cache_key, sha, launch_metadata):
+    evidence = json.dumps(
+        {"cache_key": cache_key, "object_sha256": sha, "launch_metadata": launch_metadata},
+        sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False,
+    )
+    return hashlib.sha256(evidence.encode("utf-8")).hexdigest()
+
+
+# -- _open_secure_dir_fd ---------------------------------------------------
+
+
+def test_open_secure_dir_fd_creates_private_dir(tmp_path):
+    d = tmp_path / "newcache"
+    fd = compiler._open_secure_dir_fd(d)
+    try:
+        st = os.fstat(fd)
+        assert st.st_mode & 0o777 == 0o700
+    finally:
+        os.close(fd)
+
+
+def test_open_secure_dir_fd_rejects_symlink_root(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir(mode=0o700)
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    with pytest.raises(OSError) as ei:
+        compiler._open_secure_dir_fd(link)
+    assert ei.value.errno in (errno.ELOOP, errno.ENOTDIR)
+
+
+def test_open_secure_dir_fd_rejects_world_writable(tmp_path):
+    d = tmp_path / "ww"
+    d.mkdir()
+    os.chmod(d, 0o707)
+    with pytest.raises(RuntimeError, match="group/other"):
+        compiler._open_secure_dir_fd(d)
+
+
+def test_open_secure_dir_fd_rejects_world_writable_ancestor(tmp_path):
+    p = tmp_path / "wwp"
+    p.mkdir()
+    os.chmod(p, 0o777)
+    c = p / "cache"
+    c.mkdir(mode=0o700)
+    with pytest.raises(RuntimeError, match="world-writable"):
+        compiler._open_secure_dir_fd(c)
+    os.chmod(p, 0o755)
+
+
+def test_open_secure_dir_fd_rejects_root():
+    with pytest.raises(RuntimeError, match="must not be /"):
+        compiler._open_secure_dir_fd(Path("/"))
+
+
+# -- _fstat_assert_regular_0600: nlink==1 ---------------------------------
+
+
+def test_fstat_rejects_hardlink(tmp_path):
+    p = tmp_path / "f"
+    p.write_bytes(b"x")
+    os.chmod(p, 0o600)
+    os.link(p, tmp_path / "link")
+    fd = os.open(str(p), os.O_RDONLY)
+    try:
+        with pytest.raises(RuntimeError, match="hard links"):
+            compiler._fstat_assert_regular_0600(fd, "f")
+    finally:
+        os.close(fd)
+
+
+# -- _validate_launch_metadata ---------------------------------------------
+
+
+def test_validate_launch_metadata_accepts_exact():
+    compiler._validate_launch_metadata({
+        "status": "exact",
+        "source": "cutlass-final-llvm-launch-config-field-2",
+        "launch_dynamic_smem_bytes": {"kernel0": [1024]},
+    })
+
+
+def test_validate_launch_metadata_accepts_unknown():
+    compiler._validate_launch_metadata({
+        "status": "unknown",
+        "source": "cutlass-final-llvm-launch-config-field-2",
+        "reason": "compiled-ir-unavailable",
+        "launch_dynamic_smem_bytes": {},
+    })
+
+
+def test_validate_launch_metadata_rejects_bad_status():
+    with pytest.raises(ValueError, match="status"):
+        compiler._validate_launch_metadata({
+            "status": "evil", "source": "s",
+            "launch_dynamic_smem_bytes": {},
+        })
+
+
+def test_validate_launch_metadata_rejects_non_dict():
+    with pytest.raises(ValueError, match="not a dict"):
+        compiler._validate_launch_metadata("string")
+
+
+def test_validate_launch_metadata_rejects_exact_empty_smem():
+    with pytest.raises(ValueError, match="non-empty"):
+        compiler._validate_launch_metadata({
+            "status": "exact", "source": "s",
+            "launch_dynamic_smem_bytes": {},
+        })
+
+
+def test_validate_launch_metadata_rejects_unknown_with_smem():
+    with pytest.raises(ValueError, match="empty"):
+        compiler._validate_launch_metadata({
+            "status": "unknown", "source": "s", "reason": "r",
+            "launch_dynamic_smem_bytes": {"k": [1]},
+        })
+
+
+def test_validate_launch_metadata_rejects_missing_reason():
+    with pytest.raises(ValueError, match="reason"):
+        compiler._validate_launch_metadata({
+            "status": "unknown", "source": "s",
+            "launch_dynamic_smem_bytes": {},
+        })
+
+
+def test_validate_launch_metadata_rejects_extra_key():
+    with pytest.raises(ValueError, match="extra"):
+        compiler._validate_launch_metadata({
+            "status": "exact", "source": "s",
+            "launch_dynamic_smem_bytes": {"k": [1]},
+            "evil": True,
+        })
+
+
+def test_validate_launch_metadata_rejects_negative_smem():
+    with pytest.raises(ValueError, match="nonneg"):
+        compiler._validate_launch_metadata({
+            "status": "exact", "source": "s",
+            "launch_dynamic_smem_bytes": {"k": [-1]},
+        })
+
+
+def test_validate_launch_metadata_rejects_exact_reason():
+    with pytest.raises(ValueError, match="reason"):
+        compiler._validate_launch_metadata({
+            "status": "exact",
+            "source": "s",
+            "reason": "not canonical for exact status",
+            "launch_dynamic_smem_bytes": {"k": [0]},
+        })
+
+
+# -- _verify_manifest_identity: exact v3 with launch_metadata --------------
+
+
+def test_verify_manifest_identity_accepts_valid():
+    data = b"object"
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, data)
+    sha = compiler._verify_manifest_identity(
+        m, _CK, _SIMPLE_PAYLOAD, _simple_func, len(data)
+    )
+    assert sha == m["object_sha256"]
+
+
+def test_verify_manifest_rejects_bad_launch_status():
+    data = b"object"
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, data)
+    m["launch_metadata"]["status"] = "evil"
+    m["artifact_evidence_sha256"] = _recompute_evidence_sha(
+        _CK, m["object_sha256"], m["launch_metadata"]
+    )
+    with pytest.raises(ValueError, match="status"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, len(data)
+        )
+
+
+def test_verify_manifest_rejects_missing_launch_key():
+    data = b"object"
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, data)
+    del m["launch_metadata"]["source"]
+    m["artifact_evidence_sha256"] = _recompute_evidence_sha(
+        _CK, m["object_sha256"], m["launch_metadata"]
+    )
+    with pytest.raises(ValueError, match="launch_metadata"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, len(data)
+        )
+
+
+def test_verify_manifest_rejects_extra_launch_key():
+    data = b"object"
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, data)
+    m["launch_metadata"]["evil"] = True
+    m["artifact_evidence_sha256"] = _recompute_evidence_sha(
+        _CK, m["object_sha256"], m["launch_metadata"]
+    )
+    with pytest.raises(ValueError, match="extra"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, len(data)
+        )
+
+
+def test_verify_manifest_rejects_wrong_semantic_payload():
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, b"x")
+    m["semantic_payload"] = {"tampered": True}
+    with pytest.raises(ValueError, match="semantic_payload"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, 1
+        )
+
+
+def test_verify_manifest_rejects_wrong_toolchain():
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, b"x")
+    m["toolchain"] = "wrong"
+    with pytest.raises(ValueError, match="toolchain"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, 1
+        )
+
+
+def test_verify_manifest_rejects_missing_field():
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, b"x")
+    del m["cache_payload"]
+    with pytest.raises(ValueError, match="key set"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, 1
+        )
+
+
+def test_verify_manifest_rejects_extra_field():
+    m = _make_full_manifest(_CK, _SIMPLE_PAYLOAD, _simple_func, b"x")
+    m["extra"] = True
+    with pytest.raises(ValueError, match="key set"):
+        compiler._verify_manifest_identity(
+            m, _CK, _SIMPLE_PAYLOAD, _simple_func, 1
+        )
+
+
+def test_verify_manifest_rejects_non_dict():
+    with pytest.raises(ValueError, match="not a JSON object"):
+        compiler._verify_manifest_identity(
+            "string", _CK, _SIMPLE_PAYLOAD, _simple_func, 1
+        )
+
+
+# -- _load_cute_compile_from_disk: no fallback, requires payload+func -------
+
+
+def test_load_without_payload_returns_none(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(_CK) is None
+
+
+def test_load_rejects_missing_manifest(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    entry["manifest"].unlink()
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_digest_mismatch(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    entry["object"].unlink()
+    entry["object"].write_bytes(b"evil")
+    os.chmod(entry["object"], 0o600)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_symlink_object(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    evil = tmp_path / "evil.o"
+    evil.write_bytes(b"attacker")
+    entry["object"].unlink()
+    entry["object"].symlink_to(evil)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_hardlinked_object(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    os.link(entry["object"], tmp_path / "hl.o")
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_hardlinked_manifest(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    os.link(entry["manifest"], tmp_path / "hl.json")
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_world_writable_shard(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    os.chmod(entry["shard"], 0o707)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    ) is None
+
+
+def test_load_rejects_wrong_semantic(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    assert compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD + ("extra",), _simple_func
+    ) is None
+
+
+# -- Load: /dev/fd inode-bound, unlinked staging ---------------------------
+
+
+def test_load_uses_dev_fd_path(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    paths: list[str] = []
+
+    class FakeModule:
+        def __init__(self, path):
+            paths.append(path)
+            with open(path, "rb") as f:
+                assert f.read() == entry["bytes"]
+
+        def __getattr__(self, name):
+            return "loaded"
+
+    _install_fake_external_binary_module(monkeypatch, FakeModule)
+    result = compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    )
+    assert result == "loaded"
+    assert paths[0].startswith("/dev/fd/")
+    # Staging dir cleaned up.
+    shard = entry["root"] / _CK[:2]
+    assert not [d for d in shard.iterdir() if d.name.startswith("._stage_")]
+
+
+def test_load_staging_unlinked_nlink_zero(tmp_path, monkeypatch):
+    """The staged inode is unlinked; fstat must show nlink==0."""
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    nlinks: list[int] = []
+    orig_fstat = os.fstat
+
+    class FakeModule:
+        def __init__(self, path):
+            fd = int(path.split("/")[-1])
+            nlinks.append(orig_fstat(fd).st_nlink)
+
+        def __getattr__(self, name):
+            return "loaded"
+
+    _install_fake_external_binary_module(monkeypatch, FakeModule)
+    result = compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    )
+    assert result == "loaded"
+    assert nlinks == [0]
+
+
+def test_load_swap_stage_dir_after_verify(tmp_path, monkeypatch):
+    """After digest verification, swap the staging directory. The unlinked
+    fd must still deliver the verified bytes — no name to swap."""
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    staged_bytes: list[bytes] = []
+
+    class FakeModule:
+        def __init__(self, path):
+            with open(path, "rb") as f:
+                staged_bytes.append(f.read())
+
+        def __getattr__(self, name):
+            return "loaded"
+
+    _install_fake_external_binary_module(monkeypatch, FakeModule)
+    result = compiler._load_cute_compile_from_disk(
+        _CK, _SIMPLE_PAYLOAD, _simple_func
+    )
+    assert result == "loaded"
+    assert staged_bytes == [entry["bytes"]]
+
+
+# -- _store_cute_compile_to_disk: real publication with inode verify -------
+
+
+class _FakeCompiled:
+    def __init__(self, object_bytes: bytes):
+        self._b = object_bytes
+
+    def dump_to_object(self, prefix: str):
+        return self._b
+
+
+def test_store_publishes_with_inode_verify(tmp_path, monkeypatch):
+    ck = _payload_cache_key(_SIMPLE_PAYLOAD)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(cache_root))
+    obj_bytes = b"\x7fELFfake"
+    compiler._store_cute_compile_to_disk(
+        ck, _FakeCompiled(obj_bytes),
+        cache_payload=_SIMPLE_PAYLOAD, func=_simple_func,
+    )
+    obj_path = cache_root / ck[:2] / f"{ck}.o"
+    man_path = cache_root / ck[:2] / f"{ck}.json"
+    assert obj_path.read_bytes() == obj_bytes
+    assert (os.stat(obj_path).st_mode & 0o777) == 0o600
+    assert (os.stat(man_path).st_mode & 0o777) == 0o600
+    assert (os.stat(obj_path.parent).st_mode & 0o777) == 0o700
+
+
+def test_store_then_load_roundtrip(tmp_path, monkeypatch):
+    ck = _payload_cache_key(_SIMPLE_PAYLOAD)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(cache_root))
+    obj_bytes = b"\x7fELFroundtrip"
+    compiler._store_cute_compile_to_disk(
+        ck, _FakeCompiled(obj_bytes),
+        cache_payload=_SIMPLE_PAYLOAD, func=_simple_func,
+    )
+    staged: list[bytes] = []
+
+    class FakeModule:
+        def __init__(self, path):
+            with open(path, "rb") as f:
+                staged.append(f.read())
+
+        def __getattr__(self, name):
+            return "loaded"
+
+    _install_fake_external_binary_module(monkeypatch, FakeModule)
+    result = compiler._load_cute_compile_from_disk(
+        ck, _SIMPLE_PAYLOAD, _simple_func
+    )
+    assert result == "loaded"
+    assert staged == [obj_bytes]
+
+
+def test_store_under_hostile_umask_still_0600(tmp_path, monkeypatch):
+    ck = _payload_cache_key(_SIMPLE_PAYLOAD)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(cache_root))
+    old = os.umask(0o000)
+    try:
+        compiler._store_cute_compile_to_disk(
+            ck, _FakeCompiled(b"x"),
+            cache_payload=_SIMPLE_PAYLOAD, func=_simple_func,
+        )
+    finally:
+        os.umask(old)
+    obj = cache_root / ck[:2] / f"{ck}.o"
+    assert (os.stat(obj).st_mode & 0o777) == 0o600
+
+
+def test_store_object_without_manifest_is_miss(tmp_path, monkeypatch):
+    ck = _payload_cache_key(_SIMPLE_PAYLOAD)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(cache_root))
+    compiler._store_cute_compile_to_disk(ck, _FakeCompiled(b"x"))
+    man = cache_root / ck[:2] / f"{ck}.json"
+    assert not man.exists()
+    assert compiler._load_cute_compile_from_disk(ck) is None
+
+
+def test_store_leaves_no_tmp(tmp_path, monkeypatch):
+    ck = _payload_cache_key(_SIMPLE_PAYLOAD)
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(cache_root))
+    compiler._store_cute_compile_to_disk(ck, _FakeCompiled(b"x"))
+    shard = cache_root / ck[:2]
+    assert not list(shard.glob(".*.tmp"))
+
+
+# -- _disk_cache_key_lock --------------------------------------------------
+
+
+def test_lock_creates_secure(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    with compiler._disk_cache_key_lock(_CK) as fd:
+        assert fd is not None
+        lp = entry["shard"] / f"{_CK}.lock"
+        assert (os.stat(lp).st_mode & 0o777) == 0o600
+
+
+def test_lock_rejects_symlink(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    lp = entry["shard"] / f"{_CK}.lock"
+    rl = tmp_path / "r.lock"
+    rl.write_text("")
+    lp.symlink_to(rl)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    with pytest.raises(OSError), compiler._disk_cache_key_lock(_CK):
+        pass
+
+
+def test_lock_rejects_hardlink(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    lp = entry["shard"] / f"{_CK}.lock"
+    lp.write_text("")
+    os.chmod(lp, 0o600)
+    os.link(lp, tmp_path / "hl.lock")
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    with pytest.raises(RuntimeError, match="hard links"), compiler._disk_cache_key_lock(_CK):
+        pass
+
+
+def test_lock_serializes_threads(tmp_path, monkeypatch):
+    entry = _make_secure_cache(tmp_path, _CK)
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(entry["root"]))
+    held = threading.Event()
+    done = threading.Event()
+    order: list[str] = []
+
+    def worker(name):
+        with compiler._disk_cache_key_lock(_CK):
+            order.append(f"{name}-enter")
+            if name == "first":
+                held.set()
+                done.wait(timeout=5)
+            order.append(f"{name}-exit")
+
+    t1 = threading.Thread(target=worker, args=("first",))
+    t2 = threading.Thread(target=worker, args=("second",))
+    t1.start()
+    held.wait(timeout=5)
+    t2.start()
+    import time
+    time.sleep(0.1)
+    done.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+    assert order == ["first-enter", "first-exit", "second-enter", "second-exit"]
+
+
+def test_cache_directory_creation_is_multiprocess_safe(tmp_path):
+    root = tmp_path / "multiprocess-cache"
+    ctx = multiprocessing.get_context("spawn")
+    queue = ctx.Queue()
+    processes = [
+        ctx.Process(target=_open_cache_root_worker, args=(str(root), queue))
+        for _ in range(4)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+    assert [queue.get(timeout=2) for _ in processes] == [None] * len(processes)
+
+
+def test_cache_directory_creation_tolerates_mkdir_race(tmp_path, monkeypatch):
+    """A peer creating the missing final component is a successful race."""
+    root = tmp_path / "raced-cache"
+    real_mkdir = compiler.os.mkdir
+    injected = False
+
+    def racing_mkdir(path, mode=0o777, *, dir_fd=None):
+        nonlocal injected
+        if not injected:
+            injected = True
+            real_mkdir(path, mode, dir_fd=dir_fd)
+            raise FileExistsError(errno.EEXIST, "simulated peer mkdir", path)
+        return real_mkdir(path, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(compiler.os, "mkdir", racing_mkdir)
+    fd = compiler._open_secure_dir_fd(root)
+    try:
+        st = os.fstat(fd)
+        assert stat.S_ISDIR(st.st_mode)
+        assert st.st_uid == os.geteuid()
+        assert not st.st_mode & 0o077
+    finally:
+        os.close(fd)
+
+
+def test_trellis_directory_creation_tolerates_mkdir_race(tmp_path, monkeypatch):
+    """Concurrent JIT starters may observe FileExistsError after ENOENT."""
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    root = tmp_path / "raced-trellis"
+    real_mkdir = small_m.os.mkdir
+    injected = False
+
+    def racing_mkdir(path, mode=0o777, *, dir_fd=None):
+        nonlocal injected
+        if not injected:
+            injected = True
+            real_mkdir(path, mode, dir_fd=dir_fd)
+            raise FileExistsError(errno.EEXIST, "simulated peer mkdir", path)
+        return real_mkdir(path, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(small_m.os, "mkdir", racing_mkdir)
+    assert small_m._validate_secure_build_dir(root) == str(root)
+
+
+# -- Trellis build directory -----------------------------------------------
+
+
+def test_trellis_build_dir_ignores_torch_extensions(tmp_path, monkeypatch):
+    monkeypatch.delenv("B12X_TRELLIS_BUILD_DIR", raising=False)
+    monkeypatch.setenv("TORCH_EXTENSIONS_DIR", str(tmp_path / "evil"))
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(tmp_path / "b12xcache"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    result = small_m._trellis_build_dir()
+    assert "evil" not in result
+    assert "trellis_build" in result
+
+
+def test_trellis_build_dir_env_override(tmp_path, monkeypatch):
+    d = tmp_path / "custom"
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(d))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    result = small_m._trellis_build_dir()
+    assert result == str(d.resolve())
+    assert (os.stat(result).st_mode & 0o777) == 0o700
+
+
+def test_trellis_build_dir_rejects_symlink(tmp_path, monkeypatch):
+    real = tmp_path / "r"
+    real.mkdir(mode=0o700)
+    link = tmp_path / "l"
+    link.symlink_to(real)
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(link))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    with pytest.raises(OSError):
+        small_m._trellis_build_dir()
+
+
+def test_trellis_build_dir_rejects_world_writable(tmp_path, monkeypatch):
+    d = tmp_path / "ww"
+    d.mkdir()
+    os.chmod(d, 0o707)
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(d))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    with pytest.raises(RuntimeError, match="group/other"):
+        small_m._trellis_build_dir()
+    os.chmod(d, 0o755)
+
+
+def test_trellis_build_dir_returns_normalized(tmp_path, monkeypatch):
+    d = tmp_path / "real"
+    d.mkdir(mode=0o700)
+    link = tmp_path / "link"
+    link.symlink_to(d)
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(tmp_path / "link" / ".." / "real"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    result = small_m._trellis_build_dir()
+    assert ".." not in result
+
+
+def test_trellis_validate_secure_build_dir_accepts_private(tmp_path):
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    d = tmp_path / "good"
+    result = small_m._validate_secure_build_dir(d)
+    assert result == str(d.resolve())
+    assert (os.stat(result).st_mode & 0o777) == 0o700
+
+
+def test_trellis_extension_uses_build_only_and_fd_import(tmp_path, monkeypatch):
+    """_extension must build without executing the .so, validate it, and
+    import via /dev/fd — not via torch.load which executes before return."""
+    monkeypatch.delenv("B12X_TRELLIS_BUILD_DIR", raising=False)
+    monkeypatch.setenv("TORCH_EXTENSIONS_DIR", str(tmp_path / "evil"))
+    monkeypatch.setenv("B12X_COMPILE_CACHE_DIR", str(tmp_path / "b12xcache"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    small_m._extension.cache_clear()
+
+    build_called = {"n": 0}
+    extension_load = {"n": 0, "names": [], "fds": []}
+
+    def fake_build(**kwargs):
+        build_called["n"] += 1
+        bd = kwargs.get("build_directory", "")
+        name = kwargs.get("name", "ext")
+        so_path = Path(bd) / f"{name}.so"
+        so_path.write_bytes(b"\x7fELFfake_so")
+        os.chmod(so_path, 0o755)  # Simulate normal linker output
+
+    class FakeBaton:
+        def try_acquire(self):
+            return True
+        def release(self):
+            pass
+        def wait(self):
+            pass
+
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension._write_ninja_file_and_build_library",
+        fake_build,
+    )
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension.FileBaton",
+        lambda path: FakeBaton(),
+    )
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension._is_cuda_file",
+        lambda s: True,
+    )
+
+    fake_module = SimpleNamespace(launch_k6_mcg=object())
+
+    def fake_load_extension(name, fd):
+        extension_load["n"] += 1
+        extension_load["names"].append(name)
+        extension_load["fds"].append(fd)
+        assert not os.get_inheritable(fd)
+        return fake_module
+
+    monkeypatch.setattr(small_m, "_load_python_extension_from_fd", fake_load_extension)
+
+    try:
+        result = small_m._extension()
+        assert result is fake_module
+        assert build_called["n"] == 1
+        assert extension_load["n"] == 1
+        assert extension_load["names"] == [small_m._extension_name()]
+        assert len(extension_load["fds"]) == 1
+        # The .so was fchmod'd to 0600 after build
+        bd = small_m._trellis_build_dir()
+        import glob
+        gen_dirs = glob.glob(str(Path(bd) / ".gen_*"))
+        assert len(gen_dirs) == 1
+        so_files = list(Path(gen_dirs[0]).glob("*.so"))
+        assert len(so_files) == 1
+        assert (os.stat(so_files[0]).st_mode & 0o777) == 0o600
+    finally:
+        small_m._extension.cache_clear()

--- a/tests/_lib/test_compile_cache.py
+++ b/tests/_lib/test_compile_cache.py
@@ -1180,21 +1180,9 @@ def test_trellis_extension_uses_build_only_and_fd_import(tmp_path, monkeypatch):
         so_path.write_bytes(b"\x7fELFfake_so")
         os.chmod(so_path, 0o755)  # Simulate normal linker output
 
-    class FakeBaton:
-        def try_acquire(self):
-            return True
-        def release(self):
-            pass
-        def wait(self):
-            pass
-
     monkeypatch.setattr(
         "torch.utils.cpp_extension._write_ninja_file_and_build_library",
         fake_build,
-    )
-    monkeypatch.setattr(
-        "torch.utils.cpp_extension.FileBaton",
-        lambda path: FakeBaton(),
     )
     monkeypatch.setattr(
         "torch.utils.cpp_extension._is_cuda_file",
@@ -1213,19 +1201,144 @@ def test_trellis_extension_uses_build_only_and_fd_import(tmp_path, monkeypatch):
     monkeypatch.setattr(small_m, "_load_python_extension_from_fd", fake_load_extension)
 
     try:
-        result = small_m._extension()
-        assert result is fake_module
+        assert small_m._extension() is fake_module
+        # Clearing the process-local memo simulates a fresh process. The
+        # content-addressed artifact is loaded without invoking Ninja again.
+        small_m._extension.cache_clear()
+        assert small_m._extension() is fake_module
         assert build_called["n"] == 1
-        assert extension_load["n"] == 1
-        assert extension_load["names"] == [small_m._extension_name()]
-        assert len(extension_load["fds"]) == 1
+        assert extension_load["n"] == 2
+        assert extension_load["names"] == [small_m._extension_name()] * 2
+        assert len(extension_load["fds"]) == 2
         # The .so was fchmod'd to 0600 after build
-        bd = small_m._trellis_build_dir()
-        import glob
-        gen_dirs = glob.glob(str(Path(bd) / ".gen_*"))
-        assert len(gen_dirs) == 1
-        so_files = list(Path(gen_dirs[0]).glob("*.so"))
+        bd = Path(small_m._trellis_build_dir()) / small_m._extension_name()
+        so_files = list(bd.glob("*.so"))
         assert len(so_files) == 1
         assert (os.stat(so_files[0]).st_mode & 0o777) == 0o600
+        assert (bd / ".b12x-build.lock").is_file()
+        assert (bd / ".b12x-build-complete").read_text() == f"{so_files[0].name}\n"
+    finally:
+        small_m._extension.cache_clear()
+
+
+def test_trellis_extension_concurrent_starters_share_lock(tmp_path, monkeypatch):
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(tmp_path / "trellis"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    small_m._extension.cache_clear()
+
+    build_started = threading.Event()
+    release_build = threading.Event()
+    build_count = 0
+
+    def fake_build(**kwargs):
+        nonlocal build_count
+        build_count += 1
+        build_started.set()
+        assert release_build.wait(timeout=5)
+        build_dir = Path(kwargs["build_directory"])
+        (build_dir / f"{kwargs['name']}.so").write_bytes(b"\x7fELFfake_so")
+
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension._write_ninja_file_and_build_library",
+        fake_build,
+    )
+    monkeypatch.setattr("torch.utils.cpp_extension._is_cuda_file", lambda _s: True)
+    fake_module = SimpleNamespace(launch_k6_mcg=object())
+    monkeypatch.setattr(
+        small_m,
+        "_load_python_extension_from_fd",
+        lambda _name, _fd: fake_module,
+    )
+
+    results = []
+    errors = []
+
+    def load_extension():
+        try:
+            results.append(small_m._extension())
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=load_extension) for _ in range(2)]
+    try:
+        for thread in threads:
+            thread.start()
+        assert build_started.wait(timeout=5)
+        release_build.set()
+        for thread in threads:
+            thread.join(timeout=10)
+        assert not [thread for thread in threads if thread.is_alive()]
+        assert errors == []
+        assert results == [fake_module, fake_module]
+        assert build_count == 1
+    finally:
+        release_build.set()
+        small_m._extension.cache_clear()
+
+
+def test_trellis_extension_rebuilds_interrupted_generation(tmp_path, monkeypatch):
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(tmp_path / "trellis"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    small_m._extension.cache_clear()
+
+    build_count = 0
+
+    def fake_build(**kwargs):
+        nonlocal build_count
+        build_count += 1
+        so_path = Path(kwargs["build_directory"]) / f"{kwargs['name']}.so"
+        so_path.write_bytes(b"\x7fELFpartial")
+        if build_count == 1:
+            raise RuntimeError("interrupted build")
+        so_path.write_bytes(b"\x7fELFcomplete")
+
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension._write_ninja_file_and_build_library",
+        fake_build,
+    )
+    monkeypatch.setattr("torch.utils.cpp_extension._is_cuda_file", lambda _s: True)
+    fake_module = SimpleNamespace(launch_k6_mcg=object())
+    monkeypatch.setattr(
+        small_m,
+        "_load_python_extension_from_fd",
+        lambda _name, _fd: fake_module,
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="interrupted build"):
+            small_m._extension()
+        build_dir = Path(small_m._trellis_build_dir()) / small_m._extension_name()
+        assert not (build_dir / ".b12x-build-complete").exists()
+
+        small_m._extension.cache_clear()
+        assert small_m._extension() is fake_module
+        assert build_count == 2
+        assert (build_dir / ".b12x-build-complete").is_file()
+    finally:
+        small_m._extension.cache_clear()
+
+
+def test_trellis_extension_rejects_invalid_cached_artifact(tmp_path, monkeypatch):
+    monkeypatch.setenv("B12X_TRELLIS_BUILD_DIR", str(tmp_path / "trellis"))
+    small_m = importlib.import_module("b12x.gemm.trellis_linear._small_m")
+    small_m._extension.cache_clear()
+
+    ext_name = small_m._extension_name()
+    build_dir = Path(
+        small_m._validate_secure_build_dir(
+            Path(small_m._trellis_build_dir()) / ext_name
+        )
+    )
+    outside = tmp_path / "untrusted.so"
+    outside.write_bytes(b"\x7fELFevil")
+    (build_dir / f"{ext_name}.so").symlink_to(outside)
+
+    monkeypatch.setattr(
+        "torch.utils.cpp_extension._write_ninja_file_and_build_library",
+        lambda **_kwargs: pytest.fail("invalid artifacts must not be rebuilt"),
+    )
+    try:
+        with pytest.raises(OSError):
+            small_m._extension()
     finally:
         small_m._extension.cache_clear()


### PR DESCRIPTION
Closes #168.

Hardens the CuTe/Trellis native cache against symlink, ownership, mode, inode-swap, and object-integrity attacks. Root-owned sticky shared ancestors such as `/tmp` remain supported; final cache/build directories stay private.

Verification: `tests/_lib/test_compile_cache.py` — 63 passed on Linux; 61 passed, 2 skipped on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened compiled artifact caching with integrity validation and atomic publishing.
  * Added protection against unsafe directories, symlinks, hard links, and insecure permissions.
  * Improved safe loading of cached and compiled artifacts.

* **Reliability**
  * Added stricter cache metadata validation and locking.
  * Improved build isolation and handling of generated artifacts.

* **Tests**
  * Added comprehensive coverage for cache integrity, filesystem security, locking, and build-directory validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->