### PR TITLE
security: collectively agree DCP Top-K IPC contracts

### DIFF
--- a/b12x/comm/pcie/_dcp_cute_common.py
+++ b/b12x/comm/pcie/_dcp_cute_common.py
@@ -19,6 +19,9 @@ from cutlass._mlir.dialects import llvm
 
 _FLAG_STRIDE = 32
 _MAX_RANKS = 16
+DCP_TOPK_MAX_BLOCKS = 128
+DCP_TOPK_ABI_VERSION = 1
+DCP_TOPK_COMPILE_VERSION = 4
 
 
 @dsl_user_op
@@ -145,5 +148,11 @@ def signal_bytes(max_blocks: int) -> int:
         + 2 * max_blocks * _MAX_RANKS * _FLAG_STRIDE
     ) * 4
 
-
-__all__ = ["block_pair_barrier", "signal_bytes"]
+__all__ = [
+    "DCP_TOPK_COMPILE_VERSION",
+    "DCP_TOPK_MAX_BLOCKS",
+    "_FLAG_STRIDE",
+    "_MAX_RANKS",
+    "block_pair_barrier",
+    "signal_bytes",
+]

--- a/b12x/comm/pcie/_dcp_topk_cute.py
+++ b/b12x/comm/pcie/_dcp_topk_cute.py
@@ -15,10 +15,13 @@ from b12x._lib.intrinsics import ld_global_v4_u32, st_global_v4_u32
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
 
-from ._dcp_cute_common import block_pair_barrier
+from ._dcp_cute_common import (
+    DCP_TOPK_COMPILE_VERSION,
+    DCP_TOPK_MAX_BLOCKS as _MAX_BLOCKS,
+    block_pair_barrier,
+)
 
 
-_MAX_BLOCKS = 128
 _MAX_PEERS = 8
 _PREPARED_TOPK_LAUNCHERS: set[tuple[int, int, int, int]] = set()
 
@@ -298,7 +301,7 @@ def _get_compiled_topk_stage(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "comm.pcie.dcp_topk.owner_stage",
-            4,
+            DCP_TOPK_COMPILE_VERSION,
             key,
             labels=("world_size", "rank", "topk", "threads"),
         ),

--- a/b12x/comm/pcie/pcie_dcp_topk.py
+++ b/b12x/comm/pcie/pcie_dcp_topk.py
@@ -11,30 +11,109 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 from ._cuda_ipc import CudaRTLibrary
-from ._dcp_cute_common import signal_bytes
+from ._dcp_cute_common import (
+    DCP_TOPK_ABI_VERSION,
+    DCP_TOPK_MAX_BLOCKS,
+    _FLAG_STRIDE,
+    _MAX_RANKS,
+    signal_bytes,
+)
 from .pcie_oneshot import (
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
     _align_up,
+    _broadcast_gather_object,
     _coordinated_close_channels,
     _current_stream_key,
     _device_guard,
+    _finish_collective_runtime_setup,
     _is_current_stream_capturing,
     _normalize_device,
     _OwnedSharedBuffer,
+    _require_collective_contract,
+    _require_full_grid_residency,
+    _run_collective_preallocation_setup,
 )
 
 
 SUPPORTED_WORLD_SIZES = (2, 3, 4, 6, 8)
-_MAX_BLOCKS = 128
+_MAX_BLOCKS = DCP_TOPK_MAX_BLOCKS
 _SIGNAL_BYTES = signal_bytes(_MAX_BLOCKS)
+_DCP_TOPK_CONTRACT_VERSION = 1
+
+# Internal factory token: direct CUDA construction with exchange_group is
+# only permitted through _from_prepared_factory, which sets this token.
+_FACTORY_TOKEN = object()
 
 
 def _validate_launch_config(*, threads: int, block_limit: int, world_size: int) -> None:
     if threads < world_size or threads > 512 or threads % 32 != 0:
         raise ValueError("threads must be a multiple of 32 in [32, 512]")
-    if block_limit <= 0 or block_limit > 128:
-        raise ValueError("block_limit must be in [1, 128]")
+    if block_limit <= 0 or block_limit > _MAX_BLOCKS:
+        raise ValueError(f"block_limit must be in [1, {_MAX_BLOCKS}]")
+
+
+def _host_identity() -> str:
+    """Return a kernel-level host identity for topology verification.
+
+    Uses the boot ID when available (unique per host kernel) with a
+    hostname fallback for platforms that lack /proc/sys/kernel/random/boot_id.
+    """
+    try:
+        with open("/proc/sys/kernel/random/boot_id") as f:
+            return f.read().strip()
+    except (OSError, ValueError):
+        import socket
+
+        return socket.gethostname()
+
+
+def _dcp_topk_topology_record(*, rank: int, device: torch.device) -> tuple:
+    """Gather per-rank physical topology identity.
+
+    Returns ``(group_rank, host_id, device_uuid)``.  Uses the CUDA device
+    UUID and boot ID for physical identity.
+    """
+    host_id = _host_identity()
+    device_uuid = ""
+    if device.type == "cuda":
+        props = torch.cuda.get_device_properties(device)
+        device_uuid = str(getattr(props, "uuid", "")).strip()
+        if not device_uuid:
+            raise RuntimeError(
+                "DCP top-k topology: could not determine CUDA device UUID"
+            )
+    return (int(rank), host_id, device_uuid)
+
+
+def _verify_dcp_topk_topology(
+    *, exchange_group: ProcessGroup, topology: tuple
+) -> None:
+    """Collectively verify topology uniqueness and IPC reachability."""
+    gathered = _broadcast_gather_object(topology, exchange_group)
+    if len(gathered) < 2:
+        return
+    host_ids = {record[1] for record in gathered}
+    if len(host_ids) > 1:
+        raise RuntimeError(
+            "DCP top-k topology: ranks span multiple hosts; "
+            "PCIe IPC requires all ranks on the same host"
+        )
+    device_uuids = [record[2] for record in gathered]
+    if "" in device_uuids:
+        raise RuntimeError(
+            "DCP top-k topology: one or more ranks could not determine its "
+            "CUDA device UUID; cannot verify GPU uniqueness"
+        )
+    if len(set(device_uuids)) != len(device_uuids):
+        raise RuntimeError(
+            f"DCP top-k topology: duplicate GPU UUID detected {device_uuids}"
+        )
+    ranks = [record[0] for record in gathered]
+    if ranks != list(range(len(ranks))):
+        raise RuntimeError(
+            f"DCP top-k topology: group rank ordering is not contiguous: {ranks}"
+        )
 
 
 @dataclass(frozen=True)
@@ -78,6 +157,52 @@ def _candidate_staging_layout(
     )
 
 
