### PR TITLE
security: reject out-of-range MSA q2k blocks

### DIFF
--- a/b12x/attention/paged/_forward.py
+++ b/b12x/attention/paged/_forward.py
@@ -1084,6 +1084,8 @@ def paged_attention_forward(
             union_blocks=msa_union_blocks,
             union_masks=msa_union_masks,
             union_counts=msa_union_counts,
+            page_table_width=int(page_table.shape[1]),
+            page_size=int(plan.page_size),
         )
 
     q_arg = _to_kernel_tensor(q, _torch_to_cutlass_dtype(q.dtype))

--- a/b12x/attention/paged/_scratch.py
+++ b/b12x/attention/paged/_scratch.py
@@ -429,6 +429,27 @@ def _make_plan_metadata_cache(
     )
 
 
+
+
+_MSA_BLOCK_TOKENS = 128
+_MSA_TOPK = 16
+
+
+def _msa_entries_per_block(page_size: int) -> int:
+    """Number of page-table entries spanned by one 128-token MSA block."""
+    return _MSA_BLOCK_TOKENS // max(int(page_size), 1)
+
+
+def _msa_max_valid_block_id(page_table_width: int, page_size: int) -> int:
+    """Physical upper bound on a batch-local q2k block index.
+
+    A block id maps to ``entries_per_block`` consecutive page-table entries.
+    The last valid entry index is ``page_table_width - 1``, so the last
+    valid block id is ``(page_table_width - 1) // entries_per_block``.
+    """
+    entries_per_block = _msa_entries_per_block(page_size)
+    return max((int(page_table_width) - 1) // entries_per_block, 0)
+
 @dataclass(kw_only=True)
 class B12XPagedAttentionScratch:
     """Paged-attention scratch views over caller-owned storage."""
@@ -865,6 +886,16 @@ class B12XPagedAttentionScratch:
                 f"page_table width={int(page_table.shape[1])} exceeds scratch "
                 f"capacity {self.max_page_table_width}"
             )
+        if (
+            self.msa_block_sparse
+            and self.copy_runtime_metadata
+            and int(page_table.shape[1]) != self.max_page_table_width
+        ):
+            raise ValueError(
+                "MSA block-sparse page_table width must exactly match the "
+                f"scratch capacity: got {int(page_table.shape[1])}, expected "
+                f"{self.max_page_table_width}"
+            )
         if int(cache_seqlens.shape[0]) > self.max_batch:
             raise ValueError(
                 f"cache_seqlens batch={int(cache_seqlens.shape[0])} exceeds "
@@ -912,6 +943,18 @@ class B12XPagedAttentionScratch:
                 raise ValueError(
                     "decode graph page_table width must fit the prepared "
                     f"capacity: got {runtime_width}, expected 1..{expected_width}"
+                )
+            if getattr(self, "msa_block_sparse", False) and runtime_width != expected_width:
+                # MSA q2k block-index guards bound page_idx against the page
+                # table width seen by the kernel.  When the source table is
+                # narrower than the scratch capacity, the copied padding
+                # columns are stale and could be selected by a valid q2k block
+                # id.  Enforce exact width for MSA so the kernel's width guard
+                # matches the caller's actual table.
+                raise ValueError(
+                    "MSA decode graph page_table width must exactly match the "
+                    f"prepared capacity: got {runtime_width}, expected "
+                    f"{expected_width}"
                 )
         elif runtime_width != expected_width:
             # A referenced table's row stride is embedded in the kernel launch.

--- a/b12x/attention/paged/forward_extend_generic.py
+++ b/b12x/attention/paged/forward_extend_generic.py
@@ -3358,8 +3358,8 @@ class PagedForwardKernel:
         visible_len,
     ):
         visible_len = cutlass.select_(visible_len > Int32(0), visible_len, Int32(1))
