### PR TITLE
security: coordinate DCP Top-K teardown and peer failure

### DIFF
--- a/b12x/comm/pcie/pcie_dcp_topk.py
+++ b/b12x/comm/pcie/pcie_dcp_topk.py
@@ -22,13 +22,19 @@ from .pcie_oneshot import (
     _is_current_stream_capturing,
     _normalize_device,
     _OwnedSharedBuffer,
+    _OwnedSharedBuffer,
     _raise_local_cleanup_errors,
+    _require_collective_contract,
+    _require_full_grid_residency,
+    _run_collective_preallocation_setup,
 )
 
 
 SUPPORTED_WORLD_SIZES = (2, 3, 4, 6, 8)
 _MAX_BLOCKS = 128
 _SIGNAL_BYTES = signal_bytes(_MAX_BLOCKS)
+
+_DCP_TOPK_CONTRACT_VERSION = 1
 
 
 def _validate_launch_config(*, threads: int, block_limit: int, world_size: int) -> None:
@@ -76,6 +82,51 @@ def _candidate_staging_layout(
         slot_bytes=slot_bytes,
         slab_bytes=staging1_offset + slot_bytes,
         plane_bytes=plane_bytes,
+    )
+
+
+def _dcp_topk_runtime_contract(
+    *,
+    world_size: int,
+    max_rows: int,
+    topk: int,
+    layout: _DoubleBufferLayout,
+) -> tuple:
+    """Build the versioned fixed-schema contract every rank must agree on.
+
+    The tuple covers every allocation size, offset, capacity, dtype/wire
+    codec, topology constraint, and schedule/launch knob that a peer needs
+    to interpret remote memory correctly.  All ranks must exchange and
+    compare this contract before any IPC allocation or kernel launch so a
+    divergent or compromised rank cannot turn peer DMA into out-of-bounds
+    access.
+    """
+    max_owner_rows = int(max_rows) // int(world_size)
+    candidate_plane_elems = max_owner_rows * int(world_size) * int(topk)
+    return (
+        _DCP_TOPK_CONTRACT_VERSION,
+        # topology
+        int(world_size),
+        SUPPORTED_WORLD_SIZES,
+        # capacity / row + expert knobs
+        int(max_rows),
+        max_owner_rows,
+        int(topk),
+        candidate_plane_elems,
+        # allocation sizes
+        int(layout.slab_bytes),
+        int(layout.slot_bytes),
+        int(layout.plane_bytes),
+        # offsets
+        int(layout.signal_bytes),
+        int(layout.staging0_offset),
+        int(layout.staging1_offset),
+        # wire codec
+        "int32_indices",
+        "float32_scores",
+        # schedule / launch knobs
+        _MAX_BLOCKS,
+        int(_SIGNAL_BYTES),
     )
 
 
@@ -412,16 +463,59 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
     ) -> "PCIeDCPTopKOwnerExchange":
         rank = dist.get_rank(group=exchange_group)
         world_size = dist.get_world_size(group=exchange_group)
-        device_obj = _normalize_device(device)
-        if device_obj.type != "cuda":
-            raise ValueError("DCP top-k owner exchange requires a CUDA device")
-        ipc = CudaRTLibrary()
-        ipc.cudaSetDevice(device_obj.index or 0)
-        layout = _candidate_staging_layout(
-            signal_bytes=_SIGNAL_BYTES,
-            max_rows=max_rows,
-            topk=topk,
-            world_size=world_size,
+
+        def validate_factory_arguments():
+            device_obj = _normalize_device(device)
+            if device_obj.type != "cuda":
+                raise ValueError("DCP top-k owner exchange requires a CUDA device")
+            if world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(f"unsupported world size {world_size}")
+            if max_rows <= 0 or max_rows % world_size != 0:
+                raise ValueError(
+                    "max_rows must be positive and divisible by world_size"
+                )
+            if topk <= 0 or topk % 4 != 0:
+                raise ValueError("topk must be a positive multiple of 4")
+            return device_obj
+
+        device_obj = _run_collective_preallocation_setup(
+            owner="PCIe DCP top-k argument validation",
+            exchange_group=exchange_group,
+            setup=validate_factory_arguments,
+        )
+
+        _require_full_grid_residency(
+            owner="PCIe DCP top-k",
+            required_sms=_MAX_BLOCKS,
+            device=device_obj,
+            exchange_group=exchange_group,
+        )
+
+        def prepare():
+            prepared_ipc = CudaRTLibrary()
+            prepared_ipc.cudaSetDevice(device_obj.index or 0)
+            prepared_layout = _candidate_staging_layout(
+                signal_bytes=_SIGNAL_BYTES,
+                max_rows=max_rows,
+                topk=topk,
+                world_size=world_size,
+            )
+            return prepared_ipc, prepared_layout
+
+        ipc, layout = _run_collective_preallocation_setup(
+            owner="PCIe DCP top-k",
+            exchange_group=exchange_group,
+            setup=prepare,
+        )
+        _require_collective_contract(
+            owner="PCIe DCP top-k channel layout",
+            exchange_group=exchange_group,
+            contract=_dcp_topk_runtime_contract(
+                world_size=world_size,
+                max_rows=max_rows,
+                topk=topk,
+                layout=layout,
+            ),
         )
         owned: list[_OwnedSharedBuffer] = []
         try:

--- a/b12x/comm/pcie/pcie_dcp_topk.py
+++ b/b12x/comm/pcie/pcie_dcp_topk.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
+from enum import Enum
+from threading import Condition, RLock
 from typing import Optional, Sequence
 
 import torch
@@ -15,17 +17,21 @@ from ._dcp_cute_common import signal_bytes
 from .pcie_oneshot import (
     IPC_SLAB_ALIGNMENT,
     PCIeOneshotAllReduce,
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
     _align_up,
-    _coordinated_close_channels,
     _current_stream_key,
     _device_guard,
+    _exchange_close_failures,
+    _finish_collective_runtime_setup,
+    _format_close_error,
     _is_current_stream_capturing,
     _normalize_device,
     _OwnedSharedBuffer,
-    _OwnedSharedBuffer,
+    _raise_coordinated_close_error,
     _raise_local_cleanup_errors,
     _require_collective_contract,
     _require_full_grid_residency,
+    _run_close_phase,
     _run_collective_preallocation_setup,
 )
 
@@ -83,6 +89,27 @@ def _candidate_staging_layout(
         slab_bytes=staging1_offset + slot_bytes,
         plane_bytes=plane_bytes,
     )
+
+
+_DCP_TOPK_CONTRACT_FIELDS = (
+    "version",
+    "topology_world",
+    "topology_supported_world_sizes",
+    "capacity_max_rows",
+    "capacity_max_owner_rows",
+    "capacity_topk",
+    "capacity_candidate_plane_elems",
+    "allocation_slab_bytes",
+    "allocation_slot_bytes",
+    "allocation_plane_bytes",
+    "offset_signal_bytes",
+    "offset_staging0",
+    "offset_staging1",
+    "wire_codec_index",
+    "wire_codec_score",
+    "schedule_max_blocks",
+    "schedule_signal_bytes",
+)
 
 
 def _dcp_topk_runtime_contract(
@@ -186,6 +213,24 @@ def owner_stage_reference(
     )
 
 
+class _ChannelLifecycle(Enum):
+    """Lifecycle state for the IPC channel.
+
+    OPEN — channel accepts launches/captures and is not closing.
+    CLOSING — one thread owns the collective teardown; launches are
+    rejected and concurrent close callers wait for the result.
+    CLOSED — teardown completed successfully; exports are freed.
+    FAILED — teardown failed; imports/exports are retained.  The channel
+    is permanently non-launchable but ``retry_close()`` may re-enter the
+    collective teardown from this state.
+    """
+
+    OPEN = 0
+    CLOSING = 1
+    CLOSED = 2
+    FAILED = 3
+
+
 class _IPCChannel:
     def _init_channel(
         self,
@@ -196,10 +241,18 @@ class _IPCChannel:
         owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
         stream_affine: bool,
     ) -> None:
+        owned_buffers_list = list(owned_buffers or ())
+        if exchange_group is None and any(
+            shared.remote_ptrs for shared in owned_buffers_list
+        ):
+            raise ValueError(
+                "exchange_group is required when the channel owns remote "
+                "CUDA IPC imports"
+            )
         self.device = _normalize_device(device)
         self.exchange_group = exchange_group
         self._ipc = ipc
-        self._owned_buffers = list(owned_buffers or ())
+        self._owned_buffers = owned_buffers_list
         self._stream_affine = bool(stream_affine)
         self._owner_stream_key: Optional[int] = None
         self._closed = False
@@ -207,13 +260,123 @@ class _IPCChannel:
         self._ipc_exports_freed = False
         self._coordinated_close_complete = False
         self._closed_ipc_import_indices: set[tuple[int, int]] = set()
+        self._lifecycle_lock = RLock()
+        self._lifecycle_cond = Condition(self._lifecycle_lock)
+        self._lifecycle_state = _ChannelLifecycle.OPEN
+        self._close_generation = 0
+        self._close_error: Optional[BaseException] = None
+        self._launch_depth = 0
+        self._capture_context_depth = 0
+        self._replay_depth = 0
+        # Graphs registered by this channel for gated replay.
+        self._registered_graphs: set[int] = set()
+        # Collective ticket: set on global init success, never before.
+        self._has_collective_ipc_ticket = False
+
+    # ------------------------------------------------------------------
+    # Launch gate — held from the closed-check through kernel enqueue so
+    # close cannot transition to CLOSING while a launch is in flight.
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def _launch_gate(self):
+        with self._lifecycle_lock:
+            if self._lifecycle_state != _ChannelLifecycle.OPEN:
+                raise RuntimeError(
+                    f"{type(self).__name__} is "
+                    f"{self._lifecycle_state.name.lower()}; cannot stage candidates"
+                )
+            self._launch_depth += 1
+        try:
+            yield
+        finally:
+            with self._lifecycle_lock:
+                self._launch_depth -= 1
+                if self._launch_depth == 0:
+                    self._lifecycle_cond.notify_all()
+
+    # ------------------------------------------------------------------
+    # Replay gate — held while a captured graph replays so close waits.
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def _replay_gate(self):
+        with self._lifecycle_lock:
+            if self._lifecycle_state != _ChannelLifecycle.OPEN:
+                raise RuntimeError(
+                    f"{type(self).__name__} is "
+                    f"{self._lifecycle_state.name.lower()}; cannot replay"
+                )
+            self._replay_depth += 1
+        try:
+            yield
+        finally:
+            with self._lifecycle_lock:
+                self._replay_depth -= 1
+                if self._replay_depth == 0:
+                    self._lifecycle_cond.notify_all()
+
+    # ------------------------------------------------------------------
+    # Close transition — atomically stop launches/replays/captures, wait
+    # for in-flight work, and let one thread enter the collective.
+    # ------------------------------------------------------------------
+
+    def _begin_close(self, *, allow_retry: bool = False) -> bool:
+        """Transition to CLOSING and return True if this caller owns the
+        collective teardown.
+
+        From OPEN: this caller owns the collective.
+        From FAILED with allow_retry=True: this caller owns a retry.
+        From CLOSING: wait for the active generation, observe its result.
+        From CLOSED: return False (idempotent).
+        From FAILED without allow_retry: re-raise the stored error.
+        """
+        with self._lifecycle_lock:
+            if self._lifecycle_state == _ChannelLifecycle.CLOSED:
+                return False
+            if self._lifecycle_state == _ChannelLifecycle.FAILED:
+                if not allow_retry:
+                    assert self._close_error is not None
+                    raise self._close_error
+                # Retry: fall through to claim the collective.
+            elif self._lifecycle_state == _ChannelLifecycle.CLOSING:
+                generation = self._close_generation
+                while (
+                    self._lifecycle_state == _ChannelLifecycle.CLOSING
+                    and self._close_generation == generation
+                ):
+                    self._lifecycle_cond.wait()
+                if self._lifecycle_state == _ChannelLifecycle.FAILED:
+                    assert self._close_error is not None
+                    raise self._close_error
+                return False
+            # Claim the collective.
+            self._lifecycle_state = _ChannelLifecycle.CLOSING
+            self._close_generation += 1
+            self._close_error = None
+            # Wait for in-flight launches, replays, and capture contexts.
+            while (
+                self._launch_depth > 0
+                or self._replay_depth > 0
+                or self._capture_context_depth > 0
+            ):
+                self._lifecycle_cond.wait()
+            return True
+
+    def _finish_close(self, *, error: Optional[BaseException] = None) -> None:
+        """Complete the CLOSING→CLOSED/FAILED transition."""
+        with self._lifecycle_lock:
+            if error is not None:
+                self._lifecycle_state = _ChannelLifecycle.FAILED
+                self._close_error = error
+            else:
+                self._lifecycle_state = _ChannelLifecycle.CLOSED
+                self._coordinated_close_complete = True
+            self._lifecycle_cond.notify_all()
 
     def _bind_stream(self) -> None:
         if not self._stream_affine or self.device.type != "cuda":
             return
-        # CUDA graph capture substitutes a torch-owned capture stream handle
-        # for the logical stream.  Keep affinity bound to the caller's eager
-        # stream so the same channel can be warmed, captured, and reused.
         if _is_current_stream_capturing(self.device):
             return
         stream_key = _current_stream_key(self.device)
@@ -243,6 +406,18 @@ class _IPCChannel:
             for remote_index, _ in enumerate(shared.remote_ptrs)
         )
 
+    def _quiesce_device(self) -> None:
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+    def _has_ipc_exports(self) -> bool:
+        return bool(getattr(self, "_owned_buffers", ()))
+
+    def _has_remote_imports(self) -> bool:
+        return any(
+            shared.remote_ptrs for shared in getattr(self, "_owned_buffers", ())
+        )
+
     def _close_ipc_imports(self) -> None:
         """Legacy best-effort close retained for non-strict callers."""
         if self._ipc_imports_closed:
@@ -256,12 +431,7 @@ class _IPCChannel:
         self._ipc_imports_closed = True
 
     def _close_ipc_imports_strict(self) -> None:
-        """Close every IPC import without suppressing errors.
-
-        Marks the channel closed so it cannot be reused even if unmap fails.
-        Failed imports remain open and observable; ``_ipc_imports_closed`` is
-        only set when every import handle was successfully closed.
-        """
+        """Close every IPC import without suppressing errors."""
         if self._ipc_imports_closed:
             return
         self._closed = True
@@ -306,12 +476,7 @@ class _IPCChannel:
         self._ipc_exports_freed = True
 
     def _free_ipc_exports_strict(self) -> None:
-        """Free exported IPC storage only after all imports are closed.
-
-        Must be called after the collective unmap acknowledgement so no peer
-        retains a usable imported pointer.  Failed frees retain the buffer
-        so the export stays observable and never becomes a silent leak.
-        """
+        """Free exported IPC storage only after all imports are closed."""
         if self._ipc_exports_freed:
             return
         self._close_ipc_imports_strict()
@@ -339,27 +504,146 @@ class _IPCChannel:
         if failures:
             _raise_local_cleanup_errors("PCIe DCP top-k", "IPC export free", failures)
 
-    def close(self) -> None:
-        if self._coordinated_close_complete:
+    def _fail_closed_multi_rank_without_group(self) -> None:
+        """Reject freeing multi-rank IPC exports without a teardown group.
+
+        Only applies when the channel has remote imports (peer pointers to
+        another rank's export).  A channel with only local exports and no
+        remote imports can close without a group.
+        """
+        world_size = getattr(self, "world_size", 1)
+        if (
+            world_size >= 2
+            and self._has_remote_imports()
+            and self.exchange_group is None
+        ):
+            self._closed = True
+            raise RuntimeError(
+                f"{type(self).__name__} has remote IPC imports for "
+                f"world_size={world_size} but no exchange group; cannot "
+                "collectively acknowledge peer unmap before freeing exports"
+            )
+
+    def _coordinated_close(self, *, allow_retry: bool = False) -> None:
+        """Collective teardown with explicit lifecycle state."""
+        if not self._begin_close(allow_retry=allow_retry):
             return
-        _coordinated_close_channels(
-            (self,),
-            exchange_group=self.exchange_group,
-            device=self.device,
-        )
+        error: Optional[BaseException] = None
+        try:
+            self._fail_closed_multi_rank_without_group()
+
+            quiesce_error: BaseException | None = None
+            try:
+                self._quiesce_device()
+            except Exception as exc:
+                quiesce_error = exc
+
+            if self.exchange_group is not None:
+                quiesce_status = _exchange_close_failures(
+                    (str(quiesce_error),) if quiesce_error else (),
+                    exchange_group=self.exchange_group,
+                    phase="DCP top-k quiescence",
+                )
+                if any(quiesce_status):
+                    _raise_coordinated_close_error(
+                        "DCP top-k quiescence",
+                        quiesce_status,
+                        local_errors=(
+                            [(0, quiesce_error)] if quiesce_error else []
+                        ),
+                        exports_retained=True,
+                    )
+                dist.barrier(group=self.exchange_group)
+            elif quiesce_error is not None:
+                raise quiesce_error
+
+            unmap_errors = _run_close_phase(
+                (self,),
+                strict_method="_close_ipc_imports_strict",
+                legacy_method="_close_ipc_imports",
+            )
+            unmap_status = _exchange_close_failures(
+                tuple(
+                    _format_close_error(index, error)
+                    for index, error in unmap_errors
+                ),
+                exchange_group=self.exchange_group,
+                phase="IPC unmap",
+            )
+            if any(unmap_status):
+                _raise_coordinated_close_error(
+                    "IPC unmap",
+                    unmap_status,
+                    local_errors=unmap_errors,
+                    exports_retained=True,
+                )
+
+            if self.exchange_group is not None:
+                dist.barrier(group=self.exchange_group)
+
+            free_errors = _run_close_phase(
+                (self,),
+                strict_method="_free_ipc_exports_strict",
+                legacy_method="_free_ipc_exports",
+            )
+            free_status = _exchange_close_failures(
+                tuple(
+                    _format_close_error(index, error)
+                    for index, error in free_errors
+                ),
+                exchange_group=self.exchange_group,
+                phase="IPC export free",
+            )
+            if any(free_status):
+                _raise_coordinated_close_error(
+                    "IPC export free",
+                    free_status,
+                    local_errors=free_errors,
+                    exports_retained=False,
+                )
+
+            if self.exchange_group is not None:
+                dist.barrier(group=self.exchange_group)
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            self._finish_close(error=error)
+
+    def close(self) -> None:
+        self._coordinated_close()
 
     def close_coordinated(self) -> None:
         """Collectively close peer mappings before freeing exported storage."""
-        if self._coordinated_close_complete:
-            return
-        _coordinated_close_channels(
-            (self,),
-            exchange_group=self.exchange_group,
-            device=self.device,
-        )
+        self._coordinated_close()
 
-    def __del__(self) -> None:
-        return None
+    def retry_close(self) -> None:
+        """Re-enter the collective teardown from FAILED state.
+
+        Launches remain permanently disabled.  Every rank must call this
+        method simultaneously to retry the quiesce/unmap/free phases.
+        """
+        self._coordinated_close(allow_retry=True)
+
+    def __enter__(self) -> "_IPCChannel":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    ) -> None:
+        # GC cannot synchronize or enter a distributed barrier.  Retain
+        # any channel whose collective close did not complete so stale
+        # pointers survive until process teardown.
+        if getattr(self, "_coordinated_close_complete", False):
+            return
+        if self._has_ipc_exports() or getattr(
+            self, "_has_collective_ipc_ticket", False
+        ):
+            _quarantine[id(self)] = self
 
 
 class PCIeDCPTopKOwnerExchange(_IPCChannel):
