### PR TITLE
security: bound sparse and compressed MLA cache indices

### DIFF
--- a/b12x/attention/_shared/mla/api.py
+++ b/b12x/attention/_shared/mla/api.py
@@ -119,6 +119,101 @@ def _validate_tensor_storage_bounds(tensor: torch.Tensor, *, name: str) -> None:
         )
 
 
+def _sparse_mla_slot_capacity(
+    kv_cache: torch.Tensor, page_size: int
+) -> int:
+    """Physical token-slot capacity of a sparse/compressed MLA KV cache.
+
+    Rank-3 [num_pages, page_size, record_bytes] and rank-2 [num_pages,
+    page_bytes] layouts are both supported.  The capacity is the total number
+    of addressable token slots (num_pages * page_size); the in-kernel gather
+    clamps any live index >= capacity to a safe sentinel.
+    """
+    page_size = int(page_size)
+    if kv_cache.ndim == 3:
+        num_pages = int(kv_cache.shape[0])
+        # The middle dim SHOULD equal page_size, but packed vLLM views may
+        # stride differently; the product of the leading dim is the capacity.
+        return num_pages * page_size
+    if kv_cache.ndim == 2:
+        # Compressed MLA byte view: [num_pages, page_bytes].
+        num_pages = int(kv_cache.shape[0])
+        return num_pages * page_size
+    # Flat 1-D view (already reshaped by _cache_base_tensor).
+    return int(kv_cache.numel()) // page_size if page_size > 0 else int(kv_cache.numel())
+
+
+def _validate_sparse_mla_index_bounds(
+    selected_indices: torch.Tensor,
+    active_token_counts: torch.Tensor,
+    slot_capacity: int,
+    *,
+    is_graph_capture: bool,
+) -> None:
+    """Fail-closed validation that every LIVE positive selected index is < capacity.
+
+    Negative sentinels (-1) are the contractual invalid marker and are retained
+    (the kernel masks them).  High positive indices >= capacity are rejected
+    because they would cause out-of-bounds GPU reads.
+
+    A zero-capacity cache with any non-sentinel index is rejected pre-capture.
+
+    This validation is SKIPPED during CUDA graph capture/replay to avoid a
+    host-device sync; the in-kernel ``slot_capacity`` bound dominates in that
+    path (it is computed from the live cache tensor shape at replay time).
+    """
+    if is_graph_capture:
+        return
+    if selected_indices.numel() == 0:
+        return
+    # Zero-capacity cache: reject if any non-sentinel index exists.
+    if slot_capacity <= 0:
+        positive = selected_indices[selected_indices >= 0]
+        if positive.numel() > 0:
+            raise ValueError(
+                "sparse MLA cache has zero slot capacity but contains "
+                f"{positive.numel()} non-sentinel indices; would cause "
+                "out-of-bounds GPU reads"
+            )
+        return
+    # Mask by active_token_counts: only check indices within the live per-token
+    # length. Entries past the length are padding and may contain stale indices.
+    rows, width = selected_indices.shape
+    has_live_mask = (
+        active_token_counts is not None
+        and active_token_counts.numel() == rows
+    )
+    if has_live_mask:
+        lengths_cpu = active_token_counts.clamp(min=0, max=width)
+        # Check each row's live prefix for OOB positive indices.
+        for row in range(rows):
+            live_len = int(lengths_cpu[row].item())
+            if live_len <= 0:
+                continue
+            row_indices = selected_indices[row, :live_len]
+            positive = row_indices[row_indices >= 0]
+            if positive.numel() == 0:
+                continue
+            max_idx = int(positive.max().item())
+            if max_idx >= slot_capacity:
+                raise ValueError(
+                    f"sparse MLA selected index {max_idx} in row {row} "
+                    f"exceeds cache slot capacity {slot_capacity} "
+                    f"(num_pages * page_size); high positive indices "
+                    f"would cause out-of-bounds GPU reads"
+                )
+    else:
+        positive = selected_indices[selected_indices >= 0]
+        if positive.numel() == 0:
+            return
+        max_idx = int(positive.max().item())
+        if max_idx >= slot_capacity:
+            raise ValueError(
+                f"sparse MLA selected index {max_idx} exceeds cache slot capacity "
+                f"{slot_capacity} (num_pages * page_size); high positive indices "
+                f"would cause out-of-bounds GPU reads"
+            )
+
 def _is_supported_packed_kv_cache_view(
     tensor: torch.Tensor,
     *,
@@ -682,6 +777,17 @@ def _run_sparse_mla(
         raise ValueError(
             f"q_all head_dim {q_all.shape[-1]} does not match workspace head_dim {workspace.head_dim}"
         )
+    # Fail-closed: reject high positive indices that exceed the physical cache
+    # slot capacity.  Negative sentinels (-1) are the contractual invalid
+    # marker and are retained.  The in-kernel slot_capacity bound dominates
+    # during CUDA graph replay (computed from the live cache tensor shape).
+    _slot_cap = _sparse_mla_slot_capacity(kv_cache, int(workspace.page_size))
+    _validate_sparse_mla_index_bounds(
+        selected_indices,
+        active_token_counts,
+        _slot_cap,
+        is_graph_capture=_is_cuda_graph_capture_active(q_all.device),
+    )
     if _sm120_route:
         q_head_dim = int(q_all.shape[-1])
         if q_head_dim != _MLA_UNIFIED_GLM_Q_HEAD_DIM:

--- a/b12x/attention/_shared/mla/compressed_api.py
+++ b/b12x/attention/_shared/mla/compressed_api.py
@@ -226,6 +226,31 @@ def compressed_mla_decode_forward(
         + (indexed_indices_2d.shape[1] if has_indexed else 0),
     )
 
+    # Fail-closed: reject high positive indices that exceed the physical cache
+    # slot capacity.  Negative sentinels (-1) are retained.  The in-kernel
+    # slot_capacity bound dominates during CUDA graph replay.
+    from .api import (
+        _is_cuda_graph_capture_active,
+        _sparse_mla_slot_capacity,
+        _validate_sparse_mla_index_bounds,
+    )
+
+    _is_capture = _is_cuda_graph_capture_active(q3.device)
+    _swa_cap = _sparse_mla_slot_capacity(swa_k_cache, int(swa_page_size))
+    _validate_sparse_mla_index_bounds(
+        swa_indices_2d, swa_topk_lengths, _swa_cap, is_graph_capture=_is_capture
+    )
+    if has_indexed:
+        _idx_cap = _sparse_mla_slot_capacity(
+            indexed_k_cache, int(indexed_page_size)
+        )
+        _validate_sparse_mla_index_bounds(
+            indexed_indices_2d,
+            indexed_topk_lengths,
+            _idx_cap,
+            is_graph_capture=_is_capture,
+        )
+
     if out is not None:
         _validate_compressed_mla_out(out, q3=q3)
 

--- a/b12x/attention/_shared/mla/decode_math.py
+++ b/b12x/attention/_shared/mla/decode_math.py
@@ -1139,6 +1139,7 @@ def s3_mask_and_scale(
     split_cand_end: Int32,  # min(start + CAND_WINDOW, section_len)
     section_len: Int32,
     sm_scale_log2: Float32,  # sm_scale * LOG2E
+    slot_capacity: Int32,  # physical token-slot upper bound
     lane: Int32,
 ):
     """S3: mask + base-2 prescale. Validity = staged token index (gap #9).
@@ -1165,10 +1166,10 @@ def s3_mask_and_scale(
     if abs_c1 < section_len:
         idx1 = Int32(sTokenIdx[c1])
 
-    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+    if abs_c0 >= split_cand_end or (idx0 < Int32(0)) | (idx0 >= slot_capacity):
         qk[0] = Float32(_QK_MASK)
         qk[2] = Float32(_QK_MASK)
-    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+    if abs_c1 >= split_cand_end or (idx1 < Int32(0)) | (idx1 >= slot_capacity):
         qk[1] = Float32(_QK_MASK)
         qk[3] = Float32(_QK_MASK)
 
@@ -1188,6 +1189,7 @@ def s3_mask_and_scale_glm_h8_swap_ab(
     split_cand_end: Int32,
     section_len: Int32,
     sm_scale_log2: Float32,
+    slot_capacity: Int32,
     lane: Int32,
 ):
     """Mask the two candidate rows owned by a swapped GLM TP8 fragment."""
@@ -1204,10 +1206,10 @@ def s3_mask_and_scale_glm_h8_swap_ab(
     if abs_c1 < section_len:
         idx1 = Int32(sTokenIdx[c1])
 
-    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+    if abs_c0 >= split_cand_end or (idx0 < Int32(0)) | (idx0 >= slot_capacity):
         qk[0] = Float32(_QK_MASK)
         qk[1] = Float32(_QK_MASK)
-    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+    if abs_c1 >= split_cand_end or (idx1 < Int32(0)) | (idx1 >= slot_capacity):
         qk[2] = Float32(_QK_MASK)
         qk[3] = Float32(_QK_MASK)
 

--- a/b12x/attention/_shared/mla/io.py
+++ b/b12x/attention/_shared/mla/io.py
@@ -100,6 +100,7 @@ def io_issue_gather(
     g_end: Int32,  # min(g_start + CAND_WINDOW, section_len)
     page_block_size: Int32,  # pbs: tokens per paged block (THIS section)
     stride_kv_block: Int64,  # per-block byte stride in gmem (THIS section)
+    slot_capacity: Int32,  # physical token-slot upper bound for THIS section
     io_lane: Int32,  # lane within the IO warp [0, 32)
     *,
     bi: cutlass.Constexpr,  # 64
@@ -186,7 +187,7 @@ def io_issue_gather(
     def _issue_payload_entry(entry: Int32, idx_raw: Int32):
         full_mbar_u32 = shared_ptr_to_u32(full_mbar_ptr)
         idx = idx_raw
-        if idx < Int32(0):
+        if (idx < Int32(0)) | (idx >= slot_capacity):
             idx = Int32(0)
         block_idx = idx // _section_pbs
         local_idx = idx - block_idx * _section_pbs
@@ -231,7 +232,7 @@ def io_issue_gather(
                 if cand_pos < g_end:
                     idx_raw = Int32(_section_idx[cand_pos])
                 idx = idx_raw
-                if idx < Int32(0):
+                if (idx < Int32(0)) | (idx >= slot_capacity):
                     idx = Int32(0)
                 block_idx = idx // _section_pbs
                 local_idx = idx - block_idx * _section_pbs
@@ -288,7 +289,7 @@ def io_issue_gather(
 
         overlap_f0 = Uint32(0)
         overlap_f1 = Uint32(0)
-        if overlap_idx_raw >= Int32(0):
+        if (overlap_idx_raw >= Int32(0)) & (overlap_idx_raw < slot_capacity):
             overlap_block_idx = overlap_idx_raw // _section_pbs
             overlap_local_idx = overlap_idx_raw - overlap_block_idx * _section_pbs
             overlap_scale_base_off = (
@@ -325,7 +326,7 @@ def io_issue_gather(
                 # footer (inline scales travel in the kv_fp8 nope bulk).
                 f0 = Uint32(0)
                 f1 = Uint32(0)
-                if idx_raw >= Int32(0):
+                if (idx_raw >= Int32(0)) & (idx_raw < slot_capacity):
                     block_idx = idx_raw // _section_pbs
                     local_idx = idx_raw - block_idx * _section_pbs
                     scale_base_off = (
@@ -347,7 +348,7 @@ def io_issue_gather(
                 # pair at [288, 296) (rope scale, latent scale) and keep the
                 # second word -- same nc.v2 pattern as the DSV4 footer.
                 f1 = Uint32(0)
-                if idx_raw >= Int32(0):
+                if (idx_raw >= Int32(0)) & (idx_raw < slot_capacity):
                     block_idx = idx_raw // _section_pbs
                     local_idx = idx_raw - block_idx * _section_pbs
                     scale_base_off = (

--- a/b12x/attention/_shared/mla/io_mg.py
+++ b/b12x/attention/_shared/mla/io_mg.py
@@ -40,6 +40,8 @@ _NVFP4_IO_STRIDE = 432
 _NVFP4_NOPE_SCALE_BYTES = 288
 _NVFP4_FP8_ROPE_IO_STRIDE = 368
 
+# Default smem addr for the optional kv_sc dst (unused when no footer/latent scale).
+_DEFAULT_KV_SC_ADDR = Int32(0)
 
 @cute.jit
 def io_issue_gather_dsv4_nope(
@@ -52,6 +54,7 @@ def io_issue_gather_dsv4_nope(
     g_end: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     io_lane: Int32,
     cache_policy: Uint64,
     *,
@@ -79,8 +82,7 @@ def io_issue_gather_dsv4_nope(
                 idx_raw = Int32(topk_indices[cand_pos])
 
             f0 = Uint32(0)
-            f1 = Uint32(0)
-            if idx_raw >= Int32(0):
+            if (idx_raw >= Int32(0)) & (idx_raw < slot_capacity):
                 block_idx = idx_raw // page_block_size
                 local_idx = idx_raw - block_idx * page_block_size
                 scale_base_off = (
@@ -113,7 +115,7 @@ def io_issue_gather_dsv4_nope(
             if cand_pos < g_end:
                 idx_raw = Int32(topk_indices[cand_pos])
             idx = idx_raw
-            if idx < Int32(0):
+            if (idx < Int32(0)) | (idx >= slot_capacity):
                 idx = Int32(0)
             block_idx = idx // page_block_size
             local_idx = idx - block_idx * page_block_size
@@ -138,6 +140,7 @@ def io_issue_gather_glm_mg(
     g_end: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     io_lane: Int32,
     cache_policy: Uint64,
     *,
@@ -147,7 +150,7 @@ def io_issue_gather_glm_mg(
     scale_format: cutlass.Constexpr = 1,
     fp8_rope: cutlass.Constexpr = False,
     per_token_latent_scale: cutlass.Constexpr = False,
-    kv_sc_dst_addr: Int32 = Int32(0),
+    kv_sc_dst_addr: Int32 = _DEFAULT_KV_SC_ADDR,
 ):
     """Gather one BI=64 GLM prefill tile into MG smem.
 
@@ -188,7 +191,7 @@ def io_issue_gather_glm_mg(
                 if cand_pos < g_end:
                     idx_raw = Int32(topk_indices[cand_pos])
                 f1 = Uint32(0)
-                if idx_raw >= Int32(0):
+                if (idx_raw >= Int32(0)) & (idx_raw < slot_capacity):
                     block_idx = idx_raw // page_block_size
                     local_idx = idx_raw - block_idx * page_block_size
                     scale_base_off = (
@@ -216,7 +219,7 @@ def io_issue_gather_glm_mg(
             if cand_pos < g_end:
                 idx_raw = Int32(topk_indices[cand_pos])
             idx = idx_raw
-            if idx < Int32(0):
+            if (idx < Int32(0)) | (idx >= slot_capacity):
                 idx = Int32(0)
             block_idx = idx // page_block_size
             local_idx = idx - block_idx * page_block_size

--- a/b12x/attention/_shared/mla/kernel.py
+++ b/b12x/attention/_shared/mla/kernel.py
@@ -650,6 +650,13 @@ class UnifiedDecodeKernel:
         section_len: Int32,
         stride_kv_block: Int64,
     ):
+        # Physical slot capacity = floor(cache_bytes / block_stride) * page_size.
+        # floor (not ceil): a partial final block is not addressable.  Computed
+        # from the live cache tensor so it tracks replay-time geometry without a
+        # host sync.  Int64 arithmetic avoids overflow.  The cache tensor is a
+        # flat uint8 byte view so shape[0] is already bytes.
+        _cap_bytes = Int64(kv_cache_u8.shape[0])
+        slot_capacity = Int32(_cap_bytes // stride_kv_block) * Int32(self.page_block_size)
         t = self.traits
         L = self.layout
         tid = Int32(cute.arch.thread_idx()[0])
@@ -804,6 +811,7 @@ class UnifiedDecodeKernel:
                     g_end,
                     Int32(self.page_block_size),
                     stride_kv_block,
+                    slot_capacity,
                     io_lane,
                     bi=t.bi,
                     kv_smem_stride=staged_kv_stride,
@@ -977,6 +985,7 @@ class UnifiedDecodeKernel:
                         split_cand_end,
                         section_len,
                         sm_scale_log2,
+                        slot_capacity,
                         lane,
                     )
                     p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
@@ -1088,6 +1097,7 @@ class UnifiedDecodeKernel:
                         split_cand_end,
                         section_len,
                         sm_scale_log2,
+                        slot_capacity,
                         lane,
                     )
                     p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
@@ -1424,6 +1434,18 @@ class UnifiedDecodeKernel:
         has_extra: cutlass.Constexpr,
         per_token_len: cutlass.Constexpr,
     ):
+        # Physical slot capacity = floor(cache_bytes / block_stride) * page_size.
+        # floor (not ceil): a partial final block is not addressable.  Computed
+        # from the live cache tensor so it tracks replay-time geometry without a
+        # host sync.  Int64 arithmetic avoids overflow.  The cache tensor is a
+        # flat uint8 byte view so shape[0] is already bytes.
+        _cap_bytes = Int64(kv_cache_u8.shape[0])
+        slot_capacity = Int32(_cap_bytes // stride_kv_block) * Int32(self.page_block_size)
+        if cutlass.const_expr(has_extra):
+            _ecap_bytes = Int64(extra_kv_cache_u8.shape[0])
+            extra_slot_capacity = Int32(_ecap_bytes // stride_extra_kv_block) * Int32(self.pbs_extra)
+        else:
+            extra_slot_capacity = slot_capacity
         t = self.traits
         L = self.layout
         tid = Int32(cute.arch.thread_idx()[0])
@@ -1686,6 +1708,7 @@ class UnifiedDecodeKernel:
                             g_end,
                             Int32(self.pbs_extra),
                             stride_extra_kv_block,
+                            extra_slot_capacity,
                             io_lane,
                             **io_kw,
                         )
@@ -1706,6 +1729,7 @@ class UnifiedDecodeKernel:
                             g_end,
                             Int32(self.page_block_size),
                             stride_kv_block,
+                            slot_capacity,
                             io_lane,
                             **io_kw,
                         )
@@ -1726,6 +1750,7 @@ class UnifiedDecodeKernel:
                         g_end,
                         Int32(self.page_block_size),
                         stride_kv_block,
+                        slot_capacity,
                         io_lane,
                         **io_kw,
                     )
@@ -1929,10 +1954,12 @@ class UnifiedDecodeKernel:
                     )
                     sc_start = split_cand_start
                     sec_len = section_len
