### PR TITLE
security: bound FP6 serving cache ownership

### DIFF
--- a/b12x/integration/vllm/fp6_serving.py
+++ b/b12x/integration/vllm/fp6_serving.py
@@ -47,7 +47,9 @@ End-to-end flow
 """
 from __future__ import annotations
 
+import contextlib
 import os
+import weakref
 from typing import Any, Optional
 
 import torch
@@ -56,19 +58,249 @@ ENABLE_ENV = "B12X_ENABLE_FP6"
 QUANT_METHOD = "modelopt"
 QUANT_ALGO = "W6A6"
 
-# Process-wide scratch/plan cache shared across ALL MoE layers of a model.
-# Layers run sequentially on one stream — eager and inside CUDA graphs alike —
-# so scratch reuse is safe, and every layer of a model has identical
-# (E, K, N, topk) geometry.  Per-layer caching multiplies the footprint by
-# the layer count (~40x): fatal under vLLM's CUDA-graph memory estimator.
-_SCRATCH_CACHE: dict[tuple, tuple[Any, tuple[torch.Tensor, ...]]] = {}
 
-# Deduped fused_moe weight plans, keyed by geometry.  Every MoE layer of a
-# model shares one plan object, which is what makes the scratch cache above
-# actually shared (its key includes ``id(weight_plan)``) and keeps
-# ``fused_moe.bind``'s ``experts.plan == caps.weight_plan`` check trivially
-# true for scratch planned against the shared object.
-_WEIGHT_PLAN_CACHE: dict[tuple, Any] = {}
+class CaptureOutputCache:
+    """Bounded output buffer cache keyed by the declared capture-size catalog.
+
+    Only catalogued M values (CUDA-graph capture sizes) get retained
+    ``(M, K)`` BF16 output buffers with stable addresses.  Uncatalogued
+    eager M returns ``None`` (caller allocates transiently).  Uncatalogued
+    M during CUDA-graph capture raises before any allocation.
+
+    Owner invariants (dtype, device, hidden_size) are fixed at construction
+    and validated on every ``get`` to prevent cross-model/cross-config aliasing.
+    """
+
+    def __init__(
+        self,
+        catalog: tuple[int, ...],
+        hidden_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ):
+        self._catalog = frozenset(int(m) for m in catalog)
+        self._hidden_size = int(hidden_size)
+        self._dtype = dtype
+        self._device = device
+        self._bufs: dict[int, torch.Tensor] = {}
+
+    @property
+    def catalog(self) -> frozenset[int]:
+        return self._catalog
+
+    def get(
+        self, m: int, dtype: torch.dtype, device: torch.device
+    ) -> Optional[torch.Tensor]:
+        if dtype != self._dtype or device != self._device:
+            raise RuntimeError(
+                f"B12X FP6 MoE: output cache dtype/device mismatch: "
+                f"got ({dtype}, {device}), expected ({self._dtype}, {self._device})"
+            )
+        if m not in self._catalog:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    f"B12X FP6 MoE: uncatalogued M={m} during CUDA-graph "
+                    "capture — output buffer not in capture-size catalog"
+                )
+            return None  # eager transient
+        buf = self._bufs.get(m)
+        if buf is None:
+            buf = torch.zeros(
+                m, self._hidden_size, dtype=self._dtype, device=self._device
+            )
+            self._bufs[m] = buf
+        else:
+            buf.zero_()
+        return buf
+
+    def clear(self) -> None:
+        self._bufs.clear()
+
+    def __len__(self) -> int:
+        return len(self._bufs)
+
+
+class ServingScratchArena:
+    """Model-owned scratch cache bounded by the declared capture catalog.
+
+    One arena instance is shared across ALL MoE layers of a model (layers
+    run sequentially on one stream, so scratch reuse is safe).  Only
+    catalogued M values get retained scratch with stable addresses (needed
+    for CUDA-graph capture).  Uncatalogued eager M computes transient
+    scratch that is never stored.  Uncatalogued capture M is rejected
+    before allocation.
+
+    The scratch key includes the full semantic geometry (source_format,
+    activation, E, K, N, topk, device, router_on_input) so different model
+    geometries never alias, and plan re-creation does not split generations.
+    """
+
+    def __init__(
+        self,
+        catalog: tuple[int, ...],
+        weight_plan: Any,
+        topk: int,
+        device: torch.device,
+        *,
+        source_format: str = "",
+        activation: str = "",
+        num_experts: int = 0,
+        hidden_size: int = 0,
+        intermediate_size: int = 0,
+        apply_router_weight_on_input: bool = False,
+    ):
+        self._catalog = frozenset(int(m) for m in catalog)
+        self._weight_plan = weight_plan
+        self._topk = int(topk)
+        self._device = device
+        self._router_on_input = bool(apply_router_weight_on_input)
+        # Full semantic geometry key — stable across plan re-creation.
+        self._geometry = (
+            source_format,
+            activation,
+            int(num_experts),
+            int(hidden_size),
+            int(intermediate_size),
+            self._topk,
+            str(device),
+            self._router_on_input,
+        )
+        self._scratch: dict[tuple, tuple[Any, tuple[torch.Tensor, ...]]] = {}
+
+    def validate_geometry(
+        self, *, weight_plan: Any, topk: int, device: torch.device,
+        source_format: str, activation: str, num_experts: int,
+        hidden_size: int, intermediate_size: int,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        """Raise RuntimeError if caller geometry differs from arena geometry."""
+        other = (
+            source_format, activation, int(num_experts),
+            int(hidden_size), int(intermediate_size),
+            int(topk), str(device), bool(apply_router_weight_on_input),
+        )
+        if other != self._geometry:
+            raise RuntimeError(
+                f"B12X FP6 MoE: geometry mismatch — arena has "
+                f"{self._geometry} but layer has {other}. All MoE layers "
+                "of a model must share identical geometry."
+            )
+
+    @property
+    def catalog(self) -> frozenset[int]:
+        return self._catalog
+
+    @property
+    def weight_plan(self) -> Any:
+        return self._weight_plan
+
+    def _key(self, m: int) -> tuple:
+        return (int(m), self._geometry)
+
+    def get_or_build(
+        self, m: int
+    ) -> tuple[Any, tuple[torch.Tensor, ...]]:
+        """Return retained scratch for catalogued M, transient for uncatalogued eager.
+
+        Raises RuntimeError for uncatalogued M during CUDA-graph capture.
+        """
+        if m not in self._catalog:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    f"B12X FP6 MoE: uncatalogued M={m} during CUDA-graph "
+                    "capture — scratch not in capture-size catalog"
+                )
+            # Uncatalogued eager: build transient, do not retain.
+            return self._build(m)
+        key = self._key(m)
+        cached = self._scratch.get(key)
+        if cached is not None:
+            return cached
+        plan, scratch = self._build(m)
+        self._scratch[key] = (plan, scratch)
+        return plan, scratch
+
+    def _build(self, m: int) -> tuple[Any, tuple[torch.Tensor, ...]]:
+        from b12x.moe import fused_moe
+
+        plan = fused_moe.plan(
+            fused_moe.Caps(
+                max_tokens=m,
+                num_topk=self._topk,
+                device=self._device,
+                weight_plan=self._weight_plan,
+                core_token_counts=(m,),
+                route_num_experts=0,
+                quant_mode="w6a8_mx",
+                apply_router_weight_on_input=self._router_on_input,
+            )
+        )
+        scratch = tuple(
+            torch.empty(
+                shape,
+                dtype=dtype,
+                device=plan.scratch_specs()[i].device,
+            )
+            for i, (shape, dtype) in enumerate(plan.shapes_and_dtypes())
+        )
+        return plan, scratch
+
+    def clear(self) -> None:
+        """Drop all retained scratch references.
+
+        Safe only after all CUDA graphs referencing this arena's tensors
+        have been destroyed.
+        """
+        self._scratch.clear()
+
+    def __len__(self) -> int:
+        return len(self._scratch)
+
+
+# Deduped fused_moe weight plans, keyed by geometry.  Uses WeakValueDictionary
+# so plans are garbage-collected when no live arena references them — no
+# historical accumulation.  Plans are tensor-free metadata; the weak ref
+# prevents stale geometries from accumulating across model churn.
+_WEIGHT_PLAN_CACHE: "weakref.WeakValueDictionary[tuple, Any]" = (
+    weakref.WeakValueDictionary()
+)
+
+
+def reset_serving_caches() -> None:
+    """Drop all process-wide weight-plan references.
+
+    Safe only after **all** live models' CUDA graphs have been destroyed.
+    Per-model scratch is owned by :class:`ServingScratchArena` instances and
+    cleared via their ``clear()`` method; this function only clears the
+    tensor-free plan cache.
+    """
+    _WEIGHT_PLAN_CACHE.clear()
+
+
+def capture_sizes_from_config(compilation_config: Any) -> tuple[int, ...]:
+    """Extract cudagraph_capture_sizes from a vLLM compilation config.
+
+    Handles both object and dict config forms.  Returns all positive declared
+    sizes (no upper cap — vLLM can declare capture sizes above 512).
+    Returns ``()`` if graph capture is disabled (``None`` or empty).
+    Raises ``RuntimeError`` if the attribute exists but has an unsupported type,
+    so discovery problems surface at model load, not during capture.
+    """
+    cap: Any = None
+    if isinstance(compilation_config, dict):
+        cap = compilation_config.get("cudagraph_capture_sizes")
+    else:
+        cap = getattr(compilation_config, "cudagraph_capture_sizes", None)
+    if cap is None:
+        return ()  # graph capture disabled
+    try:
+        sizes = tuple(int(s) for s in cap)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"B12X FP6: cudagraph_capture_sizes has unsupported type/value: "
+            f"{cap!r} ({exc})"
+        ) from exc
+    return tuple(sorted(s for s in sizes if s > 0))
 
 
 def get_fp6_moe_weight_plan(
@@ -79,7 +311,11 @@ def get_fp6_moe_weight_plan(
     hidden_size: int,
     intermediate_size: int,
 ) -> Any:
-    """One shared ``fused_moe.plan_weights`` result per (geometry, activation)."""
+    """One shared ``fused_moe.plan_weights`` result per (geometry, activation).
+
+    The plan is cached weakly so it is GC'd when no live arena holds a
+    strong reference, preventing historical geometry accumulation.
+    """
     from b12x.moe import fused_moe
 
     key = (
@@ -90,17 +326,19 @@ def get_fp6_moe_weight_plan(
         int(intermediate_size),
     )
     plan = _WEIGHT_PLAN_CACHE.get(key)
-    if plan is None:
-        plan = fused_moe.plan_weights(
-            quant_modes="w6a8_mx",
-            source_format=source_format,
-            activation=activation,
-            params_dtype=torch.bfloat16,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            w13_layout="w13",  # [up; gate] FC1 rows (the only w6a8_mx layout)
-        )
+    if plan is not None:
+        return plan
+    plan = fused_moe.plan_weights(
+        quant_modes="w6a8_mx",
+        source_format=source_format,
+        activation=activation,
+        params_dtype=torch.bfloat16,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        w13_layout="w13",  # [up; gate] FC1 rows (the only w6a8_mx layout)
+    )
+    with contextlib.suppress(TypeError):
         _WEIGHT_PLAN_CACHE[key] = plan
     return plan
 
@@ -161,8 +399,14 @@ def kernel_source_format_for_moe(_checkpoint_source_format: str) -> str:
 class B12XFP6MoEMethod:
     """Reference routed-MoE method backed by :mod:`b12x.moe.fused_moe`.
 