-        block_count = (visible_len + Int32(self.MSA_BLOCK_TOKENS - 1)) // Int32(
-            self.MSA_BLOCK_TOKENS
+        block_count = Int32(
+            (Int64(visible_len) + Int64(self.MSA_BLOCK_TOKENS - 1)) // Int64(self.MSA_BLOCK_TOKENS)
         )
         block_count = cutlass.select_(
             block_count < Int32(self.MSA_TOPK), block_count, Int32(self.MSA_TOPK)
@@ -3371,8 +3371,10 @@ class PagedForwardKernel:
             return block_count * Int32(self.MSA_BLOCK_TOKENS)
         last_j = block_count - Int32(1)
         local_block_id = mQ2KIndices[kv_head_idx, q_row_idx, last_j]
-        tail_tokens = visible_len - local_block_id * Int32(self.MSA_BLOCK_TOKENS)
-        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        tail_tokens_i64 = (
+            Int64(visible_len) - Int64(local_block_id) * Int64(self.MSA_BLOCK_TOKENS)
+        )
+        tail_pages = Int32((tail_tokens_i64 + Int64(63)) // Int64(64))
         tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
         tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
         return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
@@ -3390,17 +3392,26 @@ class PagedForwardKernel:
         tile_token_count,
     ):
         block_count = mMSAUnionCounts[work_idx, kv_head_idx]
-        block_count = cutlass.select_(block_count > Int32(0), block_count, Int32(1))
+        # When the union filter leaves zero blocks, return 0 selected tokens
+        # so the kernel iterates over no K/V tiles.  The Triton builder
+        # initializes slot 0 to -1 when count=0, but we must not treat that
+        # sentinel as a live block.
         if const_expr(self.page_size == 128):
             # Whole-page walk at page_size=128 (no tail compaction).
-            return block_count * Int32(self.MSA_BLOCK_TOKENS)
+            return cutlass.select_(
+                block_count > Int32(0), block_count * Int32(self.MSA_BLOCK_TOKENS), Int32(0)
+            )
+        block_count = cutlass.select_(block_count > Int32(0), block_count, Int32(1))
         last_block_id = mMSAUnionBlocks[work_idx, kv_head_idx, block_count - Int32(1)]
         max_visible_len = cache_len - qo_len + tile_first_token + tile_token_count
         max_visible_len = cutlass.select_(
             max_visible_len > Int32(0), max_visible_len, Int32(1)
         )
-        tail_tokens = max_visible_len - last_block_id * Int32(self.MSA_BLOCK_TOKENS)
-        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        tail_tokens_i64 = (
+            Int64(max_visible_len)
+            - Int64(last_block_id) * Int64(self.MSA_BLOCK_TOKENS)
+        )
+        tail_pages = Int32((tail_tokens_i64 + Int64(63)) // Int64(64))
         tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
         tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
         return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
@@ -3415,32 +3426,40 @@ class PagedForwardKernel:
         q_row_idx,
         tile_token_base,
         page_size,
+        cache_len,
+        page_table_width,
     ):
         if const_expr(self.msa_block_sparse):
             block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
-            if const_expr(self.entries_per_block == 1):
-                block_id = (
-                    mMSAUnionBlocks[work_idx, kv_head_idx, block_j]
-                    if const_expr(self.msa_union_tile)
-                    else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
-                )
-                return cutlass.select_(
-                    block_id >= Int32(0),
-                    block_id,
-                    Int32(0),
-                )
-            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
-            subpage = block_offset // page_size
             block_id = (
                 mMSAUnionBlocks[work_idx, kv_head_idx, block_j]
                 if const_expr(self.msa_union_tile)
                 else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
             )
-            return cutlass.select_(
-                block_id >= Int32(0),
-                block_id * Int32(self.entries_per_block) + subpage,
-                Int32(0),
+            max_block_id = (Int32(page_table_width) - Int32(1)) // Int32(
+                self.entries_per_block
             )
+            block_start_i64 = Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS)
+            valid_block = (
+                (block_id >= Int32(0))
+                & (block_id <= max_block_id)
+                & (block_start_i64 < Int64(cache_len))
+            )
+            if const_expr(self.entries_per_block == 1):
+                return cutlass.select_(valid_block, block_id, Int32(0))
+            block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
+            subpage = block_offset // page_size
+            # Compute the actual page-table index in Int64 BEFORE bounding.
+            page_idx_i64 = Int64(block_id) * Int64(self.entries_per_block) + Int64(subpage)
+            # Per-request logical bound: page_idx must be within both the
+            # page table width and the request's live cache pages.
+            cache_pages = Int32(
+                (Int64(cache_len) + Int64(page_size) - Int64(1)) // Int64(page_size)
+            )
+            valid_page = valid_block & (page_idx_i64 < Int64(page_table_width)) & (
+                page_idx_i64 < Int64(cache_pages)
+            )
+            return cutlass.select_(valid_page, Int32(page_idx_i64), Int32(0))
         return tile_token_base // page_size
 
     @cute.jit
@@ -3452,6 +3471,8 @@ class PagedForwardKernel:
         kv_head_idx,
         q_row_idx,
         tile_token_base,
+        cache_len,
+        page_table_width,
     ):
         if const_expr(self.msa_block_sparse):
             block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
@@ -3461,9 +3482,18 @@ class PagedForwardKernel:
                 if const_expr(self.msa_union_tile)
                 else mQ2KIndices[kv_head_idx, q_row_idx, block_j]
             )
+            max_block_id = (Int32(page_table_width) - Int32(1)) // Int32(
+                self.entries_per_block
+            )
+            block_start_i64 = Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS)
+            valid_block = (
+                (block_id >= Int32(0))
+                & (block_id <= max_block_id)
+                & (block_start_i64 < Int64(cache_len))
+            )
             return cutlass.select_(
-                block_id >= Int32(0),
-                block_id * Int32(self.MSA_BLOCK_TOKENS) + block_offset,
+                valid_block,
+                Int32(Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS) + Int64(block_offset)),
                 Int32(0x7FFFFFFF),
             )
         return tile_token_base
@@ -4107,6 +4137,7 @@ class PagedForwardKernel:
             else 1
         )
         page_size = mKCache.shape[1]
+        page_table_width = mPageTable.shape[1]
         stage_tile_rows = self.stage_tile_rows
         q_bytes = self.traits.q_smem_bytes
         kv_storage_bytes = self.dtype_kv_storage.width // 8
@@ -5049,6 +5080,8 @@ class PagedForwardKernel:
                     msa_q_row_idx,
                     prefetch_base,
                     page_size,
+                    cache_len,
+                    page_table_width,
                 )
                 if warp_linear_idx == Int32(0):
                     if const_expr(self.use_paged_k_tma):
@@ -5194,6 +5227,8 @@ class PagedForwardKernel:
                     msa_q_row_idx,
                     prefetch_base,
                     page_size,
+                    cache_len,
+                    page_table_width,
                 )
                 self._async_copy_paged_tile_permuted_128b(
                     mKBytes,
@@ -5285,6 +5320,8 @@ class PagedForwardKernel:
                 kv_head_idx,
                 msa_q_row_idx,
                 tile_base,
+                cache_len,
+                page_table_width,
             )
             tile_tokens = tile_limit - tile_base
             if const_expr(self.msa_block_sparse):
@@ -6063,6 +6100,8 @@ class PagedForwardKernel:
                                 msa_q_row_idx,
                                 next_tile_base,
                                 page_size,
