### PR TITLE
security: replace pickle-based IPC setup collectives

### DIFF
--- a/b12x/comm/pcie/overlap_probe.py
+++ b/b12x/comm/pcie/overlap_probe.py
@@ -29,6 +29,7 @@ import json
 import math
 import os
 import statistics
+import struct
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -444,22 +445,78 @@ def _global_max(values: Sequence[float]) -> tuple[float, ...]:
     return tuple(float(value) for value in tensor.tolist())
 
 
-def _topology_snapshot(device: torch.device) -> dict[str, Any]:
+def _topology_snapshot(device: torch.device, tp_group: object) -> dict[str, Any]:
     properties = torch.cuda.get_device_properties(device)
-    local_device = {
-        "rank": dist.get_rank(),
-        "visible_ordinal": device.index,
-        "pci_address": (
-            f"{properties.pci_domain_id:08x}:{properties.pci_bus_id:02x}:"
-            f"{properties.pci_device_id:02x}.0"
-        ),
-        "uuid": str(properties.uuid),
-        "name": properties.name,
-    }
-    rank_devices: list[dict[str, Any] | None] = [None] * dist.get_world_size()
-    dist.all_gather_object(rank_devices, local_device)
-    if dist.get_rank() != 0:
+    rank = dist.get_rank(group=tp_group)
+    world_size = dist.get_world_size(group=tp_group)
+    visible_ordinal = device.index if device.index is not None else 0
+
+    # Encode device topology as a fixed-schema int64 tensor on the NCCL
+    # TP group (not the default Gloo group) so the wire stays on the
+    # mandated CUDA/NCCL control backend.
+    _UUID_BYTES = 64
+    _NAME_BYTES = 128
+    uuid_bytes = str(properties.uuid).encode("utf-8")[:_UUID_BYTES]
+    name_bytes = properties.name.encode("utf-8")[:_NAME_BYTES]
+    uuid_packed = struct.unpack(
+        f"<{(_UUID_BYTES + 7) // 8}q", uuid_bytes + b"\x00" * ((_UUID_BYTES + 7) // 8 * 8 - len(uuid_bytes))
+    )
+    name_packed = struct.unpack(
+        f"<{(_NAME_BYTES + 7) // 8}q", name_bytes + b"\x00" * ((_NAME_BYTES + 7) // 8 * 8 - len(name_bytes))
+    )
+    local_wire = torch.tensor(
+        [
+            rank,
+            visible_ordinal,
+            int(properties.pci_domain_id),
+            int(properties.pci_bus_id),
+            int(properties.pci_device_id),
+            *uuid_packed,
+            *name_packed,
+        ],
+        dtype=torch.int64,
+        device=device,
+    )
+    gathered = [
+        torch.empty_like(local_wire) for _ in range(world_size)
+    ]
+    dist.all_gather(gathered, local_wire, group=tp_group)
+
+    if rank != 0:
         return {}
+
+    rank_devices: list[dict[str, Any]] = []
+    seen_ranks: set[int] = set()
+    for t in gathered:
+        vals = t.cpu().tolist()
+        peer_rank = int(vals[0])
+        if peer_rank in seen_ranks:
+            raise RuntimeError(
+                f"duplicate rank {peer_rank} in topology snapshot"
+            )
+        seen_ranks.add(peer_rank)
+        uuid_raw = struct.pack(f"<{len(uuid_packed)}q", *vals[5 : 5 + len(uuid_packed)])
+        name_raw = struct.pack(f"<{len(name_packed)}q", *vals[5 + len(uuid_packed) :])
+        rank_devices.append(
+            {
+                "rank": peer_rank,
+                "visible_ordinal": int(vals[1]),
+                "pci_address": (
+                    f"{int(vals[2]):08x}:{int(vals[3]):02x}:"
+                    f"{int(vals[4]):02x}.0"
+                ),
+                "uuid": uuid_raw.rstrip(b"\x00").decode("utf-8"),
+                "name": name_raw.rstrip(b"\x00").decode("utf-8"),
+            }
+        )
+
+    # Validate complete rank set
+    if sorted(seen_ranks) != list(range(world_size)):
+        raise RuntimeError(
+            f"topology snapshot rank set {sorted(seen_ranks)} != "
+            f"expected {list(range(world_size))}"
+        )
+
 
     def run(command: list[str]) -> str:
         try:
@@ -1180,7 +1237,7 @@ def _rotate(values: tuple[str, ...], offset: int) -> tuple[str, ...]:
 
 def run_probe(config: ProbeConfig) -> dict[str, Any] | None:
     probe = CollectiveOverlapProbe(config)
-    topology = _topology_snapshot(probe.device)
+    topology = _topology_snapshot(probe.device, probe.tp_group)
     rank = probe.rank
     modes = ("tp", "ckv", "side_first", "tp_first")
     result: dict[str, Any] = {

--- a/b12x/comm/pcie/pcie_dcp_a2a.py
+++ b/b12x/comm/pcie/pcie_dcp_a2a.py
@@ -19,7 +19,7 @@ from .pcie_oneshot import (
     _finish_collective_runtime_setup,
     _raise_local_cleanup_errors,
     _align_up,
-    _broadcast_gather_object,
+    _exchange_channel_state,
     _collective_capture_needs_preparation,
     _coordinated_close_channels,
     _current_stream_key,
@@ -352,7 +352,7 @@ class PCIeDCPA2A:
             _require_collective_contract(
                 owner="PCIe DCP A2A direct constructor",
                 exchange_group=self.exchange_group,
-                contract=(
+                contract_fields=[
                     self.world_size,
                     self.max_batch_size,
                     self.total_heads,
@@ -361,7 +361,7 @@ class PCIeDCPA2A:
                     self.output_capacity_elems,
                     self.lse_offset,
                     self.lse_capacity,
-                ),
+                ],
             )
 
         init_error = self._initialize_backend_runtime()
@@ -567,13 +567,20 @@ class PCIeDCPA2A:
         _require_collective_contract(
             owner="PCIe DCP A2A channel layout",
             exchange_group=exchange_group,
-            contract=(
+            contract_fields=[
                 int(max_batch_size),
                 int(total_heads),
                 int(head_dim),
                 int(query_head_dim),
-                layout,
-            ),
+                layout.signal_bytes,
+                layout.staging0_offset,
+                layout.staging1_offset,
+                layout.output_capacity_elems,
+                layout.lse_offset,
+                layout.lse_capacity,
+                layout.slot_bytes,
+                layout.slab_bytes,
+            ],
         )
         slab = PCIeOneshotAllReduce._allocate_shared_buffer(
             exchange_group,
@@ -1602,7 +1609,7 @@ class PCIeDCPA2APool:
             _require_collective_contract(
                 owner="PCIe DCP A2A pool overlap contract",
                 exchange_group=self.exchange_group,
-                contract=self.max_concurrent_channels,
+                contract_fields=[self.max_concurrent_channels],
             )
             _require_full_grid_residency(
                 owner="PCIe DCP A2A pool",
@@ -1706,9 +1713,11 @@ class PCIeDCPA2APool:
                 exchange_group=self.exchange_group,
                 setup=normalize_and_validate,
             )
-            local_state = (normalized, tuple(sorted(self._logical_channels)))
-            gathered = _broadcast_gather_object(local_state, self.exchange_group)
-            if any(state != local_state for state in gathered):
+            existing = tuple(sorted(self._logical_channels))
+            gathered = _exchange_channel_state(
+                normalized, existing, self.exchange_group
+            )
+            if any(state != (normalized, existing) for state in gathered):
                 raise RuntimeError(
                     "PCIe DCP A2A logical channel preparation differs across "
                     f"ranks: {gathered}"

--- a/b12x/comm/pcie/pcie_hierarchical.py
+++ b/b12x/comm/pcie/pcie_hierarchical.py
@@ -21,7 +21,12 @@ from torch.distributed import ProcessGroup
 
 from ._cuda_ipc import CudaRTLibrary
 from ._hierarchical_cute import get_hierarchical_launcher
-from .pcie_oneshot import _broadcast_gather_object, _normalize_device
+from .pcie_oneshot import (
+    _exchange_ipc_handles,
+    _exchange_setup_failures,
+    _normalize_device,
+    _require_collective_contract,
+)
 
 
 ISLAND_SIZE = 4
@@ -218,49 +223,117 @@ class PCIeHierarchicalAllReduce:
         self._local_ptr = 0
         self._remote_ptrs: list[int] = []
         self._closed = False
-
         slab_bytes = self._layout.bytes
         peer_ptrs = [0] * self.world_size
+
+        # Validate layout contract across ranks before any allocation.
+        _require_collective_contract(
+            owner="PCIe hierarchical",
+            exchange_group=exchange_group,
+            contract_fields=[
+                self.world_size,
+                self.max_elements,
+                slab_bytes,
+                self._layout.stage[0],
+                self._layout.stage[1],
+                self._layout.partial[0],
+                self._layout.partial[1],
+            ],
+        )
+
+        # Coordinated export preparation: allocate and export before
+        # exchanging handles.  A rank-local allocation failure is
+        # reported to all peers before any enters handle exchange.
+        local_ptr: int | None = None
+        local_handle: bytes | None = None
+        prepare_error: BaseException | None = None
         try:
-            self._local_ptr = self._ipc.cudaMalloc(slab_bytes)
-            self._ipc.cudaMemset(self._local_ptr, 0, slab_bytes)
-            local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
-            handles = _broadcast_gather_object(local_handle, exchange_group)
-            peer_ptrs[self.rank] = self._local_ptr
-            for peer in _selected_peers(self.rank, self.world_size):
+            local_ptr = self._ipc.cudaMalloc(slab_bytes)
+            self._ipc.cudaMemset(local_ptr, 0, slab_bytes)
+            local_handle = self._ipc.cudaIpcGetMemHandleBytes(local_ptr)
+        except Exception as exc:
+            prepare_error = exc
+
+        prepare_statuses = _exchange_setup_failures(
+            prepare_error,
+            exchange_group=exchange_group,
+            phase="PCIe hierarchical export preparation",
+            exports_retained_on_exchange_failure=False,
+        )
+        if any(prepare_statuses):
+            if local_ptr is not None:
+                with suppress(Exception):
+                    self._ipc.cudaFree(local_ptr)
+            raise RuntimeError(
+                f"PCIe hierarchical export preparation failed: {prepare_statuses}"
+            ) from prepare_error
+
+        assert local_ptr is not None
+        assert local_handle is not None
+        self._local_ptr = local_ptr
+
+        # Exchange IPC handles with typed tensor wire format.
+        try:
+            handles = _exchange_ipc_handles(
+                local_handle, exchange_group, self.device
+            )
+        except Exception as exchange_error:
+            with suppress(Exception):
+                self._ipc.cudaFree(local_ptr)
+            self._local_ptr = 0
+            raise RuntimeError(
+                "PCIe hierarchical CUDA IPC handle exchange failed"
+            ) from exchange_error
+
+        peer_ptrs[self.rank] = local_ptr
+        open_error: BaseException | None = None
+        for peer in _selected_peers(self.rank, self.world_size):
+            try:
                 remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
+            except Exception as exc:
+                if open_error is None:
+                    open_error = RuntimeError(
+                        f"failed to open CUDA IPC handle for peer {peer}"
+                    )
+                    open_error.__cause__ = exc
+                peer_ptrs[peer] = 0
+            else:
                 peer_ptrs[peer] = remote_ptr
                 self._remote_ptrs.append(remote_ptr)
-            # Keep the fixed slab addresses in the captured kernel node's
-            # parameter bank.  The CuTe rank specialization references only
-            # this rank's mapped peers, so unmapped entries remain zero and
-            # are dead at compile time.
-            self._slab_ptrs = tuple(peer_ptrs)
-            # Resolve and load the only reachable specialization before the
-            # channel is exposed.  A first call made under CUDA graph capture
-            # must never compile or load a module.
-            with torch.cuda.device(self.device):
-                for vectorized in ({False, True} if self.vectorized_bf16x2 else {False}):
-                    self._launchers[vectorized] = get_hierarchical_launcher(
-                        self.world_size,
-                        self.rank,
-                        self.device.index or 0,
-                        threads=(112 if vectorized else self.threads),
-                        wait_nanosleep_cycles=self.wait_nanosleep_cycles,
-                        double_buffered=self.double_buffered,
-                        deferred_consumption=self.deferred_consumption,
-                        vectorized_bf16x2=vectorized,
-                    )
-        except Exception:
+
+        # Coordinated import-open verdict: no rank frees its export
+        # until all peers confirm imports are open or the collective
+        # aborts.
+        open_statuses = _exchange_setup_failures(
+            open_error,
+            exchange_group=exchange_group,
+            phase="PCIe hierarchical import open",
+        )
+        if any(open_statuses):
             for ptr in self._remote_ptrs:
                 with suppress(Exception):
                     self._ipc.cudaIpcCloseMemHandle(ptr)
             self._remote_ptrs.clear()
-            if self._local_ptr:
-                with suppress(Exception):
-                    self._ipc.cudaFree(self._local_ptr)
-                self._local_ptr = 0
-            raise
+            with suppress(Exception):
+                self._ipc.cudaFree(local_ptr)
+            self._local_ptr = 0
+            raise RuntimeError(
+                f"PCIe hierarchical import open failed: {open_statuses}"
+            ) from open_error
+
+        self._slab_ptrs = tuple(peer_ptrs)
+        with torch.cuda.device(self.device):
+            for vectorized in ({False, True} if self.vectorized_bf16x2 else {False}):
+                self._launchers[vectorized] = get_hierarchical_launcher(
+                    self.world_size,
+                    self.rank,
+                    self.device.index or 0,
+                    threads=(112 if vectorized else self.threads),
+                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
+                    double_buffered=self.double_buffered,
+                    deferred_consumption=self.deferred_consumption,
+                    vectorized_bf16x2=vectorized,
+                )
 
     @property
     def mapped_peer_count(self) -> int:

--- a/b12x/comm/pcie/pcie_oneshot.py
+++ b/b12x/comm/pcie/pcie_oneshot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import struct
 import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
@@ -211,29 +212,12 @@ def _collective_capture_needs_preparation(
     """
 
     catalog = tuple(sorted(prepared_channel_ids))
-    local_state = (logical_id, catalog)
-    gathered = _broadcast_gather_object(local_state, exchange_group)
+    gathered = _exchange_capture_contract(logical_id, catalog, exchange_group)
     if not gathered:
         raise RuntimeError(f"{owner} capture contract returned no rank states")
 
     requested_ids: list[str] = []
-    for group_rank, state in enumerate(gathered):
-        if not isinstance(state, (tuple, list)) or len(state) != 2:
-            raise RuntimeError(
-                f"invalid {owner} capture contract from group rank {group_rank}"
-            )
-        requested_id, peer_catalog = state
-        if not isinstance(requested_id, str) or not isinstance(
-            peer_catalog, (tuple, list)
-        ):
-            raise RuntimeError(
-                f"invalid {owner} capture contract from group rank {group_rank}"
-            )
-        peer_catalog = tuple(peer_catalog)
-        if any(not isinstance(value, str) for value in peer_catalog):
-            raise RuntimeError(
-                f"invalid {owner} capture contract from group rank {group_rank}"
-            )
+    for _group_rank, (requested_id, peer_catalog) in enumerate(gathered):
         if peer_catalog != catalog:
             raise RuntimeError(
                 f"{owner} prepared channel catalog differs across ranks: {gathered}"
@@ -271,7 +255,148 @@ def _group_ranks(group: ProcessGroup) -> list[int]:
     return list(range(world_size))
 
 
-def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
+# ---------------------------------------------------------------------------
+# Typed tensor wire format for IPC metadata/handle exchange
+#
+# Every ProcessGroup exchange on the PCIe setup path uses a fixed-schema
+# int64 tensor envelope and dist.all_gather instead of pickle-based object
+# collectives (broadcast_object_list / all_gather_object).
+#
+# All exchanges share a COMMON fixed-size envelope so that ranks entering
+# different phases on the same group cannot cause an NCCL element-count
+# mismatch.  The envelope carries: magic, version, message kind, sender
+# group rank, world size, payload count, and payload byte length.  Every
+# received frame validates the full header before subtype decoding.
+#
+# Fallible local validation is coordinated through an infallible fixed-size
+# verdict preflight (_exchange_preflight) that runs before any payload
+# exchange, preventing asymmetric hangs when one rank's local data is
+# malformed.
+# ---------------------------------------------------------------------------
+
+_IPC_WIRE_MAGIC = 0xB12C0169
+_IPC_WIRE_VERSION = 2
+_CUDA_IPC_HANDLE_BYTES = 128
+_IPC_HANDLE_INT64S = _CUDA_IPC_HANDLE_BYTES // 8  # 16
+
+# Message kinds for the common envelope.
+_MSG_KIND_PREFLIGHT = 1
+_MSG_KIND_IPC_HANDLE = 2
+_MSG_KIND_INT_CONTRACT = 3
+_MSG_KIND_STATUS_STRINGS = 4
+_MSG_KIND_GRAPH_META = 5
+_MSG_KIND_CHANNEL_STATE = 6
+_MSG_KIND_CAPTURE_CONTRACT = 7
+
+# Common envelope: [magic, version, kind, rank, world, count, byte_len, <payload...>]
+_ENVELOPE_HEADER_INT64S = 7
+
+# Bounded capacities for variable-length fields.
+_MAX_STATUS_STR_COUNT = 8
+_MAX_STATUS_STR_LEN = 256
+_MAX_CHANNEL_ID_COUNT = 64
+_MAX_CHANNEL_ID_LEN = 64
+_MAX_GRAPH_BUFFERS = 64
+_MAX_CONTRACT_INTS = 16
+
+# Computed fixed sizes for each message kind (header + payload).
+_STR_STATUS_PAYLOAD = 1 + _MAX_STATUS_STR_COUNT + (_MAX_STATUS_STR_COUNT * _MAX_STATUS_STR_LEN + 7) // 8
+_STR_CHANNEL_BLOCK = 1 + _MAX_CHANNEL_ID_COUNT + (_MAX_CHANNEL_ID_COUNT * _MAX_CHANNEL_ID_LEN + 7) // 8
+_STR_SINGLE_BLOCK = 1 + 1 + (_MAX_CHANNEL_ID_LEN + 7) // 8
+
+_FRAME_SIZE_PREFLIGHT = _ENVELOPE_HEADER_INT64S + 3  # header + planned_kind + planned_frame_size + ok_flag
+_FRAME_SIZE_IPC_HANDLE = _ENVELOPE_HEADER_INT64S + _IPC_HANDLE_INT64S
+_FRAME_SIZE_INT_CONTRACT = _ENVELOPE_HEADER_INT64S + _MAX_CONTRACT_INTS
+_FRAME_SIZE_STATUS = _ENVELOPE_HEADER_INT64S + _STR_STATUS_PAYLOAD
+_FRAME_SIZE_GRAPH = _ENVELOPE_HEADER_INT64S + _MAX_GRAPH_BUFFERS * 2  # handles + offsets
+_FRAME_SIZE_CHANNEL_STATE = _ENVELOPE_HEADER_INT64S + _STR_CHANNEL_BLOCK * 2
+_FRAME_SIZE_CAPTURE = _ENVELOPE_HEADER_INT64S + _STR_SINGLE_BLOCK + _STR_CHANNEL_BLOCK
+
+_SIGNED_I64_MIN = -(1 << 63)
+_SIGNED_I64_MAX = (1 << 63) - 1
+
+
+def _check_i64(value: int) -> int:
+    """Clamp/validate that a Python int fits in signed int64 range."""
+    if value < _SIGNED_I64_MIN or value > _SIGNED_I64_MAX:
+        raise ValueError(f"integer {value} out of signed int64 range")
+    return int(value)
+
+
+def _pack_bytes_to_int64s(data: bytes) -> list[int]:
+    """Pack bytes into little-endian int64 values (8 bytes each)."""
+    padded_len = (len(data) + 7) // 8 * 8
+    padded = data + b"\x00" * (padded_len - len(data))
+    return list(struct.unpack(f"<{padded_len // 8}q", padded))
+
+
+def _unpack_int64s_to_bytes(values: Sequence[int], length: int) -> bytes:
+    """Unpack int64 values back to bytes, trimming to *length*."""
+    if not values:
+        return b"\x00" * length
+    packed = struct.pack(f"<{len(values)}q", *values)
+    return packed[:length]
+
+
+def _encode_strings_to_int64(
+    strings: Sequence[str], max_count: int, max_len: int
+) -> list[int]:
+    """Encode a sequence of strings into a flat int64 list.
+
+    Layout: ``[count, len0, len1, ..., len(max_count-1), packed_bytes]``
+    where each string is zero-padded to *max_len* bytes and the whole
+    byte block is packed into int64 values.
+    """
+    count = len(strings)
+    if count > max_count:
+        raise ValueError(f"string count {count} exceeds max {max_count}")
+    lengths: list[int] = [0] * max_count
+    raw = bytearray()
+    for i in range(count):
+        encoded = strings[i].encode("utf-8")
+        if len(encoded) > max_len:
+            raise ValueError(
+                f"string at index {i} is {len(encoded)} bytes, exceeds max {max_len}"
+            )
+        lengths[i] = len(encoded)
+        raw += encoded
+        raw += b"\x00" * (max_len - len(encoded))
+    raw += b"\x00" * ((max_count - count) * max_len)
+    byte_ints = _pack_bytes_to_int64s(bytes(raw))
+    return [count] + lengths + byte_ints
+
+
+def _decode_strings_from_int64(
+    values: Sequence[int], max_count: int, max_len: int
+) -> tuple[str, ...]:
+    """Decode a flat int64 list produced by :func:`_encode_strings_to_int64`."""
+    if len(values) < 1 + max_count:
+        raise ValueError(
+            f"string block too short: {len(values)} < {1 + max_count}"
+        )
+    count = int(values[0])
+    if count < 0 or count > max_count:
+        raise ValueError(f"invalid string count {count} (max {max_count})")
+    lengths = [int(v) for v in values[1 : 1 + max_count]]
+    byte_offset = 1 + max_count
+    byte_ints = list(values[byte_offset:])
+    all_bytes = _unpack_int64s_to_bytes(byte_ints, max_count * max_len)
+    result: list[str] = []
+    for i in range(count):
+        length = lengths[i]
+        if length < 0 or length > max_len:
+            raise ValueError(f"invalid string length {length} at index {i}")
+        start = i * max_len
+        result.append(all_bytes[start : start + length].decode("utf-8"))
+    return tuple(result)
+
+
+def _string_block_int64s(max_count: int, max_len: int) -> int:
+    return 1 + max_count + (max_count * max_len + 7) // 8
+
+
+def _validate_nccl_backend(group: ProcessGroup) -> None:
+    """Validate that the ProcessGroup backend is NCCL."""
     try:
         try:
             backend = dist.get_backend(group=group)
@@ -288,22 +413,446 @@ def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
         )
     if not torch.cuda.is_available():
         raise RuntimeError("PCIe oneshot IPC exchange requires CUDA")
-    return torch.device("cuda", torch.cuda.current_device())
 
 
-def _broadcast_gather_object(local_object: object, group: ProcessGroup) -> list[object]:
-    # `broadcast_object_list` is more robust than `all_gather_object` for
-    # the host-side exchange that happens around IPC setup and graph capture.
+def _all_gather_int64(
+    local_values: Sequence[int],
+    group: ProcessGroup,
+    device: torch.device,
+) -> list[list[int]]:
+    """All-gather a flat int64 vector from every rank via tensor collective.
+
+    *device* is the explicit owner device, not the ambient current device.
+    """
+    world_size = dist.get_world_size(group=group)
+    local_tensor = torch.tensor(local_values, dtype=torch.int64, device=device)
+    gathered = [torch.empty_like(local_tensor) for _ in range(world_size)]
+    dist.all_gather(gathered, local_tensor, group=group)
+    return [t.cpu().tolist() for t in gathered]
+
+
+def _validate_envelope(
+    values: Sequence[int],
+    group_rank: int,
+    world_size: int,
+    expected_kind: int,
+    expected_frame_size: int,
+) -> None:
+    """Validate the common envelope header and exact frame size."""
+    if len(values) != expected_frame_size:
+        raise RuntimeError(
+            f"IPC wire frame size mismatch from group rank {group_rank}: "
+            f"expected {expected_frame_size} int64s, got {len(values)}"
+        )
+    magic = int(values[0])
+    if magic != _IPC_WIRE_MAGIC:
+        raise RuntimeError(
+            f"IPC wire magic mismatch from group rank {group_rank}: "
+            f"expected 0x{_IPC_WIRE_MAGIC:X}, got 0x{magic:X}"
+        )
+    version = int(values[1])
+    if version != _IPC_WIRE_VERSION:
+        raise RuntimeError(
+            f"IPC wire version mismatch from group rank {group_rank}: "
+            f"expected {_IPC_WIRE_VERSION}, got {version}"
+        )
+    kind = int(values[2])
+    if kind != expected_kind:
+        raise RuntimeError(
+            f"IPC wire message kind mismatch from group rank {group_rank}: "
+            f"expected {expected_kind}, got {kind}"
+        )
+    peer_rank = int(values[3])
+    if peer_rank != group_rank:
+        raise RuntimeError(
+            f"IPC wire rank mismatch from group rank {group_rank}: "
+            f"reported rank {peer_rank}"
+        )
+    peer_world = int(values[4])
+    if peer_world != world_size:
+        raise RuntimeError(
+            f"IPC wire world size mismatch from group rank {group_rank}: "
+            f"expected {world_size}, got {peer_world}"
+        )
+    # values[5] = count, values[6] = byte_len -- validated by subtype decoder
+
+
+def _exchange_preflight(
+    local_ok: bool,
+    group: ProcessGroup,
+    device: torch.device,
+    planned_kind: int,
+    planned_frame_size: int,
+) -> list[bool]:
+    """Agree the payload shape and local-validation verdict before exchange."""
     world_size = dist.get_world_size(group=group)
     rank = dist.get_rank(group=group)
-    all_objects: list[list[object | None]] = [[None] for _ in range(world_size)]
-    all_objects[rank][0] = local_object
-    device = _object_broadcast_device(group)
-    for index, src_rank in enumerate(_group_ranks(group)):
-        dist.broadcast_object_list(
-            all_objects[index], src=src_rank, group=group, device=device
+    wire = [
+        _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_PREFLIGHT,
+        rank, world_size, 3, 24,
+        int(planned_kind), int(planned_frame_size), int(local_ok),
+    ]
+    gathered = _all_gather_int64(wire, group, device)
+    result: list[bool] = []
+    for i, values in enumerate(gathered):
+        _validate_envelope(
+            values, i, world_size, _MSG_KIND_PREFLIGHT, _FRAME_SIZE_PREFLIGHT
         )
-    return [entry[0] for entry in all_objects]
+        peer_kind = int(values[_ENVELOPE_HEADER_INT64S])
+        peer_frame_size = int(values[_ENVELOPE_HEADER_INT64S + 1])
+        if peer_kind != planned_kind or peer_frame_size != planned_frame_size:
+            raise RuntimeError(
+                f"IPC wire preflight plan mismatch from group rank {i}: "
+                f"expected kind/frame {planned_kind}/{planned_frame_size}, "
+                f"got {peer_kind}/{peer_frame_size}"
+            )
+        result.append(bool(int(values[_ENVELOPE_HEADER_INT64S + 2])))
+    return result
+
+
+def _coordinated_exchange(
+    local_ok: bool,
+    build_wire: Callable[[int, int], list[int]],
+    group: ProcessGroup,
+    device: torch.device,
+    msg_kind: int,
+    frame_size: int,
+) -> list[list[int]]:
+    """Run preflight then payload exchange, coordinating local validation failures.
+
+    *build_wire* receives (rank, world_size) and returns the full wire frame
+    (including envelope header).  If any rank's preflight reports failure,
+    all ranks raise before entering the payload gather.
+    """
+    world_size = dist.get_world_size(group=group)
+    rank = dist.get_rank(group=group)
+    ok_results = _exchange_preflight(
+        local_ok, group, device, msg_kind, frame_size
+    )
+    if not all(ok_results):
+        failed = [str(i) for i, ok in enumerate(ok_results) if not ok]
+        raise RuntimeError(
+            f"IPC wire preflight failed for group ranks {','.join(failed)}"
+        )
+    wire = build_wire(rank, world_size)
+    gathered = _all_gather_int64(wire, group, device)
+    for i, values in enumerate(gathered):
+        _validate_envelope(values, i, world_size, msg_kind, frame_size)
+    return gathered
+
+
+def _exchange_ipc_handles(
+    local_handle: bytes, group: ProcessGroup, device: Optional[torch.device] = None
+) -> list[bytes]:
+    """Exchange CUDA IPC handle bytes via typed int64 tensor collective.
+
+    Each rank contributes exactly 128 bytes of handle data, packed into 16
+    int64 values.  A coordinated preflight validates local handle length
+    on all ranks before any enters the payload gather.  Received handles
+    are validated for magic, version, kind, rank, world_size, and exact
+    frame size **before** any caller opens them with ``cudaIpcOpenMemHandle``.
+    """
+    local_ok = len(local_handle) == _CUDA_IPC_HANDLE_BYTES
+    if not local_ok:
+        local_handle = b"\x00" * _CUDA_IPC_HANDLE_BYTES  # safe placeholder
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        packed = _pack_bytes_to_int64s(local_handle)
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE,
+            rk, ws, _CUDA_IPC_HANDLE_BYTES, _CUDA_IPC_HANDLE_BYTES, *packed,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE,
+    )
+    handles: list[bytes] = []
+    for i, values in enumerate(gathered):
+        handle_bytes = _unpack_int64s_to_bytes(
+            values[_ENVELOPE_HEADER_INT64S:], _CUDA_IPC_HANDLE_BYTES
+        )
+        if len(handle_bytes) != _CUDA_IPC_HANDLE_BYTES:
+            raise RuntimeError(
+                f"CUDA IPC handle byte length mismatch from group rank {i}: "
+                f"expected {_CUDA_IPC_HANDLE_BYTES}, got {len(handle_bytes)}"
+            )
+        handles.append(handle_bytes)
+    return handles
+
+
+def _exchange_int_contract(
+    local_values: Sequence[int], group: ProcessGroup, device: Optional[torch.device] = None
+) -> list[list[int]]:
+    """Exchange integer contract values via int64 tensor collective.
+
+    All ranks must contribute the same number of fields.  A coordinated
+    preflight validates local field count and int64 range on all ranks
+    before any enters the payload gather.
+    """
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+    field_count = len(local_values)
+    local_ok = field_count <= _MAX_CONTRACT_INTS
+    if local_ok:
+        try:
+            validated = [_check_i64(int(v)) for v in local_values]
+        except (ValueError, TypeError):
+            local_ok = False
+            validated = [0] * field_count
+    else:
+        validated = []
+    field_count_safe = min(field_count, _MAX_CONTRACT_INTS)
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        padded = (validated + [0] * _MAX_CONTRACT_INTS)[:_MAX_CONTRACT_INTS]
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_INT_CONTRACT,
+            rk, ws, field_count_safe, field_count_safe * 8, *padded,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_INT_CONTRACT, _FRAME_SIZE_INT_CONTRACT,
+    )
+    result: list[list[int]] = []
+    for i, values in enumerate(gathered):
+        peer_count = int(values[5])
+        if peer_count != field_count_safe:
+            raise RuntimeError(
+                f"contract field count mismatch from group rank {i}: "
+                f"expected {field_count_safe}, got {peer_count}"
+            )
+        result.append([int(v) for v in values[_ENVELOPE_HEADER_INT64S : _ENVELOPE_HEADER_INT64S + peer_count]])
+    return result
+
+
+def _exchange_status_strings(
+    local_strings: tuple[str, ...], group: ProcessGroup, device: Optional[torch.device] = None
+) -> tuple[tuple[str, ...], ...]:
+    """Exchange bounded status/error strings via int64 tensor collective."""
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+
+    # Validate locally; preflight coordinates any failure.
+    local_ok = True
+    try:
+        if len(local_strings) > _MAX_STATUS_STR_COUNT:
+            local_ok = False
+        for s in local_strings:
+            if len(s.encode("utf-8")) > _MAX_STATUS_STR_LEN:
+                local_ok = False
+    except Exception:
+        local_ok = False
+    safe_strings = local_strings if local_ok else ()
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        encoded = _encode_strings_to_int64(
+            safe_strings, _MAX_STATUS_STR_COUNT, _MAX_STATUS_STR_LEN
+        )
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_STATUS_STRINGS,
+            rk, ws, len(safe_strings), _MAX_STATUS_STR_LEN, *encoded,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_STATUS_STRINGS, _FRAME_SIZE_STATUS,
+    )
+    result: list[tuple[str, ...]] = []
+    for _i, values in enumerate(gathered):
+        strings = _decode_strings_from_int64(
+            values[_ENVELOPE_HEADER_INT64S:], _MAX_STATUS_STR_COUNT, _MAX_STATUS_STR_LEN
+        )
+        result.append(strings)
+    return tuple(result)
+
+
+def _exchange_graph_meta(
+    local_handles: list[int],
+    local_offsets: list[int],
+    group: ProcessGroup,
+    device: Optional[torch.device] = None,
+) -> list[tuple[list[int], list[int]]]:
+    """Exchange graph-buffer IPC handles and offsets via int64 tensor collective.
+
+    Handles and offsets have **independent** cardinalities.  Each handle
+    value is a small integer (native handle id), not a 128-byte CUDA IPC
+    handle.  All values are validated as non-negative int64 before exchange.
+    """
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+    handle_count = len(local_handles)
+    offset_count = len(local_offsets)
+    local_ok = (
+        handle_count <= _MAX_GRAPH_BUFFERS
+        and offset_count <= _MAX_GRAPH_BUFFERS
+    )
+    if local_ok:
+        try:
+            for v in local_handles:
+                _check_i64(int(v))
+            for v in local_offsets:
+                _check_i64(int(v))
+        except (ValueError, TypeError):
+            local_ok = False
+    safe_h = local_handles if local_ok else []
+    safe_o = local_offsets if local_ok else []
+    h_count = min(handle_count, _MAX_GRAPH_BUFFERS)
+    o_count = min(offset_count, _MAX_GRAPH_BUFFERS)
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        padded_h = ([_check_i64(int(v)) for v in safe_h] + [0] * _MAX_GRAPH_BUFFERS)[:_MAX_GRAPH_BUFFERS]
+        padded_o = ([_check_i64(int(v)) for v in safe_o] + [0] * _MAX_GRAPH_BUFFERS)[:_MAX_GRAPH_BUFFERS]
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_GRAPH_META,
+            rk, ws, h_count, o_count, *padded_h, *padded_o,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_GRAPH_META, _FRAME_SIZE_GRAPH,
+    )
+    result: list[tuple[list[int], list[int]]] = []
+    for i, values in enumerate(gathered):
+        peer_h_count = int(values[5])
+        peer_o_count = int(values[6])
+        if peer_h_count < 0 or peer_h_count > _MAX_GRAPH_BUFFERS:
+            raise RuntimeError(
+                f"graph handle count {peer_h_count} from group rank {i} "
+                f"exceeds max {_MAX_GRAPH_BUFFERS}"
+            )
+        if peer_o_count < 0 or peer_o_count > _MAX_GRAPH_BUFFERS:
+            raise RuntimeError(
+                f"graph offset count {peer_o_count} from group rank {i} "
+                f"exceeds max {_MAX_GRAPH_BUFFERS}"
+            )
+        base = _ENVELOPE_HEADER_INT64S
+        handles = [int(v) for v in values[base : base + peer_h_count]]
+        offsets = [
+            int(v)
+            for v in values[base + _MAX_GRAPH_BUFFERS : base + _MAX_GRAPH_BUFFERS + peer_o_count]
+        ]
+        result.append((handles, offsets))
+    return result
+
+
+def _exchange_channel_state(
+    normalized: tuple[str, ...],
+    existing: tuple[str, ...],
+    group: ProcessGroup,
+    device: Optional[torch.device] = None,
+) -> list[tuple[tuple[str, ...], tuple[str, ...]]]:
+    """Exchange logical channel preparation state via int64 tensor collective."""
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+
+    local_ok = True
+    try:
+        if len(normalized) > _MAX_CHANNEL_ID_COUNT or len(existing) > _MAX_CHANNEL_ID_COUNT:
+            local_ok = False
+        for s in list(normalized) + list(existing):
+            if len(s.encode("utf-8")) > _MAX_CHANNEL_ID_LEN:
+                local_ok = False
+    except Exception:
+        local_ok = False
+    safe_norm = normalized if local_ok else ()
+    safe_exist = existing if local_ok else ()
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        norm_enc = _encode_strings_to_int64(
+            safe_norm, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN
+        )
+        exist_enc = _encode_strings_to_int64(
+            safe_exist, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN
+        )
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_CHANNEL_STATE,
+            rk, ws, len(safe_norm), len(safe_exist), *norm_enc, *exist_enc,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_CHANNEL_STATE, _FRAME_SIZE_CHANNEL_STATE,
+    )
+    block = _string_block_int64s(_MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN)
+    result: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+    for _i, values in enumerate(gathered):
+        norm_vals = values[_ENVELOPE_HEADER_INT64S : _ENVELOPE_HEADER_INT64S + block]
+        exist_vals = values[_ENVELOPE_HEADER_INT64S + block : _ENVELOPE_HEADER_INT64S + 2 * block]
+        norm = _decode_strings_from_int64(norm_vals, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN)
+        exist = _decode_strings_from_int64(exist_vals, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN)
+        result.append((norm, exist))
+    return result
+
+
+def _exchange_capture_contract(
+    logical_id: str,
+    catalog: tuple[str, ...],
+    group: ProcessGroup,
+    device: Optional[torch.device] = None,
+) -> list[tuple[str, tuple[str, ...]]]:
+    """Exchange capture contract (logical_id, catalog) via int64 tensor collective."""
+    resolved_device = device or _resolve_exchange_device(group)
+    dist.get_world_size(group=group)
+    dist.get_rank(group=group)
+
+    local_ok = True
+    try:
+        if len(logical_id.encode("utf-8")) > _MAX_CHANNEL_ID_LEN:
+            local_ok = False
+        if len(catalog) > _MAX_CHANNEL_ID_COUNT:
+            local_ok = False
+        for s in catalog:
+            if len(s.encode("utf-8")) > _MAX_CHANNEL_ID_LEN:
+                local_ok = False
+    except Exception:
+        local_ok = False
+    safe_id = logical_id if local_ok else ""
+    safe_cat = catalog if local_ok else ()
+
+    def build_wire(rk: int, ws: int) -> list[int]:
+        id_enc = _encode_strings_to_int64((safe_id,), 1, _MAX_CHANNEL_ID_LEN)
+        cat_enc = _encode_strings_to_int64(
+            safe_cat, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN
+        )
+        return [
+            _IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_CAPTURE_CONTRACT,
+            rk, ws, 1, len(safe_cat), *id_enc, *cat_enc,
+        ]
+
+    gathered = _coordinated_exchange(
+        local_ok, build_wire, group, resolved_device,
+        _MSG_KIND_CAPTURE_CONTRACT, _FRAME_SIZE_CAPTURE,
+    )
+    id_block = _string_block_int64s(1, _MAX_CHANNEL_ID_LEN)
+    cat_block = _string_block_int64s(_MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN)
+    result: list[tuple[str, tuple[str, ...]]] = []
+    for _i, values in enumerate(gathered):
+        id_vals = values[_ENVELOPE_HEADER_INT64S : _ENVELOPE_HEADER_INT64S + id_block]
+        cat_vals = values[_ENVELOPE_HEADER_INT64S + id_block : _ENVELOPE_HEADER_INT64S + id_block + cat_block]
+        decoded_id = _decode_strings_from_int64(id_vals, 1, _MAX_CHANNEL_ID_LEN)[0]
+        cat = _decode_strings_from_int64(cat_vals, _MAX_CHANNEL_ID_COUNT, _MAX_CHANNEL_ID_LEN)
+        result.append((decoded_id, cat))
+    return result
+
+
+def _resolve_exchange_device(group: ProcessGroup) -> torch.device:
+    """Resolve the CUDA device for tensor collectives.
+
+    Preserves the existing NCCL/CUDA integration contract: the ProcessGroup
+    backend must be NCCL and CUDA must be available.  Returns the current
+    CUDA device.
+    """
+    _validate_nccl_backend(group)
+    return torch.device("cuda", torch.cuda.current_device())
 
 
 @dataclass(frozen=True)
@@ -563,7 +1112,7 @@ def _exchange_setup_failures(
     """Collect a setup verdict without allowing one rank to return early."""
 
     try:
-        gathered = _broadcast_gather_object(
+        gathered = _exchange_status_strings(
             _format_setup_error(local_error), exchange_group
         )
     except Exception as exc:
@@ -576,19 +1125,7 @@ def _exchange_setup_failures(
             f"failed to exchange peer {phase} status{retention}"
         ) from exc
 
-    statuses: list[tuple[str, ...]] = []
-    for group_rank, status in enumerate(gathered):
-        if not isinstance(status, (tuple, list)):
-            retention = (
-                "; CUDA IPC exports were retained"
-                if exports_retained_on_exchange_failure
-                else ""
-            )
-            raise RuntimeError(
-                f"invalid peer {phase} status from group rank {group_rank}{retention}"
-            )
-        statuses.append(tuple(str(item) for item in status))
-    return tuple(statuses)
+    return gathered
 
 
 def _require_full_grid_residency(
@@ -683,12 +1220,13 @@ def _run_collective_preallocation_setup(
 
 
 def _require_collective_contract(
-    *, owner: str, exchange_group: ProcessGroup, contract: object
+    *, owner: str, exchange_group: ProcessGroup, contract_fields: Sequence[int]
 ) -> None:
     """Reject divergent rank-local layout/channel inputs before allocation."""
 
-    gathered = _broadcast_gather_object(contract, exchange_group)
-    if any(peer != contract for peer in gathered):
+    gathered = _exchange_int_contract(contract_fields, exchange_group)
+    local_list = list(contract_fields)
+    if any(peer != local_list for peer in gathered):
         raise RuntimeError(f"{owner} contract differs across ranks: {gathered}")
 
 
@@ -1140,22 +1678,14 @@ def _exchange_close_failures(
     if exchange_group is None:
         return (local_failures,)
     try:
-        gathered = _broadcast_gather_object(local_failures, exchange_group)
+        gathered = _exchange_status_strings(local_failures, exchange_group)
     except Exception as exc:
         raise RuntimeError(
             f"failed to exchange peer {phase} status; exported IPC allocations "
             "were not freed"
         ) from exc
 
-    statuses: list[tuple[str, ...]] = []
-    for rank_index, status in enumerate(gathered):
-        if not isinstance(status, (tuple, list)):
-            raise RuntimeError(
-                f"invalid peer {phase} status from group rank {rank_index}; "
-                "exported IPC allocations were not freed"
-            )
-        statuses.append(tuple(str(item) for item in status))
-    return tuple(statuses)
+    return gathered
 
 
 def _raise_coordinated_close_error(
@@ -2002,14 +2532,15 @@ class PCIeOneshotAllReduce:
             _require_collective_contract(
                 owner="PCIe oneshot direct constructor",
                 exchange_group=self.exchange_group,
-                contract=(
+                contract_fields=[
                     self.world_size,
                     self.max_size,
                     self.rank_data_bytes,
-                    self.eager_buffer_bytes,
-                    self._pending_eager_ptrs is not None,
-                    self._transport_policy,
-                ),
+                    int(self.eager_buffer_bytes is not None),
+                    self.eager_buffer_bytes or 0,
+                    int(self._pending_eager_ptrs is not None),
+                    *self._transport_policy,
+                ],
             )
 
         init_error = self._initialize_native_runtime()
@@ -2239,13 +2770,14 @@ class PCIeOneshotAllReduce:
         _require_collective_contract(
             owner="PCIe oneshot channel layout",
             exchange_group=exchange_group,
-            contract=(
+            contract_fields=[
                 signal_bytes,
-                eager_buffer_bytes,
+                int(eager_buffer_bytes is not None),
+                eager_buffer_bytes or 0,
                 max_size,
                 rank_data_bytes,
-                transport_policy,
-            ),
+                *transport_policy,
+            ],
         )
 
         channel_buffers = cls._allocate_eager_channel_buffers(
@@ -2437,7 +2969,7 @@ class PCIeOneshotAllReduce:
         try:
             world_size = dist.get_world_size(group=exchange_group)
             rank = dist.get_rank(group=exchange_group)
-            handles = _broadcast_gather_object(local_handle, exchange_group)
+            handles = _exchange_ipc_handles(local_handle, exchange_group)
         except Exception as exchange_error:
             # No rank has opened an import before handle exchange completes.
             # Retain both ownership and a collective retry ticket if progress
@@ -2868,8 +3400,10 @@ class PCIeOneshotAllReduce:
     def register_graph_buffers(self) -> None:
         if self.exchange_group is None:
             raise ValueError("exchange_group is required to register graph buffers")
-        local_meta = self.get_graph_buffer_ipc_meta()
-        all_meta = _broadcast_gather_object(local_meta, self.exchange_group)
+        local_handles, local_offsets = self.get_graph_buffer_ipc_meta()
+        all_meta = _exchange_graph_meta(
+            local_handles, local_offsets, self.exchange_group
+        )
         num_buffers = [len(entry[1]) for entry in all_meta]
         if any(count != num_buffers[0] for count in num_buffers):
             raise RuntimeError(
@@ -3276,15 +3810,16 @@ class PCIeOneshotAllReducePool:
             _require_collective_contract(
                 owner="PCIe oneshot pool channel layout",
                 exchange_group=self.exchange_group,
-                contract=(
+                contract_fields=[
                     self._signal_bytes,
-                    self.eager_buffer_bytes,
+                    int(self.eager_buffer_bytes is not None),
+                    self.eager_buffer_bytes or 0,
                     self.max_size,
                     self.rank_data_bytes,
-                    self.single_channel,
+                    int(self.single_channel),
                     self.max_concurrent_channels,
-                    self._transport_policy,
-                ),
+                    *self._transport_policy,
+                ],
             )
             # A genuine single-channel pool has no independent eager/graph
             # owners to name. Multi-channel distributed callers must prepare
@@ -3435,9 +3970,11 @@ class PCIeOneshotAllReducePool:
                 exchange_group=self.exchange_group,
                 setup=normalize_and_validate,
             )
-            local_state = (normalized, tuple(sorted(self._logical_channels)))
-            gathered = _broadcast_gather_object(local_state, self.exchange_group)
-            if any(state != local_state for state in gathered):
+            existing = tuple(sorted(self._logical_channels))
+            gathered = _exchange_channel_state(
+                normalized, existing, self.exchange_group
+            )
+            if any(state != (normalized, existing) for state in gathered):
                 raise RuntimeError(
                     "PCIe oneshot logical channel preparation differs across "
                     f"ranks: {gathered}"

--- a/b12x/comm/pcie/pcie_twoshot.py
+++ b/b12x/comm/pcie/pcie_twoshot.py
@@ -230,11 +230,16 @@ class PCIeTwoShotSP:
         _require_collective_contract(
             owner="PCIe twoshot channel layout",
             exchange_group=exchange_group,
-            contract=(
+            contract_fields=[
                 int(max_rows),
                 int(row_elems),
-                layout,
-            ),
+                layout.signal_bytes,
+                layout.pack_stride,
+                layout.scale_offset,
+                layout.scale_stride,
+                layout.slot_bytes,
+                layout.slab_bytes,
+            ],
         )
 
         shared = PCIeOneshotAllReduce._allocate_shared_buffer(

--- a/benchmarks/benchmark_kimi_k3_hierarchical_sequence.py
+++ b/benchmarks/benchmark_kimi_k3_hierarchical_sequence.py
@@ -31,7 +31,7 @@ from torch.utils.cpp_extension import load
 from b12x.comm.pcie import AllReduce
 from b12x.comm.pcie._cuda_ipc import CudaRTLibrary
 from b12x.comm.pcie.pcie_dcp_a2a import PCIeDCPA2APool
-from b12x.comm.pcie.pcie_oneshot import _broadcast_gather_object
+from b12x.comm.pcie.pcie_oneshot import _exchange_ipc_handles
 
 
 DEFAULT_SHAPES = (7168, 3584, 7168)
@@ -98,7 +98,7 @@ class LaneDistributedAllReducePOC:
             self._local_ptr = self._ipc.cudaMalloc(slab_bytes)
             self._ipc.cudaMemset(self._local_ptr, 0, slab_bytes)
             local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
-            handles = _broadcast_gather_object(local_handle, exchange_group)
+            handles = _exchange_ipc_handles(local_handle, exchange_group, self.device)
             peer_ptrs[self.rank] = self._local_ptr
             for peer in _lane_peers(self.rank, self.world_size):
                 ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -802,12 +802,12 @@ def test_pool_collectively_prepares_logical_channels_in_canonical_order(
         lambda stream_key: created.append(stream_key) or object(),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_dcp_a2a._exchange_channel_state",
+        lambda norm, exist, group: [(norm, exist), (norm, exist)],
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, local_status],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, local_strings),
     )
 
     pool.prepare_channels(("target", "draft"))
@@ -835,17 +835,17 @@ def test_pool_rejects_logical_channel_set_mismatch_before_allocation(monkeypatch
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if not local_state or isinstance(local_state[0], str):
-            return [local_state, ()]
-        _requested, existing = local_state
-        return [(("other",), existing), local_state]
+    def gather_status(local_strings, group):
+        return (local_strings, ())
+
+    def gather_channels(normalized, existing, group):
+        return [(("other",), existing), (normalized, existing)]
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_dcp_a2a._broadcast_gather_object", gather
+        "b12x.comm.pcie.pcie_dcp_a2a._exchange_channel_state", gather_channels
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", gather_status
     )
 
     with pytest.raises(RuntimeError, match="differs across ranks"):
@@ -870,8 +870,8 @@ def test_pool_invalid_logical_id_is_rejected_collectively(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with pytest.raises(RuntimeError, match="must not be empty"):
@@ -945,8 +945,8 @@ def test_pool_capture_requires_stable_semantic_id(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with (
@@ -981,15 +981,18 @@ def test_pool_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
         lambda device, stream=None: int(stream),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        requested, catalog = local_state
-        assert requested == "graph:target"
-        return [local_state, ("graph:draft", catalog)]
+    def gather_status(local_strings, group):
+        return (local_strings, local_strings)
+
+    def gather_capture(logical_id, catalog, group):
+        assert logical_id == "graph:target"
+        return [(logical_id, catalog), ("graph:draft", catalog)]
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", gather_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract", gather_capture
     )
 
     with pool.capture(7, channel_id="graph:target") as channel:
@@ -1018,13 +1021,17 @@ def test_pool_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        return [local_state, ("graph:target", ())]
+    def gather_status(local_strings, group):
+        return (local_strings, local_strings)
+
+    def gather_capture(logical_id, catalog, group):
+        return [(logical_id, catalog), ("graph:target", ())]
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", gather_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract", gather_capture
     )
 
     with (
@@ -1054,14 +1061,17 @@ def test_pool_capture_rejects_differing_unprepared_ids(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        _, catalog = local_state
-        return [local_state, ("graph:unknown", catalog)]
+    def gather_status(local_strings, group):
+        return (local_strings, local_strings)
+
+    def gather_capture(logical_id, catalog, group):
+        return [(logical_id, catalog), ("graph:unknown", catalog)]
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", gather_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract", gather_capture
     )
 
     with (
@@ -1095,12 +1105,16 @@ def test_pool_capture_preserves_same_id_convenience_allocation(monkeypatch):
         lambda device, stream=None: int(stream),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, local_strings),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [(logical_id, catalog), (logical_id, catalog)],
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_dcp_a2a._exchange_channel_state",
+        lambda norm, exist, group: [(norm, exist), (norm, exist)],
     )
 
     with pool.capture(7, channel_id="graph:target") as captured:
@@ -1135,8 +1149,12 @@ def test_pool_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
         lambda device, stream=None: 7 if stream is None else int(stream),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, local_strings),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [(logical_id, catalog), (logical_id, catalog)],
     )
 
     with pool.capture(7, channel_id="graph:target") as captured:

--- a/tests/comm/test_pcie_ipc_lifecycle.py
+++ b/tests/comm/test_pcie_ipc_lifecycle.py
@@ -50,8 +50,8 @@ def test_pool_explicit_close_coordinates_imports_before_exports(monkeypatch) -> 
         lambda device: events.append("synchronize"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     pool.close()
@@ -256,8 +256,8 @@ def test_twoshot_explicit_close_coordinates_unmap_then_free(monkeypatch) -> None
         lambda device: events.append("synchronize"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     runtime.close()
@@ -488,9 +488,9 @@ def test_peer_unmap_failure_is_exchanged_before_any_local_export_free(
     runtime.exchange_group = object()
     peer_statuses = iter(
         [
-            lambda local: [local, ("peer close failed",)],
-            lambda local: [local, ()],
-            lambda local: [local, ()],
+            lambda local: (local, ("peer close failed",)),
+            lambda local: (local, ()),
+            lambda local: (local, ()),
         ]
     )
 
@@ -503,8 +503,8 @@ def test_peer_unmap_failure_is_exchanged_before_any_local_export_free(
         lambda device: events.append("synchronize"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: next(peer_statuses)(local_status),
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: next(peer_statuses)(local_strings),
     )
 
     with pytest.raises(RuntimeError, match="group rank 1: peer close failed"):
@@ -548,7 +548,7 @@ def test_status_exchange_failure_retains_local_exports(monkeypatch) -> None:
         lambda *, group: events.append("barrier"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
         fail_status_exchange,
     )
 
@@ -577,10 +577,10 @@ def test_rank_that_freed_locally_retries_until_peer_free_succeeds(
     runtime.exchange_group = object()
     peer_statuses = iter(
         [
-            lambda local: [local, ()],
-            lambda local: [local, ("peer export free failed",)],
-            lambda local: [local, ()],
-            lambda local: [local, ()],
+            lambda local: (local, ()),
+            lambda local: (local, ("peer export free failed",)),
+            lambda local: (local, ()),
+            lambda local: (local, ()),
         ]
     )
 
@@ -593,8 +593,8 @@ def test_rank_that_freed_locally_retries_until_peer_free_succeeds(
         lambda device: events.append("synchronize"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: next(peer_statuses)(local_status),
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: next(peer_statuses)(local_strings),
     )
 
     with pytest.raises(RuntimeError, match="group rank 1: peer export free failed"):

--- a/tests/comm/test_pcie_ipc_wire_format.py
+++ b/tests/comm/test_pcie_ipc_wire_format.py
@@ -1,0 +1,467 @@
+"""Contract tests for the typed tensor IPC wire format (issue #169).
+
+These tests verify that:
+  * The PCIe setup path contains no pickle-based object collective.
+  * Valid multi-rank metadata round-trips through the typed tensor exchanges.
+  * Malformed version, length, rank, world, capacity, and handle bytes are
+    rejected **before** ``cudaIpcOpenMemHandle`` is called.
+  * The NCCL/CUDA control-device contract is preserved.
+  * Coordinated preflight prevents asymmetric hangs on local validation
+    failures.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from b12x.comm.pcie import pcie_oneshot
+from b12x.comm.pcie.pcie_oneshot import (
+    _CUDA_IPC_HANDLE_BYTES,
+    _FRAME_SIZE_IPC_HANDLE,
+    _IPC_WIRE_MAGIC,
+    _IPC_WIRE_VERSION,
+    _MAX_CONTRACT_INTS,
+    _MAX_GRAPH_BUFFERS,
+    _MSG_KIND_IPC_HANDLE,
+    _decode_strings_from_int64,
+    _encode_strings_to_int64,
+    _exchange_capture_contract,
+    _exchange_channel_state,
+    _exchange_graph_meta,
+    _exchange_int_contract,
+    _exchange_ipc_handles,
+    _exchange_status_strings,
+    _pack_bytes_to_int64s,
+    _unpack_int64s_to_bytes,
+    _validate_envelope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_group():
+    return MagicMock()
+
+
+def _patch_common(monkeypatch, world_size=2, rank=0):
+    """Patch dist and CUDA so exchange functions can run on CPU."""
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: world_size)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: rank)
+    monkeypatch.setattr("torch.distributed.get_backend", lambda group=None: "nccl")
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+    monkeypatch.setattr("torch.cuda.current_device", lambda: 0)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._resolve_exchange_device",
+        lambda group: torch.device("cpu"),
+    )
+
+
+def _patch_all_gather_echo(monkeypatch, world_size=2, rank=0):
+    """Patch all_gather to echo local data into every slot with correct rank."""
+    _patch_common(monkeypatch, world_size, rank)
+
+    def fake_all_gather(gathered_list, local_tensor, group=None):
+        vals = local_tensor.tolist()
+        for i, slot in enumerate(gathered_list):
+            peer_vals = list(vals)
+            if len(peer_vals) > 3:
+                peer_vals[3] = i  # set rank field in envelope
+            slot.copy_(torch.tensor(peer_vals, dtype=torch.int64))
+
+    monkeypatch.setattr("torch.distributed.all_gather", fake_all_gather)
+
+
+def _patch_all_gather_per_rank(monkeypatch, world_size, rank, per_rank_values):
+    """Patch all_gather to return caller-specified per-rank int64 lists."""
+    _patch_common(monkeypatch, world_size, rank)
+    call_count = [0]
+
+    def fake_all_gather(gathered_list, local_tensor, group=None):
+        # First call is preflight (frame size = _FRAME_SIZE_PREFLIGHT)
+        # Second call is the payload
+        if call_count[0] == 0:
+            # Preflight: preserve the production planned-kind/frame fields.
+            preflight = local_tensor.tolist()
+            for i, slot in enumerate(gathered_list):
+                peer = list(preflight)
+                peer[3] = i
+                slot.copy_(torch.tensor(peer, dtype=torch.int64))
+        else:
+            for i, slot in enumerate(gathered_list):
+                slot.copy_(torch.tensor(per_rank_values[i], dtype=torch.int64))
+        call_count[0] += 1
+
+    monkeypatch.setattr("torch.distributed.all_gather", fake_all_gather)
+
+
+def _patch_all_gather_with_preflight_failure(monkeypatch, world_size, rank, failed_ranks):
+    """Patch all_gather so preflight reports failure for specified ranks."""
+    _patch_common(monkeypatch, world_size, rank)
+
+    def fake_all_gather(gathered_list, local_tensor, group=None):
+        preflight = local_tensor.tolist()
+        for i, slot in enumerate(gathered_list):
+            peer = list(preflight)
+            peer[3] = i
+            peer[-1] = 0 if i in failed_ranks else 1
+            slot.copy_(torch.tensor(peer, dtype=torch.int64))
+
+    monkeypatch.setattr("torch.distributed.all_gather", fake_all_gather)
+
+
+def _make_ipc_handle_frame(rank, world_size, handle_bytes=None, magic=_IPC_WIRE_MAGIC, version=_IPC_WIRE_VERSION):
+    """Build a valid IPC handle wire frame."""
+    if handle_bytes is None:
+        handle_bytes = bytes(range(128))
+    packed = _pack_bytes_to_int64s(handle_bytes)
+    return [
+        magic, version, _MSG_KIND_IPC_HANDLE,
+        rank, world_size, _CUDA_IPC_HANDLE_BYTES, _CUDA_IPC_HANDLE_BYTES,
+        *packed,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# No-object-collective assertion
+# ---------------------------------------------------------------------------
+
+def test_setup_path_has_no_object_collective_calls():
+    """The pcie_oneshot source must not call any pickle-based object collective."""
+    source = inspect.getsource(pcie_oneshot)
+    for func_name in (
+        "broadcast_object_list(",
+        "all_gather_object(",
+        "gather_object(",
+        "scatter_object(",
+    ):
+        for lineno, line in enumerate(source.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#") or stripped.startswith('"""') or stripped.startswith("'''"):
+                continue
+            code_part = line.split("#")[0] if "#" in line else line
+            if func_name in code_part:
+                pytest.fail(
+                    f"Object collective {func_name!r} found at line {lineno}: {line!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Byte packing round-trip
+# ---------------------------------------------------------------------------
+
+class TestPackUnpackBytes:
+    def test_roundtrip_exact_multiple_of_8(self):
+        data = bytes(range(8))
+        packed = _pack_bytes_to_int64s(data)
+        assert len(packed) == 1
+        assert _unpack_int64s_to_bytes(packed, 8) == data
+
+    def test_roundtrip_non_multiple_of_8(self):
+        data = bytes(range(10))
+        packed = _pack_bytes_to_int64s(data)
+        assert _unpack_int64s_to_bytes(packed, 10) == data
+
+    def test_roundtrip_128_bytes(self):
+        data = bytes(range(128))
+        packed = _pack_bytes_to_int64s(data)
+        assert len(packed) == 16
+        assert _unpack_int64s_to_bytes(packed, 128) == data
+
+    def test_empty_bytes(self):
+        packed = _pack_bytes_to_int64s(b"")
+        assert packed == []
+        assert _unpack_int64s_to_bytes(packed, 0) == b""
+
+
+# ---------------------------------------------------------------------------
+# String codec
+# ---------------------------------------------------------------------------
+
+class TestStringCodec:
+    def test_roundtrip_empty(self):
+        encoded = _encode_strings_to_int64((), 4, 32)
+        assert _decode_strings_from_int64(encoded, 4, 32) == ()
+
+    def test_roundtrip_single(self):
+        encoded = _encode_strings_to_int64(("hello",), 4, 32)
+        assert _decode_strings_from_int64(encoded, 4, 32) == ("hello",)
+
+    def test_roundtrip_multiple(self):
+        strings = ("a", "bb", "ccc", "dddd")
+        encoded = _encode_strings_to_int64(strings, 4, 32)
+        assert _decode_strings_from_int64(encoded, 4, 32) == strings
+
+    def test_roundtrip_unicode(self):
+        strings = ("café", "naïve", "日本語")
+        encoded = _encode_strings_to_int64(strings, 4, 64)
+        assert _decode_strings_from_int64(encoded, 4, 64) == strings
+
+    def test_oversize_count_rejected_not_truncated(self):
+        """Oversize string count must raise, not silently truncate."""
+        with pytest.raises(ValueError, match="exceeds max"):
+            _encode_strings_to_int64(("a", "b", "c", "d", "e"), 3, 32)
+
+    def test_oversize_length_rejected_not_truncated(self):
+        """Oversize string length must raise, not silently truncate."""
+        with pytest.raises(ValueError, match="exceeds max"):
+            _encode_strings_to_int64(("x" * 100,), 1, 10)
+
+    def test_decode_rejects_negative_count(self):
+        max_count, max_len = 4, 32
+        encoded = [-1] + [0] * max_count + [0] * ((max_count * max_len + 7) // 8)
+        with pytest.raises(ValueError, match="invalid string count"):
+            _decode_strings_from_int64(encoded, max_count, max_len)
+
+    def test_decode_rejects_excessive_count(self):
+        max_count, max_len = 4, 32
+        encoded = [99] + [0] * max_count + [0] * ((max_count * max_len + 7) // 8)
+        with pytest.raises(ValueError, match="invalid string count"):
+            _decode_strings_from_int64(encoded, max_count, max_len)
+
+    def test_decode_rejects_short_block(self):
+        with pytest.raises(ValueError, match="string block too short"):
+            _decode_strings_from_int64([], 4, 32)
+
+
+# ---------------------------------------------------------------------------
+# Envelope validation
+# ---------------------------------------------------------------------------
+
+class TestEnvelopeValidation:
+    def test_valid_envelope(self):
+        frame = [_IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE, 0, 2, 128, 128]
+        _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_wrong_magic(self):
+        frame = [0xDEAD, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE, 0, 2, 128, 128]
+        with pytest.raises(RuntimeError, match="magic mismatch"):
+            _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_wrong_version(self):
+        frame = [_IPC_WIRE_MAGIC, 999, _MSG_KIND_IPC_HANDLE, 0, 2, 128, 128]
+        with pytest.raises(RuntimeError, match="version mismatch"):
+            _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_wrong_kind(self):
+        frame = [_IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, 99, 0, 2, 128, 128]
+        with pytest.raises(RuntimeError, match="message kind mismatch"):
+            _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_rank_mismatch(self):
+        frame = [_IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE, 5, 2, 128, 128]
+        with pytest.raises(RuntimeError, match="rank mismatch"):
+            _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_world_size_mismatch(self):
+        frame = [_IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE, 0, 99, 128, 128]
+        with pytest.raises(RuntimeError, match="world size mismatch"):
+            _validate_envelope(frame + [0] * 16, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+    def test_wrong_frame_size(self):
+        frame = [_IPC_WIRE_MAGIC, _IPC_WIRE_VERSION, _MSG_KIND_IPC_HANDLE, 0, 2, 128, 128]
+        with pytest.raises(RuntimeError, match="frame size mismatch"):
+            _validate_envelope(frame + [0] * 10, 0, 2, _MSG_KIND_IPC_HANDLE, _FRAME_SIZE_IPC_HANDLE)
+
+
+# ---------------------------------------------------------------------------
+# IPC handle exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeIpcHandles:
+    def test_valid_roundtrip(self, monkeypatch):
+        local = bytes(range(128))
+        _patch_all_gather_echo(monkeypatch)
+        handles = _exchange_ipc_handles(local, _make_group())
+        assert len(handles) == 2
+        assert handles[0] == local
+        assert len(handles[1]) == _CUDA_IPC_HANDLE_BYTES
+
+    def test_wrong_local_handle_size_rejected_via_preflight(self, monkeypatch):
+        """A wrong-size local handle causes preflight failure, not a hang."""
+        _patch_all_gather_with_preflight_failure(monkeypatch, 2, 0, failed_ranks={0})
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            _exchange_ipc_handles(b"\x00" * 64, _make_group())
+
+    def test_rank_mismatch_in_payload_rejected(self, monkeypatch):
+        """A peer reporting wrong rank in the payload envelope is rejected."""
+        local = bytes(range(128))
+        frame0 = _make_ipc_handle_frame(0, 2, local)
+        frame1 = _make_ipc_handle_frame(1, 2, b"\x00" * 128)
+        frame1[3] = 99  # wrong rank
+        _patch_all_gather_per_rank(monkeypatch, 2, 0, [frame0, frame1])
+        with pytest.raises(RuntimeError, match="rank mismatch"):
+            _exchange_ipc_handles(local, _make_group())
+
+    def test_version_mismatch_rejected_before_open(self, monkeypatch):
+        local = bytes(range(128))
+        frame0 = _make_ipc_handle_frame(0, 2, local)
+        frame1 = _make_ipc_handle_frame(1, 2, b"\x00" * 128, version=999)
+        _patch_all_gather_per_rank(monkeypatch, 2, 0, [frame0, frame1])
+        with pytest.raises(RuntimeError, match="version mismatch"):
+            _exchange_ipc_handles(local, _make_group())
+
+    def test_magic_mismatch_rejected(self, monkeypatch):
+        local = bytes(range(128))
+        frame0 = _make_ipc_handle_frame(0, 2, local)
+        frame1 = _make_ipc_handle_frame(1, 2, b"\x00" * 128, magic=0xDEAD)
+        _patch_all_gather_per_rank(monkeypatch, 2, 0, [frame0, frame1])
+        with pytest.raises(RuntimeError, match="magic mismatch"):
+            _exchange_ipc_handles(local, _make_group())
+
+    def test_kind_mismatch_rejected(self, monkeypatch):
+        local = bytes(range(128))
+        frame0 = _make_ipc_handle_frame(0, 2, local)
+        frame1 = _make_ipc_handle_frame(1, 2, b"\x00" * 128)
+        frame1[2] = 99  # wrong message kind
+        _patch_all_gather_per_rank(monkeypatch, 2, 0, [frame0, frame1])
+        with pytest.raises(RuntimeError, match="kind mismatch"):
+            _exchange_ipc_handles(local, _make_group())
+
+
+# ---------------------------------------------------------------------------
+# Integer contract exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeIntContract:
+    def test_valid_roundtrip(self, monkeypatch):
+        local = [1, 2, 3, 4]
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_int_contract(local, _make_group())
+        assert len(gathered) == 2
+        assert gathered[0] == local
+        assert gathered[1] == local
+
+    def test_too_many_fields_rejected_via_preflight(self, monkeypatch):
+        _patch_all_gather_with_preflight_failure(monkeypatch, 2, 0, failed_ranks={0})
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            _exchange_int_contract(list(range(_MAX_CONTRACT_INTS + 1)), _make_group())
+
+
+# ---------------------------------------------------------------------------
+# Status string exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeStatusStrings:
+    def test_valid_roundtrip(self, monkeypatch):
+        local = ("RuntimeError: boom",)
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_status_strings(local, _make_group())
+        assert isinstance(gathered, tuple)
+        assert len(gathered) == 2
+        assert gathered[0] == local
+        assert gathered[1] == local
+
+    def test_empty_strings_roundtrip(self, monkeypatch):
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_status_strings((), _make_group())
+        assert gathered == ((), ())
+
+    def test_multiple_strings_roundtrip(self, monkeypatch):
+        local = ("Error 1: bad", "Error 2: worse", "Error 3: worst")
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_status_strings(local, _make_group())
+        assert gathered[0] == local
+
+
+# ---------------------------------------------------------------------------
+# Graph meta exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeGraphMeta:
+    def test_valid_roundtrip_independent_lengths(self, monkeypatch):
+        """Handles and offsets have independent cardinalities."""
+        local_h = [100, 200, 300]
+        local_o = [0, 64]  # different length from handles
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_graph_meta(local_h, local_o, _make_group())
+        assert len(gathered) == 2
+        assert gathered[0] == (local_h, local_o)
+
+    def test_empty_meta_roundtrip(self, monkeypatch):
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_graph_meta([], [], _make_group())
+        assert gathered == [([], []), ([], [])]
+
+    def test_too_many_handles_rejected_via_preflight(self, monkeypatch):
+        _patch_all_gather_with_preflight_failure(monkeypatch, 2, 0, failed_ranks={0})
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            _exchange_graph_meta(list(range(_MAX_GRAPH_BUFFERS + 1)), [], _make_group())
+
+
+# ---------------------------------------------------------------------------
+# Channel state exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeChannelState:
+    def test_valid_roundtrip(self, monkeypatch):
+        normalized = ("chan_a", "chan_b")
+        existing = ("chan_a",)
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_channel_state(normalized, existing, _make_group())
+        assert len(gathered) == 2
+        assert gathered[0] == (normalized, existing)
+
+    def test_empty_state_roundtrip(self, monkeypatch):
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_channel_state((), (), _make_group())
+        assert gathered == [((), ()), ((), ())]
+
+
+# ---------------------------------------------------------------------------
+# Capture contract exchange
+# ---------------------------------------------------------------------------
+
+class TestExchangeCaptureContract:
+    def test_valid_roundtrip(self, monkeypatch):
+        logical_id = "graph:target"
+        catalog = ("chan_a", "chan_b", "chan_c")
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_capture_contract(logical_id, catalog, _make_group())
+        assert len(gathered) == 2
+        assert gathered[0] == (logical_id, catalog)
+
+    def test_empty_catalog_roundtrip(self, monkeypatch):
+        _patch_all_gather_echo(monkeypatch)
+        gathered = _exchange_capture_contract("single", (), _make_group())
+        assert gathered == [("single", ()), ("single", ())]
+
+
+# ---------------------------------------------------------------------------
+# Coordinated preflight
+# ---------------------------------------------------------------------------
+
+class TestCoordinatedPreflight:
+    def test_local_validation_failure_raises_before_payload(self, monkeypatch):
+        """If one rank's local data is malformed, preflight raises before
+        any rank enters the payload exchange."""
+        _patch_all_gather_with_preflight_failure(monkeypatch, 2, 0, failed_ranks={1})
+        with pytest.raises(RuntimeError, match="preflight failed"):
+            _exchange_ipc_handles(b"\x00" * 128, _make_group())
+
+
+# ---------------------------------------------------------------------------
+# NCCL / control-device contract
+# ---------------------------------------------------------------------------
+
+class TestControlDeviceContract:
+    def test_nccl_backend_required(self, monkeypatch):
+        monkeypatch.setattr("torch.distributed.get_backend", lambda group=None: "gloo")
+        monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+        monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+        monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+        with pytest.raises(RuntimeError, match="requires an NCCL process group"):
+            _exchange_ipc_handles(b"\x00" * 128, _make_group())
+
+    def test_cuda_required(self, monkeypatch):
+        monkeypatch.setattr("torch.distributed.get_backend", lambda group=None: "nccl")
+        monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+        monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+        monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+        with pytest.raises(RuntimeError, match="requires CUDA"):
+            _exchange_ipc_handles(b"\x00" * 128, _make_group())

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -11,7 +11,6 @@ from b12x.comm.pcie.pcie_oneshot import (
     PCIeOneshotAllReduce,
     PCIeOneshotAllReducePool,
     _abort_collective_ipc_setup,
-    _broadcast_gather_object,
     _compute_crossover_size,
     _finish_collective_runtime_setup,
     _group_ranks,
@@ -743,12 +742,12 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: (
-            [local_object, (), ()]
-            if isinstance(local_object, tuple)
-            else [local_object, b"remote0", b"remote1"]
-        ),
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, (), ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote0", b"remote1"],
     )
 
     with pytest.raises(RuntimeError, match="peer group rank 2"):
@@ -783,8 +782,8 @@ def test_failed_setup_export_free_is_retained_and_retryable(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: [local_object, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with pytest.raises(RuntimeError, match="exports were retained") as exc:
@@ -829,29 +828,31 @@ def test_failed_peer_setup_export_free_is_retained_and_retryable(monkeypatch):
     ipc = FakeIPC()
     status_round = 0
 
-    def exchange(local_object, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
-        if not isinstance(local_object, tuple):
-            return [local_object, b"remote"]
         status_round += 1
         if status_round == 1:  # retained-setup gate
-            return [local_object, ()]
+            return (local_strings, ())
         if status_round == 2:  # export preparation
-            return [local_object, ()]
+            return (local_strings, ())
         if status_round == 3:  # import-open verdict
-            return [local_object, ("peer open failed",)]
+            return (local_strings, ("peer open failed",))
         if status_round == 4:  # rollback-unmap verdict
-            return [local_object, ()]
+            return (local_strings, ())
         if status_round == 5:  # rollback-export-free verdict
-            return [local_object, ()]
+            return (local_strings, ())
         if status_round == 6:  # retry export-free verdict
-            return [local_object, ()]
+            return (local_strings, ())
         raise AssertionError(f"unexpected status round {status_round}")
 
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote"],
     )
 
     with pytest.raises(RuntimeError, match="exports were retained") as exc:
@@ -896,27 +897,29 @@ def test_peer_setup_and_unmap_failure_retains_export_and_closes_each_import_once
     ipc = FakeIPC()
     status_round = 0
 
-    def exchange(local_object, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
-        if not isinstance(local_object, tuple):
-            return [local_object, b"remote0", b"remote1"]
         status_round += 1
         if status_round == 1:  # retained-setup gate
-            return [local_object, (), ()]
+            return (local_strings, (), ())
         if status_round == 2:  # export preparation
-            return [local_object, (), ()]
+            return (local_strings, (), ())
         if status_round == 3:  # import-open verdict
-            return [local_object, ("peer open failed",), ()]
+            return (local_strings, ("peer open failed",), ())
         if status_round == 4:  # rollback-unmap verdict
-            return [local_object, ("peer unmap failed",), ()]
+            return (local_strings, ("peer unmap failed",), ())
         if status_round in (5, 6):  # retry unmap / retry export free
-            return [local_object, (), ()]
+            return (local_strings, (), ())
         raise AssertionError(f"unexpected status round {status_round}")
 
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote0", b"remote1"],
     )
 
     with pytest.raises(RuntimeError, match=r"retained.*peer unmap failed") as exc:
@@ -953,20 +956,25 @@ def test_handle_exchange_failure_retains_export_until_collective_retry(monkeypat
     status_round = 0
     fail_handle_exchange = True
 
-    def exchange(local_object, group):
-        nonlocal status_round, fail_handle_exchange
-        if not isinstance(local_object, tuple):
-            if fail_handle_exchange:
-                fail_handle_exchange = False
-                raise RuntimeError("injected handle exchange failure")
-            return [local_object, b"remote"]
+    def exchange_status(local_strings, group):
+        nonlocal status_round
         status_round += 1
-        return [local_object, ()]
+        return (local_strings, ())
+
+    def exchange_ipc(local_handle, group):
+        nonlocal fail_handle_exchange
+        if fail_handle_exchange:
+            fail_handle_exchange = False
+            raise RuntimeError("injected handle exchange failure")
+        return [local_handle, b"remote"]
 
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles", exchange_ipc
     )
 
     with pytest.raises(RuntimeError, match="handle exchange failed") as exc:
@@ -1010,19 +1018,21 @@ def test_import_status_exchange_failure_retains_imports_for_retry(monkeypatch):
     ipc = FakeIPC()
     status_round = 0
 
-    def exchange(local_object, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
-        if not isinstance(local_object, tuple):
-            return [local_object, b"remote"]
         status_round += 1
         if status_round == 3:
             raise RuntimeError("injected import verdict exchange failure")
-        return [local_object, ()]
+        return (local_strings, ())
 
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote"],
     )
 
     with pytest.raises(RuntimeError, match="import-open status") as exc:
@@ -1061,8 +1071,8 @@ def test_failed_native_cleanup_is_owned_and_retried_before_export_free(monkeypat
             raise RuntimeError("transient native dispose failure")
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
@@ -1110,15 +1120,15 @@ def test_peer_native_cleanup_failure_blocks_every_rank_from_unmapping(monkeypatc
         nonlocal cleanup_calls
         cleanup_calls += 1
 
-    def exchange(local_status, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
         status_round += 1
         if status_round == 1:
-            return [local_status, ("peer native dispose failed",)]
-        return [local_status, ()]
+            return (local_strings, ("peer native dispose failed",))
+        return (local_strings, ())
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
     )
 
     with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
@@ -1161,15 +1171,15 @@ def test_native_cleanup_verdict_exchange_failure_retains_imports(monkeypatch):
     ipc = FakeIPC()
     status_round = 0
 
-    def exchange(local_status, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
         status_round += 1
         if status_round == 1:
             raise RuntimeError("injected native cleanup verdict exchange failure")
-        return [local_status, ()]
+        return (local_strings, ())
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
     )
 
     with pytest.raises(RuntimeError, match="cleanup status exchange") as exc:
@@ -1211,16 +1221,16 @@ def test_initial_native_verdict_exchange_retains_complete_setup_until_retry(
     group = object()
     status_round = 0
 
-    def exchange(local_status, exchange_group):
+    def exchange_status(local_strings, exchange_group):
         nonlocal status_round
         assert exchange_group is group
         status_round += 1
         if status_round == 1:
             raise RuntimeError("injected first native verdict exchange failure")
-        return [local_status, ()]
+        return (local_strings, ())
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
     )
 
     with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
@@ -1269,15 +1279,15 @@ def test_free_status_exchange_failure_keeps_coordination_ticket_without_double_f
     ipc = FakeIPC()
     status_round = 0
 
-    def exchange(local_status, group):
+    def exchange_status(local_strings, group):
         nonlocal status_round
         status_round += 1
         if status_round == 2:
             raise RuntimeError("injected free verdict exchange failure")
-        return [local_status, ()]
+        return (local_strings, ())
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
     )
 
     with pytest.raises(RuntimeError, match="free status exchange") as exc:
@@ -1313,15 +1323,15 @@ def test_retained_generation_blocks_second_setup_before_cuda_allocation(monkeypa
     group = object()
     status_round = 0
 
-    def exchange(local_status, exchange_group):
+    def exchange_status(local_strings, exchange_group):
         nonlocal status_round
         status_round += 1
         if status_round == 2:
             raise RuntimeError("injected preparation verdict exchange failure")
-        return [local_status, ()]
+        return (local_strings, ())
 
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings", exchange_status
     )
 
     with pytest.raises(RuntimeError, match="preparation status") as exc:
@@ -1382,12 +1392,12 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: (
-            [local_object, (), ()]
-            if isinstance(local_object, tuple)
-            else [local_object, b"remote0", b"remote1"]
-        ),
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, (), ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote0", b"remote1"],
     )
 
     buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
@@ -1445,12 +1455,12 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_object, group: (
-            [local_object, (), ()]
-            if isinstance(local_object, tuple)
-            else [local_object, b"remote0", b"remote1"]
-        ),
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, (), ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_ipc_handles",
+        lambda local_handle, group: [local_handle, b"remote0", b"remote1"],
     )
 
     with pytest.raises(RuntimeError, match="memset failed"):
@@ -1467,25 +1477,18 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
 
 
 def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
-    remote_meta = {
-        0: ([1, 2, 3], [0, 64]),
-        1: ([9, 8, 7], [16, 80]),
-    }
-
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
     monkeypatch.setattr(
         "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._object_broadcast_device",
-        lambda group: "cpu",
+        "b12x.comm.pcie.pcie_oneshot._exchange_graph_meta",
+        lambda local_handles, local_offsets, group: [
+            ([1, 2, 3], [0, 64]),
+            ([9, 8, 7], [16, 80]),
+        ],
     )
-
-    def fake_broadcast(object_list, src, group=None, device=None):
-        object_list[0] = remote_meta[src]
-
-    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
 
     runtime = _make_runtime()
     runtime.exchange_group = object()
@@ -1496,12 +1499,10 @@ def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
         (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
     ]
 
-
 def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(
     monkeypatch,
 ):
     group = object()
-    sources: list[int] = []
     nonmonotonic_ranks = [7, 2, 9]
     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 1)
@@ -1509,24 +1510,8 @@ def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(
         "torch.distributed.get_process_group_ranks",
         lambda group=None: list(nonmonotonic_ranks),
     )
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._object_broadcast_device",
-        lambda group: "cpu",
-    )
-
-    def fake_broadcast(object_list, src, group=None, device=None):
-        sources.append(src)
-        object_list[0] = f"from-{src}"
-
-    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
 
     assert _group_ranks(group) == nonmonotonic_ranks
-    assert _broadcast_gather_object("local", group) == [
-        "from-7",
-        "from-2",
-        "from-9",
-    ]
-    assert sources == nonmonotonic_ranks
 
 
 def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
@@ -1536,14 +1521,8 @@ def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatc
         "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._object_broadcast_device",
-        lambda group: "cpu",
-    )
-    monkeypatch.setattr(
-        "torch.distributed.broadcast_object_list",
-        lambda object_list, src, group=None, device=None: object_list.__setitem__(
-            0, ([], [])
-        ),
+        "b12x.comm.pcie.pcie_oneshot._exchange_graph_meta",
+        lambda local_handles, local_offsets, group: [([], []), ([], [])],
     )
 
     runtime = _make_runtime()
@@ -1632,8 +1611,12 @@ def test_collective_logical_channel_preparation_is_canonical(monkeypatch):
         lambda stream_key: created.append(stream_key) or object(),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_channel_state",
+        lambda normalized, existing, group: [(normalized, existing), (normalized, existing)],
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, local_strings),
     )
 
     pool.prepare_channels(("draft", "target"))
@@ -1658,13 +1641,14 @@ def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypat
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if not local_state or isinstance(local_state[0], str):
-            return [local_state, ()]
-        _requested, existing = local_state
-        return [local_state, (("other",), existing)]
-
-    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_channel_state",
+        lambda normalized, existing, group: [(normalized, existing), (("other",), existing)],
+    )
 
     with pytest.raises(RuntimeError, match="differs across ranks"):
         pool.prepare_channels(("target",))
@@ -1687,8 +1671,8 @@ def test_invalid_logical_channel_id_is_rejected_collectively_before_allocation(
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with pytest.raises(RuntimeError, match="must not be empty"):
@@ -1705,13 +1689,14 @@ def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch)
     pool._channel_factory = None
     pool.exchange_group = object()
 
-    def gather(local_state, group):
-        if not local_state or isinstance(local_state[0], str):
-            return [local_state, ()]
-        _, existing = local_state
-        return [local_state, (("peer-channel",), existing)]
-
-    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_channel_state",
+        lambda normalized, existing, group: [(normalized, existing), (("peer-channel",), existing)],
+    )
 
     with pytest.raises(RuntimeError, match="differs across ranks"):
         pool.prepare_channels(())
@@ -1733,8 +1718,8 @@ def test_collective_capture_requires_stable_semantic_id(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_status, group: [local_status, ()],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
     )
 
     with (
@@ -1766,14 +1751,17 @@ def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatc
         lambda device, stream=None: int(stream),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        requested, catalog = local_state
-        assert requested == "graph:target"
-        return [local_state, ("graph:draft", catalog)]
-
-    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [
+            (logical_id, catalog),
+            ("graph:draft", catalog),
+        ],
+    )
 
     with pool.capture(7, channel_id="graph:target") as channel:
         assert channel is target
@@ -1798,12 +1786,17 @@ def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypa
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        return [local_state, ("graph:target", ())]
-
-    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [
+            (logical_id, catalog),
+            ("graph:target", ()),
+        ],
+    )
 
     with (
         pytest.raises(RuntimeError, match="prepared channel catalog differs"),
@@ -1829,13 +1822,17 @@ def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
         lambda stream_key: pytest.fail("channel allocation must not start"),
     )
 
-    def gather(local_state, group):
-        if local_state == ():
-            return [(), ()]
-        _, catalog = local_state
-        return [local_state, ("graph:unknown", catalog)]
-
-    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [
+            (logical_id, catalog),
+            ("graph:unknown", catalog),
+        ],
+    )
 
     with (
         pytest.raises(RuntimeError, match="unprepared logical channels"),
@@ -1865,8 +1862,19 @@ def test_collective_capture_preserves_same_id_convenience_allocation(monkeypatch
         lambda device, stream=None: int(stream),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [
+            (logical_id, catalog),
+            (logical_id, catalog),
+        ],
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_channel_state",
+        lambda normalized, existing, group: [(normalized, existing), (normalized, existing)],
     )
 
     with pool.capture(7, channel_id="graph:target") as captured:
@@ -1898,8 +1906,15 @@ def test_collective_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
         lambda device, stream=None: 7 if stream is None else int(stream),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
-        lambda local_state, group: [local_state, local_state],
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
+        lambda local_strings, group: (local_strings, ()),
+    )
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._exchange_capture_contract",
+        lambda logical_id, catalog, group: [
+            (logical_id, catalog),
+            (logical_id, catalog),
+        ],
     )
 
     with pool.capture(7, channel_id="graph:target") as captured:

--- a/tests/comm/test_pcie_preallocation_setup.py
+++ b/tests/comm/test_pcie_preallocation_setup.py
@@ -203,7 +203,9 @@ def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) ->
     monkeypatch.setattr(
         oneshot,
         "_require_collective_contract",
-        lambda **kwargs: events.append(("oneshot_contract", kwargs["contract"])),
+        lambda **kwargs: events.append(
+            ("oneshot_contract", kwargs["contract_fields"])
+        ),
     )
 
     oneshot_pool = oneshot.PCIeOneshotAllReducePool(
@@ -227,7 +229,7 @@ def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) ->
     monkeypatch.setattr(
         dcp,
         "_require_collective_contract",
-        lambda **kwargs: events.append(("dcp_contract", kwargs["contract"])),
+        lambda **kwargs: events.append(("dcp_contract", kwargs["contract_fields"])),
     )
     monkeypatch.setattr(
         dcp,
@@ -251,8 +253,8 @@ def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) ->
     oneshot_contract = next(
         contract for name, contract in events if name == "oneshot_contract"
     )
-    assert oneshot_contract[-2] == 3
-    assert ("dcp_contract", 2) in events
+    assert oneshot_contract[6] == 3
+    assert ("dcp_contract", [2]) in events
     assert ("dcp_sms", dcp.DCP_A2A_REQUIRED_SMS * 2) in events
 
 
@@ -305,8 +307,11 @@ def test_oneshot_overlap_contract_mismatch_fails_before_channel_allocation(
     monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
     monkeypatch.setattr(
         oneshot,
-        "_broadcast_gather_object",
-        lambda contract, group: [contract, (*contract[:-2], 2, contract[-1])],
+        "_exchange_int_contract",
+        lambda local_values, group: [
+            local_values,
+            local_values[:-2] + [2, local_values[-1]],
+        ],
     )
     monkeypatch.setattr(
         oneshot.PCIeOneshotAllReduce,
@@ -338,8 +343,8 @@ def test_dcp_overlap_contract_mismatch_fails_before_channel_allocation(
     )
     monkeypatch.setattr(
         oneshot,
-        "_broadcast_gather_object",
-        lambda contract, group: [contract, 1],
+        "_exchange_int_contract",
+        lambda local_values, group: [local_values, [1]],
     )
     monkeypatch.setattr(
         dcp,

--- a/tests/comm/test_pcie_twoshot.py
+++ b/tests/comm/test_pcie_twoshot.py
@@ -89,7 +89,7 @@ def test_factory_retains_twoshot_ipc_ownership_when_verdict_fails(
         classmethod(lambda cls, *args, **kwargs: shared),
     )
     monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        "b12x.comm.pcie.pcie_oneshot._exchange_status_strings",
         exchange,
     )
 


### PR DESCRIPTION
Closes #169.

Replaces pickle/object collectives in PCIe setup with fixed-size typed int64 wire frames, exact envelope validation, payload-plan agreement, coordinated preflight, and rollback-safe failure handling.

Verification: `tests/comm/test_pcie_ipc_wire_format.py` — 42 passed on Linux and macOS.