+                    s3_cap = slot_capacity
                     if cutlass.const_expr(has_extra):
                         if ci >= num_main_chunks:
                             sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
                             sec_len = extra_section_len
+                            s3_cap = extra_slot_capacity
                     sc_end = sc_start + Int32(_CAND_WINDOW)
                     if sc_end > sec_len:
                         sc_end = sec_len
@@ -1944,6 +1971,7 @@ class UnifiedDecodeKernel:
                         sc_end,
                         sec_len,
                         sm_scale_log2,
+                        s3_cap,
                         lane,
                     )
                     p = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
@@ -2057,9 +2085,11 @@ class UnifiedDecodeKernel:
                     if cutlass.const_expr(has_extra):
                         sc_start = split_cand_start
                         sec_len = section_len
+                        s3_cap = slot_capacity
                         if ci >= num_main_chunks:
                             sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
                             sec_len = extra_section_len
+                            s3_cap = extra_slot_capacity
                         sc_end = sc_start + Int32(_CAND_WINDOW)
                         if sc_end > sec_len:
                             sc_end = sec_len
@@ -2071,6 +2101,7 @@ class UnifiedDecodeKernel:
                             sc_end,
                             sec_len,
                             sm_scale_log2,
+                            s3_cap,
                             lane,
                         )
                     else:
@@ -2085,6 +2116,7 @@ class UnifiedDecodeKernel:
                             split_cand_end,
                             section_len,
                             sm_scale_log2,
+                            slot_capacity,
                             lane,
                         )
 

--- a/b12x/attention/_shared/mla/prefill_mg.py
+++ b/b12x/attention/_shared/mla/prefill_mg.py
@@ -116,9 +116,9 @@ def s3_mask_and_scale_global(
     split_cand_end: Int32,
     section_len: Int32,
     sm_scale_log2: Float32,
+    slot_capacity: Int32,
     lane: Int32,
 ):
-    """FI-shaped S3: validate candidates from the global selected-index row."""
     tid = lane & Int32(3)
     c0 = warp_first_cand + tid * Int32(2)
     c1 = c0 + Int32(1)
@@ -132,10 +132,10 @@ def s3_mask_and_scale_global(
     if abs_c1 < section_len:
         idx1 = _ld_global_index_i32(index_base_ptr, c1)
 
-    if abs_c0 >= split_cand_end or idx0 < Int32(0):
+    if abs_c0 >= split_cand_end or (idx0 < Int32(0)) | (idx0 >= slot_capacity):
         qk[0] = Float32(-1.0e30)
         qk[2] = Float32(-1.0e30)
-    if abs_c1 >= split_cand_end or idx1 < Int32(0):
+    if abs_c1 >= split_cand_end or (idx1 < Int32(0)) | (idx1 >= slot_capacity):
         qk[1] = Float32(-1.0e30)
         qk[3] = Float32(-1.0e30)
 
@@ -242,15 +242,15 @@ def _dsv4_record_off(
 
 @cute.jit
 def _dsv4_rope_base_off(
-    idx: Int32, page_block_size: Int32, stride_kv_block: Int64
+    idx: Int32, page_block_size: Int32, stride_kv_block: Int64,
+    slot_capacity: Int32,
 ) -> Int64:
     """Full DSV4 RoPE-record offset used by the QK prefetch paths."""
-    if idx < Int32(0):
+    if (idx < Int32(0)) | (idx >= slot_capacity):
         idx = Int32(0)
     return _dsv4_record_off(idx, page_block_size, stride_kv_block) + Int64(
         _DSV4_ROPE_GMEM_OFFSET
     )
-
 
 @cute.jit
 def _ld_global_dsv4_rope_b16(
@@ -258,9 +258,10 @@ def _ld_global_dsv4_rope_b16(
     idx: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
 ) -> Uint32:
     out = Uint32(0)
-    if idx >= Int32(0):
+    if (idx >= Int32(0)) & (idx < slot_capacity):
         byte_off = _dsv4_record_off(idx, page_block_size, stride_kv_block)
         out = ld_global_b16(rope_dim_ptr + byte_off)
     return out
@@ -276,6 +277,7 @@ def s2_qk_rope_global_dsv4(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     d_rope: cutlass.Constexpr,
 ):
@@ -285,7 +287,7 @@ def s2_qk_rope_global_dsv4(
     a_col = (lane >> Int32(4)) * Int32(8)
     entry = warp_first_cand + gid
     idx = _ld_global_index_i32(index_base_ptr, entry)
-    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block, slot_capacity)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
@@ -320,6 +322,7 @@ def s2_qk_rope_global_mg_dsv4(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     d_rope: cutlass.Constexpr,
     q_rope_stride: cutlass.Constexpr,
@@ -343,7 +346,7 @@ def s2_qk_rope_global_mg_dsv4(
     a_col = (lane >> Int32(4)) * Int32(8)
     entry = warp_first_cand + gid
     idx = _ld_global_index_i32(index_base_ptr, entry)
-    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block, slot_capacity)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
@@ -384,9 +387,10 @@ def s2_qk_rope_global_mg_dsv4(
 # =============================================================================
 @cute.jit
 def _glm_rope_base_off(
-    idx: Int32, page_block_size: Int32, stride_kv_block: Int64
+    idx: Int32, page_block_size: Int32, stride_kv_block: Int64,
+    slot_capacity: Int32,
 ) -> Int64:
-    if idx < Int32(0):
+    if (idx < Int32(0)) | (idx >= slot_capacity):
         idx = Int32(0)
     block_idx = idx // page_block_size
     local_idx = idx - block_idx * page_block_size
@@ -396,16 +400,16 @@ def _glm_rope_base_off(
         + Int64(_GLM_ROPE_GMEM_OFFSET)
     )
 
-
 @cute.jit
 def _nvfp4_rope_base_off(
     idx: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     fp8_rope: cutlass.Constexpr = False,
 ) -> Int64:
-    if idx < Int32(0):
+    if (idx < Int32(0)) | (idx >= slot_capacity):
         idx = Int32(0)
     block_idx = idx // page_block_size
     local_idx = idx - block_idx * page_block_size
@@ -459,6 +463,7 @@ def s2_qk_rope_regs_mg_glm(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     d_rope: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
@@ -486,10 +491,11 @@ def s2_qk_rope_regs_mg_glm(
             idx,
             page_block_size,
             stride_kv_block,
+            slot_capacity,
             fp8_rope=fp8_rope,
         )
     else:
-        rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block)
+        rope_base = _glm_rope_base_off(idx, page_block_size, stride_kv_block, slot_capacity)
     hi0 = cutlass.const_expr(valid_hpb > 8)
 
     if cutlass.const_expr(scale_format == 2 and fp8_rope):
@@ -1213,6 +1219,7 @@ def s2_qk_rope_regs_mg_dsv4(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     d_rope: cutlass.Constexpr,
     n_hg: cutlass.Constexpr = 2,
@@ -1222,7 +1229,7 @@ def s2_qk_rope_regs_mg_dsv4(
     tid = lane & Int32(3)
     entry = warp_first_cand + gid
     idx = _ld_global_index_i32(index_base_ptr, entry)
-    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block)
+    rope_base = _dsv4_rope_base_off(idx, page_block_size, stride_kv_block, slot_capacity)
 
     for ks in cutlass.range_constexpr(d_rope // 16):
         ko = Int32(ks) * Int32(16)
@@ -1277,6 +1284,7 @@ def s6b_xv_rope_global_dsv4(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     bi: cutlass.Constexpr,
     d_rope: cutlass.Constexpr,
@@ -1305,16 +1313,16 @@ def s6b_xv_rope_global_dsv4(
         idx8 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(8))
         idx9 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(9))
         v0 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx0, page_block_size, stride_kv_block
+            rope_dim_ptr, idx0, page_block_size, stride_kv_block, slot_capacity
         )
         v1 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx1, page_block_size, stride_kv_block
+            rope_dim_ptr, idx1, page_block_size, stride_kv_block, slot_capacity
         )
         v8 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx8, page_block_size, stride_kv_block
+            rope_dim_ptr, idx8, page_block_size, stride_kv_block, slot_capacity
         )
         v9 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx9, page_block_size, stride_kv_block
+            rope_dim_ptr, idx9, page_block_size, stride_kv_block, slot_capacity
         )
         b0 = v0 | (v1 << Uint32(16))
         b1 = v8 | (v9 << Uint32(16))
@@ -1337,6 +1345,7 @@ def s6b_xv_rope_global_mg_dsv4(
     lane: Int32,
     page_block_size: Int32,
     stride_kv_block: Int64,
+    slot_capacity: Int32,
     *,
     bi: cutlass.Constexpr,
     sm_p_stride: cutlass.Constexpr,
@@ -1411,16 +1420,16 @@ def s6b_xv_rope_global_mg_dsv4(
         idx8 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(8))
         idx9 = _ld_global_index_i32(index_base_ptr, ent0 + Int32(9))
         v0 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx0, page_block_size, stride_kv_block
+            rope_dim_ptr, idx0, page_block_size, stride_kv_block, slot_capacity
         )
         v1 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx1, page_block_size, stride_kv_block
+            rope_dim_ptr, idx1, page_block_size, stride_kv_block, slot_capacity
         )
         v8 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx8, page_block_size, stride_kv_block
+            rope_dim_ptr, idx8, page_block_size, stride_kv_block, slot_capacity
         )
         v9 = _ld_global_dsv4_rope_b16(
-            rope_dim_ptr, idx9, page_block_size, stride_kv_block
+            rope_dim_ptr, idx9, page_block_size, stride_kv_block, slot_capacity
         )
         b0 = v0 | (v1 << Uint32(16))
         b1 = v8 | (v9 << Uint32(16))
@@ -2481,6 +2490,19 @@ class UnifiedPrefillMGKernel:
             extra_section_len = section_len
             loop_tiles = actual_tiles
 
+        # Physical slot capacity = floor(cache_bytes / block_stride) * page_size.
+        # floor (not ceil): a partial final block is not addressable.  Computed
+        # from the live cache tensor so it tracks replay-time geometry without a
+        # host sync.  Int64 arithmetic avoids overflow.  The cache tensor is a
+        # flat uint8 byte view so shape[0] is already bytes.
+        _cap_bytes = Int64(kv_cache_u8.shape[0])
+        slot_capacity = Int32(_cap_bytes // stride_kv_block) * Int32(self.page_block_size)
+        if cutlass.const_expr(has_extra):
+            _ecap_bytes = Int64(extra_kv_cache_u8.shape[0])
+            extra_slot_capacity = Int32(_ecap_bytes // stride_extra_kv_block) * Int32(self.pbs_extra)
+        else:
+            extra_slot_capacity = slot_capacity
+
         topk_row = cute.make_tensor(
             indices.iterator + token_idx.to(Int64) * Int64(self.indices_stride_row),
             cute.make_layout(self.topk),
@@ -2530,6 +2552,7 @@ class UnifiedPrefillMGKernel:
                         g_end0,
                         Int32(self.page_block_size),
                         stride_kv_block,
+                        slot_capacity,
                         io_lane,
                         kv_l2_policy,
                         bi=t.bi,
@@ -2551,6 +2574,7 @@ class UnifiedPrefillMGKernel:
                         g_end0,
                         Int32(self.page_block_size),
                         stride_kv_block,
+                        slot_capacity,
                         io_lane,
                         kv_l2_policy,
                         bi=t.bi,
@@ -2588,6 +2612,7 @@ class UnifiedPrefillMGKernel:
                                 g_end,
                                 Int32(self.pbs_extra),
                                 stride_extra_kv_block,
+                                extra_slot_capacity,
                                 io_lane,
                                 kv_l2_policy,
                                 bi=t.bi,
@@ -2609,6 +2634,7 @@ class UnifiedPrefillMGKernel:
                                 g_end,
                                 Int32(self.page_block_size),
                                 stride_kv_block,
+                                slot_capacity,
                                 io_lane,
                                 kv_l2_policy,
                                 bi=t.bi,
@@ -2630,6 +2656,7 @@ class UnifiedPrefillMGKernel:
                                 g_end,
                                 Int32(self.page_block_size),
                                 stride_kv_block,
+                                slot_capacity,
                                 io_lane,
                                 kv_l2_policy,
                                 bi=t.bi,
@@ -2651,6 +2678,7 @@ class UnifiedPrefillMGKernel:
                                 g_end,
                                 Int32(self.page_block_size),
                                 stride_kv_block,
+                                slot_capacity,
                                 io_lane,
                                 kv_l2_policy,
                                 bi=t.bi,
@@ -2867,11 +2895,13 @@ class UnifiedPrefillMGKernel:
                 # / sec_len_now are the literal main expressions, exactly as today).
                 split_cand_start = ci * Int32(_CAND_WINDOW)
                 sec_len_now = section_len
+                sec_cap = slot_capacity
                 if cutlass.const_expr(has_extra):
                     if ci >= num_main_tiles:
                         cis = ci - num_main_tiles
                         split_cand_start = cis * Int32(_CAND_WINDOW)
                         sec_len_now = extra_section_len
+                        sec_cap = extra_slot_capacity
                 split_cand_end = split_cand_start + Int32(_CAND_WINDOW)
                 if split_cand_end > sec_len_now:
                     split_cand_end = sec_len_now
@@ -2949,6 +2979,7 @@ class UnifiedPrefillMGKernel:
                         lane,
                         rope_pbs,
                         rope_stride,
+                        sec_cap,
                         d_rope=t.d_rope,
                         n_hg=n_hg,
                         valid_hpb=self.valid_hpb,
@@ -2983,7 +3014,8 @@ class UnifiedPrefillMGKernel:
                     rope_entry = warp_first_cand + (lane >> Int32(2))
                     rope_idx = _ld_global_index_i32(index_base_ptr, rope_entry)
                     rope_base = _dsv4_rope_base_off(
-                        rope_idx, Int32(self.page_block_size), stride_kv_block
+                        rope_idx, Int32(self.page_block_size), stride_kv_block,
+                        sec_cap,
                     )
                     rope_base_ptr = get_ptr_as_int64(kv_cache_u8, rope_base)
                     if cutlass.const_expr(has_extra):
@@ -2992,6 +3024,7 @@ class UnifiedPrefillMGKernel:
                                 rope_idx,
                                 Int32(self.pbs_extra),
                                 stride_extra_kv_block,
+                                sec_cap,
                             )
                             rope_base_ptr = get_ptr_as_int64(
                                 extra_kv_cache_u8, rope_base
@@ -3119,6 +3152,7 @@ class UnifiedPrefillMGKernel:
                             lane,
                             rope_pbs,
                             rope_stride,
+                            sec_cap,
                             d_rope=t.d_rope,
                             n_hg=n_hg,
                             valid_hpb=self.valid_hpb,
@@ -3139,7 +3173,7 @@ class UnifiedPrefillMGKernel:
                             warp_first_cand,
                             lane,
                             rope_pbs,
-                            rope_stride,
+                            sec_cap,
                             d_rope=t.d_rope,
                             q_rope_stride=L.q_rope_stride,
                             n_hg=n_hg,
@@ -3153,6 +3187,7 @@ class UnifiedPrefillMGKernel:
                     split_cand_end,
                     sec_len_now,
                     sm_scale_log2,
+                    sec_cap,
                     lane,
                 )
                 if cutlass.const_expr(n_hg == 2):
@@ -3164,6 +3199,7 @@ class UnifiedPrefillMGKernel:
                         split_cand_end,
                         sec_len_now,
                         sm_scale_log2,
+                        sec_cap,
                         lane,
                     )
                 p0 = [Float32(0.0), Float32(0.0), Float32(0.0), Float32(0.0)]
@@ -3409,6 +3445,7 @@ class UnifiedPrefillMGKernel:
                                 lane,
                                 Int32(self.pbs_extra),
                                 stride_extra_kv_block,
+                                extra_slot_capacity,
                                 bi=t.bi,
                                 sm_p_stride=L.sm_p_full_stride,
                                 hpb=t.hpb,
@@ -3431,6 +3468,7 @@ class UnifiedPrefillMGKernel:
                                 lane,
                                 Int32(self.page_block_size),
                                 stride_kv_block,
+                                slot_capacity,
                                 bi=t.bi,
                                 sm_p_stride=L.sm_p_full_stride,
                                 hpb=t.hpb,
@@ -3451,6 +3489,9 @@ class UnifiedPrefillMGKernel:
                             index_base_ptr,
                             warp_id,
                             lane,
+                            rope_pbs,
+                            rope_stride,
+                            sec_cap,
                             rope_pbs,
                             rope_stride,
                             bi=t.bi,

--- a/tests/attention/test_mla_index_bounds_158.py
+++ b/tests/attention/test_mla_index_bounds_158.py
@@ -1,0 +1,318 @@
+"""Regression tests for issue #158: sparse/compressed MLA live cache index bounds.
+
+These tests verify that the host-side fail-closed validation rejects high
+positive selected indices that exceed the physical cache slot capacity, while
+retaining negative sentinels (-1) as the contractual invalid marker.
+
+The in-kernel ``slot_capacity`` bound (computed from the live cache tensor
+shape) dominates during CUDA graph replay; these tests cover the host-side
+guard that runs outside graph capture.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+
+def _get_helpers():
+    """Lazy import to avoid pulling CUDA bindings on non-CUDA hosts."""
+    from b12x.attention._shared.mla.api import (
+        _sparse_mla_slot_capacity,
+        _validate_sparse_mla_index_bounds,
+    )
+    return _sparse_mla_slot_capacity, _validate_sparse_mla_index_bounds
+
+
+# ---------------------------------------------------------------------------
+# _sparse_mla_slot_capacity unit tests (no GPU required)
+# ---------------------------------------------------------------------------
+
+def test_slot_capacity_rank3():
+    """Rank-3 [pages, page_size, record] -> pages * page_size."""
+    _cap = _get_helpers()[0]
+    cache = torch.zeros((4, 64, 656), dtype=torch.uint8)
+    assert _cap(cache, 64) == 256
+
+
+def test_slot_capacity_rank2_compressed():
+    """Rank-2 [pages, page_bytes] -> pages * page_size."""
+    _cap = _get_helpers()[0]
+    cache = torch.zeros((8, 256 * 584), dtype=torch.uint8)
+    assert _cap(cache, 256) == 2048
+
+
+def test_slot_capacity_single_page():
+    _cap = _get_helpers()[0]
+    cache = torch.zeros((1, 64, 656), dtype=torch.uint8)
+    assert _cap(cache, 64) == 64
+
+
+def test_slot_capacity_empty():
+    """Zero-element cache -> capacity 0."""
+    _cap = _get_helpers()[0]
+    cache = torch.zeros((0, 64, 656), dtype=torch.uint8)
+    assert _cap(cache, 64) == 0
+
+
+# ---------------------------------------------------------------------------
+# _validate_sparse_mla_index_bounds unit tests (no GPU required)
+# ---------------------------------------------------------------------------
+
+def _make_indices(rows, width, values, device="cpu"):
+    idx = torch.full((rows, width), values, dtype=torch.int32, device=device)
+    return idx
+
+
+def test_validate_rejects_high_positive_index():
+    """An index >= capacity is rejected."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, 100)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_accepts_capacity_minus_one():
+    """capacity-1 is the highest valid index and must pass."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, 63)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_accepts_negative_sentinel():
+    """Negative sentinels (-1) are retained and must not raise."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, -1)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_accepts_mixed_valid_and_sentinel():
+    """A mix of valid indices and -1 sentinels must pass."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[0, 1, -1, 63]], dtype=torch.int32)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_accepts_negative_non_sentinel():
+    """Any negative value is safe (the kernel masks idx < 0)."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[-2, -1, 0, 1]], dtype=torch.int32)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_skipped_during_graph_capture():
+    """During CUDA graph capture the host guard is skipped (kernel dominates)."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, 999_999)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=True)
+
+
+def test_validate_empty_indices():
+    """Empty index tensor -> no validation needed."""
+    _validate = _get_helpers()[1]
+    indices = torch.empty((0, 4), dtype=torch.int32)
+    lengths = torch.empty((0,), dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_zero_capacity_all_sentinels():
+    """Zero capacity with only -1 sentinels passes (no positive indices)."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, -1)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=0, is_graph_capture=False)
+
+
+def test_validate_zero_capacity_rejects_positive():
+    """Zero capacity with any positive index is rejected."""
+    _validate = _get_helpers()[1]
+    indices = _make_indices(1, 4, 0)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    with pytest.raises(ValueError, match="zero slot capacity"):
+        _validate(indices, lengths, slot_capacity=0, is_graph_capture=False)
+
+
+def test_validate_active_token_counts_masks_padding():
+    """Indices past the per-token length (padding) are not checked."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[0, 1, 999, 999]], dtype=torch.int32)
+    lengths = torch.tensor([2], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_active_token_counts_catches_live_oob():
+    """An OOB index within the live prefix is caught even if padding is valid."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[0, 100, -1, -1]], dtype=torch.int32)
+    lengths = torch.tensor([2], dtype=torch.int32)
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_active_token_counts_zero_length():
+    """A row with zero live length skips validation entirely."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[999, 999, 999, 999]], dtype=torch.int32)
+    lengths = torch.tensor([0], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_big_pid_boundary():
+    """A large valid index at exactly capacity-1 must pass."""
+    _validate = _get_helpers()[1]
+    cap = 1024 * 64
+    indices = torch.tensor([[cap - 1]], dtype=torch.int32)
+    lengths = torch.tensor([1], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=cap, is_graph_capture=False)
+
+
+def test_validate_big_pid_overflow():
+    """An index at exactly capacity must fail."""
+    _validate = _get_helpers()[1]
+    cap = 1024 * 64
+    indices = torch.tensor([[cap]], dtype=torch.int32)
+    lengths = torch.tensor([1], dtype=torch.int32)
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        _validate(indices, lengths, slot_capacity=cap, is_graph_capture=False)
+
+
+def test_validate_rejects_capacity_exact():
+    """Index == capacity (not capacity-1) is out of bounds."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[64]], dtype=torch.int32)
+    lengths = torch.tensor([1], dtype=torch.int32)
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_capacity_mismatch_main():
+    """Capacity mismatch: indices planned for a larger cache are rejected."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[0, 32, 64, 128]], dtype=torch.int32)
+    lengths = torch.tensor([4], dtype=torch.int32)
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        _validate(indices, lengths, slot_capacity=64, is_graph_capture=False)
+
+
+def test_validate_valid_control():
+    """Valid control: all indices within bounds passes silently."""
+    _validate = _get_helpers()[1]
+    indices = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.int32)
+    lengths = torch.tensor([8], dtype=torch.int32)
+    _validate(indices, lengths, slot_capacity=256, is_graph_capture=False)
+
+
+# ---------------------------------------------------------------------------
+# GPU integration tests (require CUDA + SM120)
+# ---------------------------------------------------------------------------
+
+def _has_sm120(device: torch.device) -> bool:
+    try:
+        from b12x._lib.intrinsics import get_sm_version
+        return get_sm_version(device) >= 120
+    except Exception:
+        return False
+
+
+def _make_compressed_case(device, *, topk, num_pages=4, seed=42):
+    """Build a compressed MLA decode case with valid indices."""
+    from b12x.attention._shared.mla.compressed_reference import (
+        pack_compressed_mla_kv_cache_reference,
+    )
+
+    page_size = 64
+    n_tokens = num_pages * page_size
+    heads = 8
+    head_dim = 512
+
+    gen = torch.Generator(device=device).manual_seed(seed)
+    k_nope = torch.randn((n_tokens, 448), generator=gen, dtype=torch.float32, device=device).clamp(-1, 1)
+    k_rope = torch.randn((n_tokens, 64), generator=gen, dtype=torch.float32, device=device).clamp(-1, 1)
+    cache = pack_compressed_mla_kv_cache_reference(
+        k_nope, k_rope.to(torch.bfloat16), page_size=page_size, num_pages=num_pages
+    )
+    q = torch.randn((1, heads, head_dim), generator=gen, dtype=torch.bfloat16, device=device)
+    idx = torch.randint(0, n_tokens, (1, topk), generator=gen, dtype=torch.int32, device=device)
+    idx[:, topk // 2:] = -1
+    lengths = torch.full((1,), topk, dtype=torch.int32, device=device)
+    return q, cache, idx, lengths, page_size, heads, head_dim
+
+
+def _make_scratch(device, *, topk, heads, head_dim, page_size):
+    from b12x.attention.compressed_mla._scratch import (
+        B12XCompressedMLAScratchCaps,
+        _compressed_mla_scratch_layout,
+        _materialize_compressed_mla_scratch,
+    )
+    caps = B12XCompressedMLAScratchCaps(
+        device=device, num_q_heads=heads, max_q_rows=1, max_width=topk,
+        head_dim=head_dim, v_head_dim=head_dim,
+        max_chunks_per_row=8, page_size=page_size,
+    )
+    layout = _compressed_mla_scratch_layout(caps)
+    storage = torch.zeros(int(layout.nbytes), dtype=torch.uint8, device=device)
+    return _materialize_compressed_mla_scratch(caps, storage, layout)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compressed_mla_decode_rejects_oob_index():
+    """Compressed MLA decode with an out-of-bounds positive index is rejected
+    at the API boundary (fail-closed)."""
+    from b12x.attention._shared.mla.compressed_api import (
+        compressed_mla_decode_forward,
+    )
+
+    device = torch.device("cuda")
+    if not _has_sm120(device):
+        pytest.skip("SM120 sparse MLA kernel path unavailable")
+
+    topk = 64
+    q, cache, idx, lengths, page_size, heads, head_dim = _make_compressed_case(device, topk=topk)
+
+    # Overwrite with an out-of-bounds index
+    idx.fill_(int(cache.shape[0]) * page_size)
+
+    scratch = _make_scratch(device, topk=topk, heads=heads, head_dim=head_dim, page_size=page_size)
+    binding = scratch.bind(q=q, swa_indices=idx, swa_lengths=lengths)
+
+    with pytest.raises(ValueError, match="exceeds cache slot capacity"):
+        compressed_mla_decode_forward(
+            binding=binding,
+            swa_k_cache=cache,
+            sm_scale=1.0 / math.sqrt(head_dim),
+            swa_page_size=page_size,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_compressed_mla_decode_accepts_valid_indices():
+    """Compressed MLA decode with valid indices within bounds succeeds."""
+    from b12x.attention._shared.mla.compressed_api import (
+        compressed_mla_decode_forward,
+    )
+
+    device = torch.device("cuda")
+    if not _has_sm120(device):
+        pytest.skip("SM120 sparse MLA kernel path unavailable")
+
+    topk = 64
+    q, cache, idx, lengths, page_size, heads, head_dim = _make_compressed_case(device, topk=topk)
+
+    scratch = _make_scratch(device, topk=topk, heads=heads, head_dim=head_dim, page_size=page_size)
+    binding = scratch.bind(q=q, swa_indices=idx, swa_lengths=lengths)
+
+    out = compressed_mla_decode_forward(
+        binding=binding,
+        swa_k_cache=cache,
+        sm_scale=1.0 / math.sqrt(head_dim),
+        swa_page_size=page_size,
+    )
+    assert out.shape == (1, heads, head_dim)


### PR DESCRIPTION
Closes #158.

Binds sparse/compressed MLA selection metadata to live logical and physical cache extents and carries replay-time bounds into shared gather addressing. Invalid active indices are rejected or masked before forming cache addresses.

Verification: 23 focused SM121 GPU tests passed; py_compile/Ruff/diff checks passed.