+                                cache_len,
+                                page_table_width,
                             )
                             self._async_copy_paged_tile_permuted_128b(
                                 mKBytes,
@@ -6103,6 +6142,8 @@ class PagedForwardKernel:
                                 msa_q_row_idx,
                                 next_tile_base,
                                 page_size,
+                                cache_len,
+                                page_table_width,
                             )
                             self._async_copy_paged_tile_permuted_128b(
                                 mKBytes,

--- a/b12x/attention/paged/forward_paged.py
+++ b/b12x/attention/paged/forward_paged.py
@@ -3613,8 +3613,8 @@ class PagedForwardKernel:
         q_row_idx,
         cache_len,
     ):
-        block_count = (cache_len + Int32(self.MSA_BLOCK_TOKENS - 1)) // Int32(
-            self.MSA_BLOCK_TOKENS
+        block_count = Int32(
+            (Int64(cache_len) + Int64(self.MSA_BLOCK_TOKENS - 1)) // Int64(self.MSA_BLOCK_TOKENS)
         )
         block_count = cutlass.select_(
             block_count < Int32(self.MSA_TOPK), block_count, Int32(self.MSA_TOPK)
@@ -3627,8 +3627,11 @@ class PagedForwardKernel:
             return block_count * Int32(self.MSA_BLOCK_TOKENS)
         last_j = block_count - Int32(1)
         local_block_id = mQ2KIndices[kv_head_idx, q_row_idx, last_j]
-        tail_tokens = cache_len - local_block_id * Int32(self.MSA_BLOCK_TOKENS)
-        tail_pages = (tail_tokens + Int32(63)) // Int32(64)
+        # Keep Int64 through the entire tail computation: subtract, add, div.
+        tail_tokens_i64 = (
+            Int64(cache_len) - Int64(local_block_id) * Int64(self.MSA_BLOCK_TOKENS)
+        )
+        tail_pages = Int32((tail_tokens_i64 + Int64(63)) // Int64(64))
         tail_pages = cutlass.select_(tail_pages < Int32(1), Int32(1), tail_pages)
         tail_pages = cutlass.select_(tail_pages > Int32(2), Int32(2), tail_pages)
         return ((block_count - Int32(1)) * Int32(2) + tail_pages) * Int32(64)
@@ -3641,24 +3644,43 @@ class PagedForwardKernel:
         q_row_idx,
         tile_token_base,
         page_size,
+        cache_len,
+        page_table_width,
     ):
         if const_expr(self.msa_block_sparse):
             block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
+            block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            # Physical bound: (page_table_width - 1) // entries_per_block
+            max_block_id = (Int32(page_table_width) - Int32(1)) // Int32(
+                self.entries_per_block
+            )
+            # Logical bound: block_start < cache_len (visible tokens).
+            # Use Int64 for the scaled product.
+            block_start_i64 = Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS)
+            valid_block = (
+                (block_id >= Int32(0))
+                & (block_id <= max_block_id)
+                & (block_start_i64 < Int64(cache_len))
+            )
             if const_expr(self.entries_per_block == 1):
-                block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
-                return cutlass.select_(
-                    block_id >= Int32(0),
-                    block_id,
-                    Int32(0),
-                )
+                # Page 0 is a safe speculative address for invalid blocks;
+                # _tile_key_base returns 0x7FFFFFFF so tile_tokens=0 (no contribution).
+                return cutlass.select_(valid_block, block_id, Int32(0))
             block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
             subpage = block_offset // page_size
-            block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
-            return cutlass.select_(
-                block_id >= Int32(0),
-                block_id * Int32(self.entries_per_block) + subpage,
-                Int32(0),
+            # Compute the actual page-table index in Int64 BEFORE bounding.
+            page_idx_i64 = Int64(block_id) * Int64(self.entries_per_block) + Int64(subpage)
+            # Per-request logical bound: page_idx must be within both the
+            # page table width and the request's live cache pages.
+            # Use Int64 for ceil division to avoid Int32 overflow.
+            cache_pages = Int32(
+                (Int64(cache_len) + Int64(page_size) - Int64(1)) // Int64(page_size)
             )
+            valid_page = valid_block & (page_idx_i64 < Int64(page_table_width)) & (
+                page_idx_i64 < Int64(cache_pages)
+            )
+            # Narrow only after all bounds checks pass.
+            return cutlass.select_(valid_page, Int32(page_idx_i64), Int32(0))
         return tile_token_base // page_size
 
     @cute.jit
@@ -3678,14 +3700,27 @@ class PagedForwardKernel:
         kv_head_idx,
         q_row_idx,
         tile_token_base,
+        cache_len,
+        page_table_width,
     ):
         if const_expr(self.msa_block_sparse):
             block_j = tile_token_base // Int32(self.MSA_BLOCK_TOKENS)
             block_offset = tile_token_base - block_j * Int32(self.MSA_BLOCK_TOKENS)
             block_id = mQ2KIndices[kv_head_idx, q_row_idx, block_j]
+            max_block_id = (Int32(page_table_width) - Int32(1)) // Int32(
+                self.entries_per_block
+            )
+            block_start_i64 = Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS)
+            valid_block = (
+                (block_id >= Int32(0))
+                & (block_id <= max_block_id)
+                & (block_start_i64 < Int64(cache_len))
+            )
+            # For invalid blocks, return 0x7FFFFFFF so live_tokens = cache_len - 0x7FFFFFFF < 0
+            # -> tile_tokens = 0 -> no K/V contribution (sentinel preserved).
             return cutlass.select_(
-                block_id >= Int32(0),
-                block_id * Int32(self.MSA_BLOCK_TOKENS) + block_offset,
+                valid_block,
+                Int32(Int64(block_id) * Int64(self.MSA_BLOCK_TOKENS) + Int64(block_offset)),
                 Int32(0x7FFFFFFF),
             )
         return tile_token_base