+def _dcp_topk_runtime_contract(
+    *,
+    world_size: int,
+    max_rows: int,
+    topk: int,
+    layout: _DoubleBufferLayout,
+    threads: int,
+    block_limit: int,
+) -> tuple:
+    """Build the versioned fixed-schema contract every rank must agree on."""
+    max_owner_rows = int(max_rows) // int(world_size)
+    candidate_plane_elems = max_owner_rows * int(world_size) * int(topk)
+    candidate_shape = (max_owner_rows, int(world_size) * int(topk))
+    candidate_stride = (int(world_size) * int(topk), 1)
+    score_plane_offset = candidate_plane_elems * 4
+    return (
+        _DCP_TOPK_CONTRACT_VERSION,
+        DCP_TOPK_ABI_VERSION,
+        int(world_size),
+        SUPPORTED_WORLD_SIZES,
+        int(max_rows),
+        max_owner_rows,
+        int(topk),
+        candidate_plane_elems,
+        candidate_shape,
+        candidate_stride,
+        score_plane_offset,
+        int(layout.slab_bytes),
+        int(layout.slot_bytes),
+        int(layout.plane_bytes),
+        int(layout.signal_bytes),
+        int(layout.staging0_offset),
+        int(layout.staging1_offset),
+        "int32_indices",
+        "float32_scores",
+        DCP_TOPK_MAX_BLOCKS,
+        int(_SIGNAL_BYTES),
+        _FLAG_STRIDE,
+        _MAX_RANKS,
+        int(threads),
+        int(block_limit),
+        True,
+        IPC_SLAB_ALIGNMENT,
+    )
+
+
 def _tensor_from_cuda_pointer(
     pointer: int,
     shape: tuple[int, ...],
@@ -91,9 +216,7 @@ def _tensor_from_cuda_pointer(
         numel *= int(extent)
     nbytes = numel * torch.empty((), dtype=dtype).element_size()
     storage = torch._C._construct_storage_from_data_pointer(
-        int(pointer),
-        device,
-        int(nbytes),
+        int(pointer), device, int(nbytes),
     )
     stride: list[int] = []
     running = 1
@@ -157,9 +280,6 @@ class _IPCChannel:
     def _bind_stream(self) -> None:
         if not self._stream_affine or self.device.type != "cuda":
             return
-        # CUDA graph capture substitutes a torch-owned capture stream handle
-        # for the logical stream.  Keep affinity bound to the caller's eager
-        # stream so the same channel can be warmed, captured, and reused.
         if _is_current_stream_capturing(self.device):
             return
         stream_key = _current_stream_key(self.device)
@@ -198,17 +318,13 @@ class _IPCChannel:
 
     def close(self) -> None:
         _coordinated_close_channels(
-            (self,),
-            exchange_group=self.exchange_group,
-            device=self.device,
+            (self,), exchange_group=self.exchange_group, device=self.device,
         )
 
     def close_coordinated(self) -> None:
         """Collectively close peer mappings before freeing exported storage."""
         _coordinated_close_channels(
-            (self,),
-            exchange_group=self.exchange_group,
-            device=self.device,
+            (self,), exchange_group=self.exchange_group, device=self.device,
         )
 
     def __del__(self) -> None:
@@ -239,10 +355,34 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         ipc: Optional[CudaRTLibrary] = None,
         owned_buffers: Optional[Sequence[_OwnedSharedBuffer]] = None,
         ext_module=None,
-        stream_affine: bool = True,
+        threads: int = 512,
+        block_limit: int = 128,
+        _factory_token: object = None,
     ) -> None:
-        # Compatibility-only: native extension injection was removed.
         del ext_module
+        device_obj = _normalize_device(device)
+
+        # Reject public CUDA construction BEFORE touching CUDA state so
+        # CPU-only CI does not initialise CUDA.
+        if device_obj.type == "cuda" and exchange_group is None:
+            raise ValueError(
+                "exchange_group is required for a CUDA PCIe DCP top-k runtime; "
+                "use from_exchange_group()"
+            )
+        if (
+            device_obj.type == "cuda"
+            and exchange_group is not None
+            and _factory_token is not _FACTORY_TOKEN
+        ):
+            raise ValueError(
+                "grouped CUDA PCIe DCP top-k construction must use "
+                "from_exchange_group()"
+            )
+
+        # Only the internal prepared path may set the device.
+        if device_obj.type == "cuda" and _factory_token is _FACTORY_TOKEN:
+            torch.cuda.set_device(device_obj)
+
         if world_size not in SUPPORTED_WORLD_SIZES:
             raise ValueError(f"unsupported world size {world_size}")
         if not 0 <= rank < world_size:
@@ -255,19 +395,38 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
             len(signal_ptrs) == len(staging0_ptrs) == len(staging1_ptrs) == world_size
         ):
             raise ValueError("signal and staging pointers must match world size")
+        _validate_launch_config(
+            threads=int(threads), block_limit=int(block_limit), world_size=world_size,
+        )
+
+        if exchange_group is not None:
+            group_rank = dist.get_rank(group=exchange_group)
+            group_world_size = dist.get_world_size(group=exchange_group)
+            if int(rank) != group_rank:
+                raise ValueError(
+                    f"supplied rank {rank} does not match process group rank "
+                    f"{group_rank}"
+                )
+            if int(world_size) != group_world_size:
+                raise ValueError(
+                    f"supplied world size {world_size} does not match process "
+                    f"group size {group_world_size}"
+                )
 
         self._init_channel(
             device=device,
             exchange_group=exchange_group,
             ipc=ipc,
             owned_buffers=owned_buffers,
-            stream_affine=stream_affine,
+            stream_affine=True,
         )
         self.rank = int(rank)
         self.world_size = int(world_size)
         self.max_rows = int(max_rows)
         self.max_owner_rows = self.max_rows // self.world_size
         self.topk = int(topk)