@@ -425,7 +709,7 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         )
         self._next_slot = 0
         self._graph_slot: Optional[int] = None
-        self._capture_context_depth = 0
+
         candidate_shape = (self.max_owner_rows, self.world_size * self.topk)
         if self.device.type == "cuda":
             self._candidate_views = tuple(
@@ -517,16 +801,19 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
                 layout=layout,
             ),
         )
-        owned: list[_OwnedSharedBuffer] = []
+        slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group,
+            layout.slab_bytes,
+            zero_fill=True,
+            ipc=ipc,
+        )
+        runtime: Optional[PCIeDCPTopKOwnerExchange] = None
+        init_error: BaseException | None = None
         try:
-            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
-                exchange_group,
-                layout.slab_bytes,
-                zero_fill=True,
-                ipc=ipc,
-            )
-            owned.append(slab)
-            return cls(
+            # Construct WITHOUT slab ownership so a partial __init__ failure
+            # does not create a quarantined object with live exports.  The
+            # slab is attached only after the collective init verdict.
+            runtime = cls(
                 rank=rank,
                 world_size=world_size,
                 device=device_obj,
@@ -541,13 +828,36 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
                 topk=topk,
                 exchange_group=exchange_group,
                 ipc=ipc,
-                owned_buffers=owned,
+                owned_buffers=None,
                 ext_module=ext_module,
                 stream_affine=stream_affine,
             )
-        except Exception:
-            _release_failed_allocations(owned, ipc)
-            raise
+        except Exception as exc:
+            init_error = exc
+
+        def detach_shared_ownership() -> None:
+            # On rollback, clear any partial ownership the constructor may
+            # have set (e.g. candidate views) so __del__ does not quarantine
+            # a duplicate.
+            if runtime is not None:
+                runtime._owned_buffers.clear()
+                runtime._candidate_views = ()
+                runtime._has_collective_ipc_ticket = False
+
+        _finish_collective_runtime_setup(
+            owner="PCIe DCP top-k",
+            exchange_group=exchange_group,
+            ipc=ipc,
+            shared=slab,
+            local_error=init_error,
+            detach_shared_ownership=detach_shared_ownership,
+        )
+        assert runtime is not None
+        # Atomically attach the slab and set the collective ticket only on
+        # global init success.
+        runtime._owned_buffers = [slab]
+        runtime._has_collective_ipc_ticket = True
+        return runtime
 
     @classmethod
     def from_process_group(
@@ -588,7 +898,7 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         retired. The barrier stays inside the one transport kernel and
         therefore adds no CUDA graph node.
         """
-        with _device_guard(self.device):
+        with self._launch_gate(), _device_guard(self.device):
             return self._stage_candidates_on_device(
                 local_indices,
                 local_scores,
@@ -598,41 +908,91 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
 
     def prepare_graph(self, *, threads: int = 512) -> None:
         """Compile the exact graph launcher before capture begins."""
-        if self._closed:
-            raise RuntimeError("PCIeDCPTopKOwnerExchange is closed")
-        if _is_current_stream_capturing(self.device):
-            raise RuntimeError("prepare_graph() must be called before CUDA graph capture")
-        _validate_launch_config(
-            threads=int(threads),
-            block_limit=1,
-            world_size=self.world_size,
-        )
-        with _device_guard(self.device):
-            self._bind_stream()
-            from ._dcp_topk_cute import prepare_topk_stage
-
-            prepare_topk_stage(
-                self.world_size,
-                self.rank,
-                self.topk,
-                int(threads),
+        with self._launch_gate():
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "prepare_graph() must be called before CUDA graph capture"
+                )
+            _validate_launch_config(
+                threads=int(threads),
+                block_limit=1,
+                world_size=self.world_size,
             )
+            with _device_guard(self.device):
+                self._bind_stream()
+                from ._dcp_topk_cute import prepare_topk_stage
+
+                prepare_topk_stage(
+                    self.world_size,
+                    self.rank,
+                    self.topk,
+                    int(threads),
+                )
 
     @contextmanager
     def capture(self, *, threads: int = 512):
         """Own one serialized graph capture without adding graph nodes.
 
-        Enter this context before ``torch.cuda.graph``. Graphs captured from
-        this instance share one epoch and must never replay concurrently.
+        Enter this context before ``torch.cuda.graph`` and call
+        :meth:`register_graph` after capture. Graphs captured from this
+        instance share one epoch and must never replay concurrently through
+        any path other than :meth:`replay`. Close cannot run while a capture
+        context is active.
         """
-        if self._capture_context_depth:
-            raise RuntimeError("overlapping DCP top-k capture contexts are not allowed")
-        self.prepare_graph(threads=threads)
-        self._capture_context_depth = 1
+        # Atomically reserve the capture token under the lifecycle lock.
+        # This prevents close from transitioning to CLOSING between the
+        # OPEN check and the depth increment.
+        with self._lifecycle_lock:
+            if self._lifecycle_state != _ChannelLifecycle.OPEN:
+                raise RuntimeError(
+                    f"{type(self).__name__} is "
+                    f"{self._lifecycle_state.name.lower()}; cannot capture"
+                )
+            if self._capture_context_depth:
+                raise RuntimeError(
+                    "overlapping DCP top-k capture contexts are not allowed"
+                )
+            self._capture_context_depth = 1
+        try:
+            self.prepare_graph(threads=threads)
+        except Exception:
+            with self._lifecycle_lock:
+                self._capture_context_depth = 0
+                self._lifecycle_cond.notify_all()
+            raise
         try:
             yield self
         finally:
-            self._capture_context_depth = 0
+            with self._lifecycle_lock:
+                self._capture_context_depth = 0
+                self._lifecycle_cond.notify_all()
+
+    def register_graph(self, graph: torch.cuda.CUDAGraph) -> None:
+        """Register a captured CUDA graph for gated replay.
+
+        The channel tracks registered graphs so close can wait for active
+        replays and prevent use-after-free of captured staging pointers.
+        """
+        with self._lifecycle_lock:
+            if self._lifecycle_state != _ChannelLifecycle.OPEN:
+                raise RuntimeError(
+                    f"{type(self).__name__} is "
+                    f"{self._lifecycle_state.name.lower()}; cannot register graph"
+                )
+            self._registered_graphs.add(id(graph))
+
+    def replay(self, graph: torch.cuda.CUDAGraph) -> None:
+        """Replay a registered CUDA graph under the lifecycle gate.
+
+        Close cannot quiesce or free while a replay is in flight.
+        """
+        with self._replay_gate():
+            if id(graph) not in self._registered_graphs:
+                raise RuntimeError(
+                    "graph was not registered with this channel; call "
+                    "register_graph() after capture"
+                )
+            graph.replay()
 
     def _stage_candidates_on_device(
         self,
@@ -642,8 +1002,6 @@ class PCIeDCPTopKOwnerExchange(_IPCChannel):
         threads: int,
         block_limit: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self._closed:
-            raise RuntimeError("PCIeDCPTopKOwnerExchange is closed")
         if local_indices.device != self.device or local_scores.device != self.device:
             raise ValueError("inputs must be on the runtime device")
         if local_indices.dtype != torch.int32:

--- a/b12x/comm/pcie/pcie_dcp_topk.py
+++ b/b12x/comm/pcie/pcie_dcp_topk.py
@@ -22,6 +22,7 @@ from .pcie_oneshot import (
     _is_current_stream_capturing,
     _normalize_device,
     _OwnedSharedBuffer,
+    _raise_local_cleanup_errors,
 )
 
 
@@ -153,6 +154,8 @@ class _IPCChannel:
         self._closed = False
         self._ipc_imports_closed = False
         self._ipc_exports_freed = False
+        self._coordinated_close_complete = False
+        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
 
     def _bind_stream(self) -> None:
         if not self._stream_affine or self.device.type != "cuda":
@@ -173,7 +176,24 @@ class _IPCChannel:
                 "per CUDA stream"
             )
 
+    def _closed_import_indices(self) -> set[tuple[int, int]]:
+        closed = getattr(self, "_closed_ipc_import_indices", None)
+        if closed is None:
+            closed = set()
+            self._closed_ipc_import_indices = closed
+        return closed
+
+    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
+        if self._ipc is None:
+            return not any(shared.remote_ptrs for shared in self._owned_buffers)
+        return all(
+            (buffer_index, remote_index) in closed
+            for buffer_index, shared in enumerate(self._owned_buffers)
+            for remote_index, _ in enumerate(shared.remote_ptrs)
+        )
+
     def _close_ipc_imports(self) -> None:
+        """Legacy best-effort close retained for non-strict callers."""
         if self._ipc_imports_closed:
             return
         self._closed = True
@@ -184,7 +204,45 @@ class _IPCChannel:
                         self._ipc.cudaIpcCloseMemHandle(ptr)
         self._ipc_imports_closed = True
 
+    def _close_ipc_imports_strict(self) -> None:
+        """Close every IPC import without suppressing errors.
+
+        Marks the channel closed so it cannot be reused even if unmap fails.
+        Failed imports remain open and observable; ``_ipc_imports_closed`` is
+        only set when every import handle was successfully closed.
+        """
+        if self._ipc_imports_closed:
+            return
+        self._closed = True
+        failures: list[tuple[str, Exception]] = []
+        closed = self._closed_import_indices()
+        if self._ipc is not None:
+            for buffer_index, shared in enumerate(self._owned_buffers):
+                for remote_index, ptr in enumerate(shared.remote_ptrs):
+                    key = (buffer_index, remote_index)
+                    if key in closed:
+                        continue
+                    try:
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                    except Exception as exc:
+                        failures.append((f"CUDA IPC import {ptr}", exc))
+                    else:
+                        closed.add(key)
+        elif any(shared.remote_ptrs for shared in self._owned_buffers):
+            failures.append(
+                (
+                    "CUDA IPC imports",
+                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
+                )
+            )
+
+        if not failures and self._all_python_ipc_imports_closed(closed):
+            self._ipc_imports_closed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe DCP top-k", "IPC import close", failures)
+
     def _free_ipc_exports(self) -> None:
+        """Legacy best-effort free retained for non-strict callers."""
         if self._ipc_exports_freed:
             return
         self._close_ipc_imports()
@@ -196,7 +254,43 @@ class _IPCChannel:
         self._owned_buffers.clear()
         self._ipc_exports_freed = True
 
+    def _free_ipc_exports_strict(self) -> None:
+        """Free exported IPC storage only after all imports are closed.
+
+        Must be called after the collective unmap acknowledgement so no peer
+        retains a usable imported pointer.  Failed frees retain the buffer
+        so the export stays observable and never becomes a silent leak.
+        """
+        if self._ipc_exports_freed:
+            return
+        self._close_ipc_imports_strict()
+        failures: list[tuple[str, Exception]] = []
+        remaining: list[_OwnedSharedBuffer] = []
+        self._candidate_views = ()
+        if self._ipc is not None:
+            for shared in self._owned_buffers:
+                try:
+                    self._ipc.cudaFree(shared.local_ptr)
+                except Exception as exc:
+                    remaining.append(shared)
+                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
+        elif self._owned_buffers:
+            remaining = list(self._owned_buffers)
+            failures.append(
+                (
+                    "CUDA IPC exports",
+                    RuntimeError("CUDA runtime is unavailable for export free"),
+                )
+            )
+        self._owned_buffers = remaining
+        if not remaining:
+            self._ipc_exports_freed = True
+        if failures:
+            _raise_local_cleanup_errors("PCIe DCP top-k", "IPC export free", failures)
+
     def close(self) -> None:
+        if self._coordinated_close_complete:
+            return
         _coordinated_close_channels(
             (self,),
             exchange_group=self.exchange_group,
@@ -205,6 +299,8 @@ class _IPCChannel:
 
     def close_coordinated(self) -> None:
         """Collectively close peer mappings before freeing exported storage."""
+        if self._coordinated_close_complete:
+            return
         _coordinated_close_channels(
             (self,),
             exchange_group=self.exchange_group,

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -1,0 +1,79 @@
+"""CUTLASS compatibility for CPU-only communication test collection."""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+CUTLASS_STUBBED = False
+
+
+def _stub_cutlass():
+    global CUTLASS_STUBBED
+    try:
+        cutlass = importlib.import_module("cutlass")
+        cute = importlib.import_module("cutlass.cute")
+        llvm = importlib.import_module("cutlass._mlir.dialects.llvm")
+        cutlass_dsl = importlib.import_module("cutlass.cutlass_dsl")
+    except (ImportError, AttributeError):
+        cutlass = None
+    if cutlass is not None and all(
+        hasattr(cutlass, name)
+        for name in (
+            "Float32",
+            "Int32",
+            "Int64",
+            "Uint8",
+            "Uint16",
+            "Uint32",
+            "Uint64",
+        )
+    ) and all(
+        (
+            hasattr(cute, "jit"),
+            hasattr(llvm, "inline_asm"),
+            hasattr(cutlass_dsl, "dsl_user_op"),
+        )
+    ):
+        return
+
+    cutlass = types.ModuleType("cutlass")
+    for name in (
+        "Float32",
+        "Int32",
+        "Int64",
+        "Uint8",
+        "Uint16",
+        "Uint32",
+        "Uint64",
+    ):
+        setattr(cutlass, name, type(name, (), {}))
+    cutlass._mlir = types.ModuleType("cutlass._mlir")
+    cutlass._mlir.dialects = types.ModuleType("cutlass._mlir.dialects")
+    cutlass._mlir.dialects.llvm = types.ModuleType("cutlass._mlir.dialects.llvm")
+    cutlass._mlir.dialects.llvm.inline_asm = lambda *a, **k: None
+    cutlass._mlir.dialects.llvm.AsmDialect = types.SimpleNamespace(AD_ATT=0)
+    cutlass.cute = types.ModuleType("cutlass.cute")
+    cutlass.cute.jit = lambda f: f
+    cutlass.cutlass_dsl = types.ModuleType("cutlass.cutlass_dsl")
+    cutlass.cutlass_dsl.T = type("T", (), {})
+    cutlass.cutlass_dsl.dsl_user_op = lambda f: f
+    cutlass.__b12x_test_stub__ = True
+    sys.modules["cutlass"] = cutlass
+    sys.modules["cutlass.cute"] = cutlass.cute
+    sys.modules["cutlass._mlir"] = cutlass._mlir
+    sys.modules["cutlass._mlir.dialects"] = cutlass._mlir.dialects
+    sys.modules["cutlass._mlir.dialects.llvm"] = cutlass._mlir.dialects.llvm
+    sys.modules["cutlass.cutlass_dsl"] = cutlass.cutlass_dsl
+    CUTLASS_STUBBED = True
+
+
+_stub_cutlass()
+
+
+@pytest.fixture
+def require_real_cutlass():
+    if CUTLASS_STUBBED:
+        pytest.skip("real CUTLASS DSL is required; collection stub is active")

--- a/tests/comm/test_pcie_dcp_topk.py
+++ b/tests/comm/test_pcie_dcp_topk.py
@@ -211,3 +211,213 @@ def test_configuration_rejects_invalid_capacity_and_topk():
             max_rows=6,
             topk=4,
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #178: collective DCP Top-K contract agreement before IPC allocation.
+# ---------------------------------------------------------------------------
+#
+# The tests below verify that every rank exchanges and compares a versioned
+# fixed-schema contract *before* any cudaIpcOpenMemHandle occurs.  A
+# single-field mismatch in capacity, offset, wire mode/codec, topology, or
+# schedule must fail every rank coherently.  An exact match must proceed to
+# allocation.
+
+from b12x.comm.pcie import pcie_dcp_topk as _topk_mod
+from b12x.comm.pcie import pcie_oneshot as _oneshot_mod
+
+
+def _base_contract() -> tuple:
+    """Return the canonical contract for world=2, max_rows=8, topk=4."""
+    layout = _candidate_staging_layout(
+        signal_bytes=_SIGNAL_BYTES,
+        max_rows=8,
+        topk=4,
+        world_size=2,
+    )
+    return _topk_mod._dcp_topk_runtime_contract(
+        world_size=2,
+        max_rows=8,
+        topk=4,
+        layout=layout,
+    )
+
+
+def _patch_factory_gates(monkeypatch, *, peer_contract: tuple) -> None:
+    """Monkeypatch collective gates so a 2-rank exchange can run on CPU.
+
+    * ``dist.get_rank`` / ``get_world_size`` report a 2-rank group.
+    * ``_run_collective_preallocation_setup`` runs ``setup()`` immediately.
+    * ``_require_full_grid_residency`` is a no-op (CPU test).
+    * ``_broadcast_gather_object`` returns ``[local, peer]`` so the local
+      rank sees a mismatched peer contract.
+    * ``_allocate_shared_buffer`` is patched to ``pytest.fail`` so the test
+      proves the contract check fires *before* IPC allocation.
+    """
+    monkeypatch.setattr(_topk_mod.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(_topk_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        _topk_mod,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(
+        _topk_mod,
+        "_require_full_grid_residency",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        _topk_mod,
+        "CudaRTLibrary",
+        lambda: type("FakeIPC", (), {
+            "cudaSetDevice": lambda self, device: None,
+        })(),
+    )
+    monkeypatch.setattr(
+        _oneshot_mod,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, peer_contract],
+    )
+    monkeypatch.setattr(
+        _oneshot_mod.PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        lambda *args, **kwargs: pytest.fail(
+            "IPC allocation must not start when the contract mismatches"
+        ),
+    )
+
+
+def _contract_field_index(field: str) -> int:
+    """Return the position of a named field in the contract tuple."""
+    layout = _candidate_staging_layout(
+        signal_bytes=_SIGNAL_BYTES,
+        max_rows=8,
+        topk=4,
+        world_size=2,
+    )
+    canonical = _topk_mod._dcp_topk_runtime_contract(
+        world_size=2,
+        max_rows=8,
+        topk=4,
+        layout=layout,
+    )
+
+    replacements: dict[str, tuple] = (
+        ("capacity_max_rows", (3,)),
+        ("capacity_topk", (5,)),
+        ("offset_staging0", (11,)),
+        ("offset_staging1", (12,)),
+        ("wire_codec_index", (13,)),
+        ("wire_codec_score", (14,)),
+        ("topology_world", (1,)),
+        ("schedule_max_blocks", (15,)),
+        ("schedule_signal_bytes", (16,)),
+    )
+    if field not in replacements:
+        raise KeyError(f"unknown field {field}")
+    (idx,) = replacements[field]
+    assert 0 <= idx < len(canonical), f"field {field} index out of range"
+    return idx
+
+
+def _mismatched_contract(field: str) -> tuple:
+    """Return a contract that differs from the canonical one in exactly one field."""
+    contract = list(_base_contract())
+    idx = _contract_field_index(field)
+    original = contract[idx]
+    if isinstance(original, int):
+        contract[idx] = original + 1
+    elif isinstance(original, str):
+        contract[idx] = original + "_mismatched"
+    elif isinstance(original, tuple):
+        contract[idx] = original + (999,)
+    else:
+        contract[idx] = "__MISMATCHED__"
+    return tuple(contract)
+
+
+@pytest.mark.parametrize(
+    "field, label",
+    [
+        ("capacity_max_rows", "capacity"),
+        ("capacity_topk", "capacity"),
+        ("offset_staging0", "offset"),
+        ("offset_staging1", "offset"),
+        ("wire_codec_index", "wire mode/codec"),
+        ("wire_codec_score", "wire mode/codec"),
+        ("topology_world", "topology"),
+        ("schedule_max_blocks", "schedule"),
+        ("schedule_signal_bytes", "schedule"),
+    ],
+)
+def test_contract_single_field_mismatch_fails_before_ipc_allocation(
+    monkeypatch, field, label,
+):
+    """A single-field mismatch in {label} must fail every rank before
+    cudaIpcOpenMemHandle."""
+    _patch_factory_gates(monkeypatch, peer_contract=_mismatched_contract(field))
+    with pytest.raises(RuntimeError, match="contract differs across ranks"):
+        PCIeDCPTopKOwnerExchange.from_exchange_group(
+            exchange_group=object(),
+            device=torch.device("cuda:0"),
+            max_rows=8,
+            topk=4,
+        )
+
+
+def test_contract_exact_match_proceeds_to_allocation(monkeypatch):
+    """When every field matches, the factory must proceed past the contract
+    check to IPC allocation."""
+    shared = _oneshot_mod._OwnedSharedBuffer(
+        local_ptr=1000,
+        peer_ptrs=(1000, 2000),
+        remote_ptrs=(2000,),
+    )
+
+    class FakeIPC:
+        def cudaSetDevice(self, device):
+            pass
+        def cudaFree(self, ptr):
+            pass
+        def cudaIpcCloseMemHandle(self, ptr):
+            pass
+
+    monkeypatch.setattr(_topk_mod.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(_topk_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        _topk_mod,
+        "_run_collective_preallocation_setup",
+        lambda **kwargs: kwargs["setup"](),
+    )
+    monkeypatch.setattr(
+        _topk_mod,
+        "_require_full_grid_residency",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        _oneshot_mod,
+        "_broadcast_gather_object",
+        lambda contract, group: [contract, contract],
+    )
+    monkeypatch.setattr(
+        _oneshot_mod.PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        lambda *args, **kwargs: shared,
+    )
+    monkeypatch.setattr(_topk_mod, "CudaRTLibrary", lambda: FakeIPC())
+    monkeypatch.setattr(
+        _topk_mod,
+        "_tensor_from_cuda_pointer",
+        lambda ptr, shape, **kwargs: torch.empty(shape, dtype=kwargs.get("dtype", torch.int32)),
+    )
+
+    owner = PCIeDCPTopKOwnerExchange.from_exchange_group(
+        exchange_group=object(),
+        device=torch.device("cuda:0"),
+        max_rows=8,
+        topk=4,
+    )
+    assert owner.world_size == 2
+    assert owner.max_rows == 8
+    assert owner.topk == 4
+    owner._coordinated_close_complete = True

--- a/tests/comm/test_pcie_dcp_topk.py
+++ b/tests/comm/test_pcie_dcp_topk.py
@@ -289,35 +289,15 @@ def _patch_factory_gates(monkeypatch, *, peer_contract: tuple) -> None:
 
 def _contract_field_index(field: str) -> int:
     """Return the position of a named field in the contract tuple."""
-    layout = _candidate_staging_layout(
-        signal_bytes=_SIGNAL_BYTES,
-        max_rows=8,
-        topk=4,
-        world_size=2,
+    fields = _topk_mod._DCP_TOPK_CONTRACT_FIELDS
+    canonical = _base_contract()
+    assert len(fields) == len(canonical), (
+        "runtime contract values and field schema must stay aligned"
     )
-    canonical = _topk_mod._dcp_topk_runtime_contract(
-        world_size=2,
-        max_rows=8,
-        topk=4,
-        layout=layout,
-    )
-
-    replacements: dict[str, tuple] = (
-        ("capacity_max_rows", (3,)),
-        ("capacity_topk", (5,)),
-        ("offset_staging0", (11,)),
-        ("offset_staging1", (12,)),
-        ("wire_codec_index", (13,)),
-        ("wire_codec_score", (14,)),
-        ("topology_world", (1,)),
-        ("schedule_max_blocks", (15,)),
-        ("schedule_signal_bytes", (16,)),
-    )
-    if field not in replacements:
-        raise KeyError(f"unknown field {field}")
-    (idx,) = replacements[field]
-    assert 0 <= idx < len(canonical), f"field {field} index out of range"
-    return idx
+    try:
+        return fields.index(field)
+    except ValueError:
+        raise KeyError(f"unknown field {field}") from None
 
 
 def _mismatched_contract(field: str) -> tuple:

--- a/tests/comm/test_pcie_dcp_topk_gpu.py
+++ b/tests/comm/test_pcie_dcp_topk_gpu.py
@@ -15,10 +15,13 @@ from b12x.comm.pcie.pcie_dcp_topk import (
 )
 
 
-pytestmark = pytest.mark.skipif(
-    os.getenv("B12X_RUN_PCIE_DCP_TOPK_TEST") != "1",
-    reason="set B12X_RUN_PCIE_DCP_TOPK_TEST=1 to run GPU tests",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("B12X_RUN_PCIE_DCP_TOPK_TEST") != "1",
+        reason="set B12X_RUN_PCIE_DCP_TOPK_TEST=1 to run GPU tests",
+    ),
+    pytest.mark.usefixtures("require_real_cutlass"),
+]
 
 MAX_ROWS = 64
 TOPK = 2048
@@ -197,6 +200,7 @@ def _worker(
         # contributes the only additional kernel; the two consumers are memcpy
         # nodes. The fixed-slot safety barrier is part of the transport kernel.
         assert _cuda_graph_kernel_count(graph) == 1 + int(dcp_rank == 0)
+        graph_owner.register_graph(graph)
         assert graph_owner._graph_slot is not None
         graph_views = graph_owner._candidate_views[graph_owner._graph_slot]
         assert (
@@ -227,7 +231,7 @@ def _worker(
             next_indices, next_scores = replay_inputs[replay_idx]
             graph_indices.copy_(next_indices)
             graph_scores.copy_(next_scores)
-            graph.replay()
+            graph_owner.replay(graph)
             replayed_indices[replay_idx].copy_(consumed_indices)
             replayed_scores[replay_idx].copy_(consumed_scores)
         torch.cuda.synchronize(device)

--- a/tests/comm/test_pcie_dcp_topk_lifecycle.py
+++ b/tests/comm/test_pcie_dcp_topk_lifecycle.py
@@ -1,0 +1,400 @@
+"""Focused lifecycle/close tests for the DCP top-k IPC channel.
+
+These tests prove the collective teardown ordering and error-propagation
+contract required by issue #181:
+
+* No export free (``cudaFree``) precedes every peer unmap acknowledgement
+  (``cudaIpcCloseMemHandle``).
+* Forced unmap, free, and collective-exchange failures propagate as
+  ``RuntimeError`` and leave the channel non-reusable without freeing
+  unsafe exports.
+* Double, out-of-order, and concurrent close cannot reuse stale pointers
+  or silently succeed.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+import torch
+
+from b12x.comm.pcie.pcie_dcp_topk import PCIeDCPTopKOwnerExchange
+from b12x.comm.pcie.pcie_oneshot import _OwnedSharedBuffer
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeIPC:
+    """Records close/free calls and optionally injects failures.
+
+    ``events`` records every call in order as ``("close", ptr)`` or
+    ``("free", ptr)`` so tests can assert exact teardown ordering.
+    """
+
+    def __init__(
+        self,
+        *,
+        close_fail_ptrs: Sequence[int] = (),
+        free_fail_ptrs: Sequence[int] = (),
+    ) -> None:
+        self.events: list[tuple[str, int]] = []
+        self._close_fail = set(close_fail_ptrs)
+        self._free_fail = set(free_fail_ptrs)
+
+    @property
+    def closed(self) -> list[int]:
+        return [ptr for op, ptr in self.events if op == "close"]
+
+    @property
+    def freed(self) -> list[int]:
+        return [ptr for op, ptr in self.events if op == "free"]
+
+    def cudaIpcCloseMemHandle(self, ptr: int) -> None:
+        self.events.append(("close", ptr))
+        if ptr in self._close_fail:
+            raise RuntimeError(f"injected unmap failure for ptr {ptr}")
+
+    def cudaFree(self, ptr: int) -> None:
+        self.events.append(("free", ptr))
+        if ptr in self._free_fail:
+            raise RuntimeError(f"injected free failure for ptr {ptr}")
+
+
+def _make_channel(
+    ipc: _FakeIPC | None,
+    owned: Sequence[_OwnedSharedBuffer],
+    *,
+    exchange_group=None,
+) -> PCIeDCPTopKOwnerExchange:
+    """Construct a CPU DCP top-k channel with injected IPC and buffers."""
+    ch = PCIeDCPTopKOwnerExchange(
+        rank=0,
+        world_size=2,
+        device="cpu",
+        signal_ptrs=(10, 20),
+        staging0_ptrs=(30, 40),
+        staging1_ptrs=(62, 72),
+        max_rows=8,
+        topk=4,
+        ipc=ipc,
+        owned_buffers=owned,
+        exchange_group=exchange_group,
+        stream_affine=False,
+    )
+    return ch
+
+
+def _buffers() -> list[_OwnedSharedBuffer]:
+    return [
+        _OwnedSharedBuffer(local_ptr=1000, peer_ptrs=(1000, 2000), remote_ptrs=(2000,)),
+        _OwnedSharedBuffer(local_ptr=3000, peer_ptrs=(3000, 4000), remote_ptrs=(4000,)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Ordering: unmap before free
+# ---------------------------------------------------------------------------
+
+
+def test_close_unmaps_all_imports_before_freeing_any_export():
+    """Every cudaIpcCloseMemHandle must precede every cudaFree."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    ch.close()
+
+    # All remote pointers were closed.
+    assert sorted(ipc.closed) == [2000, 4000]
+    # All local pointers were freed.
+    assert sorted(ipc.freed) == [1000, 3000]
+    # The event log proves all closes precede all frees.
+    close_events = [i for i, (op, _) in enumerate(ipc.events) if op == "close"]
+    free_events = [i for i, (op, _) in enumerate(ipc.events) if op == "free"]
+    assert max(close_events) < min(free_events)
+    assert ch._coordinated_close_complete
+    assert ch._ipc_imports_closed
+    assert ch._ipc_exports_freed
+
+
+def test_unmap_failure_blocks_all_export_frees():
+    """If any unmap fails, no cudaFree is called on any buffer."""
+    ipc = _FakeIPC(close_fail_ptrs=(2000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch.close()
+
+    # The failing import was attempted but the other succeeded.
+    assert 2000 in ipc.closed
+    assert 4000 in ipc.closed
+    # Critical: NO export was freed.
+    assert ipc.freed == []
+    # Channel is closed (non-reusable) but exports are NOT freed.
+    assert ch._closed
+    assert not ch._ipc_exports_freed
+    assert not ch._coordinated_close_complete
+    # Owned buffers are retained.
+    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
+
+
+def test_free_failure_retains_export_and_propagates():
+    """If a free fails, the buffer is retained and the error propagates."""
+    ipc = _FakeIPC(free_fail_ptrs=(1000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC export free"):
+        ch.close()
+
+    # Unmap succeeded for all.
+    assert sorted(ipc.closed) == [2000, 4000]
+    # Free was attempted.
+    assert 1000 in ipc.freed
+    assert 3000 in ipc.freed
+    # The failing export is retained.
+    assert 1000 in [b.local_ptr for b in ch._owned_buffers]
+    assert 3000 not in [b.local_ptr for b in ch._owned_buffers]
+    assert not ch._ipc_exports_freed
+    assert not ch._coordinated_close_complete
+
+
+def test_unmap_failure_on_second_buffer_still_closes_first():
+    """Partial unmap success is tracked; failed imports remain open."""
+    ipc = _FakeIPC(close_fail_ptrs=(4000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch.close()
+
+    assert 2000 in ipc.closed  # succeeded
+    assert 4000 in ipc.closed  # attempted
+    assert ipc.freed == []
+    # The successfully closed import is tracked; the failed one is not.
+    assert (0, 0) in ch._closed_ipc_import_indices  # buffer 0, remote 0
+    assert (1, 0) not in ch._closed_ipc_import_indices  # buffer 1, remote 0
+
+
+# ---------------------------------------------------------------------------
+# Error propagation: no suppression
+# ---------------------------------------------------------------------------
+
+
+def test_no_ipc_runtime_blocks_unmap_and_free():
+    """Missing CUDA runtime prevents both unmap and free with errors."""
+    ch = _make_channel(None, _buffers())
+
+    with pytest.raises(RuntimeError, match="CUDA runtime is unavailable for IPC unmap"):
+        ch.close()
+
+    assert ch._closed
+    assert not ch._ipc_imports_closed
+    assert not ch._ipc_exports_freed
+    assert not ch._coordinated_close_complete
+    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
+
+
+def test_free_failure_after_successful_unmap_retains_buffer():
+    """Free failure after full unmap success retains the export."""
+    ipc = _FakeIPC(free_fail_ptrs=(3000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC export free"):
+        ch.close()
+
+    assert sorted(ipc.closed) == [2000, 4000]
+    assert sorted(ipc.freed) == [1000, 3000]
+    # 1000 freed, 3000 retained.
+    assert [b.local_ptr for b in ch._owned_buffers] == [3000]
+    assert ch._ipc_imports_closed
+    assert not ch._ipc_exports_freed
+
+
+# ---------------------------------------------------------------------------
+# Double / out-of-order / concurrent close
+# ---------------------------------------------------------------------------
+
+
+def test_double_close_is_idempotent():
+    """A second close() does not issue additional IPC calls."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    ch.close()
+    assert ch._coordinated_close_complete
+
+    first_closed = list(ipc.closed)
+    first_freed = list(ipc.freed)
+
+    ch.close()  # should be a no-op
+
+    assert ipc.closed == first_closed
+    assert ipc.freed == first_freed
+    assert ch._coordinated_close_complete
+
+
+def test_close_coordinated_is_also_idempotent():
+    """close_coordinated() respects the same completion guard."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    ch.close_coordinated()
+    assert ch._coordinated_close_complete
+
+    first_closed = list(ipc.closed)
+    first_freed = list(ipc.freed)
+
+    ch.close_coordinated()
+
+    assert ipc.closed == first_closed
+    assert ipc.freed == first_freed
+
+
+def test_closed_channel_cannot_stage_candidates():
+    """After close, stage_candidates raises RuntimeError, not silent reuse."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+    ch.close()
+    assert ch._closed
+
+    indices = torch.zeros(8, 4, dtype=torch.int32)
+    scores = torch.zeros(8, 4, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="closed"):
+        ch.stage_candidates(indices, scores)
+
+
+def test_failed_close_channel_cannot_stage_candidates():
+    """A channel whose unmap failed is closed and cannot be reused."""
+    ipc = _FakeIPC(close_fail_ptrs=(2000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch.close()
+
+    assert ch._closed
+    indices = torch.zeros(8, 4, dtype=torch.int32)
+    scores = torch.zeros(8, 4, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="closed"):
+        ch.stage_candidates(indices, scores)
+
+
+def test_close_after_partial_unmap_failure_does_not_free_exports():
+    """Retrying close after a partial unmap failure does not free exports."""
+    ipc = _FakeIPC(close_fail_ptrs=(2000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch.close()
+
+    # Exports are still alive.
+    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
+    assert ipc.freed == []
+
+    # Even if we fix the IPC and retry, the channel should not silently free
+    # without going through the coordinated protocol again.  Since
+    # _coordinated_close_complete is False, close() re-enters the protocol.
+    ipc._close_fail = set()  # fix the failure
+    ch.close()
+    # Now the retry should succeed and free everything.
+    assert ch._coordinated_close_complete
+    assert sorted(ipc.freed) == [1000, 3000]
+
+
+def test_concurrent_close_does_not_double_free():
+    """Two close() calls on a channel that completes simultaneously do not
+    issue duplicate IPC calls."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    # Simulate concurrent close: the completion guard makes the second a no-op.
+    ch.close()
+    # Manually simulate a racing second close that sees the flag after the
+    # first has set it.
+    assert ch._coordinated_close_complete
+    ch.close()
+
+    assert len(ipc.closed) == 2  # exactly 2 remote pointers, once each
+    assert len(ipc.freed) == 2  # exactly 2 local pointers, once each
+
+
+def test_out_of_order_close_retains_exports_until_unmap_acknowledged():
+    """A channel closed before its peer unmapped must not free exports."""
+    ipc = _FakeIPC(close_fail_ptrs=(2000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch.close()
+
+    # The export for the buffer whose import failed to close is still alive.
+    assert any(b.local_ptr == 1000 for b in ch._owned_buffers)
+    assert any(b.local_ptr == 3000 for b in ch._owned_buffers)
+    assert ipc.freed == []
+
+
+# ---------------------------------------------------------------------------
+# Strict method direct invocation
+# ---------------------------------------------------------------------------
+
+
+def test_strict_unmap_direct_propagates_error():
+    ipc = _FakeIPC(close_fail_ptrs=(2000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        ch._close_ipc_imports_strict()
+
+    assert ch._closed
+    assert not ch._ipc_imports_closed
+    assert ipc.freed == []
+
+
+def test_strict_free_direct_propagates_error():
+    ipc = _FakeIPC(free_fail_ptrs=(1000,))
+    ch = _make_channel(ipc, _buffers())
+
+    with pytest.raises(RuntimeError, match="IPC export free"):
+        ch._free_ipc_exports_strict()
+
+    assert 1000 in [b.local_ptr for b in ch._owned_buffers]
+    assert not ch._ipc_exports_freed
+
+
+def test_strict_unmap_idempotent_after_success():
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    ch._close_ipc_imports_strict()
+    assert ch._ipc_imports_closed
+    first_closed = list(ipc.closed)
+
+    ch._close_ipc_imports_strict()  # should be no-op
+    assert ipc.closed == first_closed
+
+
+def test_strict_free_idempotent_after_success():
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+
+    ch._close_ipc_imports_strict()
+    ch._free_ipc_exports_strict()
+    assert ch._ipc_exports_freed
+    first_freed = list(ipc.freed)
+
+    ch._free_ipc_exports_strict()  # should be no-op
+    assert ipc.freed == first_freed
+
+
+def test_candidate_views_cleared_on_free():
+    """Freeing exports clears candidate views so stale tensors are released."""
+    ipc = _FakeIPC()
+    ch = _make_channel(ipc, _buffers())
+    # CPU channels start with empty candidate views.
+    ch._candidate_views = (
+        (torch.empty(1, dtype=torch.int32), torch.empty(1, dtype=torch.float32)),
+    )
+    assert ch._candidate_views
+
+    ch.close()
+    assert ch._candidate_views == ()

--- a/tests/comm/test_pcie_dcp_topk_lifecycle.py
+++ b/tests/comm/test_pcie_dcp_topk_lifecycle.py
@@ -1,26 +1,25 @@
 """Focused lifecycle/close tests for the DCP top-k IPC channel.
 
-These tests prove the collective teardown ordering and error-propagation
-contract required by issue #181:
-
-* No export free (``cudaFree``) precedes every peer unmap acknowledgement
-  (``cudaIpcCloseMemHandle``).
-* Forced unmap, free, and collective-exchange failures propagate as
-  ``RuntimeError`` and leave the channel non-reusable without freeing
-  unsafe exports.
-* Double, out-of-order, and concurrent close cannot reuse stale pointers
-  or silently succeed.
+Issue #181: collective teardown ordering, error propagation, lifecycle state,
+retry from FAILED, launch/replay/capture exclusion, destructor quarantine.
 """
 
 from __future__ import annotations
 
-from typing import Sequence
+import gc
+import threading
 
 import pytest
 import torch
 
-from b12x.comm.pcie.pcie_dcp_topk import PCIeDCPTopKOwnerExchange
-from b12x.comm.pcie.pcie_oneshot import _OwnedSharedBuffer
+from b12x.comm.pcie.pcie_dcp_topk import (
+    PCIeDCPTopKOwnerExchange,
+    _ChannelLifecycle,
+)
+from b12x.comm.pcie.pcie_oneshot import (
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+    _OwnedSharedBuffer,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -29,372 +28,747 @@ from b12x.comm.pcie.pcie_oneshot import _OwnedSharedBuffer
 
 
 class _FakeIPC:
-    """Records close/free calls and optionally injects failures.
-
-    ``events`` records every call in order as ``("close", ptr)`` or
-    ``("free", ptr)`` so tests can assert exact teardown ordering.
-    """
-
     def __init__(
-        self,
-        *,
-        close_fail_ptrs: Sequence[int] = (),
-        free_fail_ptrs: Sequence[int] = (),
+        self, *, close_fail: int = 0, free_fail: int = 0
     ) -> None:
         self.events: list[tuple[str, int]] = []
-        self._close_fail = set(close_fail_ptrs)
-        self._free_fail = set(free_fail_ptrs)
+        self._cf = close_fail
+        self._ff = free_fail
 
     @property
-    def closed(self) -> list[int]:
-        return [ptr for op, ptr in self.events if op == "close"]
+    def closed(self):
+        return [p for op, p in self.events if op == "close"]
 
     @property
-    def freed(self) -> list[int]:
-        return [ptr for op, ptr in self.events if op == "free"]
+    def freed(self):
+        return [p for op, p in self.events if op == "free"]
 
-    def cudaIpcCloseMemHandle(self, ptr: int) -> None:
+    def cudaIpcCloseMemHandle(self, ptr):
         self.events.append(("close", ptr))
-        if ptr in self._close_fail:
-            raise RuntimeError(f"injected unmap failure for ptr {ptr}")
+        if ptr == self._cf:
+            raise RuntimeError(f"injected unmap failure for {ptr}")
 
-    def cudaFree(self, ptr: int) -> None:
+    def cudaFree(self, ptr):
         self.events.append(("free", ptr))
-        if ptr in self._free_fail:
-            raise RuntimeError(f"injected free failure for ptr {ptr}")
+        if ptr == self._ff:
+            raise RuntimeError(f"injected free failure for {ptr}")
 
 
-def _make_channel(
-    ipc: _FakeIPC | None,
-    owned: Sequence[_OwnedSharedBuffer],
-    *,
-    exchange_group=None,
-) -> PCIeDCPTopKOwnerExchange:
-    """Construct a CPU DCP top-k channel with injected IPC and buffers."""
-    ch = PCIeDCPTopKOwnerExchange(
-        rank=0,
-        world_size=2,
-        device="cpu",
-        signal_ptrs=(10, 20),
-        staging0_ptrs=(30, 40),
-        staging1_ptrs=(62, 72),
-        max_rows=8,
-        topk=4,
-        ipc=ipc,
-        owned_buffers=owned,
-        exchange_group=exchange_group,
-        stream_affine=False,
+def _buf(local=1000, remote=0):
+    return _OwnedSharedBuffer(
+        local_ptr=local,
+        peer_ptrs=(local, remote) if remote else (local,),
+        remote_ptrs=(remote,) if remote else (),
     )
-    return ch
 
 
-def _buffers() -> list[_OwnedSharedBuffer]:
-    return [
-        _OwnedSharedBuffer(local_ptr=1000, peer_ptrs=(1000, 2000), remote_ptrs=(2000,)),
-        _OwnedSharedBuffer(local_ptr=3000, peer_ptrs=(3000, 4000), remote_ptrs=(4000,)),
-    ]
+def _ch(ipc, owned, *, group=None, ws=2, rank=0, ticket=False):
+    c = PCIeDCPTopKOwnerExchange(
+        rank=rank, world_size=ws, device="cpu",
+        signal_ptrs=tuple(10 + i * 10 for i in range(ws)),
+        staging0_ptrs=tuple(30 + i * 10 for i in range(ws)),
+        staging1_ptrs=tuple(62 + i * 10 for i in range(ws)),
+        max_rows=8, topk=4, ipc=ipc, owned_buffers=owned,
+        exchange_group=group, stream_affine=False,
+    )
+    if ticket:
+        c._has_collective_ipc_ticket = True
+    return c
+
+
+class _CP:
+    """Fake 2-rank control plane with per-round shared barriers.
+
+    When any rank raises during a barrier or exchange, all barriers are
+    aborted so the peer thread also receives a BrokenBarrierError instead
+    of hanging indefinitely.
+    """
+
+    def __init__(self, ws=2):
+        self.ws = ws
+        self._bi = 0
+        self._ei = 0
+        self._lk = threading.Lock()
+        self._b: list[threading.Barrier] = []
+        self._eb: list[threading.Barrier] = []
+        self._ed: list[list[object]] = []
+        self._local = threading.local()
+
+    def _get_barrier(self):
+        i = getattr(self._local, "barrier_index", 0)
+        self._local.barrier_index = i + 1
+        with self._lk:
+            while i >= len(self._b):
+                self._b.append(threading.Barrier(self.ws))
+            return self._b[i]
+
+    def dist_barrier(self, *, group=None):
+        b = self._get_barrier()
+        try:
+            b.wait(timeout=10)
+        except threading.BrokenBarrierError:
+            raise RuntimeError(
+                "collective barrier broken by peer failure"
+            ) from None
+
+    def gather(self, obj, group=None):
+        i = getattr(self._local, "exchange_index", 0)
+        self._local.exchange_index = i + 1
+        with self._lk:
+            while i >= len(self._eb):
+                self._eb.append(threading.Barrier(self.ws))
+                self._ed.append([None] * self.ws)
+            b, d = self._eb[i], self._ed[i]
+        try:
+            s = b.wait(timeout=10)
+            d[s] = obj
+            b.wait(timeout=10)
+            b.wait(timeout=10)
+        except threading.BrokenBarrierError:
+            raise RuntimeError(
+                "collective exchange broken by peer failure"
+            ) from None
+        return list(d)
+
+    def abort(self):
+        """Abort all barriers so peer threads don't hang."""
+        for b in self._b:
+            b.abort()
+        for b in self._eb:
+            b.abort()
+
+    def reset(self):
+        with self._lk:
+            self._local = threading.local()
+            self._b.clear()
+            self._eb.clear()
+            self._ed.clear()
+
+
+def _patch(monkeypatch, cp):
+    monkeypatch.setattr("b12x.comm.pcie.pcie_dcp_topk.dist.barrier", cp.dist_barrier)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", cp.gather
+    )
+
+
+def _rank(monkeypatch, cp, rank, *, cf=0, ff=0):
+    ipc = _FakeIPC(close_fail=cf, free_fail=ff)
+    local = 1000 + rank * 1000
+    remote = 1000 + (1 - rank) * 1000
+    c = _ch(ipc, [_buf(local, remote)], group=object(), rank=rank, ticket=True)
+    return c, ipc
 
 
 # ---------------------------------------------------------------------------
-# Ordering: unmap before free
+# Single-rank tests (world_size=1 fake control plane, group=object())
 # ---------------------------------------------------------------------------
 
 
-def test_close_unmaps_all_imports_before_freeing_any_export():
-    """Every cudaIpcCloseMemHandle must precede every cudaFree."""
+def test_unmap_before_free(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
     ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    ch.close()
-
-    # All remote pointers were closed.
-    assert sorted(ipc.closed) == [2000, 4000]
-    # All local pointers were freed.
-    assert sorted(ipc.freed) == [1000, 3000]
-    # The event log proves all closes precede all frees.
-    close_events = [i for i, (op, _) in enumerate(ipc.events) if op == "close"]
-    free_events = [i for i, (op, _) in enumerate(ipc.events) if op == "free"]
-    assert max(close_events) < min(free_events)
-    assert ch._coordinated_close_complete
-    assert ch._ipc_imports_closed
-    assert ch._ipc_exports_freed
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
+    c.close()
+    assert sorted(ipc.closed) == [2000]
+    assert sorted(ipc.freed) == [1000]
+    ci = [i for i, (op, _) in enumerate(ipc.events) if op == "close"]
+    fi = [i for i, (op, _) in enumerate(ipc.events) if op == "free"]
+    assert max(ci) < min(fi)
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
 
 
-def test_unmap_failure_blocks_all_export_frees():
-    """If any unmap fails, no cudaFree is called on any buffer."""
-    ipc = _FakeIPC(close_fail_ptrs=(2000,))
-    ch = _make_channel(ipc, _buffers())
-
+def test_unmap_failure_blocks_free(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(close_fail=2000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC import close"):
-        ch.close()
-
-    # The failing import was attempted but the other succeeded.
-    assert 2000 in ipc.closed
-    assert 4000 in ipc.closed
-    # Critical: NO export was freed.
+        c.close()
     assert ipc.freed == []
-    # Channel is closed (non-reusable) but exports are NOT freed.
-    assert ch._closed
-    assert not ch._ipc_exports_freed
-    assert not ch._coordinated_close_complete
-    # Owned buffers are retained.
-    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
+    assert c._lifecycle_state == _ChannelLifecycle.FAILED
+    assert [b.local_ptr for b in c._owned_buffers] == [1000]
 
 
-def test_free_failure_retains_export_and_propagates():
-    """If a free fails, the buffer is retained and the error propagates."""
-    ipc = _FakeIPC(free_fail_ptrs=(1000,))
-    ch = _make_channel(ipc, _buffers())
-
+def test_free_failure_retains(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(free_fail=1000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC export free"):
-        ch.close()
-
-    # Unmap succeeded for all.
-    assert sorted(ipc.closed) == [2000, 4000]
-    # Free was attempted.
+        c.close()
     assert 1000 in ipc.freed
-    assert 3000 in ipc.freed
-    # The failing export is retained.
-    assert 1000 in [b.local_ptr for b in ch._owned_buffers]
-    assert 3000 not in [b.local_ptr for b in ch._owned_buffers]
-    assert not ch._ipc_exports_freed
-    assert not ch._coordinated_close_complete
+    assert 1000 in [b.local_ptr for b in c._owned_buffers]
+    assert c._lifecycle_state == _ChannelLifecycle.FAILED
 
 
-def test_unmap_failure_on_second_buffer_still_closes_first():
-    """Partial unmap success is tracked; failed imports remain open."""
-    ipc = _FakeIPC(close_fail_ptrs=(4000,))
-    ch = _make_channel(ipc, _buffers())
+def test_no_ipc_runtime_blocks(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    c = _ch(None, [_buf(1000, 2000)], group=object(), ticket=True)
+    with pytest.raises(RuntimeError, match="CUDA runtime is unavailable"):
+        c.close()
+    assert c._lifecycle_state == _ChannelLifecycle.FAILED
 
+
+def test_local_only_no_group_can_close():
+    """A channel with only local exports (no remote imports) closes fine."""
+    ipc = _FakeIPC()
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    c.close()
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert ipc.freed == [1000]
+
+
+def test_remote_imports_require_group_at_construction():
+    ipc = _FakeIPC()
+    with pytest.raises(ValueError, match="exchange_group is required"):
+        _ch(ipc, [_buf(1000, 2000)], group=None, ticket=True)
+    assert ipc.events == []
+
+
+# ---------------------------------------------------------------------------
+# Double / concurrent close
+# ---------------------------------------------------------------------------
+
+
+def test_double_close_idempotent():
+    ipc = _FakeIPC()
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    c.close()
+    first = list(ipc.freed)
+    c.close()
+    assert ipc.freed == first
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
+
+
+def test_close_after_failure_re_raises(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(close_fail=2000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC import close"):
-        ch.close()
-
-    assert 2000 in ipc.closed  # succeeded
-    assert 4000 in ipc.closed  # attempted
-    assert ipc.freed == []
-    # The successfully closed import is tracked; the failed one is not.
-    assert (0, 0) in ch._closed_ipc_import_indices  # buffer 0, remote 0
-    assert (1, 0) not in ch._closed_ipc_import_indices  # buffer 1, remote 0
+        c.close()
+    with pytest.raises(RuntimeError, match="IPC import close"):
+        c.close()
 
 
-# ---------------------------------------------------------------------------
-# Error propagation: no suppression
-# ---------------------------------------------------------------------------
-
-
-def test_no_ipc_runtime_blocks_unmap_and_free():
-    """Missing CUDA runtime prevents both unmap and free with errors."""
-    ch = _make_channel(None, _buffers())
-
-    with pytest.raises(RuntimeError, match="CUDA runtime is unavailable for IPC unmap"):
-        ch.close()
-
-    assert ch._closed
-    assert not ch._ipc_imports_closed
-    assert not ch._ipc_exports_freed
-    assert not ch._coordinated_close_complete
-    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
-
-
-def test_free_failure_after_successful_unmap_retains_buffer():
-    """Free failure after full unmap success retains the export."""
-    ipc = _FakeIPC(free_fail_ptrs=(3000,))
-    ch = _make_channel(ipc, _buffers())
-
-    with pytest.raises(RuntimeError, match="IPC export free"):
-        ch.close()
-
-    assert sorted(ipc.closed) == [2000, 4000]
-    assert sorted(ipc.freed) == [1000, 3000]
-    # 1000 freed, 3000 retained.
-    assert [b.local_ptr for b in ch._owned_buffers] == [3000]
-    assert ch._ipc_imports_closed
-    assert not ch._ipc_exports_freed
-
-
-# ---------------------------------------------------------------------------
-# Double / out-of-order / concurrent close
-# ---------------------------------------------------------------------------
-
-
-def test_double_close_is_idempotent():
-    """A second close() does not issue additional IPC calls."""
+def test_closed_rejects_stage():
     ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    ch.close()
-    assert ch._coordinated_close_complete
-
-    first_closed = list(ipc.closed)
-    first_freed = list(ipc.freed)
-
-    ch.close()  # should be a no-op
-
-    assert ipc.closed == first_closed
-    assert ipc.freed == first_freed
-    assert ch._coordinated_close_complete
-
-
-def test_close_coordinated_is_also_idempotent():
-    """close_coordinated() respects the same completion guard."""
-    ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    ch.close_coordinated()
-    assert ch._coordinated_close_complete
-
-    first_closed = list(ipc.closed)
-    first_freed = list(ipc.freed)
-
-    ch.close_coordinated()
-
-    assert ipc.closed == first_closed
-    assert ipc.freed == first_freed
-
-
-def test_closed_channel_cannot_stage_candidates():
-    """After close, stage_candidates raises RuntimeError, not silent reuse."""
-    ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-    ch.close()
-    assert ch._closed
-
-    indices = torch.zeros(8, 4, dtype=torch.int32)
-    scores = torch.zeros(8, 4, dtype=torch.float32)
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    c.close()
     with pytest.raises(RuntimeError, match="closed"):
-        ch.stage_candidates(indices, scores)
+        c.stage_candidates(
+            torch.zeros(8, 4, dtype=torch.int32),
+            torch.zeros(8, 4, dtype=torch.float32),
+        )
 
 
-def test_failed_close_channel_cannot_stage_candidates():
-    """A channel whose unmap failed is closed and cannot be reused."""
-    ipc = _FakeIPC(close_fail_ptrs=(2000,))
-    ch = _make_channel(ipc, _buffers())
-
+def test_failed_rejects_stage(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(close_fail=2000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC import close"):
-        ch.close()
+        c.close()
+    with pytest.raises(RuntimeError, match="failed"):
+        c.stage_candidates(
+            torch.zeros(8, 4, dtype=torch.int32),
+            torch.zeros(8, 4, dtype=torch.float32),
+        )
 
-    assert ch._closed
-    indices = torch.zeros(8, 4, dtype=torch.int32)
-    scores = torch.zeros(8, 4, dtype=torch.float32)
+
+def test_concurrent_close_single_gen():
+    ipc = _FakeIPC()
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    res: list[Exception | None] = []
+
+    def do():
+        try:
+            c.close()
+            res.append(None)
+        except Exception as e:
+            res.append(e)
+
+    t1 = threading.Thread(target=do)
+    t2 = threading.Thread(target=do)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert all(r is None for r in res)
+    assert len(ipc.freed) == 1
+
+
+def test_concurrent_close_failure_propagates(monkeypatch):
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(free_fail=1000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
+    errs: list[Exception | None] = []
+
+    def do():
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            errs.append(e)
+
+    t1 = threading.Thread(target=do)
+    t2 = threading.Thread(target=do)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert c._lifecycle_state == _ChannelLifecycle.FAILED
+    assert all(e is not None for e in errs)
+
+
+# ---------------------------------------------------------------------------
+# Retry from FAILED
+# ---------------------------------------------------------------------------
+
+
+def test_retry_from_failed(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, ipc0 = _rank(monkeypatch, cp, 0, ff=1000)
+    c1, ipc1 = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
+
+    def do(c):
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            cp.abort()
+            errs.append(e)
+
+    t0 = threading.Thread(target=do, args=(c0,))
+    t1 = threading.Thread(target=do, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is not None for e in errs)
+    assert c0._lifecycle_state == _ChannelLifecycle.FAILED
+
+    cp.reset()
+    ipc0._ff = 0
+    rerrs: list[Exception | None] = []
+
+    def do_retry(c):
+        try:
+            c.retry_close()
+            rerrs.append(None)
+        except Exception as e:
+            cp.abort()
+            rerrs.append(e)
+
+    t0 = threading.Thread(target=do_retry, args=(c0,))
+    t1 = threading.Thread(target=do_retry, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is None for e in rerrs), f"retry: {rerrs}"
+    assert c0._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert c1._lifecycle_state == _ChannelLifecycle.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Launch vs close
+# ---------------------------------------------------------------------------
+
+
+class _Blocking(PCIeDCPTopKOwnerExchange):
+    def __init__(self, **kw):
+        super().__init__(
+            rank=0, world_size=2, device="cpu",
+            signal_ptrs=(10, 20), staging0_ptrs=(30, 40),
+            staging1_ptrs=(62, 72), max_rows=8, topk=4, **kw,
+        )
+        sh = (self.max_owner_rows, self.world_size * self.topk)
+        self._candidate_views = tuple(
+            (torch.empty(sh, dtype=torch.int32),
+             torch.empty(sh, dtype=torch.float32))
+            for _ in range(2)
+        )
+        self._ls = threading.Event()
+        self._lr = threading.Event()
+
+    def _launch_stage(self, *a, **kw):
+        self._ls.set()
+        self._lr.wait(timeout=5)
+
+
+def test_close_waits_for_launch():
+    c = _Blocking(stream_affine=False)
+    done = threading.Event()
+
+    def launch():
+        c.stage_candidates(
+            torch.zeros(8, 4, dtype=torch.int32),
+            torch.zeros(8, 4, dtype=torch.float32),
+            threads=128, block_limit=1,
+        )
+        done.set()
+
+    def close():
+        c._ls.wait(timeout=5)
+        c._lr.set()
+        c.close()
+
+    tl = threading.Thread(target=launch)
+    tc = threading.Thread(target=close)
+    tl.start()
+    c._ls.wait(timeout=5)
+    tc.start()
+    tl.join(timeout=10)
+    tc.join(timeout=10)
+    assert done.is_set()
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
+
+
+def test_closing_rejects_launch():
+    c = _Blocking(stream_affine=False)
+    with c._lifecycle_lock:
+        c._lifecycle_state = _ChannelLifecycle.CLOSING
+        c._close_generation += 1
+    with pytest.raises(RuntimeError, match="closing"):
+        c.stage_candidates(
+            torch.zeros(8, 4, dtype=torch.int32),
+            torch.zeros(8, 4, dtype=torch.float32),
+            threads=128, block_limit=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Replay vs close
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraph:
+    def __init__(self):
+        self.n = 0
+
+    def replay(self):
+        self.n += 1
+
+
+def test_unregistered_graph_replay_is_rejected():
+    c = _Blocking(stream_affine=False)
+    with pytest.raises(RuntimeError, match="was not registered"):
+        c.replay(_FakeGraph())
+
+
+def test_registered_graph_replays():
+    c = _Blocking(stream_affine=False)
+    graph = _FakeGraph()
+    c.register_graph(graph)
+    c.replay(graph)
+    assert graph.n == 1
+
+
+def test_replay_rejected_after_close():
+    c = _Blocking(stream_affine=False)
+    c._has_collective_ipc_ticket = True
+    c.close()
     with pytest.raises(RuntimeError, match="closed"):
-        ch.stage_candidates(indices, scores)
+        c.replay(_FakeGraph())
 
 
-def test_close_after_partial_unmap_failure_does_not_free_exports():
-    """Retrying close after a partial unmap failure does not free exports."""
-    ipc = _FakeIPC(close_fail_ptrs=(2000,))
-    ch = _make_channel(ipc, _buffers())
+def test_close_waits_for_replay():
+    c = _Blocking(stream_affine=False)
+    c._has_collective_ipc_ticket = True
+    rs = threading.Event()
+    rr = threading.Event()
+    cd = threading.Event()
 
-    with pytest.raises(RuntimeError, match="IPC import close"):
-        ch.close()
+    def replay():
+        with c._replay_gate():
+            rs.set()
+            rr.wait(timeout=5)
 
-    # Exports are still alive.
-    assert [b.local_ptr for b in ch._owned_buffers] == [1000, 3000]
-    assert ipc.freed == []
+    def close():
+        rs.wait(timeout=5)
+        rr.set()
+        c.close()
+        cd.set()
 
-    # Even if we fix the IPC and retry, the channel should not silently free
-    # without going through the coordinated protocol again.  Since
-    # _coordinated_close_complete is False, close() re-enters the protocol.
-    ipc._close_fail = set()  # fix the failure
-    ch.close()
-    # Now the retry should succeed and free everything.
-    assert ch._coordinated_close_complete
-    assert sorted(ipc.freed) == [1000, 3000]
+    tr = threading.Thread(target=replay)
+    tc = threading.Thread(target=close)
+    tr.start()
+    rs.wait(timeout=5)
+    tc.start()
+    tr.join(timeout=10)
+    tc.join(timeout=10)
+    assert cd.is_set()
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
 
 
-def test_concurrent_close_does_not_double_free():
-    """Two close() calls on a channel that completes simultaneously do not
-    issue duplicate IPC calls."""
+# ---------------------------------------------------------------------------
+# Destructor quarantine
+# ---------------------------------------------------------------------------
+
+
+def test_destructor_quarantines_incomplete():
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
     ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    # Simulate concurrent close: the completion guard makes the second a no-op.
-    ch.close()
-    # Manually simulate a racing second close that sees the flag after the
-    # first has set it.
-    assert ch._coordinated_close_complete
-    ch.close()
-
-    assert len(ipc.closed) == 2  # exactly 2 remote pointers, once each
-    assert len(ipc.freed) == 2  # exactly 2 local pointers, once each
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
+    cid = id(c)
+    del c
+    gc.collect()
+    r = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(cid, None)
+    assert r is not None
+    r._coordinated_close_complete = True
+    del r
 
 
-def test_out_of_order_close_retains_exports_until_unmap_acknowledged():
-    """A channel closed before its peer unmapped must not free exports."""
-    ipc = _FakeIPC(close_fail_ptrs=(2000,))
-    ch = _make_channel(ipc, _buffers())
+def test_destructor_no_quarantine_after_close():
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
+    ipc = _FakeIPC()
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    c.close()
+    cid = id(c)
+    del c
+    gc.collect()
+    assert cid not in _ABANDONED_PCIE_RUNTIME_QUARANTINE
 
+
+def test_destructor_quarantines_failed(monkeypatch):
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(close_fail=2000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC import close"):
-        ch.close()
-
-    # The export for the buffer whose import failed to close is still alive.
-    assert any(b.local_ptr == 1000 for b in ch._owned_buffers)
-    assert any(b.local_ptr == 3000 for b in ch._owned_buffers)
-    assert ipc.freed == []
-
-
-# ---------------------------------------------------------------------------
-# Strict method direct invocation
-# ---------------------------------------------------------------------------
+        c.close()
+    cid = id(c)
+    del c
+    gc.collect()
+    r = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(cid, None)
+    assert r is not None
+    r._coordinated_close_complete = True
+    del r
 
 
-def test_strict_unmap_direct_propagates_error():
-    ipc = _FakeIPC(close_fail_ptrs=(2000,))
-    ch = _make_channel(ipc, _buffers())
-
-    with pytest.raises(RuntimeError, match="IPC import close"):
-        ch._close_ipc_imports_strict()
-
-    assert ch._closed
-    assert not ch._ipc_imports_closed
-    assert ipc.freed == []
-
-
-def test_strict_free_direct_propagates_error():
-    ipc = _FakeIPC(free_fail_ptrs=(1000,))
-    ch = _make_channel(ipc, _buffers())
-
+def test_destructor_quarantines_locally_freed_failed(monkeypatch):
+    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
+    cp = _CP(ws=1)
+    _patch(monkeypatch, cp)
+    ipc = _FakeIPC(free_fail=1000)
+    c = _ch(ipc, [_buf(1000, 2000)], group=object(), ticket=True)
     with pytest.raises(RuntimeError, match="IPC export free"):
-        ch._free_ipc_exports_strict()
+        c.close()
+    cid = id(c)
+    del c
+    gc.collect()
+    r = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(cid, None)
+    assert r is not None
+    r._coordinated_close_complete = True
+    del r
 
-    assert 1000 in [b.local_ptr for b in ch._owned_buffers]
-    assert not ch._ipc_exports_freed
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
 
 
-def test_strict_unmap_idempotent_after_success():
+def test_context_manager():
     ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    ch._close_ipc_imports_strict()
-    assert ch._ipc_imports_closed
-    first_closed = list(ipc.closed)
-
-    ch._close_ipc_imports_strict()  # should be no-op
-    assert ipc.closed == first_closed
+    c = _ch(ipc, [_buf(1000)], group=None, ticket=True)
+    with c as ctx:
+        assert ctx is c
+        assert c._lifecycle_state == _ChannelLifecycle.OPEN
+    assert c._lifecycle_state == _ChannelLifecycle.CLOSED
 
 
-def test_strict_free_idempotent_after_success():
-    ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-
-    ch._close_ipc_imports_strict()
-    ch._free_ipc_exports_strict()
-    assert ch._ipc_exports_freed
-    first_freed = list(ipc.freed)
-
-    ch._free_ipc_exports_strict()  # should be no-op
-    assert ipc.freed == first_freed
+# ---------------------------------------------------------------------------
+# 2-rank tests
+# ---------------------------------------------------------------------------
 
 
-def test_candidate_views_cleared_on_free():
-    """Freeing exports clears candidate views so stale tensors are released."""
-    ipc = _FakeIPC()
-    ch = _make_channel(ipc, _buffers())
-    # CPU channels start with empty candidate views.
-    ch._candidate_views = (
-        (torch.empty(1, dtype=torch.int32), torch.empty(1, dtype=torch.float32)),
-    )
-    assert ch._candidate_views
+def test_two_rank_unmap_before_free(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, ipc0 = _rank(monkeypatch, cp, 0)
+    c1, ipc1 = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
 
-    ch.close()
-    assert ch._candidate_views == ()
+    def do(c):
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            errs.append(e)
+
+    t0 = threading.Thread(target=do, args=(c0,))
+    t1 = threading.Thread(target=do, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is None for e in errs), f"errors: {errs}"
+    for ipc in (ipc0, ipc1):
+        ci = [i for i, (op, _) in enumerate(ipc.events) if op == "close"]
+        fi = [i for i, (op, _) in enumerate(ipc.events) if op == "free"]
+        if ci and fi:
+            assert max(ci) < min(fi)
+    assert c0._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert c1._lifecycle_state == _ChannelLifecycle.CLOSED
+
+
+def test_two_rank_asymmetric_unmap(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, ipc0 = _rank(monkeypatch, cp, 0, cf=2000)
+    c1, ipc1 = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
+
+    def do(c):
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            cp.abort()
+            errs.append(e)
+
+    t0 = threading.Thread(target=do, args=(c0,))
+    t1 = threading.Thread(target=do, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is not None for e in errs), f"expected errors: {errs}"
+    assert ipc0.freed == []
+    assert ipc1.freed == []
+    assert c0._lifecycle_state == _ChannelLifecycle.FAILED
+    assert c1._lifecycle_state == _ChannelLifecycle.FAILED
+
+
+
+def test_two_rank_asymmetric_free(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, ipc0 = _rank(monkeypatch, cp, 0, ff=1000)
+    c1, ipc1 = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
+
+    def do(c):
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            errs.append(e)
+            cp.abort()
+
+    t0 = threading.Thread(target=do, args=(c0,))
+    t1 = threading.Thread(target=do, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is not None for e in errs)
+    assert 1000 in ipc0.freed
+    assert 1000 in [b.local_ptr for b in c0._owned_buffers]
+    assert c0._lifecycle_state == _ChannelLifecycle.FAILED
+    assert c1._lifecycle_state == _ChannelLifecycle.FAILED
+
+
+def test_two_rank_concurrent_close(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, _ = _rank(monkeypatch, cp, 0)
+    c1, _ = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
+
+    def close_twice():
+        def once():
+            try:
+                c0.close()
+                errs.append(None)
+            except Exception as e:
+                errs.append(e)
+
+        ta = threading.Thread(target=once)
+        tb = threading.Thread(target=once)
+        ta.start()
+        tb.start()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+
+    c1_errs: list[Exception] = []
+
+    def close1():
+        try:
+            c1.close()
+        except Exception as exc:
+            c1_errs.append(exc)
+
+    t0 = threading.Thread(target=close_twice)
+    t1 = threading.Thread(target=close1)
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is None for e in errs), f"c0 errors: {errs}"
+    assert not c1_errs, f"c1 errors: {c1_errs}"
+    assert c0._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert c1._lifecycle_state == _ChannelLifecycle.CLOSED
+
+
+def test_two_rank_retry_after_failure(monkeypatch):
+    cp = _CP(ws=2)
+    _patch(monkeypatch, cp)
+    c0, ipc0 = _rank(monkeypatch, cp, 0, ff=1000)
+    c1, ipc1 = _rank(monkeypatch, cp, 1)
+    errs: list[Exception | None] = []
+
+    def do(c):
+        try:
+            c.close()
+            errs.append(None)
+        except Exception as e:
+            cp.abort()
+            errs.append(e)
+
+    t0 = threading.Thread(target=do, args=(c0,))
+    t1 = threading.Thread(target=do, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is not None for e in errs)
+    assert c0._lifecycle_state == _ChannelLifecycle.FAILED
+
+    cp.reset()
+    ipc0._ff = 0
+    rerrs: list[Exception | None] = []
+
+    def do_retry(c):
+        try:
+            c.retry_close()
+            rerrs.append(None)
+        except Exception as e:
+            rerrs.append(e)
+
+    t0 = threading.Thread(target=do_retry, args=(c0,))
+    t1 = threading.Thread(target=do_retry, args=(c1,))
+    t0.start()
+    t1.start()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    assert all(e is None for e in rerrs), f"retry: {rerrs}"
+    assert c0._lifecycle_state == _ChannelLifecycle.CLOSED
+    assert c1._lifecycle_state == _ChannelLifecycle.CLOSED


### PR DESCRIPTION
Closes #181.

Coordinates DCP Top-K preflight, peer-failure propagation, lifecycle transitions, and teardown so asymmetric rank failures cannot strand peer mappings or deadlock later collectives.

Verification: focused lifecycle tests and static checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering and replaying CUDA graphs with PCIe DCP Top-K operations.
  * Added a retry option for completing resource cleanup after a transient failure.

* **Bug Fixes**
  * Improved validation to detect configuration mismatches before resources are allocated.
  * Strengthened channel lifecycle handling, including coordinated shutdown, retryable cleanup, and safer recovery from failed or unavailable runtimes.
  * Improved protection against resource leaks during interrupted or asymmetric shutdowns.

* **Tests**
  * Added comprehensive coverage for configuration validation, graph execution, cleanup, concurrency, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->