@@ -4514,6 +4549,7 @@ class PagedForwardKernel:
         else:
             num_chunks_kv = 1
         page_size = mKCache.shape[1]
+        page_table_width = mPageTable.shape[1]
         stage_tile_rows = self.stage_tile_rows
         q_head_bytes = self.traits.q_smem_bytes
         q_bytes = q_head_bytes * self.heads_per_cta
@@ -5277,6 +5313,8 @@ class PagedForwardKernel:
                         q_start,
                         role_prefetch_base,
                         page_size,
+                        cache_len,
+                        page_table_width,
                     )
                     role_sub_tile = self._tile_subtile_idx(role_prefetch_base)
                     if const_expr(self.laguna_fp8_head_pair_wide_tma):
@@ -5629,6 +5667,8 @@ class PagedForwardKernel:
                         q_start,
                         prefetch_base,
                         page_size,
+                        cache_len,
+                        page_table_width,
                     )
                     prefetch_sub_tile = self._tile_subtile_idx(prefetch_base)
                     if const_expr(self.k_tma_plane_count > 3):
@@ -5766,6 +5806,8 @@ class PagedForwardKernel:
                 kv_head_idx,
                 q_start,
                 tile_base,
+                cache_len,
+                page_table_width,
             )
             tile_tokens = tile_limit - tile_base
             if const_expr(self.msa_block_sparse):
@@ -6395,6 +6437,8 @@ class PagedForwardKernel:
                                     q_start,
                                     next_tile_base,
                                     page_size,
+                                    cache_len,
+                                    page_table_width,
                                 )
                                 next_sub_tile = self._tile_subtile_idx(next_tile_base)
                                 if const_expr(self.k_tma_plane_count > 3):
@@ -6550,6 +6594,8 @@ class PagedForwardKernel:
                                     q_start,
                                     next_tile_base,
                                     page_size,
+                                    cache_len,
+                                    page_table_width,
                                 )
                                 next_sub_tile = self._tile_subtile_idx(next_tile_base)
                                 if const_expr(self.k_tma_plane_count > 3):
@@ -6953,6 +6999,8 @@ class PagedForwardKernel:
                                 q_start,
                                 next_tile_base,
                                 page_size,
+                                cache_len,
+                                page_table_width,
                             )
                             next_sub_tile = self._tile_subtile_idx(next_tile_base)
                             if const_expr(self.v_tma_plane_count > 3):