+        self._threads = int(threads)
+        self._block_limit = int(block_limit)
         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
         self._staging_ptrs = (
             tuple(int(ptr) for ptr in staging0_ptrs),
@@ -279,29 +438,33 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         self._next_slot = 0
         self._graph_slot: Optional[int] = None
         self._capture_context_depth = 0
+        self._capture_rows: Optional[int] = None
+        self._capture_stage_count: int = 0
         candidate_shape = (self.max_owner_rows, self.world_size * self.topk)
         if self.device.type == "cuda":
             self._candidate_views = tuple(
                 (
                     _tensor_from_cuda_pointer(
-                        slot_ptrs[self.rank],
-                        candidate_shape,
-                        dtype=torch.int32,
-                        device=self.device,
+                        slot_ptrs[self.rank], candidate_shape,
+                        dtype=torch.int32, device=self.device,
                     ),
                     _tensor_from_cuda_pointer(
                         slot_ptrs[self.rank] + self._candidate_plane_elems * 4,
-                        candidate_shape,
-                        dtype=torch.float32,
-                        device=self.device,
+                        candidate_shape, dtype=torch.float32, device=self.device,
                     ),
                 )
                 for slot_ptrs in self._staging_ptrs
             )
         else:
-            # CPU construction remains useful for validation-only unit tests;
-            # no launch is possible until tests install synthetic views.
             self._candidate_views = ()
+
+    @classmethod
+    def _from_prepared_factory(cls, **kwargs) -> "PCIeDCPTopKOwnerExchange":
+        """Construct a runtime via the internal factory token."""
+        kwargs["_factory_token"] = _FACTORY_TOKEN
+        runtime = object.__new__(cls)
+        runtime.__init__(**kwargs)
+        return runtime
 
     @classmethod
     def from_exchange_group(
@@ -312,34 +475,88 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         max_rows: int,
         topk: int,
         ext_module=None,
-        stream_affine: bool = True,
+        threads: int = 512,
+        block_limit: int = 128,
     ) -> "PCIeDCPTopKOwnerExchange":
         rank = dist.get_rank(group=exchange_group)
         world_size = dist.get_world_size(group=exchange_group)
-        device_obj = _normalize_device(device)
-        if device_obj.type != "cuda":
-            raise ValueError("DCP top-k owner exchange requires a CUDA device")
-        ipc = CudaRTLibrary()
-        ipc.cudaSetDevice(device_obj.index or 0)
-        layout = _candidate_staging_layout(
-            signal_bytes=_SIGNAL_BYTES,
-            max_rows=max_rows,
-            topk=topk,
-            world_size=world_size,
-        )
-        owned: list[_OwnedSharedBuffer] = []
-        try:
-            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
-                exchange_group,
-                layout.slab_bytes,
-                zero_fill=True,
-                ipc=ipc,
+
+        def validate_factory_arguments():
+            device_obj = _normalize_device(device)
+            if device_obj.type != "cuda":
+                raise ValueError("DCP top-k owner exchange requires a CUDA device")
+            if device_obj.type == "cuda":
+                torch.cuda.set_device(device_obj)
+            if world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {world_size}")
+            n_max_rows = int(max_rows)
+            n_topk = int(topk)
+            n_threads = int(threads)
+            n_block_limit = int(block_limit)
+            if n_max_rows <= 0 or n_max_rows % world_size != 0:
+                raise ValueError(
+                    "max_rows must be positive and divisible by world_size"
+                )
+            if n_topk <= 0 or n_topk % 4 != 0:
+                raise ValueError("topk must be a positive multiple of 4")
+            _validate_launch_config(
+                threads=n_threads, block_limit=n_block_limit, world_size=world_size,
             )
-            owned.append(slab)
-            return cls(
-                rank=rank,
-                world_size=world_size,
-                device=device_obj,
+            topology = _dcp_topk_topology_record(rank=rank, device=device_obj)
+            return device_obj, n_max_rows, n_topk, n_threads, n_block_limit, topology
+
+        (
+            device_obj, n_max_rows, n_topk, n_threads, n_block_limit, topology,
+        ) = _run_collective_preallocation_setup(
+            owner="PCIe DCP top-k argument validation",
+            exchange_group=exchange_group,
+            setup=validate_factory_arguments,
+        )
+
+        _require_full_grid_residency(
+            owner="PCIe DCP top-k", required_sms=_MAX_BLOCKS,
+            device=device_obj, exchange_group=exchange_group,
+        )
+
+        _verify_dcp_topk_topology(
+            exchange_group=exchange_group, topology=topology,
+        )
+
+        def prepare():
+            prepared_ipc = CudaRTLibrary()
+            prepared_ipc.cudaSetDevice(device_obj.index or 0)
+            prepared_layout = _candidate_staging_layout(
+                signal_bytes=_SIGNAL_BYTES, max_rows=n_max_rows,
+                topk=n_topk, world_size=world_size,
+            )
+            from ._dcp_topk_cute import prepare_topk_stage
+            prepare_topk_stage(world_size, rank, n_topk, n_threads)
+            # Build the contract inside coordinated setup so a one-rank
+            # contract-builder/schema exception is exchanged collectively
+            # rather than exiting locally and stranding peers.
+            prepared_contract = _dcp_topk_runtime_contract(
+                world_size=world_size, max_rows=n_max_rows, topk=n_topk,
+                layout=prepared_layout, threads=n_threads, block_limit=n_block_limit,
+            )
+            return prepared_ipc, prepared_layout, prepared_contract
+
+        ipc, layout, contract = _run_collective_preallocation_setup(
+            owner="PCIe DCP top-k", exchange_group=exchange_group, setup=prepare,
+        )
+        _require_collective_contract(
+            owner="PCIe DCP top-k channel layout",
+            exchange_group=exchange_group,
+            contract=contract,
+        )
+        slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group, layout.slab_bytes, zero_fill=True, ipc=ipc,
+        )
+
+        runtime: Optional[PCIeDCPTopKOwnerExchange] = None
+        init_error: BaseException | None = None
+        try:
+            runtime = cls._from_prepared_factory(
+                rank=rank, world_size=world_size, device=device_obj,
                 signal_ptrs=slab.peer_ptrs,
                 staging0_ptrs=tuple(
                     ptr + layout.staging0_offset for ptr in slab.peer_ptrs
@@ -347,17 +564,25 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
                 staging1_ptrs=tuple(
                     ptr + layout.staging1_offset for ptr in slab.peer_ptrs
                 ),
-                max_rows=max_rows,
-                topk=topk,
-                exchange_group=exchange_group,
-                ipc=ipc,
-                owned_buffers=owned,
-                ext_module=ext_module,
-                stream_affine=stream_affine,
+                max_rows=n_max_rows, topk=n_topk,
+                exchange_group=exchange_group, ipc=ipc,
+                owned_buffers=[slab], ext_module=ext_module,
+                threads=n_threads, block_limit=n_block_limit,
             )
-        except Exception:
-            _release_failed_allocations(owned, ipc)
-            raise
+        except Exception as exc:
+            init_error = exc
+
+        def detach_shared_ownership() -> None:
+            if runtime is not None:
+                runtime._owned_buffers.clear()
+
+        _finish_collective_runtime_setup(
+            owner="PCIe DCP top-k", exchange_group=exchange_group,
+            ipc=ipc, shared=slab, local_error=init_error,
+            detach_shared_ownership=detach_shared_ownership,
+        )
+        assert runtime is not None
+        return runtime
 
     @classmethod
     def from_process_group(
@@ -368,117 +593,250 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         max_rows: int,
         topk: int,
         ext_module=None,
-        stream_affine: bool = True,
+        threads: int = 512,
+        block_limit: int = 128,
     ) -> "PCIeDCPTopKOwnerExchange":
         return cls.from_exchange_group(
-            exchange_group=process_group,
-            device=device,
-            max_rows=max_rows,
-            topk=topk,
-            ext_module=ext_module,
-            stream_affine=stream_affine,
+            exchange_group=process_group, device=device,
+            max_rows=max_rows, topk=topk, ext_module=ext_module,
+            threads=threads, block_limit=block_limit,
         )
 
     def stage_candidates(
         self,
         local_indices: torch.Tensor,
         local_scores: torch.Tensor,
-        *,
-        threads: int = 512,
-        block_limit: int = 128,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Stage exact candidates and return channel-owned owner views.
 
-        Consumers must be enqueued on this channel's stream before another
-        stage call or graph replay; the returned tensors are aliasing views,
-        not snapshots. Capture must run inside :meth:`capture`. On first CUDA
-        graph capture the channel permanently pins one staging slot. Every
-        later launch begins with the native peer barrier, so no rank can
-        overwrite that slot until every rank's prior same-stream consumer has
-        retired. The barrier stays inside the one transport kernel and
-        therefore adds no CUDA graph node.
+        The launch protocol (threads, block_limit) is fixed at construction
+        and collectively agreed.  For eager (non-capture) calls, a collective
+        pre-launch verdict exchanges (rows, blocks, slot, wait) so a
+        divergent or malformed rank fails every rank before any peer kernel
+        launches.  During CUDA graph capture, rows/slot/wait were
+        pre-agreed in :meth:`capture` so no host collective occurs inside
+        the captured path.
         """
         with _device_guard(self.device):
-            return self._stage_candidates_on_device(
-                local_indices,
-                local_scores,
-                threads=threads,
-                block_limit=block_limit,
-            )
+            return self._stage_candidates_on_device(local_indices, local_scores)
 
-    def prepare_graph(self, *, threads: int = 512) -> None:
+    def prepare_graph(self) -> None:
         """Compile the exact graph launcher before capture begins."""
         if self._closed:
             raise RuntimeError("PCIeDCPTopKOwnerExchange is closed")
         if _is_current_stream_capturing(self.device):
-            raise RuntimeError("prepare_graph() must be called before CUDA graph capture")
-        _validate_launch_config(
-            threads=int(threads),
-            block_limit=1,
-            world_size=self.world_size,
-        )
+            raise RuntimeError(
+                "prepare_graph() must be called before CUDA graph capture"
+            )
         with _device_guard(self.device):
             self._bind_stream()
-            from ._dcp_topk_cute import prepare_topk_stage
-
-            prepare_topk_stage(
-                self.world_size,
-                self.rank,
-                self.topk,
-                int(threads),
-            )
+            from ._dcp_topk_cute import is_topk_stage_prepared
+            if not is_topk_stage_prepared(
+                self.world_size, self.rank, self.topk, int(self._threads),
+            ):
+                from ._dcp_topk_cute import prepare_topk_stage
+                prepare_topk_stage(
+                    self.world_size, self.rank, self.topk, int(self._threads),
+                )
 
     @contextmanager
-    def capture(self, *, threads: int = 512):
+    def capture(self, *, rows: int):
         """Own one serialized graph capture without adding graph nodes.
 
-        Enter this context before ``torch.cuda.graph``. Graphs captured from
-        this instance share one epoch and must never replay concurrently.
+        Before yielding, collectively agrees (rows, blocks, slot, wait) so
+        the captured stage_candidates needs no host collective.  After the
+        caller's ``torch.cuda.graph`` context ends (on context exit),
+        exchanges capture success and stage-call count so no peer replays
+        a partial graph or a graph with mismatched barrier generations.
+
+        Every pre-capture operation is wrapped in a non-throwing envelope
+        so a rank with a local failure participates in the collective
+        agreement and every rank rejects coherently.
+
+        The entire capture lifecycle is wrapped in ``_device_guard`` so
+        NCCL collectives run on the owner's device, not the caller's
+        current device.
+
+        Enter this context before ``torch.cuda.graph``::
+
+            with owner.capture(rows=128), torch.cuda.graph(graph):
+                ...
         """
-        if self._capture_context_depth:
-            raise RuntimeError("overlapping DCP top-k capture contexts are not allowed")
-        self.prepare_graph(threads=threads)
-        self._capture_context_depth = 1
+        with _device_guard(self.device):
+            # Wrap every pre-capture operation in a non-throwing envelope.
+            local_error: BaseException | None = None
+            n_rows = 0
+            blocks = 0
+            proposed_slot = 0
+            wait_for_prior_consumer = True
+            try:
+                if self._capture_context_depth:
+                    raise RuntimeError(
+                        "overlapping DCP top-k capture contexts are not allowed"
+                    )
+                n_rows = int(rows)
+                if n_rows <= 0 or n_rows > self.max_rows or n_rows % self.world_size != 0:
+                    raise ValueError(
+                        f"rows must be in (0, {self.max_rows}] and divisible by world_size"
+                    )
+                self.prepare_graph()
+                owner_packs = (n_rows // self.world_size) * (self.topk // 4)
+                blocks = max(
+                    1,
+                    min(
+                        int(self._block_limit),
+                        (owner_packs + self._threads - 1) // self._threads,
+                    ),
+                )
+                # Compute proposed slot WITHOUT mutating _graph_slot.
+                proposed_slot = (
+                    self._graph_slot if self._graph_slot is not None else self._next_slot
+                )
+            except BaseException as exc:
+                local_error = exc
+
+            # Collective pre-capture agreement: every rank exchanges
+            # (has_error, rows, blocks, proposed_slot, wait).  No rank
+            # commits capture state until the verdict is unanimous.
+            capture_contract = (
+                local_error is not None,
+                n_rows,
+                blocks,
+                proposed_slot,
+                wait_for_prior_consumer,
+            )
+            if self.exchange_group is not None:
+                gathered = _broadcast_gather_object(
+                    capture_contract, self.exchange_group
+                )
+                if any(peer != capture_contract for peer in gathered):
+                    raise RuntimeError(
+                        f"DCP top-k capture contract differs across ranks: {gathered}"
+                    )
+            if local_error is not None:
+                raise local_error
+
+            # Only commit capture state after unanimous agreement.
+            self._graph_slot = proposed_slot
+            self._capture_rows = n_rows
+            self._capture_context_depth = 1
+            self._capture_stage_count = 0
+            capture_body_error: BaseException | None = None
+            try:
+                yield self
+            except BaseException as exc:
+                capture_body_error = exc
+                raise
+            finally:
+                self._capture_context_depth = 0
+                self._capture_rows = None
+                stage_count = self._capture_stage_count
+                self._capture_stage_count = 0
+                if self.exchange_group is not None:
+                    # Exchange (success, error_type, stage_count).
+                    # All ranks must capture the same number of stage
+                    # kernels (preferably exactly 1) so replay has
+                    # matching barrier generations.
+                    status = (
+                        capture_body_error is None,
+                        type(capture_body_error).__name__ if capture_body_error else "",
+                        stage_count,
+                    )
+                    gathered = _broadcast_gather_object(
+                        status, self.exchange_group
+                    )
+                    if any(peer[0] is not True for peer in gathered):
+                        raise RuntimeError(
+                            f"DCP top-k capture failed on one or more ranks: {gathered}"
+                        )
+                    counts = {peer[2] for peer in gathered}
+                    if len(counts) > 1:
+                        raise RuntimeError(
+                            f"DCP top-k capture stage count differs across ranks: {gathered}"
+                        )
+                    if stage_count != 1:
+                        raise RuntimeError(
+                            f"DCP top-k capture requires exactly 1 stage call, "
+                            f"got {stage_count}"
+                        )
+
+    def _eager_prelaunch_verdict(
+        self,
+        *,
+        rows: int,
+        blocks: int,
+        slot: int,
+        wait_for_prior_consumer: bool,
+        local_error: Optional[Exception],
+    ) -> None:
+        """Collectively verify all ranks agree on eager launch parameters."""
+        if self.exchange_group is None:
+            if local_error is not None:
+                raise local_error
+            return
+        prelaunch_contract = (
+            local_error is not None,
+            int(rows), int(blocks), int(slot),
+            bool(wait_for_prior_consumer),
+        )
+        gathered = _broadcast_gather_object(
+            prelaunch_contract, self.exchange_group
+        )
+        if any(peer != prelaunch_contract for peer in gathered):
+            raise RuntimeError(
+                f"DCP top-k pre-launch verdict differs across ranks: {gathered}"
+            )
+        if local_error is not None:
+            raise local_error
+
+    def _validate_stage_inputs(
+        self,
+        local_indices: torch.Tensor,
+        local_scores: torch.Tensor,
+    ) -> tuple[Optional[Exception], int]:
+        """Run all per-call validation, returning (error, rows).
+
+        Everything that can fail — including ndim access and stream binding —
+        is inside the try block so a malformed rank can participate in the
+        collective verdict.
+        """
+        rows = 0
         try:
-            yield self
-        finally:
-            self._capture_context_depth = 0
+            if self._closed:
+                raise RuntimeError("PCIeDCPTopKOwnerExchange is closed")
+            if local_indices.device != self.device or local_scores.device != self.device:
+                raise ValueError("inputs must be on the runtime device")
+            if local_indices.dtype != torch.int32:
+                raise ValueError("local_indices must be int32")
+            if local_scores.dtype != torch.float32:
+                raise ValueError("local_scores must be float32")
+            if local_indices.shape != local_scores.shape or local_indices.ndim != 2:
+                raise ValueError("inputs must have matching [rows, topk] shapes")
+            rows, topk = (int(value) for value in local_indices.shape)
+            if rows <= 0 or rows > self.max_rows or rows % self.world_size != 0:
+                raise ValueError(
+                    f"rows must be in (0, {self.max_rows}] and divisible by world_size"
+                )
+            if topk != self.topk:
+                raise ValueError(
+                    f"topk {topk} does not match configured topk {self.topk}"
+                )
+            if not local_indices.is_contiguous() or not local_scores.is_contiguous():
+                raise ValueError("inputs must be contiguous")
+            if int(local_indices.data_ptr()) % 16 != 0:
+                raise ValueError("local_indices data pointer must be 16-byte aligned")
+            if int(local_scores.data_ptr()) % 16 != 0:
+                raise ValueError("local_scores data pointer must be 16-byte aligned")
+            self._bind_stream()
+            return None, rows
+        except Exception as exc:
+            return exc, rows
 
     def _stage_candidates_on_device(
         self,
         local_indices: torch.Tensor,
         local_scores: torch.Tensor,
-        *,
-        threads: int,
-        block_limit: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self._closed:
-            raise RuntimeError("PCIeDCPTopKOwnerExchange is closed")
-        if local_indices.device != self.device or local_scores.device != self.device:
-            raise ValueError("inputs must be on the runtime device")
-        if local_indices.dtype != torch.int32:
-            raise ValueError("local_indices must be int32")
-        if local_scores.dtype != torch.float32:
-            raise ValueError("local_scores must be float32")
-        if local_indices.shape != local_scores.shape or local_indices.ndim != 2:
-            raise ValueError("inputs must have matching [rows, topk] shapes")
-        rows, topk = (int(value) for value in local_indices.shape)
-        if rows <= 0 or rows > self.max_rows or rows % self.world_size != 0:
-            raise ValueError(
-                f"rows must be in (0, {self.max_rows}] and divisible by world_size"
-            )
-        if topk != self.topk:
-            raise ValueError(f"topk {topk} does not match configured topk {self.topk}")
-        if not local_indices.is_contiguous() or not local_scores.is_contiguous():
-            raise ValueError("inputs must be contiguous")
-        _validate_launch_config(
-            threads=int(threads),
-            block_limit=int(block_limit),
-            world_size=self.world_size,
-        )
-        self._bind_stream()
-        owner_packs = (rows // self.world_size) * (self.topk // 4)
-        blocks = max(1, min(int(block_limit), (owner_packs + threads - 1) // threads))
         capturing = _is_current_stream_capturing(self.device)
         if capturing:
             if self._capture_context_depth <= 0:
@@ -486,36 +844,69 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
                     "DCP top-k CUDA graph capture requires an active "
                     "owner.capture() context"
                 )
-            from ._dcp_topk_cute import is_topk_stage_prepared
-
-            if not is_topk_stage_prepared(
-                self.world_size,
-                self.rank,
-                self.topk,
-                int(threads),
-            ):
-                raise RuntimeError(
-                    "cold DCP top-k CUDA graph capture is not allowed; "
-                    "enter owner.capture() before torch.cuda.graph()"
+            # During capture, rows/slot/wait were pre-agreed in capture().
+            # Validate locally — including that tensor rows match the
+            # pre-agreed capture rows — then launch with no host collective.
+            local_error, tensor_rows = self._validate_stage_inputs(
+                local_indices, local_scores
+            )
+            if local_error is not None:
+                raise local_error
+            rows = self._capture_rows
+            assert rows is not None
+            if tensor_rows != rows:
+                raise ValueError(
+                    f"captured stage tensor rows {tensor_rows} do not match "
+                    f"pre-agreed capture rows {rows}"
                 )
-        if capturing and self._graph_slot is None:
-            self._graph_slot = self._next_slot
-        if self._graph_slot is not None:
             slot = self._graph_slot
+            assert slot is not None
             wait_for_prior_consumer = True
+            owner_packs = (rows // self.world_size) * (self.topk // 4)
+            blocks = max(
+                1,
+                min(
+                    int(self._block_limit),
+                    (owner_packs + self._threads - 1) // self._threads,
+                ),
+            )
         else:
-            slot = self._next_slot
-            self._next_slot ^= 1
-            wait_for_prior_consumer = False
+            # Eager path: validate without raising (including ndim/stream),
+            # then collective verdict.
+            local_error, rows = self._validate_stage_inputs(
+                local_indices, local_scores
+            )
+            owner_packs = (rows // self.world_size) * (self.topk // 4)
+            blocks = max(
+                1,
+                min(
+                    int(self._block_limit),
+                    (owner_packs + self._threads - 1) // self._threads,
+                ),
+            )
+            # After graph capture, all launches use the pinned graph slot
+            # with wait=True to prevent overwriting before a slow consumer
+            # retires.
+            if self._graph_slot is not None:
+                slot = self._graph_slot
+                wait_for_prior_consumer = True
+            else:
+                slot = self._next_slot
+                self._next_slot ^= 1
+                wait_for_prior_consumer = False
+            self._eager_prelaunch_verdict(
+                rows=rows, blocks=blocks, slot=slot,
+                wait_for_prior_consumer=wait_for_prior_consumer,
+                local_error=local_error,
+            )
+
         self._launch_stage(
-            local_indices,
-            local_scores,
-            slot=slot,
-            rows=rows,
-            threads=int(threads),
-            blocks=blocks,
+            local_indices, local_scores, slot=slot, rows=rows,
+            threads=int(self._threads), blocks=blocks,
             wait_for_prior_consumer=wait_for_prior_consumer,
         )
+        if capturing:
+            self._capture_stage_count += 1
         candidate_views = self._candidate_views[slot] if self._candidate_views else ()
         if not candidate_views:
             raise RuntimeError("DCP top-k candidate views require a CUDA device")
@@ -524,18 +915,12 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         candidate_scores = candidate_views[1][:owner_rows]
         expected = (rows // self.world_size, self.world_size * self.topk)
         _validate_candidate_view(
-            candidate_indices,
-            expected=expected,
-            dtype=torch.int32,
-            device=self.device,
-            label="index",
+            candidate_indices, expected=expected,
+            dtype=torch.int32, device=self.device, label="index",
         )
         _validate_candidate_view(
-            candidate_scores,
-            expected=expected,
-            dtype=torch.float32,
-            device=self.device,
-            label="score",
+            candidate_scores, expected=expected,
+            dtype=torch.float32, device=self.device, label="score",
         )
         return candidate_indices, candidate_scores
 
@@ -551,21 +936,16 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         wait_for_prior_consumer: bool,
     ) -> None:
         from ._dcp_topk_cute import stage_owner_candidates
-
         with torch.cuda.device(self.device):
             stage_owner_candidates(
-                world_size=self.world_size,
-                rank=self.rank,
-                topk=self.topk,
+                world_size=self.world_size, rank=self.rank, topk=self.topk,
                 threads=threads,
                 local_indices_ptr=local_indices.data_ptr(),
                 local_scores_ptr=local_scores.data_ptr(),
                 candidate_ptrs=self._staging_ptrs[slot],
                 signal_ptrs=self._signal_ptrs,
-                rows=rows,
-                candidate_plane_elems=self._candidate_plane_elems,
-                blocks=blocks,
-                wait_for_prior_consumer=wait_for_prior_consumer,
+                rows=rows, candidate_plane_elems=self._candidate_plane_elems,
+                blocks=blocks, wait_for_prior_consumer=wait_for_prior_consumer,
             )
 
 
@@ -584,15 +964,3 @@ def _validate_candidate_view(
         or not tensor.is_contiguous()
     ):
         raise RuntimeError(f"channel returned an invalid candidate {label} view")
-
-
-def _release_failed_allocations(
-    owned: Sequence[_OwnedSharedBuffer],
-    ipc: CudaRTLibrary,
-) -> None:
-    for shared in owned:
-        for ptr in shared.remote_ptrs:
-            with suppress(Exception):
-                ipc.cudaIpcCloseMemHandle(ptr)
-        with suppress(Exception):
-            ipc.cudaFree(shared.local_ptr)

--- a/tests/comm/test_pcie_dcp_topk.py
+++ b/tests/comm/test_pcie_dcp_topk.py
@@ -7,67 +7,45 @@ from b12x.comm.pcie.pcie_dcp_topk import (
     PCIeDCPTopKOwnerExchange,
     _SIGNAL_BYTES,
     _candidate_staging_layout,
+    _dcp_topk_runtime_contract,
+    _dcp_topk_topology_record,
+    _verify_dcp_topk_topology,
     owner_stage_reference,
 )
 from b12x.comm.pcie._dcp_cute_common import signal_bytes
 
+import b12x.comm.pcie.pcie_dcp_topk as _topk_mod
+
 
 class _FakeOwner(PCIeDCPTopKOwnerExchange):
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(
-            rank=1,
-            world_size=2,
-            device="cpu",
-            signal_ptrs=(10, 20),
-            staging0_ptrs=(30, 40),
-            staging1_ptrs=(62, 72),
-            max_rows=8,
-            topk=4,
+            rank=1, world_size=2, device="cpu",
+            signal_ptrs=(10, 20), staging0_ptrs=(30, 40), staging1_ptrs=(62, 72),
+            max_rows=8, topk=4,
         )
         shape = (self.max_owner_rows, self.world_size * self.topk)
         self._candidate_views = tuple(
-            (
-                torch.empty(shape, dtype=torch.int32),
-                torch.empty(shape, dtype=torch.float32),
-            )
+            (torch.empty(shape, dtype=torch.int32), torch.empty(shape, dtype=torch.float32))
             for _ in range(2)
         )
-        self.stage_calls: list[tuple] = []
+        self.stage_calls = []
 
-    def _launch_stage(
-        self,
-        local_indices,
-        local_scores,
-        *,
-        slot,
-        rows,
-        threads,
-        blocks,
-        wait_for_prior_consumer,
-    ):
+    def _launch_stage(self, local_indices, local_scores, *, slot, rows, threads, blocks, wait_for_prior_consumer):
         owner_rows = rows // self.world_size
         row_slice = slice(self.rank * owner_rows, (self.rank + 1) * owner_rows)
         views = self._candidate_views[slot]
-        views[0][:owner_rows].copy_(
-            local_indices[row_slice].repeat(1, self.world_size)
-        )
-        views[1][:owner_rows].copy_(
-            local_scores[row_slice].repeat(1, self.world_size)
-        )
+        views[0][:owner_rows].copy_(local_indices[row_slice].repeat(1, self.world_size))
+        views[1][:owner_rows].copy_(local_scores[row_slice].repeat(1, self.world_size))
         self.stage_calls.append((slot, threads, blocks, wait_for_prior_consumer))
 
 
-def _make_owner() -> PCIeDCPTopKOwnerExchange:
+def _make_owner():
     return _FakeOwner()
 
 
 def test_candidate_staging_layout_is_aligned():
-    owner = _candidate_staging_layout(
-        signal_bytes=513,
-        max_rows=8,
-        topk=4,
-        world_size=2,
-    )
+    owner = _candidate_staging_layout(signal_bytes=513, max_rows=8, topk=4, world_size=2)
     assert owner.staging0_offset == 768
     assert owner.plane_bytes == 128
     assert owner.slot_bytes == 256
@@ -88,81 +66,53 @@ def test_owner_stage_reference_preserves_rank_major_order_and_score_bits():
             indices[rank, row].fill_(1000 * rank + 10 * row)
             score_bits[rank, row].fill_(0x3F000000 + rank * 16 + row)
     scores = score_bits.view(torch.float32)
-
     owner_indices, owner_scores = owner_stage_reference(indices, scores, 2)
-
     assert owner_indices.shape == (2, world_size * topk)
     assert owner_scores.shape == owner_indices.shape
     for owner_row, global_row in enumerate((4, 5)):
         for rank in range(world_size):
             rank_slice = slice(rank * topk, (rank + 1) * topk)
-            assert torch.equal(
-                owner_indices[owner_row, rank_slice], indices[rank, global_row]
-            )
-            assert torch.equal(
-                owner_scores[owner_row, rank_slice].view(torch.int32),
-                score_bits[rank, global_row],
-            )
+            assert torch.equal(owner_indices[owner_row, rank_slice], indices[rank, global_row])
+            assert torch.equal(owner_scores[owner_row, rank_slice].view(torch.int32), score_bits[rank, global_row])
 
 
 def test_owner_dispatches_and_disposes():
     owner = _make_owner()
     indices = torch.arange(32, dtype=torch.int32).reshape(8, 4)
     scores = torch.arange(32, dtype=torch.float32).reshape(8, 4) / 10
-
-    candidate_indices, candidate_scores = owner.stage_candidates(
-        indices,
-        scores,
-        threads=128,
-        block_limit=32,
-    )
+    candidate_indices, candidate_scores = owner.stage_candidates(indices, scores)
     assert torch.equal(candidate_indices, indices[4:].repeat(1, 2))
     assert torch.equal(candidate_scores, scores[4:].repeat(1, 2))
-    assert owner.stage_calls == [(0, 128, 1, False)]
-
+    assert owner.stage_calls == [(0, 512, 1, False)]
     owner.close()
     assert owner._closed
 
 
 @pytest.mark.parametrize("eager_calls, expected_slot", [(0, 0), (1, 1), (2, 0)])
 def test_graph_capture_pins_the_next_staging_slot_and_enables_prior_wait(
-    monkeypatch,
-    eager_calls,
-    expected_slot,
+    monkeypatch, eager_calls, expected_slot,
 ):
     owner = _make_owner()
     indices = torch.arange(32, dtype=torch.int32).reshape(8, 4)
     scores = torch.arange(32, dtype=torch.float32).reshape(8, 4)
     capture_state = False
-    monkeypatch.setattr(
-        "b12x.comm.pcie.pcie_dcp_topk._is_current_stream_capturing",
-        lambda _device: capture_state,
-    )
-    monkeypatch.setattr(owner, "prepare_graph", lambda **kwargs: None)
-    monkeypatch.setattr(
-        "b12x.comm.pcie._dcp_topk_cute.is_topk_stage_prepared",
-        lambda *args: True,
-    )
-
+    monkeypatch.setattr("b12x.comm.pcie.pcie_dcp_topk._is_current_stream_capturing", lambda _device: capture_state)
+    monkeypatch.setattr(owner, "prepare_graph", lambda: None)
+    monkeypatch.setattr("b12x.comm.pcie._dcp_topk_cute.is_topk_stage_prepared", lambda *args: True)
     for _ in range(eager_calls):
         owner.stage_candidates(indices, scores)
     capture_state = True
-    with owner.capture():
+    with owner.capture(rows=8):
         first_indices, first_scores = owner.stage_candidates(indices, scores)
     capture_state = False
     second_indices, second_scores = owner.stage_candidates(indices + 100, scores + 1)
     capture_state = True
-    with owner.capture():
+    with owner.capture(rows=8):
         third_indices, third_scores = owner.stage_candidates(indices + 200, scores + 2)
-
     assert owner._graph_slot == expected_slot
     assert first_indices.data_ptr() == second_indices.data_ptr()
     assert second_indices.data_ptr() == third_indices.data_ptr()
-    assert first_scores.data_ptr() == second_scores.data_ptr()
-    assert second_scores.data_ptr() == third_scores.data_ptr()
-    eager_stages = [
-        (slot % 2, 512, 1, False) for slot in range(eager_calls)
-    ]
+    eager_stages = [(slot % 2, 512, 1, False) for slot in range(eager_calls)]
     assert owner.stage_calls == eager_stages + [
         (expected_slot, 512, 1, True),
         (expected_slot, 512, 1, True),
@@ -171,11 +121,10 @@ def test_graph_capture_pins_the_next_staging_slot_and_enables_prior_wait(
     assert torch.equal(third_indices, (indices + 200)[4:].repeat(1, 2))
 
 
-def test_owner_rejects_invalid_contracts():
+def test_owner_rejects_invalid_inputs():
     owner = _make_owner()
     indices = torch.zeros(8, 4, dtype=torch.int32)
     scores = torch.zeros(8, 4, dtype=torch.float32)
-
     with pytest.raises(ValueError, match="matching"):
         owner.stage_candidates(indices, scores[:4])
     with pytest.raises(ValueError, match="matching"):
@@ -186,28 +135,230 @@ def test_owner_rejects_invalid_contracts():
         owner.stage_candidates(indices, scores.bfloat16())
     with pytest.raises(ValueError, match="divisible"):
         owner.stage_candidates(indices[:7], scores[:7])
-    with pytest.raises(ValueError, match="threads"):
-        owner.stage_candidates(indices, scores, threads=31)
-    with pytest.raises(ValueError, match="block_limit"):
-        owner.stage_candidates(indices, scores, block_limit=129)
 
 
 def test_configuration_rejects_invalid_capacity_and_topk():
     with pytest.raises(ValueError, match="multiple of 4"):
-        _candidate_staging_layout(
-            signal_bytes=256,
-            max_rows=8,
-            topk=6,
-            world_size=2,
-        )
+        _candidate_staging_layout(signal_bytes=256, max_rows=8, topk=6, world_size=2)
     with pytest.raises(ValueError, match="divisible"):
         PCIeDCPTopKOwnerExchange(
-            rank=0,
-            world_size=4,
-            device="cpu",
-            signal_ptrs=(1, 2, 3, 4),
-            staging0_ptrs=(5, 6, 7, 8),
-            staging1_ptrs=(9, 10, 11, 12),
-            max_rows=6,
-            topk=4,
+            rank=0, world_size=4, device="cpu",
+            signal_ptrs=(1, 2, 3, 4), staging0_ptrs=(5, 6, 7, 8),
+            staging1_ptrs=(9, 10, 11, 12), max_rows=6, topk=4,
         )
+
+
+def test_constructor_rejects_invalid_launch_protocol():
+    with pytest.raises(ValueError, match="threads"):
+        PCIeDCPTopKOwnerExchange(
+            rank=0, world_size=2, device="cpu",
+            signal_ptrs=(1, 2), staging0_ptrs=(3, 4), staging1_ptrs=(5, 6),
+            max_rows=8, topk=4, threads=31,
+        )
+    with pytest.raises(ValueError, match="block_limit"):
+        PCIeDCPTopKOwnerExchange(
+            rank=0, world_size=2, device="cpu",
+            signal_ptrs=(1, 2), staging0_ptrs=(3, 4), staging1_ptrs=(5, 6),
+            max_rows=8, topk=4, block_limit=129,
+        )
+
+
+def test_cuda_direct_constructor_requires_exchange_group():
+    with pytest.raises(ValueError, match="exchange_group is required"):
+        PCIeDCPTopKOwnerExchange(
+            rank=0, world_size=2, device="cuda:0",
+            signal_ptrs=(1, 2), staging0_ptrs=(3, 4), staging1_ptrs=(5, 6),
+            max_rows=8, topk=4,
+        )
+
+
+def test_cuda_direct_constructor_with_group_requires_factory():
+    with pytest.raises(ValueError, match="from_exchange_group"):
+        PCIeDCPTopKOwnerExchange(
+            rank=0, world_size=2, device="cuda:0",
+            signal_ptrs=(1, 2), staging0_ptrs=(3, 4), staging1_ptrs=(5, 6),
+            max_rows=8, topk=4, exchange_group=object(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #178: collective DCP Top-K contract agreement before IPC allocation.
+# ---------------------------------------------------------------------------
+
+
+def _base_layout():
+    return _candidate_staging_layout(signal_bytes=_SIGNAL_BYTES, max_rows=8, topk=4, world_size=2)
+
+
+def _base_contract():
+    layout = _base_layout()
+    return _dcp_topk_runtime_contract(
+        world_size=2, max_rows=8, topk=4, layout=layout, threads=512, block_limit=128,
+    )
+
+
+_CONTRACT_FIELDS = {
+    "abi_version": 1,
+    "topology_world": 2,
+    "capacity_max_rows": 4,
+    "capacity_topk": 6,
+    "shape_candidate": 8,
+    "stride_candidate": 9,
+    "offset_staging0": 15,
+    "offset_staging1": 16,
+    "wire_codec_index": 17,
+    "wire_codec_score": 18,
+    "signal_max_blocks": 19,
+    "signal_bytes": 20,
+    "schedule_threads": 23,
+    "schedule_block_limit": 24,
+    "stream_affine": 25,
+}
+
+
+def _mismatched_contract(field):
+    contract = list(_base_contract())
+    idx = _CONTRACT_FIELDS[field]
+    original = contract[idx]
+    if isinstance(original, bool):
+        contract[idx] = not original
+    elif isinstance(original, int):
+        contract[idx] = original + 1
+    elif isinstance(original, str):
+        contract[idx] = original + "_mismatched"
+    elif isinstance(original, tuple):
+        contract[idx] = tuple(v + 1 for v in original)
+    else:
+        contract[idx] = "__MISMATCHED__"
+    return tuple(contract)
+
+
+@pytest.mark.parametrize("field, label", [
+    ("capacity_max_rows", "capacity"),
+    ("capacity_topk", "capacity"),
+    ("offset_staging0", "offset"),
+    ("offset_staging1", "offset"),
+    ("wire_codec_index", "wire mode/codec"),
+    ("wire_codec_score", "wire mode/codec"),
+    ("topology_world", "topology"),
+    ("signal_max_blocks", "signal ABI"),
+    ("signal_bytes", "signal ABI"),
+    ("schedule_threads", "schedule"),
+    ("schedule_block_limit", "schedule"),
+    ("stream_affine", "stream affinity"),
+    ("abi_version", "ABI version"),
+    ("shape_candidate", "shape/stride"),
+    ("stride_candidate", "shape/stride"),
+])
+def test_contract_single_field_mismatch_detection(field, label):
+    canonical = _base_contract()
+    mismatched = _mismatched_contract(field)
+    assert canonical != mismatched
+    diffs = [i for i, (a, b) in enumerate(zip(canonical, mismatched, strict=True)) if a != b]
+    assert len(diffs) == 1
+    assert diffs[0] == _CONTRACT_FIELDS[field]
+
+
+def test_contract_exact_match_is_identical():
+    assert _base_contract() == _base_contract()
+
+
+def test_contract_includes_all_required_fields():
+    contract = _base_contract()
+    assert len(contract) == 27
+    assert isinstance(contract[0], int)  # version
+    assert isinstance(contract[1], int)  # ABI version
+    assert isinstance(contract[2], int)  # world_size
+    assert isinstance(contract[3], tuple)  # supported world sizes
+    assert all(isinstance(contract[i], int) for i in range(4, 8))  # capacity
+    assert isinstance(contract[8], tuple)  # shape
+    assert isinstance(contract[9], tuple)  # stride
+    assert isinstance(contract[10], int)  # score plane offset
+    assert all(isinstance(contract[i], int) for i in range(11, 14))  # alloc sizes
+    assert all(isinstance(contract[i], int) for i in range(14, 17))  # offsets
+    assert isinstance(contract[17], str)  # wire codec
+    assert isinstance(contract[18], str)  # wire codec
+    assert all(isinstance(contract[i], int) for i in range(19, 23))  # signal ABI
+    assert isinstance(contract[23], int)  # threads
+    assert isinstance(contract[24], int)  # block_limit
+    assert isinstance(contract[25], bool)  # stream_affine (always True)
+    assert isinstance(contract[26], int)  # IPC alignment
+
+
+def test_topology_record_structure():
+    record = _dcp_topk_topology_record(rank=0, device=torch.device("cpu"))
+    assert len(record) == 3
+    assert record[0] == 0
+    assert isinstance(record[1], str)
+    assert isinstance(record[2], str)
+
+
+def test_verify_topology_rejects_duplicate_gpu(monkeypatch):
+    record_a = (0, "host", "GPU-uuid-0")
+    record_b = (1, "host", "GPU-uuid-0")
+    monkeypatch.setattr(_topk_mod, "_broadcast_gather_object", lambda obj, group: [record_a, record_b])
+    with pytest.raises(RuntimeError, match="duplicate GPU UUID"):
+        _verify_dcp_topk_topology(exchange_group=object(), topology=record_a)
+
+
+def test_verify_topology_rejects_multi_host(monkeypatch):
+    record_a = (0, "host-a", "GPU-uuid-0")
+    record_b = (1, "host-b", "GPU-uuid-1")
+    monkeypatch.setattr(_topk_mod, "_broadcast_gather_object", lambda obj, group: [record_a, record_b])
+    with pytest.raises(RuntimeError, match="multiple hosts"):
+        _verify_dcp_topk_topology(exchange_group=object(), topology=record_a)
+
+
+def test_verify_topology_rejects_empty_uuid(monkeypatch):
+    record_a = (0, "host", "")
+    record_b = (1, "host", "GPU-uuid-1")
+    monkeypatch.setattr(_topk_mod, "_broadcast_gather_object", lambda obj, group: [record_a, record_b])
+    with pytest.raises(RuntimeError, match="UUID"):
+        _verify_dcp_topk_topology(exchange_group=object(), topology=record_a)
+
+
+def test_verify_topology_rejects_noncontiguous_ranks(monkeypatch):
+    record_a = (0, "host", "GPU-uuid-0")
+    record_b = (2, "host", "GPU-uuid-1")
+    monkeypatch.setattr(_topk_mod, "_broadcast_gather_object", lambda obj, group: [record_a, record_b])
+    with pytest.raises(RuntimeError, match="contiguous"):
+        _verify_dcp_topk_topology(exchange_group=object(), topology=record_a)
+
+
+def test_verify_topology_accepts_unique(monkeypatch):
+    record_a = (0, "host", "GPU-uuid-0")
+    record_b = (1, "host", "GPU-uuid-1")
+    monkeypatch.setattr(_topk_mod, "_broadcast_gather_object", lambda obj, group: [record_a, record_b])
+    _verify_dcp_topk_topology(exchange_group=object(), topology=record_a)
+
+
+def test_require_collective_contract_rejects_mismatch(monkeypatch):
+    """Exercise the actual _require_collective_contract production gate."""
+    canonical = _base_contract()
+    mismatched = _mismatched_contract("capacity_max_rows")
+    monkeypatch.setattr(
+        _topk_mod,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, mismatched],
+    )
+    with pytest.raises(RuntimeError, match="contract differs across ranks"):
+        _topk_mod._require_collective_contract(
+            owner="test",
+            exchange_group=object(),
+            contract=canonical,
+        )
+
+
+def test_require_collective_contract_accepts_match(monkeypatch):
+    """Exact match must pass the production gate."""
+    canonical = _base_contract()
+    monkeypatch.setattr(
+        _topk_mod,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, contract],
+    )
+    _topk_mod._require_collective_contract(
+        owner="test",
+        exchange_group=object(),
+        contract=canonical,
+    )

--- a/tests/comm/test_pcie_dcp_topk_contract_gpu.py
+++ b/tests/comm/test_pcie_dcp_topk_contract_gpu.py
@@ -1,0 +1,326 @@
+"""Gated two-rank NCCL/CUDA test for DCP Top-K collective contract validation.
+
+Run with:
+
+    B12X_PCIE_TEST_DCP_TOPK_CONTRACT=1 CUDA_VISIBLE_DEVICES=0,1 \
+    python -m pytest tests/comm/test_pcie_dcp_topk_contract_gpu.py -xvs
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from b12x.comm.pcie.pcie_dcp_topk import PCIeDCPTopKOwnerExchange
+from b12x.comm.pcie import pcie_oneshot as _oneshot_mod
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _expect_collective_rejection(monkeypatch_target, operation) -> None:
+    """Assert every rank rejects before IPC open, then rendezvous."""
+    # Track whether IPC allocation was attempted.
+    ipc_opened = [False]
+    original_alloc = _oneshot_mod.PCIeOneshotAllReduce._allocate_shared_buffer
+
+    def tracking_alloc(*args, **kwargs):
+        ipc_opened[0] = True
+        return original_alloc(*args, **kwargs)
+
+    _oneshot_mod.PCIeOneshotAllReduce._allocate_shared_buffer = tracking_alloc
+    try:
+        with pytest.raises(RuntimeError):
+            operation()
+    finally:
+        _oneshot_mod.PCIeOneshotAllReduce._allocate_shared_buffer = original_alloc
+    assert not ipc_opened[0], "IPC allocation must not start when the contract mismatches"
+    dist.barrier()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=90),
+    )
+    import b12x.comm.pcie.pcie_dcp_topk as _topk_mod
+    group = dist.group.WORLD
+    try:
+        _expect_collective_rejection(
+            None,
+            lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                exchange_group=group, device=device,
+                max_rows=8 if rank == 0 else 16, topk=4,
+            ),
+        )
+
+        # Divergent topk.
+        _expect_collective_rejection(
+            None,
+            lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                exchange_group=group, device=device,
+                max_rows=8, topk=4 if rank == 0 else 8,
+            ),
+        )
+
+        # Divergent threads.
+        _expect_collective_rejection(
+            None,
+            lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                exchange_group=group, device=device,
+                max_rows=8, topk=4,
+                threads=512 if rank == 0 else 256,
+            ),
+        )
+
+        # Divergent block_limit.
+        _expect_collective_rejection(
+            None,
+            lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                exchange_group=group, device=device,
+                max_rows=8, topk=4,
+                block_limit=128 if rank == 0 else 64,
+            ),
+        )
+
+        # Asymmetric argument parse failure: rank 1 passes object() for
+        # max_rows whose int() raises. Coordinated error envelope must
+        # reject every rank before IPC allocation.
+        _expect_collective_rejection(
+            None,
+            lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                exchange_group=group, device=device,
+                max_rows=8 if rank == 0 else object(), topk=4,
+            ),
+        )
+
+        original_contract = _topk_mod._dcp_topk_runtime_contract
+        # Asymmetric contract field mutation: rank 1's contract builder
+        # returns a contract with a mutated staging offset. Must fail every
+        # rank before IPC allocation via _require_collective_contract.
+        def mutating_contract(*args, **kwargs):
+            contract = original_contract(*args, **kwargs)
+            if rank == 1:
+                contract_list = list(contract)
+                contract_list[15] = contract_list[15] + 256  # staging0_offset
+                return tuple(contract_list)
+            return contract
+
+        _topk_mod._dcp_topk_runtime_contract = mutating_contract
+        try:
+            _expect_collective_rejection(
+                None,
+                lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                    exchange_group=group, device=device, max_rows=8, topk=4,
+                ),
+            )
+        finally:
+            _topk_mod._dcp_topk_runtime_contract = original_contract
+
+        # Asymmetric topology: rank 1 returns a duplicate UUID.
+        original_topology = _topk_mod._dcp_topk_topology_record
+
+        def dup_uuid_topology(*, rank, device):
+            record = original_topology(rank=rank, device=device)
+            return (record[0], record[1], "DUPLICATE-UUID")
+
+        _topk_mod._dcp_topk_topology_record = dup_uuid_topology
+        try:
+            _expect_collective_rejection(
+                None,
+                lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                    exchange_group=group, device=device, max_rows=8, topk=4,
+                ),
+            )
+        finally:
+            _topk_mod._dcp_topk_topology_record = original_topology
+
+        # Asymmetric contract-builder failure: rank 1's contract builder
+        # raises. Must fail every rank before IPC allocation.
+
+        original_contract = _topk_mod._dcp_topk_runtime_contract
+
+        def failing_contract(*args, **kwargs):
+            if rank == 1:
+                raise RuntimeError("injected contract builder failure")
+            return original_contract(*args, **kwargs)
+
+        _topk_mod._dcp_topk_runtime_contract = failing_contract
+        try:
+            _expect_collective_rejection(
+                None,
+                lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                    exchange_group=group, device=device, max_rows=8, topk=4,
+                ),
+            )
+        finally:
+            _topk_mod._dcp_topk_runtime_contract = original_contract
+
+        # Injected prepare_topk_stage (compiler) failure on rank 1.
+        import b12x.comm.pcie._dcp_topk_cute as _cute_mod
+        original_prepare = _cute_mod.prepare_topk_stage
+
+        def failing_prepare(*args, **kwargs):
+            if rank == 1:
+                raise RuntimeError("injected compiler failure")
+            original_prepare(*args, **kwargs)
+
+        _cute_mod.prepare_topk_stage = failing_prepare
+        try:
+            _expect_collective_rejection(
+                None,
+                lambda: PCIeDCPTopKOwnerExchange.from_exchange_group(
+                    exchange_group=group, device=device, max_rows=8, topk=4,
+                ),
+            )
+        finally:
+            _cute_mod.prepare_topk_stage = original_prepare
+
+        # Direct CUDA constructor without exchange_group rejected.
+        with pytest.raises(ValueError, match="exchange_group is required"):
+            PCIeDCPTopKOwnerExchange(
+                rank=rank, world_size=world_size, device=device,
+                signal_ptrs=tuple(0 for _ in range(world_size)),
+                staging0_ptrs=tuple(0 for _ in range(world_size)),
+                staging1_ptrs=tuple(0 for _ in range(world_size)),
+                max_rows=8, topk=4,
+            )
+        dist.barrier()
+
+        # Direct CUDA constructor WITH exchange_group but no factory token.
+        with pytest.raises(ValueError, match="from_exchange_group"):
+            PCIeDCPTopKOwnerExchange(
+                rank=rank, world_size=world_size, device=device,
+                signal_ptrs=tuple(0 for _ in range(world_size)),
+                staging0_ptrs=tuple(0 for _ in range(world_size)),
+                staging1_ptrs=tuple(0 for _ in range(world_size)),
+                max_rows=8, topk=4, exchange_group=group,
+            )
+        dist.barrier()
+
+        # Exact match: construction proceeds.
+
+        # Post-allocation constructor failure: inject _tensor_from_cuda_pointer
+        # failure on rank 1. Every rank must receive setup failure, rendezvous,
+        # then successfully construct a fresh owner to prove the collective
+        # remains usable and ownership was not leaked/double-freed.
+        original_tensor_fn = _topk_mod._tensor_from_cuda_pointer
+
+        class _FailTensor:
+            pass
+
+        def failing_tensor_fn(pointer, shape, *, dtype, device):
+            if rank == 1:
+                raise RuntimeError("injected tensor construction failure")
+            return original_tensor_fn(pointer, shape, dtype=dtype, device=device)
+
+        _topk_mod._tensor_from_cuda_pointer = failing_tensor_fn
+        try:
+            with pytest.raises(RuntimeError):
+                PCIeDCPTopKOwnerExchange.from_exchange_group(
+                    exchange_group=group, device=device, max_rows=8, topk=4,
+                )
+            dist.barrier()
+        finally:
+            _topk_mod._tensor_from_cuda_pointer = original_tensor_fn
+
+        # Fresh construction after rollback must succeed.
+        fresh_owner = PCIeDCPTopKOwnerExchange.from_exchange_group(
+            exchange_group=group, device=device, max_rows=8, topk=4,
+        )
+        assert fresh_owner.world_size == world_size
+        fresh_owner.close_coordinated()
+        dist.barrier()
+        owner = PCIeDCPTopKOwnerExchange.from_exchange_group(
+            exchange_group=group, device=device, max_rows=8, topk=4,
+        )
+        assert owner.world_size == world_size
+
+        # Eager stage with matching rows.
+        indices = torch.arange(8 * 4, dtype=torch.int32, device=device).reshape(8, 4)
+        scores = torch.arange(8 * 4, dtype=torch.float32, device=device).reshape(8, 4)
+        candidate_indices, candidate_scores = owner.stage_candidates(indices, scores)
+        assert candidate_indices.shape == (4, world_size * 4)
+        dist.barrier()
+
+        # Eager stage divergence: rank 0 rows=8, rank 1 rows=4.
+        wrong_indices = torch.arange(4 * 4, dtype=torch.int32, device=device).reshape(4, 4)
+        wrong_scores = torch.arange(4 * 4, dtype=torch.float32, device=device).reshape(4, 4)
+        with pytest.raises(RuntimeError, match="pre-launch verdict differs"):
+            owner.stage_candidates(
+                indices if rank == 0 else wrong_indices,
+                scores if rank == 0 else wrong_scores,
+            )
+        dist.barrier()
+
+        # Asymmetric invalid capture rows: rank 0 passes 8, rank 1 passes 7
+        # (not divisible by world_size). The pre-capture collective must
+        # reject every rank coherently.
+        with pytest.raises(RuntimeError), owner.capture(rows=8 if rank == 0 else 7):
+            pass
+        dist.barrier()
+
+        # Capture-body failure: rank 1 passes wrong-row tensor inside
+        # capture. The post-capture exchange must reject every rank.
+        capture_owner = PCIeDCPTopKOwnerExchange.from_exchange_group(
+            exchange_group=group, device=device, max_rows=8, topk=4,
+        )
+        graph2 = torch.cuda.CUDAGraph(keep_graph=True)
+        dist.barrier()
+        body_error = None
+        try:
+            with capture_owner.capture(rows=8), torch.cuda.graph(graph2):
+                # Rank 1 passes 4-row tensor but capture agreed on 8.
+                stage_indices = indices if rank == 0 else wrong_indices
+                stage_scores = scores if rank == 0 else wrong_scores
+                capture_owner.stage_candidates(stage_indices, stage_scores)
+        except Exception as exc:
+            body_error = exc
+        assert body_error is not None
+        dist.barrier()
+        capture_owner.close_coordinated()
+
+        # Graph capture with matching rows.
+        graph_owner = PCIeDCPTopKOwnerExchange.from_exchange_group(
+            exchange_group=group, device=device, max_rows=8, topk=4,
+        )
+        graph = torch.cuda.CUDAGraph(keep_graph=True)
+        dist.barrier()
+        with graph_owner.capture(rows=8), torch.cuda.graph(graph):
+            graph_indices, graph_scores = graph_owner.stage_candidates(indices, scores)
+        assert graph.raw_cuda_graph() is not None
+        graph_owner.close_coordinated()
+        owner.close_coordinated()
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_dcp_topk_contract_divergence_rejects_all_ranks_before_ipc() -> None:
+    if os.getenv("B12X_PCIE_TEST_DCP_TOPK_CONTRACT") != "1":
+        pytest.skip("set B12X_PCIE_TEST_DCP_TOPK_CONTRACT=1 to run this test")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    world_size = 2
+    if torch.cuda.device_count() < world_size:
+        pytest.skip("two CUDA devices are required")
+    mp.spawn(
+        _worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/tests/comm/test_pcie_dcp_topk_gpu.py
+++ b/tests/comm/test_pcie_dcp_topk_gpu.py
@@ -182,7 +182,7 @@ def _worker(
         )
         graph = torch.cuda.CUDAGraph(keep_graph=True)
         dist.barrier()
-        with graph_owner.capture(), torch.cuda.graph(graph):
+        with graph_owner.capture(rows=graph_rows), torch.cuda.graph(graph):
             graph_candidate_indices, graph_candidate_scores = (
                 graph_owner.stage_candidates(graph_indices, graph_scores)
             )


### PR DESCRIPTION
Closes #178.

Requires normalized argument, topology, compiler/layout, allocation, eager-launch, and graph-capture agreement before DCP Top-K IPC allocation or launch. Constructor failures use coordinated rollback.

Peer review: APPROVE at 01a2611; focused GPU contract corpus included.