-    Holds one layer's prepared experts and weight plan; scratch/plan tensors come
-    from the process-wide shared cache (see ``_SCRATCH_CACHE``).
+    Holds one layer's prepared experts and weight plan.  Scratch/plan tensors
+    come from the owner's :class:`ServingScratchArena` (if provided) or are
+    transient (if no arena — standalone eager path).
+
+    Scratch retention is bounded by the arena's capture-size catalog.  Only
+    catalogued M values get retained scratch with stable addresses.  Uncatalogued
+    eager M computes transient scratch that is never stored.  Uncatalogued M
+    during CUDA-graph capture is rejected before any cache lookup or allocation.
     """
 
     def __init__(
@@ -172,49 +416,93 @@ class B12XFP6MoEMethod:
         *,
         input_scales_static: bool = True,
         apply_router_weight_on_input: bool = False,
+        arena: Optional[ServingScratchArena] = None,
     ):
         self.experts_prepared = experts_prepared
         self.weight_plan = weight_plan
         self.input_scales_static = input_scales_static
         self.apply_router_weight_on_input = apply_router_weight_on_input
+        self.arena = arena
+
+    def update_experts(self, new_prepared: Any) -> None:
+        """Copy new prepared weight values into existing storage (reload-safe).
+
+        vLLM's ``reload_weights()`` does NOT destroy CUDA graphs, so
+        graph-captured weight pointers must stay stable.  This copies the
+        tensor data from ``new_prepared`` into the existing
+        ``self.experts_prepared`` storage, preserving every ``data_ptr``
+        that a captured graph may reference.
+
+        Raises RuntimeError if shapes/dtypes/devices don't match (topology
+        change requires graph destruction and recapture, not in-place copy).
+        """
+        old = self.experts_prepared
+        # The prepared object is opaque (from fused_moe.prepare_weights).
+        # Copy every tensor attribute from new into old, preserving data_ptr.
+        for attr_name in dir(new_prepared):
+            if attr_name.startswith("_"):
+                continue
+            new_val = getattr(new_prepared, attr_name, None)
+            old_val = getattr(old, attr_name, None)
+            if not isinstance(new_val, torch.Tensor):
+                continue
+            if not isinstance(old_val, torch.Tensor):
+                raise RuntimeError(
+                    f"B12X FP6 MoE: reload attribute '{attr_name}' is a "
+                    f"tensor in new prepared but not in old — topology "
+                    f"changed, cannot copy in-place. Destroy CUDA graphs "
+                    f"and call unload_serving() before reloading."
+                )
+            if (
+                new_val.shape != old_val.shape
+                or new_val.dtype != old_val.dtype
+                or new_val.device != old_val.device
+            ):
+                raise RuntimeError(
+                    f"B12X FP6 MoE: reload attribute '{attr_name}' has "
+                    f"shape/dtype/device mismatch: "
+                    f"new={tuple(new_val.shape)},{new_val.dtype},"
+                    f"{new_val.device} vs "
+                    f"old={tuple(old_val.shape)},{old_val.dtype},"
+                    f"{old_val.device}. Topology changed — destroy CUDA "
+                    f"graphs and call unload_serving() before reloading."
+                )
+            old_val.copy_(new_val)
 
     def _plan_and_scratch(
         self, m: int, topk: int, device: torch.device
     ) -> tuple[Any, tuple[torch.Tensor, ...]]:
+        if self.arena is not None:
+            return self.arena.get_or_build(m)
+        # No arena (standalone eager path): always transient, never retained.
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"B12X FP6 MoE: uncatalogued M={m} during CUDA-graph "
+                "capture — no scratch arena configured"
+            )
         from b12x.moe import fused_moe
 
-        key = (
-            int(m),
-            int(topk),
-            device,
-            id(self.weight_plan),
-            bool(self.apply_router_weight_on_input),
+        plan = fused_moe.plan(
+            fused_moe.Caps(
+                max_tokens=m,
+                num_topk=topk,
+                device=device,
+                weight_plan=self.weight_plan,
+                core_token_counts=(m,),
+                route_num_experts=0,
+                quant_mode="w6a8_mx",
+                apply_router_weight_on_input=self.apply_router_weight_on_input,
+            )
         )
-        cached = _SCRATCH_CACHE.get(key)
-        if cached is None:
-            plan = fused_moe.plan(
-                fused_moe.Caps(
-                    max_tokens=m,
-                    num_topk=topk,
-                    device=device,
-                    weight_plan=self.weight_plan,
-                    core_token_counts=(m,),
-                    route_num_experts=0,
-                    quant_mode="w6a8_mx",
-                    apply_router_weight_on_input=self.apply_router_weight_on_input,
-                )
+        scratch = tuple(
+            torch.empty(
+                shape,
+                dtype=dtype,
+                device=plan.scratch_specs()[i].device,
             )
-            scratch = tuple(
-                torch.empty(
-                    shape,
-                    dtype=dtype,
-                    device=plan.scratch_specs()[i].device,
-                )
-                for i, (shape, dtype) in enumerate(plan.shapes_and_dtypes())
-            )
-            cached = (plan, scratch)
-            _SCRATCH_CACHE[key] = cached
-        return cached
+            for i, (shape, dtype) in enumerate(plan.shapes_and_dtypes())
+        )
+        return plan, scratch
 
     def apply(
         self,
@@ -243,6 +531,9 @@ class B12XFP6MoEMethod:
                 f"with {self.apply_router_weight_on_input}, apply() got "
                 f"{router_on_input}"
             )
+        # Check catalog membership and capture state BEFORE cache lookup or
+        # allocation.  A direct caller supplying a caller-owned output during
+        # capture must not reach _build_scratch for an uncatalogued M.
         if output is None:
             if torch.cuda.is_current_stream_capturing():
                 raise RuntimeError(
@@ -255,6 +546,8 @@ class B12XFP6MoEMethod:
                 dtype=hidden_states.dtype,
                 device=device,
             )
+        # _plan_and_scratch checks capture/catalog and raises for uncatalogued
+        # capture before any allocation.
         plan, scratch = self._plan_and_scratch(m, topk, device)
         binding = fused_moe.bind(
             plan,

--- a/b12x/integration/vllm/fp6_serving.py
+++ b/b12x/integration/vllm/fp6_serving.py
@@ -60,12 +60,12 @@ QUANT_ALGO = "W6A6"
 
 
 class CaptureOutputCache:
-    """Bounded output buffer cache keyed by the declared capture-size catalog.
+    """Bounded output storage for graph and eager execution.
 
-    Only catalogued M values (CUDA-graph capture sizes) get retained
-    ``(M, K)`` BF16 output buffers with stable addresses.  Uncatalogued
-    eager M returns ``None`` (caller allocates transiently).  Uncatalogued
-    M during CUDA-graph capture raises before any allocation.
+    Catalogued M values get exact-shape buffers whose addresses remain stable
+    for CUDA graphs. Uncatalogued eager values share one geometrically grown
+    capacity buffer, bounded by ``eager_max_tokens``. Capture rejects both
+    uncatalogued sizes and unprepared catalogued sizes before allocation.
 
     Owner invariants (dtype, device, hidden_size) are fixed at construction
     and validated on every ``get`` to prevent cross-model/cross-config aliasing.
@@ -77,16 +77,39 @@ class CaptureOutputCache:
         hidden_size: int,
         dtype: torch.dtype,
         device: torch.device,
+        *,
+        eager_max_tokens: Optional[int] = None,
     ):
         self._catalog = frozenset(int(m) for m in catalog)
         self._hidden_size = int(hidden_size)
         self._dtype = dtype
         self._device = device
+        catalog_max = max(self._catalog, default=0)
+        if eager_max_tokens is None:
+            eager_max_tokens = catalog_max
+        self._eager_max_tokens = max(int(eager_max_tokens), catalog_max)
         self._bufs: dict[int, torch.Tensor] = {}
+        self._eager_buf: Optional[torch.Tensor] = None
 
     @property
     def catalog(self) -> frozenset[int]:
         return self._catalog
+
+    @property
+    def eager_capacity(self) -> int:
+        return 0 if self._eager_buf is None else int(self._eager_buf.shape[0])
+
+    @property
+    def eager_max_tokens(self) -> int:
+        return self._eager_max_tokens
+
+    def _next_eager_capacity(self, m: int) -> int:
+        if m > self._eager_max_tokens:
+            raise RuntimeError(
+                f"B12X FP6 MoE: eager M={m} exceeds configured capacity "
+                f"{self._eager_max_tokens}"
+            )
+        return min(self._eager_max_tokens, 1 << (max(m, 1) - 1).bit_length())
 
     def get(
         self, m: int, dtype: torch.dtype, device: torch.device
@@ -102,9 +125,24 @@ class CaptureOutputCache:
                     f"B12X FP6 MoE: uncatalogued M={m} during CUDA-graph "
                     "capture — output buffer not in capture-size catalog"
                 )
-            return None  # eager transient
+            if self._eager_buf is None or self.eager_capacity < m:
+                capacity = self._next_eager_capacity(m)
+                self._eager_buf = torch.zeros(
+                    capacity,
+                    self._hidden_size,
+                    dtype=self._dtype,
+                    device=self._device,
+                )
+            output = self._eager_buf[:m]
+            output.zero_()
+            return output
         buf = self._bufs.get(m)
         if buf is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    f"B12X FP6 MoE: catalogued M={m} was not prepared before "
+                    "CUDA-graph capture"
+                )
             buf = torch.zeros(
                 m, self._hidden_size, dtype=self._dtype, device=self._device
             )
@@ -115,6 +153,7 @@ class CaptureOutputCache:
 
     def clear(self) -> None:
         self._bufs.clear()
+        self._eager_buf = None
 
     def __len__(self) -> int:
         return len(self._bufs)
@@ -126,9 +165,9 @@ class ServingScratchArena:
     One arena instance is shared across ALL MoE layers of a model (layers
     run sequentially on one stream, so scratch reuse is safe).  Only
     catalogued M values get retained scratch with stable addresses (needed
-    for CUDA-graph capture).  Uncatalogued eager M computes transient
-    scratch that is never stored.  Uncatalogued capture M is rejected
-    before allocation.
+    for CUDA-graph capture). Uncatalogued eager M values share one
+    geometrically grown plan and scratch allocation, bounded by
+    ``eager_max_tokens``. Capture never builds plans or allocates scratch.
 
     The scratch key includes the full semantic geometry (source_format,
     activation, E, K, N, topk, device, router_on_input) so different model
@@ -148,6 +187,7 @@ class ServingScratchArena:
         hidden_size: int = 0,
         intermediate_size: int = 0,
         apply_router_weight_on_input: bool = False,
+        eager_max_tokens: Optional[int] = None,
     ):
         self._catalog = frozenset(int(m) for m in catalog)
         self._weight_plan = weight_plan
@@ -166,6 +206,13 @@ class ServingScratchArena:
             self._router_on_input,
         )
         self._scratch: dict[tuple, tuple[Any, tuple[torch.Tensor, ...]]] = {}
+        catalog_max = max(self._catalog, default=0)
+        if eager_max_tokens is None:
+            eager_max_tokens = catalog_max
+        self._eager_max_tokens = max(int(eager_max_tokens), catalog_max)
+        self._eager: Optional[
+            tuple[int, Any, tuple[torch.Tensor, ...]]
+        ] = None
 
     def validate_geometry(
         self, *, weight_plan: Any, topk: int, device: torch.device,
@@ -194,15 +241,31 @@ class ServingScratchArena:
     def weight_plan(self) -> Any:
         return self._weight_plan
 
+    @property
+    def eager_capacity(self) -> int:
+        return 0 if self._eager is None else self._eager[0]
+
+    @property
+    def eager_max_tokens(self) -> int:
+        return self._eager_max_tokens
+
+    def _next_eager_capacity(self, m: int) -> int:
+        if m > self._eager_max_tokens:
+            raise RuntimeError(
+                f"B12X FP6 MoE: eager M={m} exceeds configured capacity "
+                f"{self._eager_max_tokens}"
+            )
+        return min(self._eager_max_tokens, 1 << (max(m, 1) - 1).bit_length())
+
     def _key(self, m: int) -> tuple:
         return (int(m), self._geometry)
 
     def get_or_build(
         self, m: int
     ) -> tuple[Any, tuple[torch.Tensor, ...]]:
-        """Return retained scratch for catalogued M, transient for uncatalogued eager.
+        """Return exact graph scratch or the bounded reusable eager slot.
 
-        Raises RuntimeError for uncatalogued M during CUDA-graph capture.
+        Raises RuntimeError rather than planning or allocating during capture.
         """
         if m not in self._catalog:
             if torch.cuda.is_current_stream_capturing():