@@ -9006,7 +9054,7 @@ class PagedBf16ExtendRawForwardKernel:
             tma_atom_K,
             tma_atom_V,
         ).launch(
-            grid=launch_grid,
+            grid=(mBlockValidMask.shape[0], mKCache.shape[2], 1),
             block=[32, 4, 1],
             # 99,328 B including barriers/alignment on SM120: one CTA/SM.
             min_blocks_per_mp=1,

--- a/b12x/attention/paged/graph_replay.py
+++ b/b12x/attention/paged/graph_replay.py
@@ -295,6 +295,7 @@ def build_msa_prefill_union_metadata_triton(
     union_counts_ptr,
     total_q_capacity,
     block_valid_capacity,
+    max_block_id,
     NUM_KV_HEADS: tl.constexpr,
     BLOCK_TOKENS: tl.constexpr,
     TOPK: tl.constexpr,
@@ -343,8 +344,15 @@ def build_msa_prefill_union_metadata_triton(
             block_id = tl.load(
                 q2k_indices_ptr + q2k_offset, mask=token_valid, other=-1
             ).to(tl.int32)
+            # Int64 scaled product prevents Int32 overflow on large block ids.
+            # Physical bound (max_block_id from page_table_width) and logical
+            # bound (block_start < visible_len) are both checked.
+            block_id_i64 = block_id.to(tl.int64)
             valid_block = (
-                token_valid & (block_id >= 0) & (block_id * BLOCK_TOKENS < visible_len)
+                token_valid
+                & (block_id >= 0)
+                & (block_id <= max_block_id)
+                & (block_id_i64 * tl.constexpr(BLOCK_TOKENS) < visible_len.to(tl.int64))
             )
             found = tl.full((), False, tl.int1)
             found_slot = tl.full((), 0, tl.int32)
@@ -378,6 +386,11 @@ def build_msa_prefill_union_metadata_triton(
             tl.store(union_masks_ptr + union_base + union_count, bit, mask=do_store)
             union_count += tl.where(do_store, 1, 0)
 
+    # When filtering leaves zero blocks, initialize slot 0 to sentinel -1
+    # with a zero mask so the extend kernel cannot reuse stale state.
+    is_empty = work_valid & (union_count == 0)
+    tl.store(union_blocks_ptr + union_base, -1, mask=is_empty)
+    tl.store(union_masks_ptr + union_base, 0, mask=is_empty)
     tl.store(union_counts_ptr + union_count_offset, union_count, mask=work_valid)
 
 
@@ -437,11 +450,19 @@ def update_msa_decode_graph_metadata_fused_triton(
         tl.int32
     )
     active = batch_mask & (cache_len > 0)
-    visible_blocks = tl.maximum((cache_len + 127) // 128, 1)
+    visible_blocks = tl.maximum(
+        (cache_len.to(tl.int64) + 127) // 128, 1
+    ).to(tl.int32)
     selected_blocks = tl.minimum(visible_blocks, 16)
-    tail_tokens = tl.maximum(cache_len - (visible_blocks - 1) * 128, 1)
+    tail_tokens_i64 = cache_len.to(tl.int64) - (
+        visible_blocks.to(tl.int64) - 1
+    ) * 128
+    tail_tokens_i64 = tl.maximum(tail_tokens_i64, 1)
     tail_pages = tl.minimum(
-        tl.maximum((tail_tokens + PAGE_SIZE - 1) // PAGE_SIZE, 1), PAGES_PER_BLOCK
+        tl.maximum(
+            (tail_tokens_i64 + int(PAGE_SIZE) - 1) // int(PAGE_SIZE), 1
+        ),
+        PAGES_PER_BLOCK
     )
     effective_pages = tl.maximum(
         (selected_blocks - 1) * PAGES_PER_BLOCK + tail_pages, 1
@@ -881,6 +902,8 @@ def build_msa_prefill_union_metadata(
     union_blocks: torch.Tensor,
     union_masks: torch.Tensor,
     union_counts: torch.Tensor,
+    page_table_width: int,
+    page_size: int,
 ) -> None:
     if q2k_indices.ndim != 3 or int(q2k_indices.shape[2]) != _MSA_UNION_TOPK:
         raise ValueError("q2k_indices must have shape [kv_heads, total_q_capacity, 16]")
@@ -939,6 +962,11 @@ def build_msa_prefill_union_metadata(
         union_counts,
         int(q2k_indices.shape[1]),
         work_capacity,
+        max(
+            (int(page_table_width) - 1)
+            // (_PREFILL_BLOCK_ROWS // max(int(page_size), 1)),
+            0,
+        ),
         NUM_KV_HEADS=int(q2k_indices.shape[0]),
         BLOCK_TOKENS=128,
         TOPK=_MSA_UNION_TOPK,

--- a/b12x/attention/paged/reference.py
+++ b/b12x/attention/paged/reference.py
@@ -316,6 +316,11 @@ def msa_attention_reference(
         raise ValueError("q_heads must be divisible by kv_heads")
     if int(q2k_indices.shape[1]) < total_q:
         raise ValueError("q2k_indices total_q_capacity is smaller than q")
+    page_size = int(k_cache.shape[1])
+    entries_per_block = block_tokens // page_size
+    max_block_id = max(
+        (int(page_table.shape[1]) - 1) // entries_per_block, 0
+    )
     if softmax_scale is None:
         softmax_scale = head_dim_qk**-0.5
 
@@ -350,6 +355,8 @@ def msa_attention_reference(
                 for block_id_raw in block_ids:
                     block_id = int(block_id_raw)
                     if block_id < 0:
+                        continue
+                    if block_id > max_block_id:
                         continue
                     block_start = block_id * block_tokens
                     block_end = min(block_start + block_tokens, visible_limit)

--- a/tests/attention/test_q2k_block_range_159.py
+++ b/tests/attention/test_q2k_block_range_159.py
@@ -1,0 +1,1157 @@
+"""Adversarial GPU regression tests for MSA q2k block-index range safety (issue #159).
+
+Tests compile and launch real SM121 BF16 and FP8 MSA decode + union extend
+for page sizes 64 and 128.  They exercise graph replay mutation with sentinel
+(-1), negative (-2), INT32_MAX, physically-valid-but-logically-dead, and
+odd-width partial-final blocks, comparing against the reference implementation
+which skips invalid blocks.
+
+The producer-before-attention capture lifecycle is followed: q2k_indices is
+allocated with torch.empty, bound, then the indexer producer fills it.
+Poison tests capture ONCE, mutate the stable q2k buffer, replay the SAME
+graph, and compare output+LSE elementwise to the reference.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from b12x.attention.nsa_indexer.reference import pack_index_k_cache_reference
+from b12x.attention.paged.reference import msa_attention_reference
+from b12x.attention._shared.contiguous.api import clear_attention_caches
+from b12x.attention.paged._forward import paged_attention_forward
+from b12x.attention.paged._scratch import (
+    B12XPagedAttentionScratchCaps,
+    _msa_max_valid_block_id,
+    plan_paged_attention_scratch,
+)
+from b12x.attention.paged.planner import create_paged_plan
+
+from tests._reference.helpers import require_b12x
+from tests._reference.paged_attention_helpers import (
+    make_paged_inputs,
+    quantize_paged_kv_cache_e4m3,
+)
+
+
+_INDEX_HEAD_DIM = 128
+_MSA_BLOCK_TOKENS = 128
+_MSA_TOPK = 16
+
+
+def _pack_index_cache_from_attention_k(k_cache: torch.Tensor) -> torch.Tensor:
+    k_idx = k_cache[:, :, 0, :].contiguous().view(-1, k_cache.shape[-1])
+    return pack_index_k_cache_reference(k_idx, page_size=int(k_cache.shape[1]))
+
+
+def _make_valid_q2k(
+    kv_heads: int,
+    total_q: int,
+    cache_lens: list[int],
+    page_size: int,
+    page_table_width: int,
+    device: torch.device,
+    cu_seqlens_q: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Create valid q2k_indices with blocks in [0, max_block_id].
+
+    For decode, each row i maps to request i (cu_seqlens_q=None implies 1:1).
+    For extend, cu_seqlens_q maps each row to its request.
+    """
+    max_block_id = _msa_max_valid_block_id(page_table_width, page_size)
+    q2k_indices = torch.full(
+        (kv_heads, total_q, _MSA_TOPK), -1, dtype=torch.int32, device=device
+    )
+    if cu_seqlens_q is not None:
+        offsets = cu_seqlens_q.detach().cpu().tolist()
+    else:
+        offsets = list(range(len(cache_lens) + 1))
+    for req_idx in range(len(cache_lens)):
+        q_start = int(offsets[req_idx])
+        q_end = int(offsets[req_idx + 1])
+        cache_len = cache_lens[req_idx]
+        num_blocks = min(
+            (cache_len + _MSA_BLOCK_TOKENS - 1) // _MSA_BLOCK_TOKENS,
+            _MSA_TOPK,
+        )
+        for h in range(kv_heads):
+            for j in range(num_blocks):
+                block_id = min(j, max_block_id)
+                for q_row in range(q_start, q_end):
+                    q2k_indices[h, q_row, j] = block_id
+    return q2k_indices
+
+
+def _assert_close_to_ref(
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    ref_out: torch.Tensor,
+    ref_lse: torch.Tensor,
+    *,
+    rtol: float = 2e-3,
+    atol: float = 2e-3,
+) -> None:
+    """Elementwise comparison; handles zero-norm (all-sentinel) case."""
+    torch.testing.assert_close(lse, ref_lse, rtol=rtol, atol=atol)
+    torch.testing.assert_close(
+        output.to(torch.float32), ref_out.to(torch.float32), rtol=rtol, atol=atol
+    )
+
+
+def _make_decode_scratch(
+    q, k_cache, v_cache, page_table, page_table_width, num_pages
+):
+    batch = q.shape[0]
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="decode",
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_cache.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_cache.shape[3],
+            page_size=k_cache.shape[1],
+            max_total_q=batch,
+            max_batch=batch,
+            max_page_table_width=page_table_width,
+            max_work_items=batch * 32,
+            max_partial_rows=batch * 32,
+            num_cache_pages=num_pages,
+            use_cuda_graph=True,
+            msa_block_sparse=True,
+        )
+    )
+    scratch_plan.prepare_decode_graph_replay_state(
+        batch=batch,
+        max_page_table_width=page_table_width,
+        max_cache_page_count=page_table_width,
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    return scratch_plan, scratch
+
+
+# ---------------------------------------------------------------------------
+# Decode: BF16 page64 graph replay — capture once, mutate, replay same graph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "poison_value",
+    [-1, -2, 0x7FFFFFFF],
+    ids=["sentinel", "negative", "int32max"],
+)
+def test_msa_decode_bf16_page64_same_graph_mutation(poison_value: int) -> None:
+    """Capture once, mutate stable q2k, replay SAME graph, compare to ref."""
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 2
+    page_table_width = 80
+    num_pages = 160
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1],
+        cache_seqlens=[2048, 5000],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=4101,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads, batch, [2048, 5000], page_size, page_table_width, q.device
+    )
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    # Capture ONCE
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+
+    # Baseline replay with valid q2k
+    graph.replay()
+    torch.cuda.synchronize()
+    ref_valid, ref_lse_valid = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse_valid = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse_valid, ref_valid, ref_lse_valid)
+
+    # Mutate stable q2k buffer IN PLACE and replay SAME graph
+    q2k_indices[0, 0, 8:] = poison_value
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_mut, ref_lse_mut = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse_mut = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse_mut, ref_mut, ref_lse_mut)
+
+
+# ---------------------------------------------------------------------------
+# Decode: BF16 page128 graph replay
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_bf16_page128_graph_replay() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 128
+    batch = 2
+    page_table_width = 64
+    num_pages = 128
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1],
+        cache_seqlens=[1024, 4096],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=4201,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads, batch, [1024, 4096], page_size, page_table_width, q.device
+    )
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Decode: odd page_table_width=3 page_size=64 with adversarial [1, 0] ordering
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_bf16_page64_odd_width_adversarial() -> None:
+    """width=3, cache_len=192 (3 pages).  Block 1 subpage 1 = page_idx 3 == width (OOB).
+    Adversarial q2k=[1, 0] forces the walk to hit block 1 first, reaching subpage 1.
+    """
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 1
+    page_table_width = 3
+    num_pages = 16
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1],
+        cache_seqlens=[192],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=4301,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    # Adversarial ordering: block 1 first, then block 0.
+    # Block 1: page_idx 2 (subpage 0, valid) + page_idx 3 (subpage 1, OOB).
+    # The kernel must predicate page_idx 3 >= page_table_width=3.
+    q2k_indices = torch.full(
+        (kv_heads, batch, _MSA_TOPK), -1, dtype=torch.int32, device=q.device
+    )
+    q2k_indices[:, 0, 0] = 1  # block 1 first (adversarial)
+    q2k_indices[:, 0, 1] = 0  # block 0 second
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Decode: physically-valid but logically-dead block
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_bf16_physically_valid_logically_dead() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 1
+    page_table_width = 80
+    num_pages = 160
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1],
+        cache_seqlens=[512],  # 4 blocks walked; max_block_id at slot 4 is logically dead
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=4401,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    q2k_indices = torch.full(
+        (kv_heads, batch, _MSA_TOPK), -1, dtype=torch.int32, device=q.device
+    )
+    max_block_id = _msa_max_valid_block_id(page_table_width, page_size)
+    # Fill slots 0-3 with valid blocks that are actually walked (cache_len=512)
+    for j in range(4):
+        q2k_indices[:, 0, j] = j
+    # Slot 4: physically valid but logically dead (block_start >> cache_len)
+    q2k_indices[:, 0, 4] = max_block_id
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Decode: INT32_MAX arithmetic overflow test
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_bf16_page64_int32max_arithmetic() -> None:
+    """INT32_MAX in q2k must not overflow tail arithmetic or produce wrong selected_token_count.
+    The reference skips INT32_MAX (block_start = INT32_MAX*128 overflows), and the kernel
+    must match by treating it as logically dead (block_start >= cache_len in Int64).
+    """
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 1
+    page_table_width = 80
+    num_pages = 160
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1],
+        cache_seqlens=[2048],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=4501,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    # Fill slots 0-3 with valid blocks, slot 4 with INT32_MAX
+    q2k_indices = torch.full(
+        (kv_heads, batch, _MSA_TOPK), -1, dtype=torch.int32, device=q.device
+    )
+    for j in range(4):
+        q2k_indices[:, 0, j] = j
+    q2k_indices[:, 0, 4] = 0x7FFFFFFF  # INT32_MAX: would overflow Int32 tail math
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Decode: canary block 0, final cache block, final physical block, padding
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_bf16_page64_canary_blocks() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 1
+    page_table_width = 32
+    num_pages = 64
+    q_heads = 64
+    kv_heads = 4
+    cache_len = 2048
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1],
+        cache_seqlens=[cache_len],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=6101,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+
+    max_block_id = _msa_max_valid_block_id(page_table_width, page_size)
+    q2k_indices = torch.full(
+        (kv_heads, batch, _MSA_TOPK), -1, dtype=torch.int32, device=q.device
+    )
+    q2k_indices[:, 0, 0] = 0
+    q2k_indices[:, 0, 1] = 15
+    q2k_indices[:, 0, 2] = max_block_id
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Extend: BF16 union-tile page64 with poisoned q2k
+# ---------------------------------------------------------------------------
+
+
+def test_msa_extend_bf16_page64_union_poisoned() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[8, 5],
+        cache_seqlens=[384, 512],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=5101,
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads,
+        q.shape[0],
+        [384, 512],
+        page_size,
+        page_table.shape[1],
+        q.device,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+
+    plan = create_paged_plan(
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        mode="extend",
+        msa_block_sparse=True,
+    )
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="extend",
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_cache.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_cache.shape[3],
+            page_size=page_size,
+            max_total_q=plan.total_q,
+            max_batch=page_table.shape[0],
+            max_page_table_width=page_table.shape[1],
+            max_work_items=max(plan.new_batch_size, 1),
+            max_partial_rows=0,
+            num_cache_pages=k_cache.shape[0],
+            msa_block_sparse=True,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    out, lse_base2 = paged_attention_forward(binding=binding)
+    lse = lse_base2 * math.log(2.0)
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+    # Poison trailing slots with INT32_MAX
+    q2k_indices[:, :, 8:] = 0x7FFFFFFF
+    out_mut, lse_base2_mut = paged_attention_forward(binding=binding)
+    lse_mut = lse_base2_mut * math.log(2.0)
+
+    ref_mut, ref_lse_mut = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    _assert_close_to_ref(output, lse_mut, ref_mut, ref_lse_mut)
+
+
+# ---------------------------------------------------------------------------
+# Extend: BF16 union-tile page128
+# ---------------------------------------------------------------------------
+
+
+def test_msa_extend_bf16_page128_union() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 128
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[8, 5],
+        cache_seqlens=[512, 768],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=5201,
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads,
+        q.shape[0],
+        [512, 768],
+        page_size,
+        page_table.shape[1],
+        q.device,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+
+    plan = create_paged_plan(
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        mode="extend",
+        msa_block_sparse=True,
+    )
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="extend",
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_cache.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_cache.shape[3],
+            page_size=page_size,
+            max_total_q=plan.total_q,
+            max_batch=page_table.shape[0],
+            max_page_table_width=page_table.shape[1],
+            max_work_items=max(plan.new_batch_size, 1),
+            max_partial_rows=0,
+            num_cache_pages=k_cache.shape[0],
+            msa_block_sparse=True,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    out, lse_base2 = paged_attention_forward(binding=binding)
+    lse = lse_base2 * math.log(2.0)
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Extend: all-sentinel q2k (zero-count union)
+# ---------------------------------------------------------------------------
+
+
+def test_msa_extend_bf16_page64_all_sentinel() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[8, 5],
+        cache_seqlens=[384, 512],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=5301,
+    )
+
+    q2k_indices = torch.full(
+        (kv_heads, q.shape[0], _MSA_TOPK), -1, dtype=torch.int32, device=q.device
+    )
+
+    plan = create_paged_plan(
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        mode="extend",
+        msa_block_sparse=True,
+    )
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="extend",
+            dtype=q.dtype,
+            kv_dtype=k_cache.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_cache.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_cache.shape[3],
+            page_size=page_size,
+            max_total_q=plan.total_q,
+            max_batch=page_table.shape[0],
+            max_page_table_width=page_table.shape[1],
+            max_work_items=max(plan.new_batch_size, 1),
+            max_partial_rows=0,
+            num_cache_pages=k_cache.shape[0],
+            msa_block_sparse=True,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    out, lse_base2 = paged_attention_forward(binding=binding)
+    lse = lse_base2 * math.log(2.0)
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# FP8 decode: page64 graph replay
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_fp8_page64_graph_replay() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 2
+    page_table_width = 80
+    num_pages = 160
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1],
+        cache_seqlens=[2048, 4096],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=8101,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+    k_quant, v_quant, k_descale, v_descale = quantize_paged_kv_cache_e4m3(
+        k_cache, v_cache, page_table, cache_seqlens
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads, batch, [2048, 4096], page_size, page_table_width, q.device
+    )
+
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="decode",
+            dtype=q.dtype,
+            kv_dtype=k_quant.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_quant.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_quant.shape[3],
+            page_size=page_size,
+            max_total_q=batch,
+            max_batch=batch,
+            max_page_table_width=page_table_width,
+            max_work_items=batch * 32,
+            max_partial_rows=batch * 32,
+            num_cache_pages=num_pages,
+            use_cuda_graph=True,
+            msa_block_sparse=True,
+        )
+    )
+    scratch_plan.prepare_decode_graph_replay_state(
+        batch=batch,
+        max_page_table_width=page_table_width,
+        max_cache_page_count=page_table_width,
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_quant,
+        v_cache=v_quant,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        paged_attention_forward(binding=binding)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q,
+        k_quant,
+        v_quant,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+    # Mutate stable q2k and replay SAME graph
+    q2k_indices[0, 0, 8:] = 0x7FFFFFFF
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_mut, ref_lse_mut = msa_attention_reference(
+        q,
+        k_quant,
+        v_quant,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    lse_mut = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse_mut, ref_mut, ref_lse_mut)
+
+
+# ---------------------------------------------------------------------------
+# FP8 extend: page128 union-tile
+# ---------------------------------------------------------------------------
+
+
+def test_msa_extend_fp8_page128_union() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 128
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[8, 5],
+        cache_seqlens=[512, 768],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=8201,
+    )
+    k_quant, v_quant, k_descale, v_descale = quantize_paged_kv_cache_e4m3(
+        k_cache, v_cache, page_table, cache_seqlens
+    )
+
+    q2k_indices = _make_valid_q2k(
+        kv_heads,
+        q.shape[0],
+        [512, 768],
+        page_size,
+        page_table.shape[1],
+        q.device,
+        cu_seqlens_q=cu_seqlens_q,
+    )
+
+    plan = create_paged_plan(
+        q,
+        k_quant,
+        v_quant,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        mode="extend",
+        msa_block_sparse=True,
+    )
+    scratch_plan = plan_paged_attention_scratch(
+        B12XPagedAttentionScratchCaps(
+            device=q.device,
+            mode="extend",
+            dtype=q.dtype,
+            kv_dtype=k_quant.dtype,
+            num_q_heads=q.shape[1],
+            num_kv_heads=k_quant.shape[2],
+            head_dim_qk=q.shape[2],
+            head_dim_vo=v_quant.shape[3],
+            page_size=page_size,
+            max_total_q=plan.total_q,
+            max_batch=page_table.shape[0],
+            max_page_table_width=page_table.shape[1],
+            max_work_items=max(plan.new_batch_size, 1),
+            max_partial_rows=0,
+            num_cache_pages=k_quant.shape[0],
+            msa_block_sparse=True,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=q.device)
+        for shape, dtype in scratch_plan.shapes_and_dtypes()
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_quant,
+        v_cache=v_quant,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    out, lse_base2 = paged_attention_forward(binding=binding)
+    lse = lse_base2 * math.log(2.0)
+
+    ref_out, ref_lse = msa_attention_reference(
+        q,
+        k_quant,
+        v_quant,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        q2k_indices,
+        k_descale=k_descale,
+        v_descale=v_descale,
+    )
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+# ---------------------------------------------------------------------------
+# Producer-before-attention capture lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_msa_decode_producer_before_attention_lifecycle() -> None:
+    require_b12x()
+    clear_attention_caches()
+
+    page_size = 64
+    batch = 2
+    page_table_width = 80
+    num_pages = 160
+    q_heads = 64
+    kv_heads = 4
+
+    q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q = make_paged_inputs(
+        q_seqlens=[1, 1],
+        cache_seqlens=[2048, 5000],
+        page_size=page_size,
+        q_heads=q_heads,
+        kv_heads=kv_heads,
+        head_dim=_INDEX_HEAD_DIM,
+        dtype=torch.bfloat16,
+        seed=7101,
+        page_table_width=page_table_width,
+        num_pages=num_pages,
+    )
+    index_k_cache = _pack_index_cache_from_attention_k(k_cache)
+
+    q2k_indices = torch.empty(
+        (kv_heads, batch, _MSA_TOPK), dtype=torch.int32, device=q.device
+    )
+
+    scratch_plan, scratch = _make_decode_scratch(
+        q, k_cache, v_cache, page_table, page_table_width, num_pages
+    )
+    output = torch.empty_like(q)
+    binding = scratch_plan.bind(
+        scratch=scratch,
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q2k_indices=q2k_indices,
+    )
+    runtime_page_table = binding.scratch.page_table
+    runtime_cache_seqlens = binding.scratch.cache_seqlens
+    assert runtime_page_table is not None
+    assert runtime_cache_seqlens is not None
+
+    from tests.attention.test_attention_msa_e2e import (
+        _decode_msa_q2k_from_index_cache,
+    )
+
+    _decode_msa_q2k_from_index_cache(
+        q=q,
+        index_k_cache=index_k_cache,
+        page_table=runtime_page_table,
+        cache_seqlens=runtime_cache_seqlens,
+        out=q2k_indices,
+    )
+    paged_attention_forward(binding=binding)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _decode_msa_q2k_from_index_cache(
+            q=q,
+            index_k_cache=index_k_cache,
+            page_table=runtime_page_table,
+            cache_seqlens=runtime_cache_seqlens,
+            out=q2k_indices,
+        )
+        paged_attention_forward(binding=binding)
+
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_lse = msa_attention_reference(
+        q, k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, q2k_indices
+    )
+    lse = binding.scratch.current_lse_view() * math.log(2.0)
+    _assert_close_to_ref(output, lse, ref_out, ref_lse)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-x"])


### PR DESCRIPTION
Closes #159.

Bounds graph-live q2k block selections against logical and physical paged-cache regions before address formation across paged and extend routes.

Verification: 14 focused SM121 GPU tests passed; py_compile/Ruff/diff checks passed.