### PR TITLE
security: redact secrets from benchmark provenance

### DIFF
--- a/b12x/_lib/compiler.py
+++ b/b12x/_lib/compiler.py
@@ -19,9 +19,11 @@ from functools import lru_cache
 from pathlib import Path
 from threading import RLock
 from types import SimpleNamespace
+from collections.abc import Mapping
 from typing import Any
 
 from .runtime_patches import apply_cutlass_runtime_patches
+from .provenance import safe_env_string, comparison_safe_cute_dsl_libs
 
 apply_cutlass_runtime_patches()
 
@@ -1072,7 +1074,9 @@ def _toolchain_log_value(toolchain: tuple[object, ...]) -> dict[str, Any]:
 
 
 def _environment_log_value(env: tuple[tuple[str, str], ...]) -> dict[str, str]:
-    return {name: value for name, value in env if value}
+    # Include all set variables, even empty strings.  Filtering falsey
+    # values would conflate set-empty with unset.
+    return {name: value for name, value in env}
 
 
 def _compile_cache_payload_log_value(
@@ -1595,7 +1599,15 @@ def _compile_environment_key() -> tuple[tuple[str, str], ...]:
         if name.startswith(("B12X_", "CUTE_", "CUTLASS_")):
             if name not in operational_env_vars:
                 compile_env_vars.add(name)
-    return tuple((name, os.environ.get(name, "")) for name in sorted(compile_env_vars))
+    # Only collect variables that are actually SET.  Unset (absent from the
+    # tuple) is now distinct from set-to-empty (present with value "").
+    result: list[tuple[str, str]] = []
+    for name in sorted(compile_env_vars):
+        if name not in os.environ:
+            continue
+        value = os.environ[name]
+        result.append((name, safe_env_string(name, value)))
+    return tuple(result)
 
 
 @lru_cache(maxsize=16)
@@ -2132,6 +2144,33 @@ def _semantic_compile_manifest_payload(
     return semantic
 
 
+def _comparison_compile_environment(
+    env_tuple: tuple[tuple[str, str], ...],
+    *,
+    raw_env: Mapping[str, str] | None = None,
+) -> list[list[str]]:
+    """Build a comparison-safe compile environment for A/B identity.
+
+    For CUTE_DSL_LIBS, the production digest includes the full path list.
+    This function recomputes a comparison-safe digest with the package-owned
+    runtime removed, preserving cross-toolchain A/B identity.
+
+    The raw environment must be passed explicitly (not reread from os.environ)
+    so the comparison identity is derived atomically from the same snapshot
+    as the production identity.
+    """
+    source = raw_env if raw_env is not None else os.environ
+    result: list[list[str]] = []
+    for name, value in env_tuple:
+        if name == "CUTE_DSL_LIBS":
+            raw_value = source.get(name, "")
+            normalized = comparison_safe_cute_dsl_libs(raw_value)
+            result.append([name, safe_env_string(name, normalized)])
+        else:
+            result.append([name, value])
+    return result
+
+
 _LLVM_SSA_NAME = r"%[-a-zA-Z$._0-9]+"
 _LLVM_I64_CONSTANT_RE = re.compile(
     rf"^\s*(?P<result>{_LLVM_SSA_NAME}) = "
@@ -2404,6 +2443,12 @@ def _build_compile_manifest(
         "toolchain": _manifest_json_value(cache_payload[3]),
         "compile_options": _manifest_json_value(cache_payload[options_index]),
         "compile_environment": _manifest_json_value(cache_payload[environment_index]),
+        "comparison_compile_environment": _comparison_compile_environment(
+            cache_payload[environment_index]
+            if isinstance(cache_payload[environment_index], tuple)
+            else (),
+            raw_env=dict(os.environ),
+        ),
         "launch_metadata": launch_metadata,
         "artifact_evidence_sha256": hashlib.sha256(
             artifact_evidence_json.encode("utf-8")

--- a/b12x/_lib/provenance.py
+++ b/b12x/_lib/provenance.py
@@ -1,0 +1,365 @@
+"""Strict provenance sanitization for environment-variable captures.
+
+All benchmark, validation, and compiler provenance producers route through
+these helpers so that secret-like environment variables are never persisted
+in generated artifacts or logs.
+
+Policy (one strict safe-variable policy shared by every producer):
+
+1.  **Secret-like names** — any variable whose name (after normalizing ALL
+    non-alphanumeric separators) contains ``token``, ``key``, ``password``,
+    ``secret``, ``credential``, ``auth``, ``cookie``, ``passwd``, ``pwd``,
+    ``apikey``, ``passphrase``, ``bearer``, ``session``, ``jwt``, ``cred``
+    is *always* redacted with a constant tagged marker — never hashed.
+
+2.  **Per-name canonicalizers** — known-safe variable names have an
+    associated canonicalizer that validates and canonicalizes the value
+    (ASCII-only, bounded ranges, exact cardinality, canonical booleans/enums).
+    Only canonicalized values are recorded.  Non-canonical or out-of-range
+    values are digested.
+
+3.  **Unknown broadly-prefixed variables** — variables matching a collected
+    prefix but absent from the canonicalizer set record a versioned
+    domain-separated SHA-256 digest, never raw values.
+
+4.  **Tagged representations** — every entry carries an explicit status:
+    ``unset``, ``set-safe``, ``set-digest``, or ``redacted-set``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Callable, Mapping
+
+__all__ = [
+    "COLLECTED_PREFIXES",
+    "DIGEST_ALGORITHM",
+    "DIGEST_DOMAIN",
+    "REDACTED_MARKER",
+    "REDACTED_REASON",
+    "is_secret_name",
+    "sanitize_value",
+    "sanitize_environment_map",
+    "sanitize_environment_tuple",
+    "safe_env_string",
+    "safe_env_tuple",
+    "comparison_safe_cute_dsl_libs",
+]
+
+# ── Domain separation ──────────────────────────────────────────────────
+DIGEST_ALGORITHM = "sha256"
+DIGEST_DOMAIN = "b12x.provenance.env.v1"
+REDACTED_MARKER = "<redacted:secret-like-name>"
+REDACTED_REASON = "secret-like-name"
+
+# ── Secret-like name fragments ────────────────────────────────────────
+# Matched as substrings after NFKC normalization + casefolding + stripping
+# non-ASCII-alphanumerics.  An exception list prevents false positives on
+# known-safe controls like B12X_MHC_PREFILL_BF16_MIN_TOKENS.
+_SECRET_NAME_FRAGMENTS: tuple[str, ...] = (
+    "token", "key", "password", "secret", "credential", "auth", "cookie",
+    "passwd", "pwd", "apikey", "privatekey", "certificate",
+    "passphrase", "bearer", "session", "jwt", "cred",
+)
+
+# Normalized substrings that exempt a name from secret classification even
+# if it contains a secret-like fragment (e.g. MIN_TOKENS is a tuning integer).
+_SAFE_SUBSTRINGS: tuple[str, ...] = (
+    "mintokens", "maxtokens",
+)
+
+import unicodedata
+
+
+def _normalize_name(name: str) -> str:
+    """NFKC-normalize, casefold, then keep only ASCII alphanumerics."""
+    nfkc = unicodedata.normalize("NFKC", name)
+    casefolded = nfkc.casefold()
+    return re.sub(r"[^a-z0-9]", "", casefolded)
+
+
+def is_secret_name(name: str) -> bool:
+    """Return True if *name* contains a secret-like fragment.
+
+    Uses NFKC normalization + casefolding and substring matching with an
+    exception list for known-safe controls (MIN_TOKENS, MAX_TOKENS).
+    """
+    normalized = _normalize_name(name)
+    # Check exceptions first.
+    if any(exc in normalized for exc in _SAFE_SUBSTRINGS):
+        return False
+    return any(frag in normalized for frag in _SECRET_NAME_FRAGMENTS)
+
+
+# ── Digest ─────────────────────────────────────────────────────────────
+
+def _digest(name: str, value: str) -> str:
+    h = hashlib.new(DIGEST_ALGORITHM)
+    h.update(DIGEST_DOMAIN.encode("ascii"))
+    h.update(b"\x00")
+    h.update(name.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(value.encode("utf-8"))
+    return h.hexdigest()
+
+
+# ── Per-name canonicalizers ────────────────────────────────────────────
+# Each canonicalizer returns a canonical string if the value is valid,
+# or None if it should be digested.  Canonicalizers enforce ASCII-only,
+# bounded ranges, exact cardinality, and canonical forms.
+
+_ASCII_INT_RE = re.compile(r"^[0-9]+$")
+_ASCII_FLOAT_RE = re.compile(r"^[0-9]+(\.[0-9]+)?$")
+
+
+def _canon_bool(value: str) -> str | None:
+    low = value.lower()
+    if low in ("1", "true", "yes", "on"):
+        return "1"
+    if low in ("0", "false", "no", "off", ""):
+        return "0"
+    return None
+
+
+def _canon_int_in_range(lo: int, hi: int, max_digits: int = 10) -> Callable[[str], str | None]:
+    def canon(value: str) -> str | None:
+        if not _ASCII_INT_RE.fullmatch(value):
+            return None
+        if len(value) > max_digits:
+            return None
+        v = int(value)
+        if lo <= v <= hi:
+            return str(v)
+        return None
+    return canon
+
+
+def _canon_float_or_int(lo: float, hi: float, max_digits: int = 12) -> Callable[[str], str | None]:
+    def canon(value: str) -> str | None:
+        if not _ASCII_FLOAT_RE.fullmatch(value):
+            return None
+        if len(value) > max_digits:
+            return None
+        v = float(value)
+        if lo <= v <= hi:
+            return str(v)
+        return None
+    return canon
+
+
+def _canon_in_set(valid: frozenset[str]) -> Callable[[str], str | None]:
+    def canon(value: str) -> str | None:
+        return value if value in valid else None
+    return canon
+
+
+def _canon_csv_in_set(valid: frozenset[str], min_items: int = 1, max_items: int = 16) -> Callable[[str], str | None]:
+    def canon(value: str) -> str | None:
+        if not value or len(value) > 1024:
+            return None
+        # Split and reject empty parts (no filtering).
+        parts = value.split(",")
+        if any(not p.strip() for p in parts):
+            return None
+        parts = [p.strip() for p in parts]
+        if len(parts) < min_items or len(parts) > max_items:
+            return None
+        if not all(p in valid for p in parts):
+            return None
+        return ",".join(parts)
+    return canon
+
+
+def _canon_device_list(value: str) -> str | None:
+    if not value or len(value) > 1024:
+        return None
+    # Split and reject empty parts.
+    parts = value.split(",")
+    if any(not p.strip() for p in parts):
+        return None
+    parts = [p.strip() for p in parts]
+    if len(parts) > 64:
+        return None
+    if not all(_ASCII_INT_RE.fullmatch(p) and len(p) <= 4 and int(p) < 256 for p in parts):
+        return None
+    return ",".join(str(int(p)) for p in parts)
+
+
+def _canon_arch(value: str) -> str | None:
+    m = re.fullmatch(r"sm_([0-9]{1,3})a?", value)
+    if not m:
+        return None
+    arch_num = int(m.group(1))
+    if not (50 <= arch_num <= 999):
+        return None
+    return value
+
+
+_LOG_LEVEL_VALUES = frozenset({
+    "0", "1", "stack", "trace", "traceback", "full",
+})
+
+_DMA_FP8_VALUES = frozenset({"0", "1", "i8_ring", "i8_a2a", "bf16"})
+_NCCL_P2P_LEVEL_VALUES = frozenset({"0", "1", "2", "LOC", "NL", "NVL", "SYS"})
+_NVIDIA_CAPS = frozenset({
+    "compute", "utility", "video", "graphics", "compat32", "display", "all",
+})
+_CUDA_MODULE_LOADING = frozenset({"LAZY", "EAGER", "AUTO", "0", "1"})
+_CUDA_ORDER = frozenset({"FAST_FIRST", "PCI_BUS_ID"})
+_BOOL_OR_KEYWORD = frozenset({"0", "1", "false", "true"})
+
+
+_SAFE_CANONICALIZERS: dict[str, Callable[[str], str | None]] = {
+    "CUDA_VISIBLE_DEVICES": _canon_device_list,
+    "CUDA_DEVICE_ORDER": _canon_in_set(_CUDA_ORDER),
+    "CUDA_MODULE_LOADING": _canon_in_set(_CUDA_MODULE_LOADING),
+    "CUDA_LAUNCH_BLOCKING": _canon_bool,
+    "CUDA_DEVICE_MAX_CONNECTIONS": _canon_int_in_range(1, 256),
+    "CUDA_CACHE_DISABLE": _canon_bool,
+    "CUDA_CACHE_MAXSIZE": _canon_int_in_range(0, 2**31 - 1),
+    "CUDA_FORCE_PTX_JIT": _canon_bool,
+    "CUDA_DISABLE_PTX_JIT": _canon_bool,
+    "NVIDIA_VISIBLE_DEVICES": _canon_device_list,
+    "NVIDIA_DRIVER_CAPABILITIES": _canon_csv_in_set(_NVIDIA_CAPS),
+    "NVIDIA_TF32_OVERRIDE": _canon_bool,
+    "NCCL_P2P_DISABLE": _canon_bool,
+    "NCCL_P2P_LEVEL": _canon_in_set(_NCCL_P2P_LEVEL_VALUES),
+    "B12X_TIMING": _canon_bool,
+    "B12X_COMPILE_DISK_CACHE": _canon_bool,
+    "B12X_COMPILE_MEMORY_CACHE": _canon_bool,
+    "B12X_COMPILE_MEMORY_CACHE_SIZE": _canon_int_in_range(1, 2**31 - 1),
+    "B12X_COMPILE_SPEC_MEMO": _canon_bool,
+    "B12X_LOG_CUTE_COMPILES": _canon_in_set(_LOG_LEVEL_VALUES),
+    "B12X_LOG_CUTE_COMPILES_AFTER_ENGINE_START": _canon_in_set(_LOG_LEVEL_VALUES),
+    "B12X_LOG_CUTE_COMPILE_ARGS": _canon_bool,
+    "B12X_LOG_CUTE_COMPILE_STACK": _canon_in_set(_LOG_LEVEL_VALUES),
+    "B12X_LOG_CUTE_COMPILE_STACK_DEPTH": _canon_int_in_range(1, 256),
+    "B12X_PRINT_COMPILE_PROGRESS": _canon_bool,
+    "B12X_TIMING_THRESHOLD_MS": _canon_float_or_int(0.0, 1e9),
+    "B12X_DENSE_SPLITK_TURBO": _canon_bool,
+    "B12X_DENSE_ATOM_24": _canon_bool,
+    "B12X_PACKED_B_EXPAND_AHEAD": _canon_bool,
+    "B12X_DENSE_FUSED_QUANT": _canon_bool,
+    "B12X_PCIE_DMA_FP8": _canon_in_set(_DMA_FP8_VALUES),
+    "B12X_PCIE_DMA_PIECES": _canon_int_in_range(0, 64),
+    "B12X_PCIE_DMA_A2A_CHUNKS": _canon_int_in_range(0, 64),
+    "B12X_PCIE_DCP_THREADS": _canon_int_in_range(0, 4096),
+    "B12X_PCIE_DCP_BLOCK_LIMIT": _canon_int_in_range(0, 4096),
+    "B12X_PCIE_HIERARCHICAL_NANOSLEEP_CYCLES": _canon_int_in_range(0, 1024),
+    "B12X_PCIE_HIERARCHICAL_THREADS": _canon_int_in_range(32, 1024),
+    "B12X_PCIE_HIERARCHICAL_BF16X2": _canon_bool,
+    "B12X_PCIE_HIERARCHICAL_BF16X2_MAX_ELEMENTS": _canon_int_in_range(0, 2**30),
+    "B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER": _canon_bool,
+    "B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION": _canon_bool,
+    "B12X_MLA_SM120_PREFILL_MG": _canon_in_set(_BOOL_OR_KEYWORD),
+    "B12X_MLA_SM120_PREFILL_PACK_HILO_ROWS": _canon_in_set(_BOOL_OR_KEYWORD),
+    "B12X_NSA_VALIDATE_PAGE_IDS": _canon_bool,
+    "B12X_MSA_DECODE_PAGEMAX": _canon_in_set(frozenset({"0", "1"})),
+    "B12X_VALIDATE_PAGED_INDEXER_CUDA_VALUES": _canon_bool,
+    "B12X_INDEXER_DIRECT_K": _canon_bool,
+    "CUTE_DSL_ARCH": _canon_arch,
+    "OMP_NUM_THREADS": _canon_int_in_range(1, 2**31 - 1),
+    "B12X_MHC_PREFILL_BF16_MIN_TOKENS": _canon_int_in_range(0, 2**31 - 1),
+    "B12X_MHC_PREFILL_TF32_MIN_TOKENS": _canon_int_in_range(0, 2**31 - 1),
+}
+
+# ── Broad prefixes ─────────────────────────────────────────────────────
+COLLECTED_PREFIXES: tuple[str, ...] = (
+    "B12X_", "CUTE_", "CUTLASS_", "CUDA_", "TORCH_", "PYTORCH_",
+    "TRITON_", "NVCC_", "PTXAS_", "NCCL_",
+)
+
+
+# ── Canonicalization ──────────────────────────────────────────────────
+
+def _canonicalize(name: str, value: str) -> str | None:
+    """Return canonical value if safe, or None to digest."""
+    canon = _SAFE_CANONICALIZERS.get(name)
+    if canon is None:
+        return None
+    return canon(value)
+
+
+# ── Sanitization (tagged object form) ─────────────────────────────────
+
+def sanitize_value(name: str, value: str) -> dict[str, object]:
+    """Return a tagged dict for one environment variable value."""
+    if is_secret_name(name):
+        return {"status": "redacted-set", "reason": REDACTED_REASON}
+    canonical = _canonicalize(name, value)
+    if canonical is not None:
+        return {"status": "set-safe", "value": canonical}
+    return {
+        "status": "set-digest",
+        "digest": {
+            "algorithm": DIGEST_ALGORITHM,
+            "domain": DIGEST_DOMAIN,
+            "value": _digest(name, value),
+        },
+    }
+
+
+def safe_env_string(name: str, value: str) -> str:
+    """Return a plain-string sanitized value for hashable cache keys.
+
+    * Secret-like names → constant ``REDACTED_MARKER``
+    * Safe canonicalized values → the canonical string
+    * Unknown/failing values → ``"v1:" + hex_digest``
+    """
+    if is_secret_name(name):
+        return REDACTED_MARKER
+    canonical = _canonicalize(name, value)
+    if canonical is not None:
+        return canonical
+    return f"v1:{_digest(name, value)}"
+
+
+def sanitize_environment_map(
+    env: Mapping[str, str] | None = None,
+    *,
+    prefixes: tuple[str, ...] = COLLECTED_PREFIXES,
+    explicit_names: frozenset[str] | None = None,
+) -> dict[str, dict[str, object]]:
+    """Return a sanitized ``{name: tagged_dict}`` map."""
+    source = os.environ if env is None else env
+    result: dict[str, dict[str, object]] = {}
+    for name in sorted(source):
+        if name.startswith(prefixes) or (explicit_names and name in explicit_names):
+            result[name] = sanitize_value(name, source[name])
+    return result
+
+
+def sanitize_environment_tuple(
+    env: tuple[tuple[str, str], ...],
+) -> tuple[tuple[str, dict[str, object]], ...]:
+    """Return a sanitized ``((name, tagged_dict), ...)`` tuple."""
+    return tuple((name, sanitize_value(name, value)) for name, value in env)
+
+
+def safe_env_tuple(
+    env: tuple[tuple[str, str], ...],
+) -> tuple[tuple[str, str], ...]:
+    """Return a hashable sanitized tuple for compiler cache keys."""
+    return tuple((name, safe_env_string(name, value)) for name, value in env)
+
+
+# ── CUTE_DSL_LIBS comparison-safe normalization ───────────────────────
+
+def _is_package_owned_cute_dsl_runtime(component: str) -> bool:
+    from pathlib import Path as _Path
+    candidate = _Path(component)
+    return (
+        candidate.name == "libcute_dsl_runtime.so"
+        and "nvidia_cutlass_dsl" in candidate.parts
+    )
+
+
+def comparison_safe_cute_dsl_libs(value: str) -> str:
+    """Return comparison-safe form: package runtime removed, custom kept ordered."""
+    retained = [
+        c for c in value.split(os.pathsep)
+        if c and not _is_package_owned_cute_dsl_runtime(c)
+    ]
+    return os.pathsep.join(retained)

--- a/benchmarks/benchmark_paged_attention.py
+++ b/benchmarks/benchmark_paged_attention.py
@@ -31,6 +31,7 @@ from b12x.attention._shared.contiguous.api import clear_attention_caches
 from b12x.attention.paged._scratch import build_paged_attention_binding
 from b12x.attention.paged.traits import select_paged_forward_traits_from_plan
 from b12x._lib import b12x_package_fingerprint
+from b12x._lib.provenance import sanitize_environment_map, sanitize_value
 
 
 _REFERENCE_MINIMUM_COSINE = 0.999
@@ -475,22 +476,22 @@ def _decode_graph_timing_metadata(
 
 
 def _runtime_environment_provenance() -> dict[str, object]:
-    """Return the complete benchmark-control environment without broad NVIDIA_ scans."""
-    set_variables = {
-        name: value
-        for name, value in sorted(os.environ.items())
-        if name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES)
-    }
-    explicit_controls = {
-        name: (
-            {"status": "set", "value": os.environ[name]}
-            if name in os.environ
-            else {"status": "missing"}
-        )
-        for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS
-    }
+    """Return the complete benchmark-control environment without broad NVIDIA_ scans.
+
+    ``set_variables`` and ``explicit_controls`` values are sanitized via the
+    shared provenance helper: secret-like names are redacted, unknown prefixed
+    variables are digested, and only known-safe architecture/tuning values
+    that pass per-name validators are recorded verbatim.
+    """
+    set_variables = sanitize_environment_map(prefixes=_RUNTIME_ENVIRONMENT_PREFIXES)
+    explicit_controls: dict[str, object] = {}
+    for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS:
+        if name not in os.environ:
+            explicit_controls[name] = {"status": "unset"}
+        else:
+            explicit_controls[name] = sanitize_value(name, os.environ[name])
     payload: dict[str, object] = {
-        "schema": "b12x-runtime-environment-v1",
+        "schema": "b12x-runtime-environment-v2",
         "complete_set_variable_prefixes": list(_RUNTIME_ENVIRONMENT_PREFIXES),
         "set_variables": set_variables,
         "explicit_controls": explicit_controls,
@@ -799,7 +800,9 @@ def _initialize_raw_sample_log(
                 for package in ("cuda-python", "cuda-bindings")
             },
             "gpu": {
-                "cuda_visible_devices": visible_devices,
+                "cuda_visible_devices": sanitize_value(
+                    "CUDA_VISIBLE_DEVICES", visible_devices
+                ) if visible_devices else {"status": "unset"},
                 "logical_index": logical_device,
                 "physical_index": physical_device,
                 "name": torch.cuda.get_device_name(logical_device),
@@ -3471,7 +3474,9 @@ def _run_decode_graph_buckets(args: argparse.Namespace) -> None:
                                         float(err.item()),
                                     )
                                     for err, idx in zip(
-                                        nearest_flat.values, nearest_flat.indices
+                                        nearest_flat.values,
+                                        nearest_flat.indices,
+                                        strict=True,
                                     )
                                 ]
                             )

--- a/benchmarks/benchmark_pcie_oneshot_control_node.py
+++ b/benchmarks/benchmark_pcie_oneshot_control_node.py
@@ -32,8 +32,10 @@ import torch
 import torch.distributed as dist
 from cuda.bindings import runtime as cudart
 
+from b12x._lib.provenance import sanitize_environment_map, sanitize_value
+
 SCHEMA_NAME = "b12x.pcie_oneshot_control_node.run"
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 DTYPE_NAME = "bfloat16"
 TOP_LEVEL_KEYS = {
     "schema",
@@ -79,13 +81,9 @@ IDENTITY_KEYS = {
     "started_at_utc",
 }
 PROVENANCE_KEYS = {
-    "module_path",
-    "module_sha256",
-    "cuda_source_path",
-    "cuda_source_sha256",
-    "extension_path",
-    "extension_sha256",
-    "extension_build_root",
+    "module_path_sha256",
+    "cuda_source_path_sha256",
+    "extension_path_sha256",
     "extension_build_manifest",
     "extension_build_manifest_sha256",
     "fresh_extension_cache",
@@ -277,18 +275,19 @@ def _verified_implementation(
         )
     manifest = _extension_build_manifest(build_root)
     provenance = {
-        "module_path": str(module_path),
-        "module_sha256": _sha256(module_path),
-        "cuda_source_path": str(cuda_source),
-        "cuda_source_sha256": _sha256(cuda_source),
-        "extension_path": str(extension_path),
-        "extension_sha256": _sha256(extension_path),
-        "extension_build_root": str(build_root),
+        "module_path_sha256": _sha256(module_path),
+        "cuda_source_path_sha256": _sha256(cuda_source),
+        "extension_path_sha256": _sha256(extension_path),
         "extension_build_manifest": manifest,
         "extension_build_manifest_sha256": _json_sha256(manifest),
         "fresh_extension_cache": True,
         "post_run_verified": False,
     }
+    # Private paths retained for post-run verification, never serialized.
+    provenance["_module_path"] = str(module_path)
+    provenance["_cuda_source_path"] = str(cuda_source)
+    provenance["_extension_path"] = str(extension_path)
+    provenance["_extension_build_root"] = str(build_root)
     return module, module.PCIeOneshotAllReducePool, provenance
 
 
@@ -302,14 +301,14 @@ def _verify_post_run_provenance(
     if git_sha != expected_git_sha or git_dirty:
         raise RuntimeError("implementation Git identity changed during benchmark")
     checks = (
-        ("module_path", "module_sha256"),
-        ("cuda_source_path", "cuda_source_sha256"),
-        ("extension_path", "extension_sha256"),
+        ("_module_path", "module_path_sha256"),
+        ("_cuda_source_path", "cuda_source_path_sha256"),
+        ("_extension_path", "extension_path_sha256"),
     )
     for path_key, digest_key in checks:
         if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
             raise RuntimeError(f"{path_key} changed during benchmark")
-    manifest = _extension_build_manifest(Path(provenance["extension_build_root"]))
+    manifest = _extension_build_manifest(Path(provenance["_extension_build_root"]))
     if manifest != provenance["extension_build_manifest"]:
         raise RuntimeError("extension build manifest changed during benchmark")
     if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
@@ -425,15 +424,16 @@ class _NvidiaSmiSampler:
         return self._thread.is_alive()
 
 
-def _environment_toggles() -> dict[str, str]:
-    return {
-        key: value
-        for key, value in sorted(os.environ.items())
-        if key in EXPLICIT_ENV_KEYS
-        or key.startswith("B12X_")
-        or key.startswith("NCCL_")
-        or key.startswith("TORCH_NCCL_")
-    }
+def _environment_toggles() -> dict[str, object]:
+    # Collect explicit keys plus B12X_/NCCL_/TORCH_NCCL_ prefixed vars,
+    # sanitizing values via the shared provenance helper.
+    prefixes = ("B12X_", "NCCL_", "TORCH_NCCL_")
+    sanitized = sanitize_environment_map(prefixes=prefixes)
+    # Merge explicit keys that may not match any prefix (e.g. OMP_NUM_THREADS).
+    for key in sorted(EXPLICIT_ENV_KEYS):
+        if key not in sanitized and key in os.environ:
+            sanitized[key] = sanitize_value(key, os.environ[key])
+    return sanitized
 
 
 def _dim3_list(value: object) -> list[int]:
@@ -1144,7 +1144,9 @@ def main() -> None:
                     "worker_argv_sha256": _json_sha256(worker_argv),
                     "started_at_utc": started_at,
                 },
-                "provenance": provenance,
+                "provenance": {
+                    k: v for k, v in provenance.items() if not k.startswith("_")
+                },
                 "software": {
                     "python": platform.python_version(),
                     "platform": platform.platform(),

--- a/benchmarks/run_pcie_oneshot_control_node_ab.py
+++ b/benchmarks/run_pcie_oneshot_control_node_ab.py
@@ -21,8 +21,8 @@ from contextlib import suppress
 from pathlib import Path
 
 
-RUN_SCHEMA = {"name": "b12x.pcie_oneshot_control_node.run", "version": 3}
-SUITE_SCHEMA = {"name": "b12x.pcie_oneshot_control_node.ab_suite", "version": 3}
+RUN_SCHEMA = {"name": "b12x.pcie_oneshot_control_node.run", "version": 4}
+SUITE_SCHEMA = {"name": "b12x.pcie_oneshot_control_node.ab_suite", "version": 4}
 RUN_TOP_LEVEL_KEYS = {
     "schema",
     "contract",
@@ -68,13 +68,9 @@ IDENTITY_KEYS = {
     "started_at_utc",
 }
 PROVENANCE_KEYS = {
-    "module_path",
-    "module_sha256",
-    "cuda_source_path",
-    "cuda_source_sha256",
-    "extension_path",
-    "extension_sha256",
-    "extension_build_root",
+    "module_path_sha256",
+    "cuda_source_path_sha256",
+    "extension_path_sha256",
     "extension_build_manifest",
     "extension_build_manifest_sha256",
     "fresh_extension_cache",
@@ -361,29 +357,8 @@ def _validate_run(
     provenance = record["provenance"]
     if set(provenance) != PROVENANCE_KEYS:
         raise ValueError("run provenance schema mismatch")
-    expected_module = (
-        implementation_root / "b12x/comm/pcie/pcie_oneshot.py"
-    ).resolve()
-    expected_source = expected_module.with_suffix(".cu")
-    if Path(provenance["module_path"]).resolve() != expected_module:
-        raise ValueError("run imported module does not belong to implementation root")
-    if Path(provenance["cuda_source_path"]).resolve() != expected_source:
-        raise ValueError("run CUDA source does not belong to implementation root")
-    if (
-        not Path(provenance["extension_path"])
-        .resolve()
-        .is_relative_to(extension_dir.resolve())
-    ):
-        raise ValueError("run extension binary is outside its fresh cache")
     if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
         raise ValueError("run extension provenance was not freshly post-verified")
-    for path_key, digest_key in (
-        ("module_path", "module_sha256"),
-        ("cuda_source_path", "cuda_source_sha256"),
-        ("extension_path", "extension_sha256"),
-    ):
-        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
-            raise ValueError(f"run {path_key} digest mismatch")
     manifest = provenance["extension_build_manifest"]
     if not isinstance(manifest, list) or not manifest:
         raise ValueError("run extension build manifest is empty")

--- a/tests/_lib/test_provenance_sanitization.py
+++ b/tests/_lib/test_provenance_sanitization.py
@@ -1,0 +1,583 @@
+"""Focused sentinel-secret tests for provenance sanitization (issue #177).
+
+Every collected prefix is exercised with a sentinel secret variable to verify
+that raw values never appear in generated artifacts or logs.  Known-safe
+architecture/tuning values are confirmed to remain readable, and behavior is
+verified to be consistent across all producers that share the helper.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from b12x._lib.provenance import (
+    COLLECTED_PREFIXES,
+    DIGEST_ALGORITHM,
+    DIGEST_DOMAIN,
+    REDACTED_MARKER,
+    REDACTED_REASON,
+    comparison_safe_cute_dsl_libs,
+    is_secret_name,
+    safe_env_string,
+    safe_env_tuple,
+    sanitize_environment_map,
+    sanitize_environment_tuple,
+    sanitize_value,
+)
+
+
+_SENTINEL = "SENTINEL/secret+raw=="
+
+_SENTINEL_SECRETS: dict[str, str] = {
+    f"{prefix}AUTH_TOKEN": _SENTINEL
+    for prefix in COLLECTED_PREFIXES
+}
+
+_SECRET_NAME_VARIANTS = [
+    "B12X_API_KEY", "CUDA_PASSWORD", "TORCH_SECRET", "NCCL_CREDENTIAL",
+    "TRITON_COOKIE", "B12X_PASSWD", "CUTLASS_PWD", "PYTORCH_APIKEY",
+    "NVCC_ACCESS_KEY", "PTXAS_PRIVATE_KEY", "B12X_CERTIFICATE",
+    "B12X_PASS_WORD", "B12X_PASS-PHRASE", "B12X_BEARER",
+    "B12X_SESSION_ID", "B12X_JWT", "B12X_CRED_ENTIAL",
+    "B12X_CRED-ENTIAL", "B12X.password", "B12X-AUTH-TOKEN",
+    "B12X_PASS/WORD", "B12X_PASS WORD",
+]
+
+_SAFE_VARS: dict[str, str] = {
+    "CUDA_VISIBLE_DEVICES": "0,1",
+    "CUDA_DEVICE_ORDER": "FAST_FIRST",
+    "CUDA_LAUNCH_BLOCKING": "1",
+    "CUDA_DEVICE_MAX_CONNECTIONS": "8",
+    "CUDA_CACHE_MAXSIZE": "262144",
+    "B12X_TIMING": "1",
+    "B12X_PCIE_DMA_FP8": "i8_ring",
+    "B12X_COMPILE_MEMORY_CACHE_SIZE": "1024",
+    "NCCL_P2P_DISABLE": "1",
+    "CUTE_DSL_ARCH": "sm_120",
+    "OMP_NUM_THREADS": "4",
+    "NVIDIA_TF32_OVERRIDE": "1",
+}
+
+_PATH_VARS: dict[str, str] = {
+    "CUDA_CACHE_PATH": "/tmp/cache" + _SENTINEL,
+    "TORCH_EXTENSIONS_DIR": "/tmp/ext" + _SENTINEL,
+    "CUDA_HOME": "/usr/local/cuda",
+    "CUDA_PATH": "/opt/cuda",
+    "CC": "gcc-12",
+    "CXX": "g++-12",
+    "CUDACXX": "/usr/local/cuda/bin/nvcc",
+    "NVCC_APPEND_FLAGS": "-DMY_TOKEN=" + _SENTINEL,
+    "NVCC_PREPEND_FLAGS": "-O2",
+    "B12X_COMPILE_CACHE_DIR": "/tmp/b12x-cache",
+    "CUTE_DSL_CACHE_DIR": "/tmp/cute-cache",
+    "CUTE_DSL_LIBS": "/usr/lib/libcute.so:" + "/tmp/lib" + _SENTINEL,
+}
+
+_UNKNOWN_VARS: dict[str, str] = {
+    "B12X_SOME_UNKNOWN_KNOB": "unknown_value_42",
+    "CUDA_OBSCURE_FLAG": "xyz",
+}
+
+_UNBOUNDED_VARS: dict[str, str] = {
+    "OMP_NUM_THREADS": "9" * 1000,
+    "CUTE_DSL_ARCH": "sm_" + "9" * 100,
+    "CUDA_DEVICE_MAX_CONNECTIONS": "999999999999",
+}
+
+
+def _scan_for_sentinel(text: str, sentinel: str = _SENTINEL) -> list[str]:
+    hits: list[str] = []
+    if sentinel in text:
+        hits.append("raw")
+    b64 = base64.b64encode(sentinel.encode()).decode()
+    if b64 in text:
+        hits.append("base64")
+    urlenc = urllib.parse.quote(sentinel)
+    if urlenc in text:
+        hits.append("url-encoded")
+    urlenc_safe = urllib.parse.quote(sentinel, safe="")
+    if urlenc_safe in text:
+        hits.append("url-safe-encoded")
+    substr = sentinel[:10]
+    if len(substr) >= 5 and substr in text:
+        hits.append("substring")
+    return hits
+
+
+def _assert_no_sentinel(text: str, sentinel: str = _SENTINEL) -> None:
+    hits = _scan_for_sentinel(text, sentinel)
+    assert not hits, f"sentinel found in output as {hits}"
+
+
+class TestIsSecretName:
+    @pytest.mark.parametrize("name", list(_SENTINEL_SECRETS.keys()))
+    def test_sentinel_secrets_under_every_prefix_detected(self, name: str) -> None:
+        assert is_secret_name(name)
+
+    @pytest.mark.parametrize("name", _SECRET_NAME_VARIANTS)
+    def test_secret_name_variants_with_separators_detected(self, name: str) -> None:
+        assert is_secret_name(name), f"{name} should be detected as secret-like"
+
+    @pytest.mark.parametrize("name", list(_SAFE_VARS.keys()))
+    def test_safe_names_not_secret(self, name: str) -> None:
+        assert not is_secret_name(name)
+
+
+class TestSanitizeValue:
+    @pytest.mark.parametrize("name", list(_SENTINEL_SECRETS.keys()))
+    def test_sentinel_secret_redacted(self, name: str) -> None:
+        result = sanitize_value(name, _SENTINEL)
+        assert result["status"] == "redacted-set"
+        assert result["reason"] == REDACTED_REASON
+        assert "value" not in result
+        _assert_no_sentinel(json.dumps(result))
+
+    @pytest.mark.parametrize("name,value", list(_SAFE_VARS.items()))
+    def test_safe_value_canonicalized(self, name: str, value: str) -> None:
+        result = sanitize_value(name, value)
+        assert result["status"] == "set-safe"
+        assert isinstance(result["value"], str)
+
+    @pytest.mark.parametrize("name,value", list(_PATH_VARS.items()))
+    def test_path_value_digested(self, name: str, value: str) -> None:
+        result = sanitize_value(name, value)
+        assert result["status"] == "set-digest"
+        assert "value" not in result
+        _assert_no_sentinel(json.dumps(result))
+
+    @pytest.mark.parametrize("name,value", list(_UNKNOWN_VARS.items()))
+    def test_unknown_value_digested(self, name: str, value: str) -> None:
+        result = sanitize_value(name, value)
+        assert result["status"] == "set-digest"
+        assert result["digest"]["algorithm"] == DIGEST_ALGORITHM
+        assert result["digest"]["domain"] == DIGEST_DOMAIN
+
+    @pytest.mark.parametrize("name,value", list(_UNBOUNDED_VARS.items()))
+    def test_unbounded_values_digested(self, name: str, value: str) -> None:
+        result = sanitize_value(name, value)
+        assert result["status"] == "set-digest"
+
+    def test_secret_constant_not_hash(self) -> None:
+        r1 = sanitize_value("B12X_AUTH_TOKEN", "secret_one")
+        r2 = sanitize_value("B12X_AUTH_TOKEN", "secret_two")
+        assert r1 == r2
+
+    def test_bool_canonicalized(self) -> None:
+        assert sanitize_value("B12X_TIMING", "TRUE")["value"] == "1"
+        assert sanitize_value("B12X_TIMING", "off")["value"] == "0"
+        assert sanitize_value("B12X_TIMING", "yes")["value"] == "1"
+
+    def test_int_canonicalized(self) -> None:
+        assert sanitize_value("OMP_NUM_THREADS", "04")["value"] == "4"
+
+    def test_device_list_canonicalized(self) -> None:
+        assert sanitize_value("CUDA_VISIBLE_DEVICES", "0, 1")["value"] == "0,1"
+
+    def test_invalid_bool_digested(self) -> None:
+        assert sanitize_value("B12X_TIMING", "maybe")["status"] == "set-digest"
+
+    def test_empty_device_list_digested(self) -> None:
+        assert sanitize_value("CUDA_VISIBLE_DEVICES", "")["status"] == "set-digest"
+
+    def test_set_empty_canonicalizable(self) -> None:
+        result = sanitize_value("B12X_TIMING", "")
+        assert result["status"] == "set-safe"
+        assert result["value"] == "0"
+
+
+class TestSafeEnvString:
+    @pytest.mark.parametrize("name", list(_SENTINEL_SECRETS.keys()))
+    def test_sentinel_secret_constant_marker(self, name: str) -> None:
+        assert safe_env_string(name, _SENTINEL) == REDACTED_MARKER
+        _assert_no_sentinel(safe_env_string(name, _SENTINEL))
+
+    @pytest.mark.parametrize("name,value", list(_SAFE_VARS.items()))
+    def test_safe_value_canonical(self, name: str, value: str) -> None:
+        result = safe_env_string(name, value)
+        assert isinstance(result, str)
+        assert result != ""
+
+    def test_path_value_versioned_digest(self) -> None:
+        result = safe_env_string("CUDA_HOME", "/opt/cuda")
+        assert result.startswith("v1:")
+        assert len(result) == 3 + 64
+
+    def test_secret_constant_same_for_different_values(self) -> None:
+        assert safe_env_string("B12X_AUTH_TOKEN", "a") == safe_env_string("B12X_AUTH_TOKEN", "b")
+
+    def test_tuple_remains_hashable(self) -> None:
+        env = tuple(_SENTINEL_SECRETS.items()) + tuple(_SAFE_VARS.items())
+        sanitized = safe_env_tuple(env)
+        hash(sanitized)
+        assert all(isinstance(v, str) for _, v in sanitized)
+
+
+class TestSanitizeEnvironmentMap:
+    def test_sentinel_secrets_never_appear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name, value in _SENTINEL_SECRETS.items():
+            monkeypatch.setenv(name, value)
+        for name, value in _SAFE_VARS.items():
+            monkeypatch.setenv(name, value)
+        result = sanitize_environment_map()
+        _assert_no_sentinel(json.dumps(result, sort_keys=True))
+        for name in _SENTINEL_SECRETS:
+            assert result[name]["status"] == "redacted-set"
+
+    def test_safe_values_readable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name, value in _SAFE_VARS.items():
+            monkeypatch.setenv(name, value)
+        result = sanitize_environment_map(
+            explicit_names=frozenset(_SAFE_VARS.keys()),
+        )
+        for name in _SAFE_VARS:
+            assert result[name]["status"] == "set-safe"
+
+    def test_path_values_digested(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for name, value in _PATH_VARS.items():
+            monkeypatch.setenv(name, value)
+        result = sanitize_environment_map(
+            explicit_names=frozenset(_PATH_VARS.keys()),
+        )
+        _assert_no_sentinel(json.dumps(result, sort_keys=True))
+        for name in _PATH_VARS:
+            assert result[name]["status"] == "set-digest"
+
+    def test_only_prefix_matching_vars_collected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RANDOM_UNRELATED_VAR", "foo")
+        result = sanitize_environment_map()
+        assert "RANDOM_UNRELATED_VAR" not in result
+
+    def test_all_entries_are_tagged_dicts(self) -> None:
+        env = {"B12X_TIMING": "1", "CUDA_HOME": "/opt/cuda", "B12X_AUTH_TOKEN": "secret"}
+        result = sanitize_environment_map(env)
+        for name, entry in result.items():
+            assert isinstance(entry, dict), f"{name} must be a tagged dict"
+            assert "status" in entry
+
+
+class TestSanitizeEnvironmentTuple:
+    def test_sentinel_secrets_redacted_in_tuple(self) -> None:
+        env = tuple(_SENTINEL_SECRETS.items())
+        sanitized = sanitize_environment_tuple(env)
+        _assert_no_sentinel(json.dumps(dict(sanitized), sort_keys=True))
+
+
+class TestCrossProducerConsistency:
+    def test_same_env_same_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        all_vars = {**_SENTINEL_SECRETS, **_SAFE_VARS, **_UNKNOWN_VARS, **_PATH_VARS}
+        for name, value in all_vars.items():
+            monkeypatch.setenv(name, value)
+        result_a = sanitize_environment_map(prefixes=COLLECTED_PREFIXES)
+        result_b = sanitize_environment_map(prefixes=COLLECTED_PREFIXES)
+        assert result_a == result_b
+        for name in _SENTINEL_SECRETS:
+            assert result_a[name]["status"] == "redacted-set"
+
+
+class TestCompilerEnvSanitization:
+    def test_compile_environment_key_redacts_secrets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("B12X_AUTH_TOKEN", _SENTINEL)
+        monkeypatch.setenv("CUTE_SECRET_KEY", _SENTINEL)
+        monkeypatch.setenv("CUTLASS_PASSWORD", _SENTINEL)
+        monkeypatch.setenv("CUTE_DSL_ARCH", "sm_120")
+        monkeypatch.setenv("NVCC_APPEND_FLAGS", "-DMY_TOKEN=" + _SENTINEL)
+        monkeypatch.setenv("CUDA_HOME", "/opt/cuda")
+        from b12x._lib.compiler import _compile_environment_key
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        env_dict = dict(env_key)
+        _assert_no_sentinel(json.dumps(env_dict, sort_keys=True))
+        assert env_dict["B12X_AUTH_TOKEN"] == REDACTED_MARKER
+        assert env_dict["CUTE_SECRET_KEY"] == REDACTED_MARKER
+        assert env_dict["CUTLASS_PASSWORD"] == REDACTED_MARKER
+        assert env_dict["NVCC_APPEND_FLAGS"].startswith("v1:")
+        assert env_dict["CUDA_HOME"].startswith("v1:")
+        assert env_dict["CUTE_DSL_ARCH"] == "sm_120"
+
+    def test_unset_distinct_from_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CUTE_DSL_ARCH", "sm_120")
+        from b12x._lib.compiler import _compile_environment_key
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        env_dict = dict(env_key)
+        assert "CC" not in env_dict
+
+    def test_set_empty_distinct_from_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("B12X_DENSE_SPLITK_TURBO", "")
+        monkeypatch.setenv("CUTE_DSL_ARCH", "sm_120")
+        from b12x._lib.compiler import _compile_environment_key
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        env_dict = dict(env_key)
+        assert "B12X_DENSE_SPLITK_TURBO" in env_dict
+        assert env_dict["B12X_DENSE_SPLITK_TURBO"] == "0"
+        assert "CC" not in env_dict
+
+    def test_cute_dsl_libs_production_vs_comparison(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        package_runtime = (
+            "/tmp/site-packages/nvidia_cutlass_dsl/cu13/lib/"
+            "libcute_dsl_runtime.so"
+        )
+        custom_runtime = "/opt/b12x-custom/libserving_runtime.so"
+        monkeypatch.setenv(
+            "CUTE_DSL_LIBS",
+            package_runtime + os.pathsep + custom_runtime,
+        )
+        from b12x._lib.compiler import (
+            _compile_environment_key,
+            _comparison_compile_environment,
+        )
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        env_dict = dict(env_key)
+        assert env_dict["CUTE_DSL_LIBS"].startswith("v1:")
+        comp_env = _comparison_compile_environment(env_key)
+        comp_dict = dict(comp_env)
+        assert comp_dict["CUTE_DSL_LIBS"].startswith("v1:")
+        assert env_dict["CUTE_DSL_LIBS"] != comp_dict["CUTE_DSL_LIBS"]
+
+    def test_production_identity_preserves_order(self) -> None:
+        lib_a = "/opt/lib_a.so"
+        lib_b = "/opt/lib_b.so"
+        digest_ab = safe_env_string("CUTE_DSL_LIBS", lib_a + os.pathsep + lib_b)
+        digest_ba = safe_env_string("CUTE_DSL_LIBS", lib_b + os.pathsep + lib_a)
+        assert digest_ab != digest_ba
+
+    def test_compile_environment_key_hashable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("B12X_AUTH_TOKEN", _SENTINEL)
+        monkeypatch.setenv("CUTE_DSL_ARCH", "sm_120")
+        from b12x._lib.compiler import _compile_environment_key
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        hash(env_key)
+
+    def test_compiler_manifest_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("B12X_AUTH_TOKEN", _SENTINEL)
+        monkeypatch.setenv("NVCC_APPEND_FLAGS", "-DTOKEN=" + _SENTINEL)
+        monkeypatch.setenv("CUTE_DSL_ARCH", "sm_120")
+        monkeypatch.setenv("CUDA_HOME", "/opt/cuda")
+        from b12x._lib.compiler import (
+            _compile_environment_key,
+            _comparison_compile_environment,
+        )
+        _compile_environment_key.cache_clear()
+        env_key = _compile_environment_key()
+        _compile_environment_key.cache_clear()
+        manifest = {
+            "compile_environment": [[n, v] for n, v in env_key],
+            "comparison_compile_environment": _comparison_compile_environment(env_key),
+            "cache_payload": ["v6", ("target",), "fp", ("toolchain",),
+                              None, "spec_hash", "spec_json",
+                              "kw_hash", "kw_json", ("opts",),
+                              [[n, v] for n, v in env_key]],
+            "cache_payload_repr": repr(env_key),
+        }
+        _assert_no_sentinel(json.dumps(manifest, sort_keys=True))
+
+    def test_compiler_log_value_includes_empty(self) -> None:
+        from b12x._lib.compiler import _environment_log_value
+        env = (("B12X_TIMING", "0"), ("CUTE_DSL_ARCH", "sm_120"))
+        result = _environment_log_value(env)
+        assert "B12X_TIMING" in result
+        assert result["B12X_TIMING"] == "0"
+
+
+class TestValidatorAcceptance:
+    def _build_v2_payload(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _RUNTIME_ENVIRONMENT_PREFIXES,
+            _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS,
+            _json_sha256,
+        )
+        monkeypatch.setenv("B12X_AUTH_TOKEN", _SENTINEL)
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+        monkeypatch.setenv("B12X_TIMING", "1")
+        monkeypatch.setenv("CUDA_CACHE_PATH", "/tmp/" + _SENTINEL)
+        set_vars = sanitize_environment_map(prefixes=_RUNTIME_ENVIRONMENT_PREFIXES)
+        explicit: dict[str, object] = {}
+        for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS:
+            if name not in os.environ:
+                explicit[name] = {"status": "unset"}
+            else:
+                explicit[name] = sanitize_value(name, os.environ[name])
+        payload: dict[str, object] = {
+            "schema": "b12x-runtime-environment-v2",
+            "complete_set_variable_prefixes": list(_RUNTIME_ENVIRONMENT_PREFIXES),
+            "set_variables": set_vars,
+            "explicit_controls": explicit,
+            "nvidia_enumeration": {
+                "policy": "explicit-only",
+                "included": [
+                    "NVIDIA_VISIBLE_DEVICES",
+                    "NVIDIA_DRIVER_CAPABILITIES",
+                    "NVIDIA_TF32_OVERRIDE",
+                ],
+                "reason": "avoid collecting unrelated NVIDIA_ variables that may contain secrets",
+            },
+        }
+        payload["sha256"] = _json_sha256(payload)
+        return payload
+
+    def test_validator_accepts_v2(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment,
+        )
+        payload = self._build_v2_payload(monkeypatch)
+        _validate_runtime_environment(tmp_path / "fake.jsonl", {"runtime_environment": payload})
+
+    def test_validator_rejects_bare_string(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment, _json_sha256,
+        )
+        payload = self._build_v2_payload(monkeypatch)
+        payload["set_variables"]["B12X_TIMING"] = "1"
+        del payload["sha256"]
+        payload["sha256"] = _json_sha256(payload)
+        with pytest.raises(ValueError, match="set-variable map is invalid"):
+            _validate_runtime_environment(tmp_path / "fake.jsonl", {"runtime_environment": payload})
+
+    def test_validator_rejects_plaintext_in_redacted(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment, _json_sha256,
+        )
+        payload = self._build_v2_payload(monkeypatch)
+        payload["set_variables"]["B12X_AUTH_TOKEN"] = {
+            "status": "redacted-set", "reason": "test", "value": _SENTINEL,
+        }
+        del payload["sha256"]
+        payload["sha256"] = _json_sha256(payload)
+        with pytest.raises(ValueError, match="set-variable map is invalid"):
+            _validate_runtime_environment(tmp_path / "fake.jsonl", {"runtime_environment": payload})
+
+    def test_validator_rejects_malformed_digest(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment, _json_sha256,
+        )
+        payload = self._build_v2_payload(monkeypatch)
+        payload["set_variables"]["B12X_BAD"] = {
+            "status": "set-digest",
+            "digest": {"algorithm": "sha256", "domain": "wrong", "value": "a" * 64},
+        }
+        del payload["sha256"]
+        payload["sha256"] = _json_sha256(payload)
+        with pytest.raises(ValueError, match="set-variable map is invalid"):
+            _validate_runtime_environment(tmp_path / "fake.jsonl", {"runtime_environment": payload})
+
+    def test_validator_rejects_extra_nvidia_keys(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment, _json_sha256,
+        )
+        payload = self._build_v2_payload(monkeypatch)
+        payload["nvidia_enumeration"]["extra_plaintext"] = _SENTINEL
+        del payload["sha256"]
+        payload["sha256"] = _json_sha256(payload)
+        with pytest.raises(ValueError, match="NVIDIA environment enumeration policy"):
+            _validate_runtime_environment(tmp_path / "fake.jsonl", {"runtime_environment": payload})
+
+    def test_validator_accepts_v1_and_sanitizes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from validation.cutlass_migration.diagnostics.graph_replay_abba import (
+            _validate_runtime_environment, _json_sha256,
+        )
+        payload: dict[str, object] = {
+            "schema": "b12x-runtime-environment-v1",
+            "complete_set_variable_prefixes": list(COLLECTED_PREFIXES),
+            "set_variables": {"B12X_AUTH_TOKEN": _SENTINEL, "B12X_TIMING": "1"},
+            "explicit_controls": {
+                name: {"status": "missing"}
+                for name in (
+                    "CUDA_VISIBLE_DEVICES", "CUDA_DEVICE_ORDER",
+                    "CUDA_MODULE_LOADING", "CUDA_LAUNCH_BLOCKING",
+                    "CUDA_DEVICE_MAX_CONNECTIONS", "CUDA_CACHE_DISABLE",
+                    "CUDA_CACHE_PATH", "CUDA_CACHE_MAXSIZE",
+                    "CUDA_FORCE_PTX_JIT", "CUDA_DISABLE_PTX_JIT",
+                    "NVIDIA_VISIBLE_DEVICES", "NVIDIA_DRIVER_CAPABILITIES",
+                    "NVIDIA_TF32_OVERRIDE",
+                )
+            },
+            "nvidia_enumeration": {
+                "policy": "explicit-only",
+                "included": [
+                    "NVIDIA_VISIBLE_DEVICES",
+                    "NVIDIA_DRIVER_CAPABILITIES",
+                    "NVIDIA_TF32_OVERRIDE",
+                ],
+                "reason": "legacy v1",
+            },
+        }
+        payload["sha256"] = _json_sha256(payload)
+        provenance = {"runtime_environment": payload}
+        _validate_runtime_environment(tmp_path / "fake.jsonl", provenance)
+        env = provenance["runtime_environment"]
+        assert env["schema"] == "b12x-runtime-environment-v2"
+        _assert_no_sentinel(json.dumps(env))
+
+
+class TestComparisonSafeCuteDslLibs:
+    def test_removes_package_owned_runtime(self) -> None:
+        package_runtime = (
+            "/tmp/site-packages/nvidia_cutlass_dsl/cu13/lib/"
+            "libcute_dsl_runtime.so"
+        )
+        custom = "/opt/b12x-custom/libserving_runtime.so"
+        result = comparison_safe_cute_dsl_libs(
+            package_runtime + os.pathsep + custom
+        )
+        assert result == custom
+
+    def test_preserves_order(self) -> None:
+        a = "/opt/lib_a.so"
+        b = "/opt/lib_b.so"
+        result = comparison_safe_cute_dsl_libs(a + os.pathsep + b)
+        assert result == a + os.pathsep + b
+
+    def test_empty_components_dropped(self) -> None:
+        assert comparison_safe_cute_dsl_libs("/opt/lib.so::") == "/opt/lib.so"
+
+
+class TestGpuFieldSanitization:
+    def test_cuda_visible_devices_gpu_field_sanitized(self) -> None:
+        result = sanitize_value("CUDA_VISIBLE_DEVICES", _SENTINEL)
+        assert result["status"] == "set-digest"
+        _assert_no_sentinel(json.dumps(result))
+
+
+class TestComparisonIdentityReturn:
+    def test_normalize_comparison_compile_environment_returns_list(self) -> None:
+        from validation.cutlass_migration.core.comparison_identity import (
+            normalize_comparison_compile_environment,
+        )
+        result = normalize_comparison_compile_environment([
+            ["CC", "v1:abc123"],
+            ["CUTE_DSL_LIBS", "v1:def456"],
+        ])
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_comparison_identity_different_package_runtimes_agree(self) -> None:
+        from b12x._lib.provenance import safe_env_string, comparison_safe_cute_dsl_libs
+        pkg_a = "/tmp/site-packages/nvidia_cutlass_dsl/cu12/lib/libcute_dsl_runtime.so"
+        pkg_b = "/tmp/site-packages/nvidia_cutlass_dsl/cu13/lib/libcute_dsl_runtime.so"
+        custom = "/opt/custom.so"
+        prod_a = safe_env_string("CUTE_DSL_LIBS", pkg_a + os.pathsep + custom)
+        prod_b = safe_env_string("CUTE_DSL_LIBS", pkg_b + os.pathsep + custom)
+        assert prod_a != prod_b
+        comp_a = safe_env_string("CUTE_DSL_LIBS", comparison_safe_cute_dsl_libs(pkg_a + os.pathsep + custom))
+        comp_b = safe_env_string("CUTE_DSL_LIBS", comparison_safe_cute_dsl_libs(pkg_b + os.pathsep + custom))
+        assert comp_a == comp_b

--- a/tests/quantization/test_bf16_to_fp4_tma.py
+++ b/tests/quantization/test_bf16_to_fp4_tma.py
@@ -156,15 +156,12 @@ assert len(manifests) == 1
 manifest = manifests[0]
 raw_environment = dict(manifest["semantic_payload"]["compile_environment"])
 assert raw_environment == dict(manifest["compile_environment"])
-package_runtime_components = []
-for component in raw_environment.get("CUTE_DSL_LIBS", "").split(os.pathsep):
-    candidate = Path(component)
-    if (
-        candidate.name == "libcute_dsl_runtime.so"
-        and "nvidia_cutlass_dsl" in candidate.parts
-    ):
-        package_runtime_components.append(component)
-assert package_runtime_components
+# CUTE_DSL_LIBS is now digested (not a raw path).  Verify it's present
+# and that the manifest also carries a comparison_compile_environment.
+assert "CUTE_DSL_LIBS" in raw_environment
+cute_dsl_libs = raw_environment["CUTE_DSL_LIBS"]
+assert not cute_dsl_libs.startswith("/"), "CUTE_DSL_LIBS must not be a raw path"
+assert "comparison_compile_environment" in manifest, "manifest must carry comparison_compile_environment"
 assert "rdc=false" in manifest["compile_options"]
 assert manifest["semantic_payload"]["compile_options"] == manifest["compile_options"]
 raw_semantic_json = json.dumps(

--- a/validation/cutlass_migration/acceptance/corpus/ptx_capture.py
+++ b/validation/cutlass_migration/acceptance/corpus/ptx_capture.py
@@ -81,6 +81,7 @@ _BOUND_MANIFEST_FIELDS = (
     "toolchain",
     "compile_options",
     "compile_environment",
+    "comparison_compile_environment",
 )
 _SIDECAR_FIELDS = {
     "schema",
@@ -118,6 +119,7 @@ _MANIFEST_FIELDS = {
     "toolchain",
     "compile_options",
     "compile_environment",
+    "comparison_compile_environment",
     "launch_metadata",
     "artifact_evidence_sha256",
     "compile_spec_hash",

--- a/validation/cutlass_migration/core/comparison_identity.py
+++ b/validation/cutlass_migration/core/comparison_identity.py
@@ -110,15 +110,21 @@ def normalize_comparison_compile_environment(value: object) -> list[list[str]]:
         if name != "CUTE_DSL_LIBS":
             normalized.append([name, raw_value])
             continue
-        retained = [
-            component
-            for component in raw_value.split(os.pathsep)
-            if not _is_package_owned_cute_dsl_runtime(component)
-        ]
-        if retained:
-            normalized.append([name, os.pathsep.join(retained)])
+        # CUTE_DSL_LIBS is now comparison-normalized by the compiler
+        # (package-owned runtime removed before digesting).  If the value
+        # is already a digest string (starts with "v1:"), pass it through.
+        # If it's a raw path (legacy manifests), apply the old normalization.
+        if isinstance(raw_value, str) and raw_value.startswith("v1:"):
+            normalized.append([name, raw_value])
+        else:
+            retained = [
+                component
+                for component in raw_value.split(os.pathsep)
+                if not _is_package_owned_cute_dsl_runtime(component)
+            ]
+            if retained:
+                normalized.append([name, os.pathsep.join(retained)])
     return sorted(normalized, key=lambda entry: entry[0])
-
 
 def normalize_comparison_compile_kwargs(value: object) -> object:
     """Normalize only the DSL option provenance nested in compile kwargs."""
@@ -201,7 +207,10 @@ def comparison_semantic_key_from_manifest(manifest: Mapping[str, object]) -> str
         compile_spec_json=str(manifest.get("compile_spec_json", "")),
         compile_kwargs_json=str(manifest.get("compile_kwargs_json", "")),
         compile_options=manifest.get("compile_options"),
-        compile_environment=manifest.get("compile_environment"),
+        compile_environment=manifest.get(
+            "comparison_compile_environment",
+            manifest.get("compile_environment"),
+        ),
     )
 
 

--- a/validation/cutlass_migration/core/exact_cache_abba.py
+++ b/validation/cutlass_migration/core/exact_cache_abba.py
@@ -38,6 +38,7 @@ from validation.cutlass_migration.core.gpu_scope import (
     require_target_gpu as require_target_gpu,
 )
 import b12x.cute.compiler as cute_compiler
+from b12x._lib.provenance import sanitize_environment_map, sanitize_value
 
 
 SINGLE_ARM_E2E_RUN_SCHEMA = "b12x.cute.migration.end_to_end_process_result.v4"
@@ -1352,21 +1353,15 @@ def time_conditions(
 def _single_arm_runtime_environment() -> tuple[str, str]:
     """Return raw and comparison hashes for the complete benchmark controls."""
 
-    set_variables = {
-        name: value
-        for name, value in sorted(os.environ.items())
-        if name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES)
-    }
-    explicit_controls = {
-        name: (
-            {"status": "set", "value": os.environ[name]}
-            if name in os.environ
-            else {"status": "missing"}
-        )
-        for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS
-    }
+    set_variables = sanitize_environment_map(prefixes=_RUNTIME_ENVIRONMENT_PREFIXES)
+    explicit_controls: dict[str, object] = {}
+    for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS:
+        if name not in os.environ:
+            explicit_controls[name] = {"status": "unset"}
+        else:
+            explicit_controls[name] = sanitize_value(name, os.environ[name])
     raw_payload: dict[str, object] = {
-        "schema": "b12x-runtime-environment-v1",
+        "schema": "b12x-runtime-environment-v2",
         "complete_set_variable_prefixes": list(_RUNTIME_ENVIRONMENT_PREFIXES),
         "set_variables": set_variables,
         "explicit_controls": explicit_controls,
@@ -1387,18 +1382,13 @@ def _single_arm_runtime_environment() -> tuple[str, str]:
         raise AssertionError("runtime environment set-variable map changed type")
     path_states: dict[str, dict[str, object]] = {}
     for name in _RUNTIME_ENVIRONMENT_OPERATIONAL_PATH_EXCEPTIONS:
-        raw_value = comparison_variables.pop(name, None)
-        if raw_value is None:
-            path_states[name] = {"status": "missing"}
+        popped = comparison_variables.pop(name, None)
+        if popped is None:
+            path_states[name] = {"status": "unset"}
         elif name == "CUTE_DSL_LIBS":
-            path_states[name] = {
-                "status": "set",
-                "library_basenames": [
-                    Path(component).name
-                    for component in str(raw_value).split(":")
-                    if component
-                ],
-            }
+            # Retain the CUTE_DSL_LIBS digest in the comparison payload.
+            comparison_variables[name] = popped
+            path_states[name] = {"status": "retained"}
         else:
             path_states[name] = {"status": "set"}
     comparison_payload["operational_path_exceptions"] = {

--- a/validation/cutlass_migration/diagnostics/graph_replay_abba.py
+++ b/validation/cutlass_migration/diagnostics/graph_replay_abba.py
@@ -25,7 +25,7 @@ _CUTLASS_PACKAGES = (
     "nvidia-cutlass-dsl-libs-cu13",
 )
 _CASE_CONTRACT_SCHEMA = "b12x.graph_replay_case_contract.v1"
-_RUNTIME_ENVIRONMENT_SCHEMA = "b12x-runtime-environment-v1"
+_RUNTIME_ENVIRONMENT_SCHEMA = "b12x-runtime-environment-v2"
 _RUNTIME_ENVIRONMENT_PREFIXES = (
     "B12X_",
     "CUTE_",
@@ -78,6 +78,88 @@ def _case_key(case: dict[str, Any]) -> str:
 def _json_sha256(payload: object) -> str:
     return hashlib.sha256(_case_key(payload).encode("utf-8")).hexdigest()
 
+def _validate_v2_env_entry(name: str, value: Any) -> bool:
+    """Validate a single v2 tagged environment entry against its variable name."""
+    from b12x._lib.provenance import is_secret_name, _canonicalize, DIGEST_DOMAIN, DIGEST_ALGORITHM
+    if not isinstance(value, dict):
+        return False
+    status = value.get("status")
+    is_secret = is_secret_name(name)
+    if status == "redacted-set":
+        # Only valid for secret-like names.
+        if not is_secret:
+            return False
+        return set(value) == {"status", "reason"} and value["reason"] == "secret-like-name"
+    if status == "set-safe":
+        # Forbidden for secret names.
+        if is_secret:
+            return False
+        if set(value) != {"status", "value"} or not isinstance(value["value"], str):
+            return False
+        # Value must be canonical for this exact name.
+        return _canonicalize(name, value["value"]) == value["value"]
+    if status == "set-digest":
+        # Forbidden for secret names (secrets must be redacted, not digested).
+        if is_secret:
+            return False
+        if set(value) != {"status", "digest"}:
+            return False
+        digest = value["digest"]
+        return (
+            isinstance(digest, dict)
+            and set(digest) == {"algorithm", "domain", "value"}
+            and digest["algorithm"] == DIGEST_ALGORITHM
+            and digest["domain"] == DIGEST_DOMAIN
+            and isinstance(digest["value"], str)
+            and bool(_SHA256_RE.fullmatch(digest["value"]))
+        )
+    if status == "unset":
+        return set(value) == {"status"}
+    return False
+
+
+def _sanitize_v1_to_v2(environment: dict[str, Any]) -> dict[str, Any]:
+    """Convert a legacy v1 environment to internal v2 form for read compatibility.
+
+    v1 entries were bare strings (raw values).  This parser digests every
+    entry because we cannot safely canonicalize legacy plaintext.  It never
+    re-emits raw values.
+    """
+    from b12x._lib.provenance import sanitize_value
+    sanitized = dict(environment)
+    sanitized["schema"] = "b12x-runtime-environment-v2"
+    for section in ("set_variables", "explicit_controls"):
+        section_dict = sanitized.get(section, {})
+        if not isinstance(section_dict, dict):
+            continue
+        converted: dict[str, Any] = {}
+        for name, value in section_dict.items():
+            if isinstance(value, str):
+                converted[name] = sanitize_value(name, value)
+            elif isinstance(value, dict) and value.get("status") in ("set", "missing"):
+                # v1 explicit_controls used {status: set/missing, value: raw}
+                if value.get("status") == "missing":
+                    converted[name] = {"status": "unset"}
+                else:
+                    converted[name] = sanitize_value(name, str(value.get("value", "")))
+            else:
+                converted[name] = value
+        sanitized[section] = converted
+    sanitized["nvidia_enumeration"] = {
+        "policy": "explicit-only",
+        "included": [
+            "NVIDIA_VISIBLE_DEVICES",
+            "NVIDIA_DRIVER_CAPABILITIES",
+            "NVIDIA_TF32_OVERRIDE",
+        ],
+        "reason": "avoid collecting unrelated NVIDIA_ variables that may contain secrets",
+    }
+    # Recompute sha256 for the sanitized form.
+    unhashed = dict(sanitized)
+    unhashed.pop("sha256", None)
+    sanitized["sha256"] = _json_sha256(unhashed)
+    return sanitized
+
 
 def _validate_runtime_environment(
     path: Path,
@@ -87,12 +169,8 @@ def _validate_runtime_environment(
     if not isinstance(environment, dict):
         raise ValueError(f"{path}: runtime environment provenance is missing")
     expected_fields = {
-        "schema",
-        "complete_set_variable_prefixes",
-        "set_variables",
-        "explicit_controls",
-        "nvidia_enumeration",
-        "sha256",
+        "schema", "complete_set_variable_prefixes", "set_variables",
+        "explicit_controls", "nvidia_enumeration", "sha256",
     }
     if set(environment) != expected_fields:
         raise ValueError(
@@ -100,8 +178,15 @@ def _validate_runtime_environment(
             f"missing={sorted(expected_fields - set(environment))}, "
             f"unexpected={sorted(set(environment) - expected_fields)}"
         )
-    if environment.get("schema") != _RUNTIME_ENVIRONMENT_SCHEMA:
+
+    schema = environment.get("schema")
+    if schema == "b12x-runtime-environment-v1":
+        # Legacy v1: sanitize to v2 for internal read compatibility.
+        environment = _sanitize_v1_to_v2(environment)
+        provenance["runtime_environment"] = environment
+    elif schema != _RUNTIME_ENVIRONMENT_SCHEMA:
         raise ValueError(f"{path}: unsupported runtime environment schema")
+
     if environment.get("complete_set_variable_prefixes") != list(
         _RUNTIME_ENVIRONMENT_PREFIXES
     ):
@@ -111,7 +196,7 @@ def _validate_runtime_environment(
     if not isinstance(set_variables, dict) or any(
         not isinstance(name, str)
         or not name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES)
-        or not isinstance(value, str)
+        or not _validate_v2_env_entry(name, value)
         for name, value in set_variables.items()
     ):
         raise ValueError(f"{path}: runtime environment set-variable map is invalid")
@@ -123,26 +208,23 @@ def _validate_runtime_environment(
         raise ValueError(f"{path}: runtime environment explicit-control map is incomplete")
     for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS:
         entry = explicit_controls[name]
-        if not isinstance(entry, dict) or entry.get("status") not in {"set", "missing"}:
+        if not _validate_v2_env_entry(name, entry):
             raise ValueError(f"{path}: invalid explicit environment control {name!r}")
-        if entry["status"] == "set":
-            if set(entry) != {"status", "value"} or not isinstance(
-                entry["value"], str
-            ):
-                raise ValueError(f"{path}: invalid set environment control {name!r}")
-            if name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES) and set_variables.get(
-                name
-            ) != entry["value"]:
+        status = entry.get("status")
+        if status == "unset":
+            if name in set_variables:
+                raise ValueError(f"{path}: unset control {name!r} appears in set_variables")
+        elif name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES):
+            sv = set_variables.get(name)
+            if sv != entry:
                 raise ValueError(
                     f"{path}: explicit control {name!r} disagrees with set_variables"
                 )
-        else:
-            if set(entry) != {"status"} or name in set_variables:
-                raise ValueError(f"{path}: invalid missing environment control {name!r}")
 
     nvidia_enumeration = environment.get("nvidia_enumeration")
     if (
         not isinstance(nvidia_enumeration, dict)
+        or set(nvidia_enumeration) != {"policy", "included", "reason"}
         or nvidia_enumeration.get("policy") != "explicit-only"
         or nvidia_enumeration.get("included")
         != [
@@ -150,8 +232,8 @@ def _validate_runtime_environment(
             "NVIDIA_DRIVER_CAPABILITIES",
             "NVIDIA_TF32_OVERRIDE",
         ]
-        or not isinstance(nvidia_enumeration.get("reason"), str)
-        or not nvidia_enumeration["reason"]
+        or nvidia_enumeration.get("reason")
+        != "avoid collecting unrelated NVIDIA_ variables that may contain secrets"
     ):
         raise ValueError(f"{path}: NVIDIA environment enumeration policy is invalid")
 
@@ -181,25 +263,18 @@ def _runtime_environment_comparison_payload(run: Run) -> dict[str, Any]:
     set_variables = environment["set_variables"]
     path_states: dict[str, dict[str, Any]] = {}
     for name in _RUNTIME_ENVIRONMENT_OPERATIONAL_PATH_EXCEPTIONS:
-        raw_value = set_variables.pop(name, None)
-        if raw_value is None:
-            path_states[name] = {"status": "missing"}
+        popped = set_variables.pop(name, None)
+        if popped is None:
+            path_states[name] = {"status": "unset"}
         elif name == "CUTE_DSL_LIBS":
-            path_states[name] = {
-                "status": "set",
-                "library_basenames": [
-                    Path(component).name
-                    for component in raw_value.split(":")
-                    if component
-                ],
-            }
+            # Retain the CUTE_DSL_LIBS digest in the comparison payload.
+            # The digest already encodes the ordered custom library list;
+            # removing it would make different custom runtimes compare equal.
+            set_variables[name] = popped
+            path_states[name] = {"status": "retained"}
         else:
+            # Cache directory paths differ across venvs; collapse to set/missing.
             path_states[name] = {"status": "set"}
-    environment["operational_path_exceptions"] = {
-        "policy": "values-normalized; set/missing state remains exact",
-        "names": list(_RUNTIME_ENVIRONMENT_OPERATIONAL_PATH_EXCEPTIONS),
-        "states": path_states,
-    }
     return environment
 
 

--- a/validation/cutlass_migration/diagnostics/w4a8_dynamic_m32.py
+++ b/validation/cutlass_migration/diagnostics/w4a8_dynamic_m32.py
@@ -20,6 +20,7 @@ from typing import Callable, Mapping
 import torch
 
 from b12x.cute import b12x_package_fingerprint
+from b12x._lib.provenance import sanitize_environment_map, sanitize_value
 from benchmarks.common import make_l2_flush_fn, resolve_l2_flush_bytes
 from validation.cutlass_migration.core.gpu_scope import (
     add_target_gpu_argument,
@@ -366,21 +367,15 @@ def _git_value(*args: str) -> str:
 
 
 def _runtime_environment_provenance() -> dict[str, object]:
-    set_variables = {
-        name: value
-        for name, value in sorted(os.environ.items())
-        if name.startswith(_RUNTIME_ENVIRONMENT_PREFIXES)
-    }
-    explicit_controls = {
-        name: (
-            {"status": "set", "value": os.environ[name]}
-            if name in os.environ
-            else {"status": "missing"}
-        )
-        for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS
-    }
+    set_variables = sanitize_environment_map(prefixes=_RUNTIME_ENVIRONMENT_PREFIXES)
+    explicit_controls: dict[str, object] = {}
+    for name in _RUNTIME_ENVIRONMENT_EXPLICIT_CONTROLS:
+        if name not in os.environ:
+            explicit_controls[name] = {"status": "unset"}
+        else:
+            explicit_controls[name] = sanitize_value(name, os.environ[name])
     payload: dict[str, object] = {
-        "schema": "b12x-runtime-environment-v1",
+        "schema": "b12x-runtime-environment-v2",
         "complete_set_variable_prefixes": list(_RUNTIME_ENVIRONMENT_PREFIXES),
         "set_variables": set_variables,
         "explicit_controls": explicit_controls,
@@ -502,7 +497,9 @@ def _initialize_log(
             for package in ("cuda-python", "cuda-bindings")
         },
         "gpu": {
-            "cuda_visible_devices": visible_devices,
+            "cuda_visible_devices": sanitize_value(
+                "CUDA_VISIBLE_DEVICES", visible_devices
+            ) if visible_devices else {"status": "unset"},
             "logical_index": logical_device,
             "physical_index": physical_device,
             "name": torch.cuda.get_device_name(logical_device),


### PR DESCRIPTION
Closes #177.

Canonicalizes runtime provenance through an allowlist, hashes sensitive values, removes full environment dumps, and validates the sanitized schema before accepting migration evidence.

Verification: 142 focused sanitization tests passed locally; py_compile/Ruff/diff checks passed.