@@ -210,12 +273,20 @@ class ServingScratchArena:
                     f"B12X FP6 MoE: uncatalogued M={m} during CUDA-graph "
                     "capture — scratch not in capture-size catalog"
                 )
-            # Uncatalogued eager: build transient, do not retain.
-            return self._build(m)
+            if self._eager is None or self._eager[0] < m:
+                capacity = self._next_eager_capacity(m)
+                plan, scratch = self._build(capacity)
+                self._eager = (capacity, plan, scratch)
+            return self._eager[1], self._eager[2]
         key = self._key(m)
         cached = self._scratch.get(key)
         if cached is not None:
             return cached
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"B12X FP6 MoE: catalogued M={m} was not prepared before "
+                "CUDA-graph capture"
+            )
         plan, scratch = self._build(m)
         self._scratch[key] = (plan, scratch)
         return plan, scratch
@@ -252,6 +323,7 @@ class ServingScratchArena:
         have been destroyed.
         """
         self._scratch.clear()
+        self._eager = None
 
     def __len__(self) -> int:
         return len(self._scratch)
@@ -403,10 +475,10 @@ class B12XFP6MoEMethod:
     come from the owner's :class:`ServingScratchArena` (if provided) or are
     transient (if no arena — standalone eager path).
 
-    Scratch retention is bounded by the arena's capture-size catalog.  Only
-    catalogued M values get retained scratch with stable addresses.  Uncatalogued
-    eager M computes transient scratch that is never stored.  Uncatalogued M
-    during CUDA-graph capture is rejected before any cache lookup or allocation.
+    Scratch retention is bounded by the arena's capture-size catalog plus one
+    reusable eager-capacity slot. Catalogued M values retain exact stable
+    addresses. Capture rejects unprepared or uncatalogued sizes before any
+    planning or allocation.
     """
 
     def __init__(

--- a/b12x/integration/vllm/plugin.py
+++ b/b12x/integration/vllm/plugin.py
@@ -181,6 +181,30 @@ def _resolve_capture_catalog() -> tuple[int, ...]:
     )
 
 
+def _resolve_eager_max_tokens(catalog: tuple[int, ...]) -> int:
+    """Resolve the model's bounded eager MoE token capacity."""
+    catalog_max = max(catalog, default=0)
+    try:
+        from vllm.config import get_current_vllm_config
+
+        cfg = get_current_vllm_config()
+        scheduler_config = cfg.scheduler_config
+        if isinstance(scheduler_config, dict):
+            configured = scheduler_config.get("max_num_batched_tokens")
+        else:
+            configured = getattr(scheduler_config, "max_num_batched_tokens", None)
+        if configured is not None and int(configured) > 0:
+            return max(catalog_max, int(configured))
+    except Exception:
+        logger.debug("vLLM scheduler config unavailable for FP6 eager capacity")
+    if catalog_max > 0:
+        return catalog_max
+    raise RuntimeError(
+        "B12X FP6: cannot resolve eager MoE capacity because both "
+        "max_num_batched_tokens and the capture-size catalog are unavailable"
+    )
+
+
 def _rebuild_b12x_fp6_config(model_dir: Optional[str]) -> Any:
     register_b12x_fp6()
     assert _CONFIG_CLS is not None
@@ -195,6 +219,61 @@ def _norm_key(name: str) -> str:
     name = name.removeprefix("model.")
     name = name.replace("language_model.model.", "language_model.")
     return name
+
+
+def _store_graph_visible_dense_state(
+    layer: Any, weight: Any, gemm_weight: torch.Tensor
+) -> None:
+    """Install or update dense tensors without invalidating captured pointers."""
+    tensor_values = {
+        "b12x_fp6_gemm_weight": gemm_weight,
+        "b12x_fp6_scales": weight.scale_storage,
+        "b12x_fp6_gscale": weight.global_scale,
+    }
+    metadata = {
+        "b12x_fp6_fmt": weight.fmt,
+        "b12x_fp6_act_fmt": weight.act_fmt,
+        "b12x_fp6_out_features": weight.out_features,
+        "b12x_fp6_in_features": weight.in_features,
+    }
+    if not hasattr(layer, "b12x_fp6_gemm_weight"):
+        for name, value in tensor_values.items():
+            setattr(layer, name, value)
+        for name, value in metadata.items():
+            setattr(layer, name, value)
+        return
+
+    for name, new_value in metadata.items():
+        old_value = getattr(layer, name, None)
+        if old_value != new_value:
+            raise RuntimeError(
+                f"B12X FP6 dense reload changed {name}: "
+                f"old={old_value!r}, new={new_value!r}. Destroy CUDA graphs "
+                "before changing dense topology or formats."
+            )
+    for name, new_value in tensor_values.items():
+        old_value = getattr(layer, name, None)
+        if not isinstance(old_value, torch.Tensor):
+            raise RuntimeError(
+                f"B12X FP6 dense reload cannot preserve {name}: existing "
+                "graph-visible storage is missing or is not a tensor. Destroy "
+                "CUDA graphs before reloading."
+            )
+        if (
+            old_value.shape != new_value.shape
+            or old_value.dtype != new_value.dtype
+            or old_value.device != new_value.device
+        ):
+            raise RuntimeError(
+                f"B12X FP6 dense reload cannot preserve {name}: "
+                f"new={tuple(new_value.shape)},{new_value.dtype},"
+                f"{new_value.device} vs old={tuple(old_value.shape)},"
+                f"{old_value.dtype},{old_value.device}. Destroy CUDA graphs "
+                "before changing dense topology."
+            )
+    with torch.no_grad():
+        for name, new_value in tensor_values.items():
+            getattr(layer, name).copy_(new_value)
 
 
 def register_b12x_fp6() -> None:
@@ -331,43 +410,14 @@ def register_b12x_fp6() -> None:
                 )
             if not w.use_packed_gemm:
                 w.packed = torch.empty(0, dtype=torch.uint8, device=dev)
+            import b12x.quantization.mxfp6.fp6_dense_op  # noqa: F401
+
+            _store_graph_visible_dense_state(layer, w, gemm_w)
             layer.b12x_fp6_weight = w
             layer.weight.data = torch.empty(0, dtype=dt, device=dev)
             layer.weight_scale.data = torch.empty(
                 0, dtype=layer.weight_scale.dtype, device=dev
             )
-            import b12x.quantization.mxfp6.fp6_dense_op  # noqa: F401
-
-            # Reload guard: if graph-visible dense tensors already exist,
-            # copy new values into existing storage (preserve data_ptr).
-            if hasattr(layer, "b12x_fp6_gemm_weight"):
-                old_gw = layer.b12x_fp6_gemm_weight
-                if (
-                    isinstance(old_gw, torch.Tensor)
-                    and old_gw.shape == gemm_w.shape
-                    and old_gw.dtype == gemm_w.dtype
-                    and old_gw.device == gemm_w.device
-                ):
-                    old_gw.copy_(gemm_w)
-                else:
-                    layer.b12x_fp6_gemm_weight = gemm_w
-                old_scales = getattr(layer, "b12x_fp6_scales", None)
-                if (
-                    isinstance(old_scales, torch.Tensor)
-                    and old_scales.shape == w.scale_storage.shape
-                    and old_scales.dtype == w.scale_storage.dtype
-                    and old_scales.device == w.scale_storage.device
-                ):
-                    old_scales.copy_(w.scale_storage)
-                else:
-                    layer.b12x_fp6_scales = w.scale_storage
-            else:
-                layer.b12x_fp6_gemm_weight = gemm_w
-                layer.b12x_fp6_scales = w.scale_storage
-            layer.b12x_fp6_fmt = w.fmt
-            layer.b12x_fp6_act_fmt = w.act_fmt
-            layer.b12x_fp6_out_features = w.out_features
-            layer.b12x_fp6_in_features = w.in_features
             if self.act_fmt_overrides and act_fmt != self.default_act_fmt:
                 logger.info(
                     "B12X FP6: act_fmt override %s -> %s (default %s)",
@@ -659,7 +709,11 @@ def register_b12x_fp6() -> None:
                 apply_router_weight_on_input=router_on_input,
             )
             self._out_cache = CaptureOutputCache(
-                catalog, k, torch.bfloat16, dev
+                catalog,
+                k,
+                torch.bfloat16,
+                dev,
+                eager_max_tokens=arena.eager_max_tokens,
             )
             self.core = B12XFP6MoEMethod(
                 prepared,
@@ -884,6 +938,7 @@ def register_b12x_fp6() -> None:
                 )
                 return self._serving_catalog, self._shared_arena
             self._serving_catalog = _resolve_capture_catalog()
+            eager_max_tokens = _resolve_eager_max_tokens(self._serving_catalog)
             self._shared_arena = ServingScratchArena(
                 self._serving_catalog,
                 weight_plan,
@@ -895,6 +950,7 @@ def register_b12x_fp6() -> None:
                 hidden_size=hidden_size,
                 intermediate_size=intermediate_size,
                 apply_router_weight_on_input=apply_router_weight_on_input,
+                eager_max_tokens=eager_max_tokens,
             )
             self._serving_initialized = True
             return self._serving_catalog, self._shared_arena

--- a/b12x/integration/vllm/plugin.py
+++ b/b12x/integration/vllm/plugin.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 
 import logging
 import os
+import weakref
+from contextlib import suppress
 from typing import Any, Optional
 
 import torch
@@ -45,9 +47,13 @@ from b12x.integration.vllm.fp6_serving import (
     QUANT_ALGO,
     QUANT_METHOD,
     B12XFP6MoEMethod,
+    CaptureOutputCache,
+    ServingScratchArena,
+    capture_sizes_from_config,
     get_fp6_moe_weight_plan,
     is_b12x_fp6_enabled,
     kernel_source_format_for_moe,
+    reset_serving_caches,
 )
 
 MODEL_DIR_ENV = "B12X_FP6_MODEL_DIR"
@@ -69,6 +75,7 @@ _MOE_WARM_MAX_M = 64
 # Dense decode/verify token counts warm-run at load time.
 _DENSE_WARM_DECODE_MS = (1, 2, 4, 5, 8, 16)
 _DENSE_WARMED_SHAPES: set[tuple] = set()
+_DENSE_WARM_MAX_SHAPES = 256  # bounded — prevents unbounded historical growth
 
 # Fused vLLM module suffix -> ordered HF constituent projection names.
 _FUSED_PARTS: dict[str, tuple[str, ...]] = {
@@ -80,6 +87,7 @@ _FUSED_PARTS: dict[str, tuple[str, ...]] = {
 
 _registered = False
 _CONFIG_CLS: Optional[type] = None
+_live_configs: "weakref.WeakSet[Any]" = weakref.WeakSet()
 logger = logging.getLogger("b12x.vllm_fp6")
 
 
@@ -104,6 +112,73 @@ def _moe_warm_decode_ms() -> tuple[int, ...]:
     except Exception:
         logger.debug("vLLM config unavailable for MoE warm sizes", exc_info=True)
     return tuple(sorted(s for s in sizes if 1 <= s <= _MOE_WARM_MAX_M))
+
+
+# Re-export the production function for plugin-internal use and test access.
+_capture_sizes_from_config = capture_sizes_from_config
+
+
+_CAPTURE_SIZES_ENV = "B12X_FP6_CAPTURE_SIZES"
+
+
+def _resolve_capture_catalog() -> tuple[int, ...]:
+    """Derive the authoritative capture-size catalog from the live vLLM config.
+
+    Reads ``cudagraph_capture_sizes`` from the finalized vLLM compilation
+    config.  All positive declared sizes are retained (no artificial upper
+    cap).  ``B12X_MOE_WARM_MS`` does NOT influence this catalog — it only
+    affects decode warmup token counts via :func:`_moe_warm_decode_ms`.
+
+    Fails closed: if vLLM config is unavailable or the capture sizes
+    attribute is ``None`` (auto-inference pre-finalization) or cannot be
+    parsed, raises ``RuntimeError`` so the problem surfaces at model load
+    rather than silently producing an empty catalog that would reject all
+    captures.
+
+    A compatibility fallback is available via ``B12X_FP6_CAPTURE_SIZES``
+    for deployments where vLLM config is not finalized at plugin load time.
+    """
+    # Try vLLM config first.
+    try:
+        from vllm.config import get_current_vllm_config
+
+        cfg = get_current_vllm_config()
+        compilation_config = cfg.compilation_config
+    except Exception:
+        pass  # fall through to env fallback
+    else:
+        cap: Any = None
+        if isinstance(compilation_config, dict):
+            cap = compilation_config.get("cudagraph_capture_sizes")
+        else:
+            cap = getattr(compilation_config, "cudagraph_capture_sizes", None)
+        if cap is not None:
+            return capture_sizes_from_config(compilation_config)
+        # cap is None — could be auto-inference or disabled. Fall through.
+
+    # Env fallback for compatibility.
+    env = os.environ.get(_CAPTURE_SIZES_ENV, "").strip()
+    if env:
+        try:
+            sizes = tuple(int(v) for v in env.replace(",", " ").split())
+        except ValueError as exc:
+            raise RuntimeError(
+                f"B12X FP6: malformed {_CAPTURE_SIZES_ENV}={env!r} ({exc})"
+            ) from exc
+        catalog = tuple(sorted(s for s in sizes if s > 0))
+        if catalog:
+            logger.info(
+                "B12X FP6: using %s=%s for capture catalog (vLLM config "
+                "unavailable or None)", _CAPTURE_SIZES_ENV, catalog,
+            )
+            return catalog
+
+    raise RuntimeError(
+        f"B12X FP6: cannot resolve capture-size catalog. vLLM config is "
+        f"unavailable or cudagraph_capture_sizes is None. Set explicit "
+        f"capture sizes in vLLM compilation config, or set "
+        f"{_CAPTURE_SIZES_ENV} env var."
+    )
 
 
 def _rebuild_b12x_fp6_config(model_dir: Optional[str]) -> Any:
@@ -263,9 +338,32 @@ def register_b12x_fp6() -> None:
             )
             import b12x.quantization.mxfp6.fp6_dense_op  # noqa: F401
 
-            layer.b12x_fp6_gemm_weight = gemm_w
-            layer.b12x_fp6_scales = w.scale_storage
-            layer.b12x_fp6_gscale = w.global_scale
+            # Reload guard: if graph-visible dense tensors already exist,
+            # copy new values into existing storage (preserve data_ptr).
+            if hasattr(layer, "b12x_fp6_gemm_weight"):
+                old_gw = layer.b12x_fp6_gemm_weight
+                if (
+                    isinstance(old_gw, torch.Tensor)
+                    and old_gw.shape == gemm_w.shape
+                    and old_gw.dtype == gemm_w.dtype
+                    and old_gw.device == gemm_w.device
+                ):
+                    old_gw.copy_(gemm_w)
+                else:
+                    layer.b12x_fp6_gemm_weight = gemm_w
+                old_scales = getattr(layer, "b12x_fp6_scales", None)
+                if (
+                    isinstance(old_scales, torch.Tensor)
+                    and old_scales.shape == w.scale_storage.shape
+                    and old_scales.dtype == w.scale_storage.dtype
+                    and old_scales.device == w.scale_storage.device
+                ):
+                    old_scales.copy_(w.scale_storage)
+                else:
+                    layer.b12x_fp6_scales = w.scale_storage
+            else:
+                layer.b12x_fp6_gemm_weight = gemm_w
+                layer.b12x_fp6_scales = w.scale_storage
             layer.b12x_fp6_fmt = w.fmt
             layer.b12x_fp6_act_fmt = w.act_fmt
             layer.b12x_fp6_out_features = w.out_features
@@ -366,27 +464,38 @@ def register_b12x_fp6() -> None:
     from vllm.model_executor.utils import set_weight_attrs
 
     class _VllmMoEMethod(FusedMoEMethodBase):  # type: ignore[misc]
-        _OUT_BUF_MAX_M = 512
-
-        def __init__(self, moe_config: Any, source_format: str):
+        def __init__(
+            self, moe_config: Any, source_format: str, config: Any
+        ):
             super().__init__(moe_config)
             self.source_format = source_format
+            self._config = config
             self.core: Optional[B12XFP6MoEMethod] = None
-            self._out_bufs: dict[int, torch.Tensor] = {}
+            self._out_cache: Optional[CaptureOutputCache] = None
 
         def _output_for(self, x: torch.Tensor) -> Optional[torch.Tensor]:
             m = int(x.shape[0])
-            if m > self._OUT_BUF_MAX_M:
-                if not torch.cuda.is_current_stream_capturing():
-                    return None
-                return torch.zeros(m, x.shape[1], dtype=x.dtype, device=x.device)
-            buf = self._out_bufs.get(m)
-            if buf is None:
-                buf = torch.zeros(m, x.shape[1], dtype=x.dtype, device=x.device)
-                self._out_bufs[m] = buf
-            else:
-                buf.zero_()
-            return buf
+            if self._out_cache is None:
+                if torch.cuda.is_current_stream_capturing():
+                    raise RuntimeError(
+                        "B12X FP6 MoE: output cache not initialized before "
+                        "CUDA-graph capture"
+                    )
+                return None
+            return self._out_cache.get(m, x.dtype, x.device)
+
+        def unload(self) -> None:
+            """Drop this layer's retained output references.
+
+            Must be called only after vLLM has quiesced execution and
+            destroyed all CUDA graphs referencing this layer's tensors.
+            The model-owned shared scratch arena is cleared separately by
+            :meth:`B12XFp6Config.unload_serving`.
+            """
+            if self._out_cache is not None:
+                self._out_cache.clear()
+                self._out_cache = None
+            self.core = None
 
         def create_weights(
             self,
@@ -491,8 +600,9 @@ def register_b12x_fp6() -> None:
             ones_e = torch.ones(e, dtype=torch.float32, device=dev)
             ones_1 = torch.ones(1, dtype=torch.float32, device=dev)
             kernel_src = kernel_source_format_for_moe(self.source_format)
-            # Shared per-geometry plan object: makes the process-wide scratch
-            # cache in fp6_serving actually shared across all MoE layers.
+            # Shared per-geometry plan object (process-wide, tensor-free).
+            # Each model's ServingScratchArena holds a strong reference to the
+            # plan it was constructed with.
             weight_plan = get_fp6_moe_weight_plan(
                 source_format=kernel_src,
                 activation=activation,
@@ -523,19 +633,41 @@ def register_b12x_fp6() -> None:
                 p.data = torch.empty(0, dtype=p.dtype, device=dev)
             if dev.type == "cuda":
                 torch.cuda.empty_cache()
+            # Weight-only reload: vLLM's reload_weights() does NOT destroy
+            # CUDA graphs, so graph-captured output/scratch/weight pointers
+            # MUST stay stable.  Copy new prepared weight values into the
+            # existing storage (same data_ptr), never replace the objects.
+            if self.core is not None:
+                self.core.update_experts(prepared)
+                return
 
+            topk = int(getattr(self.moe, "experts_per_token", 0) or 8)
+            router_on_input = bool(
+                getattr(layer, "apply_router_weight_on_input", False)
+            )
+            # Get the model-shared scratch arena from the config (one per
+            # model, shared across all MoE layers — layers run sequentially).
+            catalog, arena = self._config._init_shared_serving(
+                weight_plan,
+                topk,
+                dev,
+                source_format=kernel_src,
+                activation=activation,
+                num_experts=e,
+                hidden_size=k,
+                intermediate_size=n,
+                apply_router_weight_on_input=router_on_input,
+            )
+            self._out_cache = CaptureOutputCache(
+                catalog, k, torch.bfloat16, dev
+            )
             self.core = B12XFP6MoEMethod(
                 prepared,
                 weight_plan,
-                apply_router_weight_on_input=bool(
-                    getattr(layer, "apply_router_weight_on_input", False)
-                ),
+                apply_router_weight_on_input=router_on_input,
+                arena=arena,
             )
             if dev.type == "cuda":
-                topk = int(getattr(self.moe, "experts_per_token", 0) or 8)
-                router_on_input = bool(
-                    getattr(layer, "apply_router_weight_on_input", False)
-                )
                 for m in _moe_warm_decode_ms():
                     x = torch.zeros(m, k, dtype=torch.bfloat16, device=dev)
                     ids = (
@@ -590,6 +722,10 @@ def register_b12x_fp6() -> None:
             self._match_miss: list[str] = []
             self._miss_count = 0
             self._warned_zero_overlap = False
+            self._moe_methods: list[_VllmMoEMethod] = []
+            self._shared_arena: Optional[ServingScratchArena] = None
+            self._serving_catalog: tuple[int, ...] = ()
+            self._serving_initialized = False
 
         def __reduce__(self):
             return (_rebuild_b12x_fp6_config, (self._model_dir,))
@@ -674,6 +810,8 @@ def register_b12x_fp6() -> None:
                 act_fmt_overrides=self._act_fmt_overrides,
             )
             self._loaded = True
+            # Track for process-wide teardown (weak — doesn't prevent GC).
+            _live_configs.add(self)
             logger.info(
                 "B12X FP6: %d FP6 modules discovered in %s "
                 "(source_format=%s act_fmt=%s overrides=%d)",
@@ -714,6 +852,71 @@ def register_b12x_fp6() -> None:
                 self._match_miss[0] if self._match_miss else "?",
             )
 
+        def _init_shared_serving(
+            self, weight_plan: Any, topk: int, device: torch.device,
+            *, source_format: str, activation: str, num_experts: int,
+            hidden_size: int, intermediate_size: int,
+            apply_router_weight_on_input: bool,
+        ) -> tuple[tuple[int, ...], ServingScratchArena]:
+            """Get the model-shared scratch arena, validating geometry match.
+
+            All MoE layers of a model share one arena because they run
+            sequentially on one stream and have identical geometry.  If a
+            later layer has different geometry, raises RuntimeError immediately
+            rather than silently misbinding scratch.
+            """
+            if self._serving_initialized:
+                if self._shared_arena is None:
+                    raise RuntimeError(
+                        "B12X FP6: serving initialized but arena is None"
+                    )
+                # Validate that this layer's geometry matches the arena's.
+                self._shared_arena.validate_geometry(
+                    weight_plan=weight_plan,
+                    topk=topk,
+                    device=device,
+                    source_format=source_format,
+                    activation=activation,
+                    num_experts=num_experts,
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    apply_router_weight_on_input=apply_router_weight_on_input,
+                )
+                return self._serving_catalog, self._shared_arena
+            self._serving_catalog = _resolve_capture_catalog()
+            self._shared_arena = ServingScratchArena(
+                self._serving_catalog,
+                weight_plan,
+                topk,
+                device,
+                source_format=source_format,
+                activation=activation,
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+            )
+            self._serving_initialized = True
+            return self._serving_catalog, self._shared_arena
+
+        def unload_serving(self) -> None:
+            """Release all model-owned serving caches after graphs are destroyed.
+
+            Call **after** vLLM has quiesced execution and destroyed all
+            CUDA graphs for this model.  Clears per-layer output caches and
+            the model-owned shared scratch arena, then drops references.
+            Does not affect other live models' arenas.  Does NOT clear
+            _moe_methods so that subsequent reload/unload cycles can still
+            find existing methods.
+            """
+            for method in self._moe_methods:
+                method.unload()
+            if self._shared_arena is not None:
+                self._shared_arena.clear()
+                self._shared_arena = None
+            self._serving_initialized = False
+            self._serving_catalog = ()
+
         def get_quant_method(self, layer: Any, prefix: str):
             from vllm.model_executor.layers.linear import (
                 LinearBase,
@@ -746,7 +949,9 @@ def register_b12x_fp6() -> None:
             if is_moe:
                 if self._has_fp6_experts(prefix):
                     logger.info("B12X FP6: bound FP6 MoE %s", prefix)
-                    return _VllmMoEMethod(layer.moe_config, self._source_format)
+                    method = _VllmMoEMethod(layer.moe_config, self._source_format, self)
+                    self._moe_methods.append(method)
+                    return method
                 logger.info("B12X FP6: vLLM-native MoE fallback for %s", prefix)
                 return None
 
@@ -781,6 +986,50 @@ def register_b12x_fp6() -> None:
 
     _CONFIG_CLS = B12XFp6Config
     _registered = True
+
+    # Register a shutdown hook by monkey-patching GPUModelRunner.shutdown.
+    # vLLM does not provide a plugin lifecycle hook for model unload, so we
+    # wrap the runner's shutdown to quiesce execution, clear CUDA graphs,
+    # and then call unload_serving() on every live b12x config.
+    try:
+        from vllm.v1.worker.gpu_model_runner import GPUModelRunner as _Runner
+
+        _orig_shutdown = _Runner.shutdown
+
+        def _b12x_shutdown(self_runner: Any) -> None:
+            # Quiesce: synchronize the device before touching graphs.
+            try:
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+            except Exception:
+                pass
+            # Clear graph owners (full, piecewise, etc.) if present.
+            for attr in ("graph_runners", "cuda_graph_executor"):
+                runners = getattr(self_runner, attr, None)
+                if runners is None:
+                    continue
+                if isinstance(runners, dict):
+                    for entry in runners.values():
+                        graph = getattr(entry, "cuda_graph", None)
+                        if graph is not None:
+                            with suppress(Exception):
+                                graph.reset()
+                elif hasattr(runners, "reset"):
+                    with suppress(Exception):
+                        runners.reset()
+            # Now safe to unload serving caches (graphs are destroyed).
+            for cfg in list(_live_configs):
+                try:
+                    cfg.unload_serving()
+                except Exception:
+                    logger.debug("unload_serving during shutdown failed", exc_info=True)
+            reset_serving_caches()
+            # Call original shutdown.
+            _orig_shutdown(self_runner)
+
+        _Runner.shutdown = _b12x_shutdown
+    except Exception:
+        logger.debug("Could not patch GPUModelRunner.shutdown", exc_info=True)
 
 
 def _dense_weight_from_loaded(
@@ -820,3 +1069,14 @@ def _dense_weight_from_loaded(
         ),
         out_features_unsharded=out_features_unsharded,
     )
+
+
+def unload_b12x_fp6_serving() -> None:
+    """Process-wide teardown: clear the tensor-free weight-plan cache.
+
+    Safe only after **all** live models have been unloaded via their
+    ``B12XFp6Config.unload_serving()`` (which clears per-model scratch
+    arenas and output caches after destroying CUDA graphs).  This function
+    clears the process-wide weak plan cache for last-process cleanup.
+    """
+    reset_serving_caches()

--- a/tests/integration/test_fp6_serving_cache_bounds.py
+++ b/tests/integration/test_fp6_serving_cache_bounds.py
@@ -1,0 +1,716 @@
+"""Focused integration tests for bounded FP6 serving output/scratch caches (issue #164).
+
+Tests the real production classes from :mod:`b12x.integration.vllm.fp6_serving`:
+:class:`CaptureOutputCache`, :class:`ServingScratchArena`, and
+:class:`B12XFP6MoEMethod` — with a patched ``fused_moe`` module that provides
+a proper ``Caps`` dataclass and matching ``scratch_specs``/``shapes_and_dtypes``.
+
+Also tests the plugin-side catalog derivation function
+:func:`capture_sizes_from_config`.
+
+Covers: catalog-bounded retention across M=1..512, stable addresses for
+catalogued sizes, transient uncatalogued eager, uncatalogued capture rejection
+before allocation, multi-owner isolation/churn, shared arena across layers,
+dtype/device validation, pointer stability/zeroing, and teardown ordering.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+try:
+    import torch
+
+    _has_torch = True
+except ImportError:
+    torch = None  # type: ignore[assignment]
+    _has_torch = False
+
+requires_torch = pytest.mark.skipif(not _has_torch, reason="torch not installed")
+
+_DTYPE = torch.float32
+_DEV = torch.device("cpu")
+
+
+@pytest.fixture(autouse=True)
+def _patch_capture_check(monkeypatch):
+    """Patch is_current_stream_capturing to return False (eager mode) for CPU."""
+    if _has_torch:
+        monkeypatch.setattr(
+            torch.cuda, "is_current_stream_capturing", lambda: False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fake fused_moe module with proper Caps and matching scratch specs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCaps:
+    max_tokens: int
+    num_topk: int
+    device: Any
+    weight_plan: Any
+    core_token_counts: tuple
+    route_num_experts: int
+    quant_mode: str
+    apply_router_weight_on_input: bool
+
+
+class _FakeScratchSpec:
+    def __init__(self, device: Any):
+        self.device = device
+
+
+class _FakePlan:
+    """Fake plan with scratch_specs count matching shapes_and_dtypes."""
+
+    def __init__(self, m: int, topk: int, device: Any):
+        self._m = m
+        self._topk = topk
+        self._device = device
+
+    def scratch_specs(self):
+        return [_FakeScratchSpec(self._device), _FakeScratchSpec(self._device)]
+
+    def shapes_and_dtypes(self):
+        return [
+            ((self._m, 64), torch.float32),
+            ((self._topk, self._m), torch.int32),
+        ]
+
+
+class _FakeFusedMoe:
+    Caps = _FakeCaps
+
+    @staticmethod
+    def plan(caps: _FakeCaps) -> _FakePlan:
+        return _FakePlan(caps.max_tokens, caps.num_topk, caps.device)
+
+    @staticmethod
+    def bind(plan: Any, **kw: Any) -> dict:
+        return kw
+
+    @staticmethod
+    def run(binding: dict) -> Any:
+        return binding["output"]
+
+    @staticmethod
+    def plan_weights(**kw: Any) -> Any:
+        # Use a class that supports __weakref__ so WeakValueDictionary works.
+        class _WeakPlan:
+            def __init__(self, **kw):
+                self._kw = kw
+            def __getattr__(self, name):
+                return self._kw[name]
+        return _WeakPlan(**kw)
+
+    @staticmethod
+    def prepare_weights(**kw: Any) -> Any:
+        return kw.get("plan")
+
+
+@pytest.fixture
+def mock_fused_moe(monkeypatch):
+    """Inject a fake fused_moe so production classes work without CUDA kernels.
+
+    Saves and restores both sys.modules entries AND the package attribute
+    on the b12x.moe package (if imported) to avoid order-poisoning.
+    """
+    saved_mod = sys.modules.get("b12x.moe.fused_moe")
+    saved_pkg = sys.modules.get("b12x.moe")
+    saved_attr = None
+    if saved_pkg is not None and hasattr(saved_pkg, "fused_moe"):
+        saved_attr = saved_pkg.fused_moe
+    fake = _FakeFusedMoe()
+    mod = types.ModuleType("b12x.moe.fused_moe")
+    mod.Caps = fake.Caps
+    mod.plan = fake.plan
+    mod.bind = fake.bind
+    mod.run = fake.run
+    mod.plan_weights = fake.plan_weights
+    mod.prepare_weights = fake.prepare_weights
+    monkeypatch.setitem(sys.modules, "b12x.moe.fused_moe", mod)
+    # Also patch the package attribute if b12x.moe is already imported
+    if saved_pkg is not None:
+        saved_pkg.fused_moe = mod
+    yield mod
+    # Restore original sys.modules state
+    if saved_mod is not None:
+        sys.modules["b12x.moe.fused_moe"] = saved_mod
+    else:
+        sys.modules.pop("b12x.moe.fused_moe", None)
+    if saved_pkg is not None:
+        sys.modules["b12x.moe"] = saved_pkg
+        if saved_attr is not None:
+            saved_pkg.fused_moe = saved_attr
+        elif hasattr(saved_pkg, "fused_moe"):
+            del saved_pkg.fused_moe
+
+
+@pytest.fixture
+def clean_plan_cache():
+    """Clear the process-wide weight-plan cache before and after each test."""
+    from b12x.integration.vllm import fp6_serving
+
+    fp6_serving._WEIGHT_PLAN_CACHE.clear()
+    yield
+    fp6_serving._WEIGHT_PLAN_CACHE.clear()
+
+
+def _make_arena(catalog, **kw):
+    from b12x.integration.vllm.fp6_serving import ServingScratchArena
+
+    plan = types.SimpleNamespace()
+    return ServingScratchArena(
+        catalog, plan, kw.get("topk", 2), _DEV,
+        source_format=kw.get("source_format", "mxfp6_e2m3"),
+        activation=kw.get("activation", "silu"),
+        num_experts=kw.get("num_experts", 8),
+        hidden_size=kw.get("hidden_size", 512),
+        intermediate_size=kw.get("intermediate_size", 256),
+        apply_router_weight_on_input=kw.get("apply_router_weight_on_input", False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CaptureOutputCache (production class from fp6_serving)
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestCaptureOutputCache:
+    """Contract: output cache is bounded by the declared catalog."""
+
+    def test_catalogued_m_retains_and_reuses(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8, 16, 32),
+            hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        buf1 = cache.get(8, _DTYPE, _DEV)
+        assert buf1 is not None
+        assert buf1.shape == (8, 128)
+        buf1.fill_(1.0)
+        buf2 = cache.get(8, _DTYPE, _DEV)
+        assert buf2 is buf1
+        assert buf2.sum() == 0.0, "reused buffer must be zeroed"
+
+    def test_uncatalogued_eager_returns_none(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        assert cache.get(7, _DTYPE, _DEV) is None
+
+    def test_retained_count_equals_catalog_size_across_m1_to_512(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        catalog = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+        cache = CaptureOutputCache(
+            catalog=catalog, hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        for m in range(1, 513):
+            cache.get(m, _DTYPE, _DEV)
+        assert len(cache) == len(catalog)
+
+    def test_clear_empties_all(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        for m in (1, 2, 4, 8):
+            cache.get(m, _DTYPE, _DEV)
+        assert len(cache) == 4
+        cache.clear()
+        assert len(cache) == 0
+
+    def test_stable_address_across_diversity(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        catalog = (1, 8, 32)
+        cache = CaptureOutputCache(
+            catalog=catalog, hidden_size=64, dtype=_DTYPE, device=_DEV,
+        )
+        first = {m: cache.get(m, _DTYPE, _DEV) for m in catalog}
+        for _ in range(10):
+            for m in range(1, 513):
+                cache.get(m, _DTYPE, _DEV)
+        for m in catalog:
+            assert cache.get(m, _DTYPE, _DEV) is first[m], f"M={m} address changed"
+
+    def test_uncatalogued_capture_rejected(self, monkeypatch):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="uncatalogued M=7"):
+            cache.get(7, _DTYPE, _DEV)
+        buf = cache.get(8, _DTYPE, _DEV)
+        assert buf is not None and buf.shape == (8, 128)
+
+    def test_dtype_mismatch_rejected(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        with pytest.raises(RuntimeError, match="dtype/device mismatch"):
+            cache.get(8, torch.bfloat16, _DEV)
+
+    def test_device_mismatch_rejected(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        with pytest.raises(RuntimeError, match="dtype/device mismatch"):
+            cache.get(8, _DTYPE, torch.device("meta"))
+
+
+# ---------------------------------------------------------------------------
+# ServingScratchArena (production class from fp6_serving)
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestServingScratchArena:
+    """Contract: scratch arena is model-owned and bounded by catalog."""
+
+    def test_catalogued_m_retains_scratch(self, mock_fused_moe):
+        arena = _make_arena((1, 2, 4, 8))
+        p1, s1 = arena.get_or_build(4)
+        p2, s2 = arena.get_or_build(4)
+        assert p1 is p2 and s1 is s2
+
+    def test_uncatalogued_eager_no_retention(self, mock_fused_moe):
+        arena = _make_arena((1, 2, 4, 8))
+        arena.get_or_build(7)
+        assert len(arena) == 0
+
+    def test_retained_count_bounded_across_m1_to_512(self, mock_fused_moe):
+        catalog = (1, 2, 4, 8, 16, 32)
+        arena = _make_arena(catalog)
+        for m in range(1, 513):
+            arena.get_or_build(m)
+        assert len(arena) == len(catalog)
+
+    def test_catalogued_scratch_stable_across_diversity(self, mock_fused_moe):
+        catalog = (1, 8, 32)
+        arena = _make_arena(catalog)
+        refs = {m: arena.get_or_build(m) for m in catalog}
+        for m in range(1, 513):
+            if m not in set(catalog):
+                arena.get_or_build(m)
+        for m in catalog:
+            p, s = arena.get_or_build(m)
+            assert p is refs[m][0] and s is refs[m][1]
+
+    def test_empty_catalog_retains_nothing(self, mock_fused_moe):
+        arena = _make_arena(())
+        for m in (1, 2, 4, 8, 16, 32, 64, 128):
+            arena.get_or_build(m)
+        assert len(arena) == 0
+
+    def test_uncatalogued_capture_rejected_before_allocation(
+        self, mock_fused_moe, monkeypatch
+    ):
+        arena = _make_arena((1, 2, 4, 8))
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="uncatalogued M=7"):
+            arena.get_or_build(7)
+        assert len(arena) == 0
+
+    def test_clear_empties_all(self, mock_fused_moe):
+        arena = _make_arena((1, 2, 4, 8))
+        for m in (1, 2, 4, 8):
+            arena.get_or_build(m)
+        assert len(arena) == 4
+        arena.clear()
+        assert len(arena) == 0
+
+    def test_different_geometries_dont_alias(self, mock_fused_moe):
+        arena_a = _make_arena((1, 2, 4, 8), hidden_size=512, intermediate_size=256)
+        arena_b = _make_arena((1, 2, 4, 8), hidden_size=1024, intermediate_size=512)
+        _, s_a = arena_a.get_or_build(4)
+        _, s_b = arena_b.get_or_build(4)
+        assert s_a is not s_b
+
+    def test_validate_geometry_mismatch_raises(self, mock_fused_moe):
+        """Arena must reject a layer with different geometry."""
+        arena = _make_arena((1, 2, 4, 8), hidden_size=512, intermediate_size=256)
+        with pytest.raises(RuntimeError, match="geometry mismatch"):
+            arena.validate_geometry(
+                weight_plan=arena.weight_plan, topk=2, device=_DEV,
+                source_format="mxfp6_e2m3", activation="silu",
+                num_experts=8, hidden_size=1024, intermediate_size=512,
+                apply_router_weight_on_input=False,
+            )
+
+    def test_validate_geometry_match_succeeds(self, mock_fused_moe):
+        """Arena must accept a layer with matching geometry."""
+        arena = _make_arena((1, 2, 4, 8), hidden_size=512, intermediate_size=256)
+        arena.validate_geometry(
+            weight_plan=arena.weight_plan, topk=2, device=_DEV,
+            source_format="mxfp6_e2m3", activation="silu",
+            num_experts=8, hidden_size=512, intermediate_size=256,
+            apply_router_weight_on_input=False,
+        )  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Multi-owner isolation
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestMultiOwnerIsolation:
+    """Contract: separate model owners do not share or accumulate scratch."""
+
+    def test_two_owners_isolated(self, mock_fused_moe):
+        arena_a = _make_arena((1, 2))
+        arena_b = _make_arena((4, 8))
+        arena_a.get_or_build(1)
+        arena_a.get_or_build(2)
+        arena_b.get_or_build(4)
+        arena_b.get_or_build(8)
+        assert len(arena_a) == 2 and len(arena_b) == 2
+        arena_a.get_or_build(4)
+        assert len(arena_a) == 2
+        arena_b.get_or_build(1)
+        assert len(arena_b) == 2
+
+    def test_churn_does_not_accumulate(self, mock_fused_moe):
+        for catalog in [(1, 2), (4, 8), (16, 32), (64, 128)]:
+            arena = _make_arena(catalog)
+            for m in range(1, 513):
+                arena.get_or_build(m)
+            assert len(arena) == len(catalog)
+            arena.clear()
+            assert len(arena) == 0
+
+    def test_clear_one_does_not_affect_other(self, mock_fused_moe):
+        arena_a = _make_arena((1, 2))
+        arena_b = _make_arena((4, 8))
+        arena_a.get_or_build(1)
+        arena_b.get_or_build(4)
+        arena_a.clear()
+        assert len(arena_a) == 0 and len(arena_b) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared arena across layers: one arena serves multiple B12XFP6MoEMethod instances
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestSharedArenaAcrossLayers:
+    """Contract: one arena shared across layers — scratch is catalog-sized, not
+    catalog × layers."""
+
+    def test_shared_arena_scratch_count_independent_of_layer_count(
+        self, mock_fused_moe
+    ):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        catalog = (1, 2, 4, 8)
+        arena = _make_arena(catalog)
+        plan = arena.weight_plan
+        methods = [
+            B12XFP6MoEMethod(
+                experts_prepared=None, weight_plan=plan, arena=arena,
+            )
+            for _ in range(40)
+        ]
+        for method in methods:
+            for m in catalog:
+                x = torch.zeros(m, 64, dtype=torch.bfloat16)
+                ids = torch.zeros(m, 2, dtype=torch.int32)
+                w = torch.full((m, 2), 0.5, dtype=torch.float32)
+                method.apply(x, w, ids)
+        assert len(arena) == len(catalog), (
+            f"shared arena retained {len(arena)}, expected {len(catalog)}"
+        )
+
+    def test_shared_arena_stable_addresses_across_layers(self, mock_fused_moe):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        catalog = (1, 2, 4, 8)
+        arena = _make_arena(catalog)
+        plan = arena.weight_plan
+        m1 = B12XFP6MoEMethod(experts_prepared=None, weight_plan=plan, arena=arena)
+        m2 = B12XFP6MoEMethod(experts_prepared=None, weight_plan=plan, arena=arena)
+        x = torch.zeros(4, 64, dtype=torch.bfloat16)
+        ids = torch.zeros(4, 2, dtype=torch.int32)
+        w = torch.full((4, 2), 0.5, dtype=torch.float32)
+        m1.apply(x, w, ids)
+        p1, s1 = arena.get_or_build(4)
+        m2.apply(x, w, ids)
+        p2, s2 = arena.get_or_build(4)
+        assert p1 is p2 and s1 is s2
+
+
+# ---------------------------------------------------------------------------
+# B12XFP6MoEMethod: public apply() route with capture rejection
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestB12XFP6MoEMethodCaptureRejection:
+    """Contract: public apply() rejects uncatalogued capture before allocation."""
+
+    def test_apply_uncatalogued_capture_raises_with_caller_output(
+        self, mock_fused_moe, monkeypatch
+    ):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        arena = _make_arena((1, 2, 4, 8))
+        method = B12XFP6MoEMethod(
+            experts_prepared=None, weight_plan=arena.weight_plan, arena=arena,
+        )
+        x = torch.zeros(7, 64, dtype=torch.bfloat16)
+        ids = torch.zeros(7, 2, dtype=torch.int32)
+        w = torch.full((7, 2), 0.5, dtype=torch.float32)
+        output = torch.zeros(7, 64, dtype=torch.bfloat16)
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="uncatalogued M=7"):
+            method.apply(x, w, ids, output=output)
+
+    def test_apply_uncatalogued_eager_works_without_retention(self, mock_fused_moe):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        arena = _make_arena((1, 2, 4, 8))
+        method = B12XFP6MoEMethod(
+            experts_prepared=None, weight_plan=arena.weight_plan, arena=arena,
+        )
+        x = torch.zeros(7, 64, dtype=torch.bfloat16)
+        ids = torch.zeros(7, 2, dtype=torch.int32)
+        w = torch.full((7, 2), 0.5, dtype=torch.float32)
+        result = method.apply(x, w, ids)
+        assert result is not None and result.shape == (7, 64)
+        assert len(arena) == 0
+
+    def test_apply_no_arena_capture_raises(self, mock_fused_moe, monkeypatch):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        method = B12XFP6MoEMethod(
+            experts_prepared=None, weight_plan=types.SimpleNamespace(),
+        )
+        x = torch.zeros(4, 64, dtype=torch.bfloat16)
+        ids = torch.zeros(4, 2, dtype=torch.int32)
+        w = torch.full((4, 2), 0.5, dtype=torch.float32)
+        output = torch.zeros(4, 64, dtype=torch.bfloat16)
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="no scratch arena"):
+            method.apply(x, w, ids, output=output)
+
+    def test_apply_catalogued_eager_reuses_scratch(self, mock_fused_moe):
+        from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
+
+        arena = _make_arena((1, 2, 4, 8))
+        method = B12XFP6MoEMethod(
+            experts_prepared=None, weight_plan=arena.weight_plan, arena=arena,
+        )
+        x = torch.zeros(4, 64, dtype=torch.bfloat16)
+        ids = torch.zeros(4, 2, dtype=torch.int32)
+        w = torch.full((4, 2), 0.5, dtype=torch.float32)
+        method.apply(x, w, ids)
+        assert len(arena) == 1
+        method.apply(x, w, ids)
+        assert len(arena) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pointer stability and zeroing
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestPointerStabilityAndZeroing:
+    """Contract: catalogued output buffers are stable and zeroed on reuse."""
+
+    def test_output_zeroed_on_reuse(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(8,), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        buf = cache.get(8, _DTYPE, _DEV)
+        buf.fill_(3.14)
+        buf2 = cache.get(8, _DTYPE, _DEV)
+        assert buf2 is buf and buf2.sum() == 0.0
+
+    def test_scratch_stable_address_across_calls(self, mock_fused_moe):
+        arena = _make_arena((4, 8))
+        p1, s1 = arena.get_or_build(4)
+        p2, s2 = arena.get_or_build(8)
+        p3, s3 = arena.get_or_build(4)
+        p4, s4 = arena.get_or_build(8)
+        assert p1 is p3 and s1 is s3 and p2 is p4 and s2 is s4
+
+
+# ---------------------------------------------------------------------------
+# Teardown ordering
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestTeardownOrdering:
+    """Contract: clear drops references; cleared arena has no retained tensors."""
+
+    def test_clear_then_empty(self, mock_fused_moe):
+        arena = _make_arena((1, 2, 4, 8))
+        for m in (1, 2, 4, 8):
+            arena.get_or_build(m)
+        assert len(arena) == 4
+        arena.clear()
+        assert len(arena) == 0
+        arena.get_or_build(3)
+        assert len(arena) == 0
+
+    def test_output_cache_clear_then_empty(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        for m in (1, 2, 4, 8):
+            cache.get(m, _DTYPE, _DEV)
+        assert len(cache) == 4
+        cache.clear()
+        assert len(cache) == 0
+        buf = cache.get(8, _DTYPE, _DEV)
+        assert buf is not None and len(cache) == 1
+
+    def test_reset_serving_caches_clears_plan_cache(
+        self, mock_fused_moe, clean_plan_cache
+    ):
+        from b12x.integration.vllm import fp6_serving
+        from b12x.integration.vllm.fp6_serving import reset_serving_caches
+
+        class _WeakObj:
+            pass
+        obj = _WeakObj()  # hold strong reference
+        fp6_serving._WEIGHT_PLAN_CACHE[("test",)] = obj
+        assert len(fp6_serving._WEIGHT_PLAN_CACHE) > 0
+        reset_serving_caches()
+        assert len(fp6_serving._WEIGHT_PLAN_CACHE) == 0
+        del obj  # drop strong ref — weak entry already cleared by reset
+
+
+# ---------------------------------------------------------------------------
+# Catalog derivation: capture_sizes_from_config (fp6_serving)
+# ---------------------------------------------------------------------------
+
+
+@requires_torch
+class TestCaptureCatalogDerivation:
+    """Contract: catalog derived from authoritative vLLM config, not env."""
+
+    def test_object_config_form(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = types.SimpleNamespace(cudagraph_capture_sizes=[1, 2, 4, 8, 16])
+        assert capture_sizes_from_config(cfg) == (1, 2, 4, 8, 16)
+
+    def test_dict_config_form(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = {"cudagraph_capture_sizes": [1, 2, 4, 8]}
+        assert capture_sizes_from_config(cfg) == (1, 2, 4, 8)
+
+    def test_none_means_disabled(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = types.SimpleNamespace(cudagraph_capture_sizes=None)
+        assert capture_sizes_from_config(cfg) == ()
+
+    def test_retains_sizes_above_512(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = types.SimpleNamespace(cudagraph_capture_sizes=[1, 512, 1024, 2048])
+        result = capture_sizes_from_config(cfg)
+        assert 1024 in result and 2048 in result and len(result) == 4
+
+    def test_drops_zero_and_negative(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = types.SimpleNamespace(cudagraph_capture_sizes=[0, -1, 1, 4])
+        assert capture_sizes_from_config(cfg) == (1, 4)
+
+    def test_unsupported_type_raises(self):
+        from b12x.integration.vllm.fp6_serving import capture_sizes_from_config
+
+        cfg = types.SimpleNamespace(cudagraph_capture_sizes="not-a-list")
+        with pytest.raises(RuntimeError, match="unsupported type"):
+            capture_sizes_from_config(cfg)
+
+
+@requires_torch
+class TestResolveCaptureCatalogEnvFallback:
+    """Contract: _resolve_capture_catalog env fallback and fail-closed."""
+
+    def test_env_fallback_when_vllm_unavailable(self, monkeypatch):
+        """B12X_FP6_CAPTURE_SIZES provides catalog when vLLM config is absent."""
+        try:
+            from b12x.integration.vllm.plugin import _resolve_capture_catalog
+        except ImportError:
+            pytest.skip("plugin import requires cutlass/vLLM")
+        monkeypatch.setenv("B12X_FP6_CAPTURE_SIZES", "1,2,4,8,16")
+        result = _resolve_capture_catalog()
+        assert result == (1, 2, 4, 8, 16)
+
+    def test_fails_closed_when_no_source(self, monkeypatch):
+        """Without vLLM config or env, raises RuntimeError."""
+        try:
+            from b12x.integration.vllm.plugin import _resolve_capture_catalog
+        except ImportError:
+            pytest.skip("plugin import requires cutlass/vLLM")
+        monkeypatch.delenv("B12X_FP6_CAPTURE_SIZES", raising=False)
+        with pytest.raises(RuntimeError, match="cannot resolve capture-size catalog"):
+            _resolve_capture_catalog()
+
+    def test_warm_env_does_not_affect_catalog(self, monkeypatch):
+        """B12X_MOE_WARM_MS must not appear in capture catalog."""
+        try:
+            from b12x.integration.vllm.plugin import _resolve_capture_catalog
+        except ImportError:
+            pytest.skip("plugin import requires cutlass/vLLM")
+        monkeypatch.setenv("B12X_MOE_WARM_MS", "1,2,4,8")
+        monkeypatch.setenv("B12X_FP6_CAPTURE_SIZES", "16,32")
+        result = _resolve_capture_catalog()
+        assert result == (16, 32)
+        assert 1 not in result and 8 not in result
+
+
+@requires_torch
+class TestWeakPlanCache:
+    """Contract: plan cache uses weak refs — plans GC'd when no arena holds them."""
+
+    def test_plan_garbage_collected_when_arena_dropped(self, mock_fused_moe, clean_plan_cache):
+        import gc
+        from b12x.integration.vllm import fp6_serving
+        from b12x.integration.vllm.fp6_serving import get_fp6_moe_weight_plan
+
+        plan = get_fp6_moe_weight_plan(
+            source_format="mxfp6_e2m3", activation="silu",
+            num_experts=8, hidden_size=512, intermediate_size=256,
+        )
+        assert len(fp6_serving._WEIGHT_PLAN_CACHE) > 0
+        # Drop our strong reference
+        del plan
+        gc.collect()
+        # Weak cache should now be empty (no strong refs from arena)
+        assert len(fp6_serving._WEIGHT_PLAN_CACHE) == 0, (
+            "plan cache must be weak — plans GC'd when no arena references them"
+        )

--- a/tests/integration/test_fp6_serving_cache_bounds.py
+++ b/tests/integration/test_fp6_serving_cache_bounds.py
@@ -9,9 +9,9 @@ Also tests the plugin-side catalog derivation function
 :func:`capture_sizes_from_config`.
 
 Covers: catalog-bounded retention across M=1..512, stable addresses for
-catalogued sizes, transient uncatalogued eager, uncatalogued capture rejection
-before allocation, multi-owner isolation/churn, shared arena across layers,
-dtype/device validation, pointer stability/zeroing, and teardown ordering.
+catalogued sizes, one bounded reusable uncatalogued eager slot, capture
+rejection before allocation, multi-owner isolation/churn, shared arena across
+layers, dtype/device validation, pointer stability/zeroing, and teardown.
 """
 from __future__ import annotations
 
@@ -175,6 +175,7 @@ def _make_arena(catalog, **kw):
         hidden_size=kw.get("hidden_size", 512),
         intermediate_size=kw.get("intermediate_size", 256),
         apply_router_weight_on_input=kw.get("apply_router_weight_on_input", False),
+        eager_max_tokens=kw.get("eager_max_tokens", 512),
     )
 
 
@@ -202,13 +203,21 @@ class TestCaptureOutputCache:
         assert buf2 is buf1
         assert buf2.sum() == 0.0, "reused buffer must be zeroed"
 
-    def test_uncatalogued_eager_returns_none(self):
+    def test_uncatalogued_eager_reuses_capacity_view(self):
         from b12x.integration.vllm.fp6_serving import CaptureOutputCache
 
         cache = CaptureOutputCache(
             catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+            eager_max_tokens=64,
         )
-        assert cache.get(7, _DTYPE, _DEV) is None
+        first = cache.get(7, _DTYPE, _DEV)
+        assert first is not None and first.shape == (7, 128)
+        assert cache.eager_capacity == 8
+        ptr = first.data_ptr()
+        first.fill_(1.0)
+        second = cache.get(6, _DTYPE, _DEV)
+        assert second is not None and second.data_ptr() == ptr
+        assert second.shape == (6, 128) and second.sum() == 0.0
 
     def test_retained_count_equals_catalog_size_across_m1_to_512(self):
         from b12x.integration.vllm.fp6_serving import CaptureOutputCache
@@ -216,6 +225,7 @@ class TestCaptureOutputCache:
         catalog = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
         cache = CaptureOutputCache(
             catalog=catalog, hidden_size=128, dtype=_DTYPE, device=_DEV,
+            eager_max_tokens=512,
         )
         for m in range(1, 513):
             cache.get(m, _DTYPE, _DEV)
@@ -239,6 +249,7 @@ class TestCaptureOutputCache:
         catalog = (1, 8, 32)
         cache = CaptureOutputCache(
             catalog=catalog, hidden_size=64, dtype=_DTYPE, device=_DEV,
+            eager_max_tokens=512,
         )
         first = {m: cache.get(m, _DTYPE, _DEV) for m in catalog}
         for _ in range(10):
@@ -253,11 +264,47 @@ class TestCaptureOutputCache:
         cache = CaptureOutputCache(
             catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
         )
+        prepared = cache.get(8, _DTYPE, _DEV)
         monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
         with pytest.raises(RuntimeError, match="uncatalogued M=7"):
             cache.get(7, _DTYPE, _DEV)
         buf = cache.get(8, _DTYPE, _DEV)
-        assert buf is not None and buf.shape == (8, 128)
+        assert buf is prepared and buf.shape == (8, 128)
+
+    def test_catalogued_capture_miss_rejected_before_allocation(self, monkeypatch):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="was not prepared"):
+            cache.get(8, _DTYPE, _DEV)
+        assert len(cache) == 0
+
+    def test_catalogued_hit_does_not_query_capture_state(self, monkeypatch):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+        )
+        prepared = cache.get(8, _DTYPE, _DEV)
+        monkeypatch.setattr(
+            torch.cuda,
+            "is_current_stream_capturing",
+            lambda: pytest.fail("prepared output queried capture state"),
+        )
+        assert cache.get(8, _DTYPE, _DEV) is prepared
+
+    def test_uncatalogued_eager_capacity_bound(self):
+        from b12x.integration.vllm.fp6_serving import CaptureOutputCache
+
+        cache = CaptureOutputCache(
+            catalog=(1, 2, 4, 8), hidden_size=128, dtype=_DTYPE, device=_DEV,
+            eager_max_tokens=32,
+        )
+        with pytest.raises(RuntimeError, match="exceeds configured capacity 32"):
+            cache.get(33, _DTYPE, _DEV)
 
     def test_dtype_mismatch_rejected(self):
         from b12x.integration.vllm.fp6_serving import CaptureOutputCache
@@ -293,9 +340,12 @@ class TestServingScratchArena:
         p2, s2 = arena.get_or_build(4)
         assert p1 is p2 and s1 is s2
 
-    def test_uncatalogued_eager_no_retention(self, mock_fused_moe):
+    def test_uncatalogued_eager_reuses_one_capacity_slot(self, mock_fused_moe):
         arena = _make_arena((1, 2, 4, 8))
-        arena.get_or_build(7)
+        p1, s1 = arena.get_or_build(7)
+        assert arena.eager_capacity == 8
+        p2, s2 = arena.get_or_build(6)
+        assert p1 is p2 and s1 is s2
         assert len(arena) == 0
 
     def test_retained_count_bounded_across_m1_to_512(self, mock_fused_moe):
@@ -330,6 +380,32 @@ class TestServingScratchArena:
         with pytest.raises(RuntimeError, match="uncatalogued M=7"):
             arena.get_or_build(7)
         assert len(arena) == 0
+
+    def test_catalogued_capture_miss_rejected_before_allocation(
+        self, mock_fused_moe, monkeypatch
+    ):
+        arena = _make_arena((1, 2, 4, 8))
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        with pytest.raises(RuntimeError, match="was not prepared"):
+            arena.get_or_build(8)
+        assert len(arena) == 0 and arena.eager_capacity == 0
+
+    def test_catalogued_hit_does_not_query_capture_state(
+        self, mock_fused_moe, monkeypatch
+    ):
+        arena = _make_arena((1, 2, 4, 8))
+        prepared = arena.get_or_build(8)
+        monkeypatch.setattr(
+            torch.cuda,
+            "is_current_stream_capturing",
+            lambda: pytest.fail("prepared scratch queried capture state"),
+        )
+        assert arena.get_or_build(8) == prepared
+
+    def test_uncatalogued_eager_capacity_bound(self, mock_fused_moe):
+        arena = _make_arena((1, 2, 4, 8), eager_max_tokens=32)
+        with pytest.raises(RuntimeError, match="exceeds configured capacity 32"):
+            arena.get_or_build(33)
 
     def test_clear_empties_all(self, mock_fused_moe):
         arena = _make_arena((1, 2, 4, 8))
@@ -486,7 +562,7 @@ class TestB12XFP6MoEMethodCaptureRejection:
         with pytest.raises(RuntimeError, match="uncatalogued M=7"):
             method.apply(x, w, ids, output=output)
 
-    def test_apply_uncatalogued_eager_works_without_retention(self, mock_fused_moe):
+    def test_apply_uncatalogued_eager_reuses_bounded_slot(self, mock_fused_moe):
         from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
 
         arena = _make_arena((1, 2, 4, 8))
@@ -498,7 +574,11 @@ class TestB12XFP6MoEMethodCaptureRejection:
         w = torch.full((7, 2), 0.5, dtype=torch.float32)
         result = method.apply(x, w, ids)
         assert result is not None and result.shape == (7, 64)
-        assert len(arena) == 0
+        assert len(arena) == 0 and arena.eager_capacity == 8
+        _, first_scratch = arena.get_or_build(7)
+        method.apply(x, w, ids)
+        _, second_scratch = arena.get_or_build(7)
+        assert first_scratch is second_scratch
 
     def test_apply_no_arena_capture_raises(self, mock_fused_moe, monkeypatch):
         from b12x.integration.vllm.fp6_serving import B12XFP6MoEMethod
@@ -574,7 +654,7 @@ class TestTeardownOrdering:
             arena.get_or_build(m)
         assert len(arena) == 4
         arena.clear()
-        assert len(arena) == 0
+        assert len(arena) == 0 and arena.eager_capacity == 0
         arena.get_or_build(3)
         assert len(arena) == 0
 
@@ -588,9 +668,73 @@ class TestTeardownOrdering:
             cache.get(m, _DTYPE, _DEV)
         assert len(cache) == 4
         cache.clear()
-        assert len(cache) == 0
+        assert len(cache) == 0 and cache.eager_capacity == 0
         buf = cache.get(8, _DTYPE, _DEV)
         assert buf is not None and len(cache) == 1
+
+
+@requires_torch
+class TestDenseGraphVisibleReload:
+    """Dense reload keeps every graph-visible tensor address stable."""
+
+    @staticmethod
+    def _weight(value: float, *, gscale_shape: tuple[int, ...] = (1,)):
+        return types.SimpleNamespace(
+            scale_storage=torch.full((8,), value, dtype=torch.uint8),
+            global_scale=torch.full(gscale_shape, value, dtype=torch.float32),
+            fmt="e2m3",
+            act_fmt="e4m3",
+            out_features=128,
+            in_features=256,
+        )
+
+    def test_initial_load_installs_gscale(self):
+        from b12x.integration.vllm.plugin import _store_graph_visible_dense_state
+
+        layer = types.SimpleNamespace()
+        weight = self._weight(1)
+        gemm = torch.full((4, 8), 1, dtype=torch.uint8)
+        _store_graph_visible_dense_state(layer, weight, gemm)
+        assert layer.b12x_fp6_gscale is weight.global_scale
+        assert layer.b12x_fp6_gemm_weight is gemm
+
+    def test_reload_copies_gscale_without_changing_pointer(self):
+        from b12x.integration.vllm.plugin import _store_graph_visible_dense_state
+
+        layer = types.SimpleNamespace()
+        first = self._weight(1)
+        _store_graph_visible_dense_state(
+            layer, first, torch.full((4, 8), 1, dtype=torch.uint8)
+        )
+        pointers = {
+            name: getattr(layer, name).data_ptr()
+            for name in (
+                "b12x_fp6_gemm_weight",
+                "b12x_fp6_scales",
+                "b12x_fp6_gscale",
+            )
+        }
+        second = self._weight(2)
+        _store_graph_visible_dense_state(
+            layer, second, torch.full((4, 8), 2, dtype=torch.uint8)
+        )
+        for name, pointer in pointers.items():
+            assert getattr(layer, name).data_ptr() == pointer
+        assert torch.equal(layer.b12x_fp6_gscale, second.global_scale)
+
+    def test_reload_rejects_gscale_shape_change_before_copying(self):
+        from b12x.integration.vllm.plugin import _store_graph_visible_dense_state
+
+        layer = types.SimpleNamespace()
+        first = self._weight(1)
+        first_gemm = torch.full((4, 8), 1, dtype=torch.uint8)
+        _store_graph_visible_dense_state(layer, first, first_gemm)
+        second = self._weight(2, gscale_shape=(2,))
+        with pytest.raises(RuntimeError, match="cannot preserve b12x_fp6_gscale"):
+            _store_graph_visible_dense_state(
+                layer, second, torch.full((4, 8), 2, dtype=torch.uint8)
+            )
+        assert torch.equal(layer.b12x_fp6_gemm_weight, first_gemm)
 
     def test_reset_serving_caches_clears_plan_cache(
         self, mock_fused_moe, clean_plan_cache


### PR DESCRIPTION
Closes #164.

Keys FP6 serving output/scratch caches by capture-size catalogs, rejects unplanned shapes, and unloads graph-owned state without stale allocator aliases.

Verification: 42 focused integration tests passed on Linux; py_compile/Ruff/diff checks passed.