### PR TITLE
[II] Ignore inactive routes in dynamic MoE kernels

### DIFF
--- a/b12x/moe/_shared/kernels/dynamic.py
+++ b/b12x/moe/_shared/kernels/dynamic.py
@@ -2998,7 +2998,13 @@ class MoEDynamicKernelBackend:
             hist_idx = flat_tid
             while hist_idx < total_pairs:
                 expert_id = topk_ids[hist_idx].to(Int32)
-                atomic_add_global_i32(get_ptr_as_int64(row_counts, expert_id), Int32(1))
+                # A route outside the local expert domain is inactive. vLLM
+                # uses -1 for scheduler padding, and expert-parallel callers
+                # may use the same contract for non-local routes.
+                if expert_id >= Int32(0) and expert_id < num_experts:
+                    atomic_add_global_i32(
+                        get_ptr_as_int64(row_counts, expert_id), Int32(1)
+                    )
                 hist_idx += flat_stride
 
             self._resident_grid_barrier(
@@ -3102,29 +3108,33 @@ class MoEDynamicKernelBackend:
                                 pair_idx = token_idx * num_topk + topk_slot
                                 expert_id = topk_ids[pair_idx].to(Int32)
                                 weight = topk_weights[pair_idx].to(cutlass.Float32)
-                                if cutlass.const_expr(self.direct_routing):
-                                    row = Int32(0)
-                                    phys_tile = pair_idx
-                                else:
-                                    row = atomic_add_global_i32(
-                                        get_ptr_as_int64(expert_write_rows, expert_id),
-                                        Int32(1),
+                                phys_row = Int32(-1)
+                                if expert_id >= Int32(0) and expert_id < num_experts:
+                                    if cutlass.const_expr(self.direct_routing):
+                                        row = Int32(0)
+                                        phys_tile = pair_idx
+                                    else:
+                                        row = atomic_add_global_i32(
+                                            get_ptr_as_int64(
+                                                expert_write_rows, expert_id
+                                            ),
+                                            Int32(1),
+                                        )
+                                        phys_tile = expert_tile_base[
+                                            expert_id
+                                        ] + row // Int32(self.tile_shape_mnk[0])
+                                    phys_row = phys_tile * Int32(
+                                        self.tile_shape_mnk[0]
+                                    ) + row % Int32(self.tile_shape_mnk[0])
+                                    map_value = token_idx
+                                    if cutlass.const_expr(self.deterministic_output):
+                                        map_value = pair_idx
+                                    st_global_i32(
+                                        get_ptr_as_int64(token_map, phys_row), map_value
                                     )
-                                    phys_tile = expert_tile_base[
-                                        expert_id
-                                    ] + row // Int32(self.tile_shape_mnk[0])
-                                phys_row = phys_tile * Int32(
-                                    self.tile_shape_mnk[0]
-                                ) + row % Int32(self.tile_shape_mnk[0])
-                                map_value = token_idx
-                                if cutlass.const_expr(self.deterministic_output):
-                                    map_value = pair_idx
-                                st_global_i32(
-                                    get_ptr_as_int64(token_map, phys_row), map_value
-                                )
-                                st_global_f32(
-                                    get_ptr_as_int64(token_weights, phys_row), weight
-                                )
+                                    st_global_f32(
+                                        get_ptr_as_int64(token_weights, phys_row), weight
+                                    )
                                 slot = route_slot_base + topk_slot
                                 _st_shared_i32(
                                     route_phys_rows_addr + slot * Int32(4), phys_row
@@ -3202,18 +3212,19 @@ class MoEDynamicKernelBackend:
                                                 phys_row = shared_route_phys_rows[
                                                     cache_slot
                                                 ]
-                                                output_offset = (
-                                                    phys_row * output_bytes_per_row
-                                                    + block_start
-                                                    + Int32(payload_pair * 8)
-                                                )
-                                                st_global_u64(
-                                                    get_ptr_as_int64(
-                                                        packed_a_storage,
-                                                        output_offset,
-                                                    ),
-                                                    packed64,
-                                                )
+                                                if phys_row >= Int32(0):
+                                                    output_offset = (
+                                                        phys_row * output_bytes_per_row
+                                                        + block_start
+                                                        + Int32(payload_pair * 8)
+                                                    )
+                                                    st_global_u64(
+                                                        get_ptr_as_int64(
+                                                            packed_a_storage,
+                                                            output_offset,
+                                                        ),
+                                                        packed64,
+                                                    )
                                     if cutlass.const_expr(
                                         self.materialize_intermediate
                                     ):
@@ -3225,9 +3236,12 @@ class MoEDynamicKernelBackend:
                                             phys_row = shared_route_phys_rows[
                                                 cache_slot
                                             ]
-                                            scale_storage[
-                                                phys_row * mx_blocks_per_row + blk_idx
-                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                            if phys_row >= Int32(0):
+                                                scale_storage[
+                                                    phys_row * mx_blocks_per_row + blk_idx
+                                                ] = Uint8(
+                                                    mx_scale_byte & Uint32(0xFF)
+                                                )
                                     blk_idx += Int32(self.input_warps_per_token * 32)
                             else:
                                 blk_idx = lane_id + token_partition * Int32(32)
@@ -3287,18 +3301,19 @@ class MoEDynamicKernelBackend:
                                                     route_phys_rows_addr
                                                     + slot * Int32(4)
                                                 )
-                                                output_offset = (
-                                                    phys_row * output_bytes_per_row
-                                                    + block_start
-                                                    + Int32(payload_pair * 8)
-                                                )
-                                                st_global_u64(
-                                                    get_ptr_as_int64(
-                                                        packed_a_storage,
-                                                        output_offset,
-                                                    ),
-                                                    packed64,
-                                                )
+                                                if phys_row >= Int32(0):
+                                                    output_offset = (
+                                                        phys_row * output_bytes_per_row
+                                                        + block_start
+                                                        + Int32(payload_pair * 8)
+                                                    )
+                                                    st_global_u64(
+                                                        get_ptr_as_int64(
+                                                            packed_a_storage,
+                                                            output_offset,
+                                                        ),
+                                                        packed64,
+                                                    )
                                                 topk_slot += Int32(1)
                                     if cutlass.const_expr(
                                         self.materialize_intermediate
@@ -3313,9 +3328,12 @@ class MoEDynamicKernelBackend:
                                             phys_row = _ld_shared_i32(
                                                 route_phys_rows_addr + slot * Int32(4)
                                             )
-                                            scale_storage[
-                                                phys_row * mx_blocks_per_row + blk_idx
-                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                            if phys_row >= Int32(0):
+                                                scale_storage[
+                                                    phys_row * mx_blocks_per_row + blk_idx
+                                                ] = Uint8(
+                                                    mx_scale_byte & Uint32(0xFF)
+                                                )
                                             topk_slot += Int32(1)
                                     blk_idx += Int32(self.input_warps_per_token * 32)
                         else:
@@ -3326,18 +3344,23 @@ class MoEDynamicKernelBackend:
                                     phys_row = _ld_shared_i32(
                                         route_phys_rows_addr + slot * Int32(4)
                                     )
-                                    route_output_base[cache_slot] = (
-                                        phys_row * output_bytes_per_row
-                                    )
-                                    # Scale storage is tiled in 128-row SF
-                                    # atoms, independently of the MMA tile.
-                                    sf_atom = phys_row >> Int32(7)
-                                    sf_row = phys_row & Int32(127)
-                                    route_scale_base[cache_slot] = (
-                                        sf_atom * num_k_tiles * Int32(32 * 4 * 4)
-                                        + (sf_row % Int32(32)) * Int32(4 * 4)
-                                        + (sf_row // Int32(32)) * Int32(4)
-                                    )
+                                    route_output_base[cache_slot] = Int32(-1)
+                                    route_scale_base[cache_slot] = Int32(-1)
+                                    if phys_row >= Int32(0):
+                                        route_output_base[cache_slot] = (
+                                            phys_row * output_bytes_per_row
+                                        )
+                                        # Scale storage is tiled in 128-row SF
+                                        # atoms, independently of the MMA tile.
+                                        sf_atom = phys_row >> Int32(7)
+                                        sf_row = phys_row & Int32(127)
+                                        route_scale_base[cache_slot] = (
+                                            sf_atom
+                                            * num_k_tiles
+                                            * Int32(32 * 4 * 4)
+                                            + (sf_row % Int32(32)) * Int32(4 * 4)
+                                            + (sf_row // Int32(32)) * Int32(4)
+                                        )
 
                                 sf_idx = lane_id
                                 while sf_idx < sf_blocks_per_row:
@@ -3371,18 +3394,21 @@ class MoEDynamicKernelBackend:
                                         k_tile_idx * Int32(32 * 4 * 4) + inner_k_idx
                                     )
                                     for cache_slot in cutlass.range_constexpr(8):
-                                        output_offset = route_output_base[
-                                            cache_slot
-                                        ] + sf_idx * Int32(8)
-                                        st_global_u64(
-                                            get_ptr_as_int64(
-                                                packed_a_storage, output_offset
-                                            ),
-                                            packed64,
-                                        )
-                                        scale_storage[
-                                            route_scale_base[cache_slot] + scale_k_base
-                                        ] = scale_byte
+                                        output_base = route_output_base[cache_slot]
+                                        if output_base >= Int32(0):
+                                            output_offset = output_base + sf_idx * Int32(
+                                                8
+                                            )
+                                            st_global_u64(
+                                                get_ptr_as_int64(
+                                                    packed_a_storage, output_offset
+                                                ),
+                                                packed64,
+                                            )
+                                            scale_storage[
+                                                route_scale_base[cache_slot]
+                                                + scale_k_base
+                                            ] = scale_byte
                                     sf_idx += Int32(32)
                             else:
                                 sf_idx = lane_id
@@ -3417,35 +3443,36 @@ class MoEDynamicKernelBackend:
                                         phys_row = _ld_shared_i32(
                                             route_phys_rows_addr + slot * Int32(4)
                                         )
-                                        output_offset = (
-                                            phys_row * output_bytes_per_row
-                                            + sf_idx * Int32(8)
-                                        )
-                                        st_global_u64(
-                                            get_ptr_as_int64(
-                                                packed_a_storage, output_offset
-                                            ),
-                                            packed64,
-                                        )
+                                        if phys_row >= Int32(0):
+                                            output_offset = (
+                                                phys_row * output_bytes_per_row
+                                                + sf_idx * Int32(8)
+                                            )
+                                            st_global_u64(
+                                                get_ptr_as_int64(
+                                                    packed_a_storage, output_offset
+                                                ),
+                                                packed64,
+                                            )
 
-                                        # scale_storage uses 128-row SF atoms
-                                        # (tile_atom_to_shape_SF); index by the 128-atom
-                                        # (phys_row>>7) + row-within-atom, NOT the MMA
-                                        # tile (which may be 64). Identity at tile_m==128.
-                                        k_tile_idx = sf_idx // Int32(4)
-                                        sf_atom = phys_row >> Int32(7)
-                                        sf_row = phys_row & Int32(127)
-                                        outer_m_idx = sf_row % Int32(32)
-                                        inner_m_idx = sf_row // Int32(32)
-                                        inner_k_idx = sf_idx % Int32(4)
-                                        scale_offset = (
-                                            sf_atom * num_k_tiles * Int32(32 * 4 * 4)
-                                            + k_tile_idx * Int32(32 * 4 * 4)
-                                            + outer_m_idx * Int32(4 * 4)
-                                            + inner_m_idx * Int32(4)
-                                            + inner_k_idx
-                                        )
-                                        scale_storage[scale_offset] = scale_byte
+                                            # Scale storage uses 128-row SF atoms,
+                                            # independently of the MMA tile.
+                                            k_tile_idx = sf_idx // Int32(4)
+                                            sf_atom = phys_row >> Int32(7)
+                                            sf_row = phys_row & Int32(127)
+                                            outer_m_idx = sf_row % Int32(32)
+                                            inner_m_idx = sf_row // Int32(32)
+                                            inner_k_idx = sf_idx % Int32(4)
+                                            scale_offset = (
+                                                sf_atom
+                                                * num_k_tiles
+                                                * Int32(32 * 4 * 4)
+                                                + k_tile_idx * Int32(32 * 4 * 4)
+                                                + outer_m_idx * Int32(4 * 4)
+                                                + inner_m_idx * Int32(4)
+                                                + inner_k_idx
+                                            )
+                                            scale_storage[scale_offset] = scale_byte
                                         topk_slot += Int32(1)
                                     sf_idx += Int32(32)
 
@@ -3469,28 +3496,33 @@ class MoEDynamicKernelBackend:
                                     expert_id = _ld_shared_i32(
                                         route_expert_ids_addr + slot * Int32(4)
                                     )
-                                    phys_tile = phys_row // Int32(
-                                        self.tile_shape_mnk[0]
-                                    )
-                                    completed = atomic_add_global_i32(
-                                        get_ptr_as_int64(tile_write_count, phys_tile),
-                                        Int32(1),
-                                    ) + Int32(1)
-                                    if completed == Int32(self.tile_shape_mnk[0]):
-                                        self._publish_ready_tasks(
-                                            task_tail,
-                                            task_ready,
-                                            task_expert,
-                                            task_m_tile,
-                                            task_slice_begin,
-                                            task_slice_count,
-                                            task_valid_rows,
-                                            route_gate_tile_cnt,
-                                            task_slice_chunk,
-                                            expert_id,
-                                            phys_tile,
-                                            Int32(self.tile_shape_mnk[0]),
+                                    if phys_row >= Int32(0):
+                                        phys_tile = phys_row // Int32(
+                                            self.tile_shape_mnk[0]
                                         )
+                                        completed = atomic_add_global_i32(
+                                            get_ptr_as_int64(
+                                                tile_write_count, phys_tile
+                                            ),
+                                            Int32(1),
+                                        ) + Int32(1)
+                                        if completed == Int32(
+                                            self.tile_shape_mnk[0]
+                                        ):
+                                            self._publish_ready_tasks(
+                                                task_tail,
+                                                task_ready,
+                                                task_expert,
+                                                task_m_tile,
+                                                task_slice_begin,
+                                                task_slice_count,
+                                                task_valid_rows,
+                                                route_gate_tile_cnt,
+                                                task_slice_chunk,
+                                                expert_id,
+                                                phys_tile,
+                                                Int32(self.tile_shape_mnk[0]),
+                                            )
                                     topk_slot += Int32(1)
                 else:
                     warp_item = Int32(0)
@@ -3501,12 +3533,15 @@ class MoEDynamicKernelBackend:
                         weight = cutlass.Float32(0.0)
                         row = Int32(0)
                         phys_tile = Int32(0)
+                        route_is_valid = Int32(0)
                         if pair_idx < total_pairs:
                             expert_id = topk_ids[pair_idx].to(Int32)
                             token_idx = pair_idx // num_topk
                             weight = topk_weights[pair_idx].to(cutlass.Float32)
+                            if expert_id >= Int32(0) and expert_id < num_experts:
+                                route_is_valid = Int32(1)
 
-                            if lane_id == Int32(0):
+                            if lane_id == Int32(0) and route_is_valid > Int32(0):
                                 if cutlass.const_expr(self.direct_routing):
                                     row = Int32(0)
                                     phys_tile = pair_idx
@@ -3535,8 +3570,16 @@ class MoEDynamicKernelBackend:
                             phys_tile = cute.arch.shuffle_sync(phys_tile, Int32(0))
                             expert_id = cute.arch.shuffle_sync(expert_id, Int32(0))
                             token_idx = cute.arch.shuffle_sync(token_idx, Int32(0))
+                            route_is_valid = cute.arch.shuffle_sync(
+                                route_is_valid, Int32(0)
+                            )
 
-                            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                            safe_expert_id = expert_id
+                            if route_is_valid == Int32(0):
+                                safe_expert_id = Int32(0)
+                            gs_value = input_global_scale[safe_expert_id].to(
+                                cutlass.Float32
+                            )
                             if cutlass.const_expr(self.is_w4a8):
                                 # w4a8: per-32 dynamic UE8M0 + E4M3 payload, no
                                 # global scale. Payload stored plain row-major;
@@ -3574,24 +3617,25 @@ class MoEDynamicKernelBackend:
                                                 values, block_max
                                             )
                                         )
-                                    output_offset = (
-                                        phys_row * output_bytes_per_row + block_start
-                                    )
-                                    for pair_idx in cutlass.range_constexpr(4):
-                                        packed64 = (
-                                            Uint64(payload[pair_idx * 2 + 1])
-                                            << Uint64(32)
-                                        ) | Uint64(payload[pair_idx * 2])
-                                        st_global_u64(
-                                            get_ptr_as_int64(
-                                                packed_a_storage,
-                                                output_offset + Int32(pair_idx * 8),
-                                            ),
-                                            packed64,
+                                    if route_is_valid > Int32(0):
+                                        output_offset = (
+                                            phys_row * output_bytes_per_row + block_start
                                         )
-                                    scale_storage[
-                                        phys_row * mx_blocks_per_row + blk_idx
-                                    ] = Uint8(mx_scale_byte & Uint32(0xFF))
+                                        for pair_idx in cutlass.range_constexpr(4):
+                                            packed64 = (
+                                                Uint64(payload[pair_idx * 2 + 1])
+                                                << Uint64(32)
+                                            ) | Uint64(payload[pair_idx * 2])
+                                            st_global_u64(
+                                                get_ptr_as_int64(
+                                                    packed_a_storage,
+                                                    output_offset + Int32(pair_idx * 8),
+                                                ),
+                                                packed64,
+                                            )
+                                        scale_storage[
+                                            phys_row * mx_blocks_per_row + blk_idx
+                                        ] = Uint8(mx_scale_byte & Uint32(0xFF))
                                     blk_idx += Int32(32)
                             elif cutlass.const_expr(self.is_w6a8):
                                 # w6a8_mx: MXFP8-E4M3 K/32 byte-container
@@ -3624,36 +3668,38 @@ class MoEDynamicKernelBackend:
                                             self.mxfp6_fmt_a,
                                         )
                                     )
-                                    output_offset = (
-                                        phys_tile * Int32(self.tile_shape_mnk[0])
-                                        + row % Int32(self.tile_shape_mnk[0])
-                                    ) * output_bytes_per_row + (
-                                        sf_idx * packed_bytes_per_sf_block
-                                    )
-                                    moe_mxfp6_store_expanded_global(
-                                        packed_a_storage,
-                                        output_offset,
-                                        containers,
-                                    )
+                                    if route_is_valid > Int32(0):
+                                        output_offset = (
+                                            phys_tile * Int32(self.tile_shape_mnk[0])
+                                            + row % Int32(self.tile_shape_mnk[0])
+                                        ) * output_bytes_per_row + (
+                                            sf_idx * packed_bytes_per_sf_block
+                                        )
+                                        moe_mxfp6_store_expanded_global(
+                                            packed_a_storage,
+                                            output_offset,
+                                            containers,
+                                        )
 
-                                    k_tile_idx = sf_idx // Int32(4)
-                                    inner_k_idx = sf_idx % Int32(4)
-                                    # scale_storage uses 128-row SF atoms: index by
-                                    # the 128-atom + row-within-atom, not the MMA
-                                    # tile. Identity at tile_m==128.
-                                    phys_row = phys_tile * Int32(
-                                        self.tile_shape_mnk[0]
-                                    ) + row % Int32(self.tile_shape_mnk[0])
-                                    sf_atom = phys_row >> Int32(7)
-                                    sf_row = phys_row & Int32(127)
-                                    scale_offset = (
-                                        sf_atom * num_k_tiles * Int32(32 * 4 * 4)
-                                        + k_tile_idx * Int32(32 * 4 * 4)
-                                        + (sf_row % Int32(32)) * Int32(4 * 4)
-                                        + (sf_row // Int32(32)) * Int32(4)
-                                        + inner_k_idx
-                                    )
-                                    scale_storage[scale_offset] = scale_byte
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        # Scale storage uses 128-row SF atoms,
+                                        # independently of the MMA tile.
+                                        phys_row = phys_tile * Int32(
+                                            self.tile_shape_mnk[0]
+                                        ) + row % Int32(self.tile_shape_mnk[0])
+                                        sf_atom = phys_row >> Int32(7)
+                                        sf_row = phys_row & Int32(127)
+                                        scale_offset = (
+                                            sf_atom
+                                            * num_k_tiles
+                                            * Int32(32 * 4 * 4)
+                                            + k_tile_idx * Int32(32 * 4 * 4)
+                                            + (sf_row % Int32(32)) * Int32(4 * 4)
+                                            + (sf_row // Int32(32)) * Int32(4)
+                                            + inner_k_idx
+                                        )
+                                        scale_storage[scale_offset] = scale_byte
                                     sf_idx += Int32(32)
                             else:
                                 sf_idx = lane_id
@@ -3682,35 +3728,37 @@ class MoEDynamicKernelBackend:
                                             values, block_max, gs_value
                                         )
 
-                                    output_offset = (
-                                        phys_tile * Int32(self.tile_shape_mnk[0])
-                                        + row % Int32(self.tile_shape_mnk[0])
-                                    ) * output_bytes_per_row + sf_idx * Int32(8)
-                                    st_global_u64(
-                                        get_ptr_as_int64(
-                                            packed_a_storage, output_offset
-                                        ),
-                                        packed64,
-                                    )
+                                    if route_is_valid > Int32(0):
+                                        output_offset = (
+                                            phys_tile * Int32(self.tile_shape_mnk[0])
+                                            + row % Int32(self.tile_shape_mnk[0])
+                                        ) * output_bytes_per_row + sf_idx * Int32(8)
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed64,
+                                        )
 
-                                    k_tile_idx = sf_idx // Int32(4)
-                                    inner_k_idx = sf_idx % Int32(4)
-                                    # scale_storage uses 128-row SF atoms: index by the
-                                    # 128-atom + row-within-atom, not the MMA tile.
-                                    # Identity at tile_m==128.
-                                    phys_row = phys_tile * Int32(
-                                        self.tile_shape_mnk[0]
-                                    ) + row % Int32(self.tile_shape_mnk[0])
-                                    sf_atom = phys_row >> Int32(7)
-                                    sf_row = phys_row & Int32(127)
-                                    scale_offset = (
-                                        sf_atom * num_k_tiles * Int32(32 * 4 * 4)
-                                        + k_tile_idx * Int32(32 * 4 * 4)
-                                        + (sf_row % Int32(32)) * Int32(4 * 4)
-                                        + (sf_row // Int32(32)) * Int32(4)
-                                        + inner_k_idx
-                                    )
-                                    scale_storage[scale_offset] = scale_byte
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        # Scale storage uses 128-row SF atoms,
+                                        # independently of the MMA tile.
+                                        phys_row = phys_tile * Int32(
+                                            self.tile_shape_mnk[0]
+                                        ) + row % Int32(self.tile_shape_mnk[0])
+                                        sf_atom = phys_row >> Int32(7)
+                                        sf_row = phys_row & Int32(127)
+                                        scale_offset = (
+                                            sf_atom
+                                            * num_k_tiles
+                                            * Int32(32 * 4 * 4)
+                                            + k_tile_idx * Int32(32 * 4 * 4)
+                                            + (sf_row % Int32(32)) * Int32(4 * 4)
+                                            + (sf_row // Int32(32)) * Int32(4)
+                                            + inner_k_idx
+                                        )
+                                        scale_storage[scale_offset] = scale_byte
                                     sf_idx += Int32(32)
 
                             if cutlass.const_expr(self.work_is_streaming):
@@ -3721,7 +3769,10 @@ class MoEDynamicKernelBackend:
                                 _threadfence()
                                 cute.arch.sync_warp()
 
-                                if lane_id == Int32(0):
+                                if (
+                                    lane_id == Int32(0)
+                                    and route_is_valid > Int32(0)
+                                ):
                                     completed = atomic_add_global_i32(
                                         get_ptr_as_int64(tile_write_count, phys_tile),
                                         Int32(1),
@@ -3769,6 +3820,17 @@ class MoEDynamicKernelBackend:
                     pair_flush = Int32(bidz)
                     while pair_flush < total_pairs:
                         expert_flush = topk_ids[pair_flush].to(Int32)
+                        valid_rows = Int32(0)
+                        if (
+                            expert_flush >= Int32(0)
+                            and expert_flush < num_experts
+                        ):
+                            valid_rows = Int32(1)
+                        else:
+                            # Deferred direct tasks use an arithmetic slot per
+                            # route. Keep the slot addressable, but give an
+                            # inactive route a safe expert index and no work.
+                            expert_flush = Int32(0)
                         self._publish_deferred_tasks(
                             task_expert,
                             task_valid_rows,
@@ -3776,7 +3838,7 @@ class MoEDynamicKernelBackend:
                             task_slice_chunk,
                             expert_flush,
                             pair_flush,
-                            Int32(1),
+                            valid_rows,
                         )
                         pair_flush += Int32(gdim_z)
                 else:
@@ -4417,12 +4479,14 @@ class MoEDynamicKernelBackend:
                 if materialized_slot < materialized_tail:
                     route_idx = materialized_slot // route_gate_tile_cnt
                     route_slice = materialized_slot - route_idx * route_gate_tile_cnt
-                    work_item[_WORK_EXPERT] = topk_ids[route_idx].to(Int32)
-                    work_item[_WORK_M_TILE] = route_idx
-                    work_item[_WORK_SLICE_BEGIN] = route_slice
-                    work_item[_WORK_SLICE_COUNT] = Int32(1)
-                    work_item[_WORK_VALID_ROWS] = Int32(1)
-                    has_task = Int32(1)
+                    route_expert = topk_ids[route_idx].to(Int32)
+                    if route_expert >= Int32(0) and route_expert < num_experts:
+                        work_item[_WORK_EXPERT] = route_expert
+                        work_item[_WORK_M_TILE] = route_idx
+                        work_item[_WORK_SLICE_BEGIN] = route_slice
+                        work_item[_WORK_SLICE_COUNT] = Int32(1)
+                        work_item[_WORK_VALID_ROWS] = Int32(1)
+                        has_task = Int32(1)
                 else:
                     is_done = Int32(1)
                 materialized_slot += Int32(gdim_z)
@@ -4541,6 +4605,12 @@ class MoEDynamicKernelBackend:
                     not self.work_is_persistent_grid and not self.w4a8_m1_materialized
                 ):
                     self._load_shared_work_item(work_item, ctrl_base_addr)
+                # Direct routing retains arithmetic task slots for graph-stable
+                # scheduling. An inactive route carries zero valid rows and
+                # must not reach any expert weight or scale load.
+                if work_item[_WORK_VALID_ROWS] <= Int32(0):
+                    has_task = Int32(0)
+            if has_task > Int32(0):
                 task_m_tile_idx_cache = work_item[_WORK_M_TILE]
                 task_valid_rows_cache = work_item[_WORK_VALID_ROWS]
                 tile_m_base_cache = task_m_tile_idx_cache * Int32(
@@ -8763,29 +8833,30 @@ class MoEDynamicKernelBackend:
                         phase2_slot - phase2_m_tile * phase2_task_output_tiles
                     )
                     phase2_expert = topk_ids[phase2_m_tile].to(Int32)
-                    self._run_w4a8_materialized_fc2(
-                        intermediate_u32,
-                        down_rp,
-                        down_sfb_rp,
-                        scatter_output,
-                        token_map,
-                        token_weights,
-                        down_alpha,
-                        global_scale,
-                        sa_flat_addr,
-                        w4a8_sb0,
-                        w4a8_sb1,
-                        w4a8_sfbb,
-                        Int32(tidx),
-                        warp_idx,
-                        phase2_m_tile,
-                        phase2_expert,
-                        phase2_output_tile,
-                        Int32(1),
-                        rows_capacity,
-                        gate_tile_cnt,
-                        phase2_packed_output_tiles,
-                    )
+                    if phase2_expert >= Int32(0) and phase2_expert < num_experts:
+                        self._run_w4a8_materialized_fc2(
+                            intermediate_u32,
+                            down_rp,
+                            down_sfb_rp,
+                            scatter_output,
+                            token_map,
+                            token_weights,
+                            down_alpha,
+                            global_scale,
+                            sa_flat_addr,
+                            w4a8_sb0,
+                            w4a8_sb1,
+                            w4a8_sfbb,
+                            Int32(tidx),
+                            warp_idx,
+                            phase2_m_tile,
+                            phase2_expert,
+                            phase2_output_tile,
+                            Int32(1),
+                            rows_capacity,
+                            gate_tile_cnt,
+                            phase2_packed_output_tiles,
+                        )
                     cute.arch.sync_threads()
                     phase2_slot += Int32(gdim_z)
             else:

--- a/b12x/moe/_shared/kernels/dynamic.py
+++ b/b12x/moe/_shared/kernels/dynamic.py
@@ -2944,43 +2944,66 @@ class MoEDynamicKernelBackend:
             # one thread per K32 quantization block, plus one thread per route.
             # Fold it into phase 0 so the existing resident barrier publishes
             # both the cleared output and the prepared input in one step.
-            m1_blk_idx = flat_tid
-            while m1_blk_idx < mx_blocks_per_row:
-                m1_block_start = m1_blk_idx * Int32(32)
-                m1_values, m1_block_max = _load_bf16x32_to_f32(
-                    a_input,
-                    m1_block_start,
-                )
-                if cutlass.const_expr(self.w4a8_trellis):
-                    m1_payload, m1_mx_scale_byte = quantize_block_fp8_mx(
-                        _w4a8_trellis_permute_k32(m1_values),
-                        m1_block_max,
+            m1_lane_id = Int32(tidx) & Int32(31)
+            m1_has_active_route = Int32(0)
+            if m1_lane_id == Int32(0):
+                m1_route_idx = Int32(0)
+                while m1_route_idx < total_pairs:
+                    m1_route_expert_id = topk_ids[m1_route_idx].to(Int32)
+                    if (
+                        m1_route_expert_id >= Int32(0)
+                        and m1_route_expert_id < num_experts
+                    ):
+                        m1_has_active_route = Int32(1)
+                        m1_route_idx = total_pairs
+                    else:
+                        m1_route_idx += Int32(1)
+            m1_has_active_route = cute.arch.shuffle_sync(
+                m1_has_active_route, Int32(0)
+            )
+
+            if m1_has_active_route > Int32(0):
+                m1_blk_idx = flat_tid
+                while m1_blk_idx < mx_blocks_per_row:
+                    m1_block_start = m1_blk_idx * Int32(32)
+                    m1_values, m1_block_max = _load_bf16x32_to_f32(
+                        a_input,
+                        m1_block_start,
                     )
-                else:
-                    m1_payload, m1_mx_scale_byte = quantize_block_fp8_mx(
-                        m1_values,
-                        m1_block_max,
+                    if cutlass.const_expr(self.w4a8_trellis):
+                        m1_payload, m1_mx_scale_byte = quantize_block_fp8_mx(
+                            _w4a8_trellis_permute_k32(m1_values),
+                            m1_block_max,
+                        )
+                    else:
+                        m1_payload, m1_mx_scale_byte = quantize_block_fp8_mx(
+                            m1_values,
+                            m1_block_max,
+                        )
+                    for m1_payload_pair in cutlass.range_constexpr(4):
+                        m1_packed64 = (
+                            Uint64(m1_payload[m1_payload_pair * 2 + 1]) << Uint64(32)
+                        ) | Uint64(m1_payload[m1_payload_pair * 2])
+                        st_global_u64(
+                            get_ptr_as_int64(
+                                packed_a_storage,
+                                m1_block_start + Int32(m1_payload_pair * 8),
+                            ),
+                            m1_packed64,
+                        )
+                    scale_storage[m1_blk_idx] = Uint8(
+                        m1_mx_scale_byte & Uint32(0xFF)
                     )
-                for m1_payload_pair in cutlass.range_constexpr(4):
-                    m1_packed64 = (
-                        Uint64(m1_payload[m1_payload_pair * 2 + 1]) << Uint64(32)
-                    ) | Uint64(m1_payload[m1_payload_pair * 2])
-                    st_global_u64(
-                        get_ptr_as_int64(
-                            packed_a_storage,
-                            m1_block_start + Int32(m1_payload_pair * 8),
-                        ),
-                        m1_packed64,
-                    )
-                scale_storage[m1_blk_idx] = Uint8(m1_mx_scale_byte & Uint32(0xFF))
-                m1_blk_idx += flat_stride
+                    m1_blk_idx += flat_stride
 
             if flat_tid < total_pairs:
-                m1_physical_row = flat_tid * Int32(self.tile_shape_mnk[0])
-                token_map[m1_physical_row] = Int32(0)
-                token_weights[m1_physical_row] = topk_weights[flat_tid].to(
-                    cutlass.Float32
-                )
+                m1_slot_expert_id = topk_ids[flat_tid].to(Int32)
+                if m1_slot_expert_id >= Int32(0) and m1_slot_expert_id < num_experts:
+                    m1_physical_row = flat_tid * Int32(self.tile_shape_mnk[0])
+                    token_map[m1_physical_row] = Int32(0)
+                    token_weights[m1_physical_row] = topk_weights[flat_tid].to(
+                        cutlass.Float32
+                    )
 
         cute.arch.sync_threads()
         self._resident_grid_barrier(
@@ -3148,180 +3171,312 @@ class MoEDynamicKernelBackend:
                         else:
                             cute.arch.sync_warp()
 
-                        if cutlass.const_expr(self.is_w4a8):
-                            # A token's BF16 row is identical for every routed
-                            # expert. The materialized specialization stores one
-                            # quantized row per token and gathers it in FC1; the
-                            # route-expanded path fans it out to each route.
-                            # That path keeps only physical rows in rmem here to
-                            # stay below the two-CTA register-residency limit.
-                            if num_topk == Int32(8):
-                                for cache_slot in cutlass.range_constexpr(8):
-                                    slot = route_slot_base + Int32(cache_slot)
-                                    shared_route_phys_rows[cache_slot] = _ld_shared_i32(
-                                        route_phys_rows_addr + slot * Int32(4)
-                                    )
+                        token_has_active_route = Int32(0)
+                        if lane_id == Int32(0):
+                            active_topk_slot = Int32(0)
+                            while active_topk_slot < num_topk:
+                                slot = route_slot_base + active_topk_slot
+                                if _ld_shared_i32(
+                                    route_phys_rows_addr + slot * Int32(4)
+                                ) >= Int32(0):
+                                    token_has_active_route = Int32(1)
+                                    active_topk_slot = num_topk
+                                else:
+                                    active_topk_slot += Int32(1)
+                        token_has_active_route = cute.arch.shuffle_sync(
+                            token_has_active_route, Int32(0)
+                        )
 
-                                blk_idx = lane_id + token_partition * Int32(32)
-                                while blk_idx < mx_blocks_per_row:
-                                    block_start = blk_idx * Int32(32)
-                                    values, block_max = _load_bf16x32_to_f32(
-                                        a_input,
-                                        token_idx * Int32(a_input.shape[1])
-                                        + block_start,
-                                    )
-                                    if cutlass.const_expr(self.w4a8_trellis):
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                _w4a8_trellis_permute_k32(
-                                                    values
-                                                ),
-                                                block_max,
-                                            )
+                        if token_has_active_route > Int32(0):
+                            if cutlass.const_expr(self.is_w4a8):
+                                # A token's BF16 row is identical for every routed
+                                # expert. The materialized specialization stores one
+                                # quantized row per token and gathers it in FC1; the
+                                # route-expanded path fans it out to each route.
+                                # That path keeps only physical rows in rmem here to
+                                # stay below the two-CTA register-residency limit.
+                                if num_topk == Int32(8):
+                                    for cache_slot in cutlass.range_constexpr(8):
+                                        slot = route_slot_base + Int32(cache_slot)
+                                        shared_route_phys_rows[cache_slot] = _ld_shared_i32(
+                                            route_phys_rows_addr + slot * Int32(4)
                                         )
-                                    else:
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                values, block_max
-                                            )
+
+                                    blk_idx = lane_id + token_partition * Int32(32)
+                                    while blk_idx < mx_blocks_per_row:
+                                        block_start = blk_idx * Int32(32)
+                                        values, block_max = _load_bf16x32_to_f32(
+                                            a_input,
+                                            token_idx * Int32(a_input.shape[1])
+                                            + block_start,
                                         )
-                                    for payload_pair in cutlass.range_constexpr(4):
-                                        packed64 = (
-                                            Uint64(payload[payload_pair * 2 + 1])
-                                            << Uint64(32)
-                                        ) | Uint64(payload[payload_pair * 2])
+                                        if cutlass.const_expr(self.w4a8_trellis):
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    _w4a8_trellis_permute_k32(
+                                                        values
+                                                    ),
+                                                    block_max,
+                                                )
+                                            )
+                                        else:
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    values, block_max
+                                                )
+                                            )
+                                        for payload_pair in cutlass.range_constexpr(4):
+                                            packed64 = (
+                                                Uint64(payload[payload_pair * 2 + 1])
+                                                << Uint64(32)
+                                            ) | Uint64(payload[payload_pair * 2])
+                                            if cutlass.const_expr(
+                                                self.materialize_intermediate
+                                            ):
+                                                output_offset = (
+                                                    token_idx * output_bytes_per_row
+                                                    + block_start
+                                                    + Int32(payload_pair * 8)
+                                                )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage,
+                                                        output_offset,
+                                                    ),
+                                                    packed64,
+                                                )
+                                            else:
+                                                for cache_slot in cutlass.range_constexpr(
+                                                    8
+                                                ):
+                                                    phys_row = shared_route_phys_rows[
+                                                        cache_slot
+                                                    ]
+                                                    if phys_row >= Int32(0):
+                                                        output_offset = (
+                                                            phys_row * output_bytes_per_row
+                                                            + block_start
+                                                            + Int32(payload_pair * 8)
+                                                        )
+                                                        st_global_u64(
+                                                            get_ptr_as_int64(
+                                                                packed_a_storage,
+                                                                output_offset,
+                                                            ),
+                                                            packed64,
+                                                        )
                                         if cutlass.const_expr(
                                             self.materialize_intermediate
                                         ):
-                                            output_offset = (
-                                                token_idx * output_bytes_per_row
-                                                + block_start
-                                                + Int32(payload_pair * 8)
-                                            )
-                                            st_global_u64(
-                                                get_ptr_as_int64(
-                                                    packed_a_storage,
-                                                    output_offset,
-                                                ),
-                                                packed64,
-                                            )
+                                            scale_storage[
+                                                token_idx * mx_blocks_per_row + blk_idx
+                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
                                         else:
-                                            for cache_slot in cutlass.range_constexpr(
-                                                8
-                                            ):
+                                            for cache_slot in cutlass.range_constexpr(8):
                                                 phys_row = shared_route_phys_rows[
                                                     cache_slot
                                                 ]
                                                 if phys_row >= Int32(0):
-                                                    output_offset = (
-                                                        phys_row * output_bytes_per_row
-                                                        + block_start
-                                                        + Int32(payload_pair * 8)
+                                                    scale_storage[
+                                                        phys_row * mx_blocks_per_row + blk_idx
+                                                    ] = Uint8(
+                                                        mx_scale_byte & Uint32(0xFF)
                                                     )
-                                                    st_global_u64(
-                                                        get_ptr_as_int64(
-                                                            packed_a_storage,
-                                                            output_offset,
-                                                        ),
-                                                        packed64,
-                                                    )
-                                    if cutlass.const_expr(
-                                        self.materialize_intermediate
-                                    ):
-                                        scale_storage[
-                                            token_idx * mx_blocks_per_row + blk_idx
-                                        ] = Uint8(mx_scale_byte & Uint32(0xFF))
-                                    else:
-                                        for cache_slot in cutlass.range_constexpr(8):
-                                            phys_row = shared_route_phys_rows[
-                                                cache_slot
-                                            ]
-                                            if phys_row >= Int32(0):
-                                                scale_storage[
-                                                    phys_row * mx_blocks_per_row + blk_idx
-                                                ] = Uint8(
-                                                    mx_scale_byte & Uint32(0xFF)
+                                        blk_idx += Int32(self.input_warps_per_token * 32)
+                                else:
+                                    blk_idx = lane_id + token_partition * Int32(32)
+                                    while blk_idx < mx_blocks_per_row:
+                                        block_start = blk_idx * Int32(32)
+                                        values, block_max = _load_bf16x32_to_f32(
+                                            a_input,
+                                            token_idx * Int32(a_input.shape[1])
+                                            + block_start,
+                                        )
+                                        if cutlass.const_expr(self.w4a8_trellis):
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    _w4a8_trellis_permute_k32(
+                                                        values
+                                                    ),
+                                                    block_max,
                                                 )
-                                    blk_idx += Int32(self.input_warps_per_token * 32)
-                            else:
-                                blk_idx = lane_id + token_partition * Int32(32)
-                                while blk_idx < mx_blocks_per_row:
-                                    block_start = blk_idx * Int32(32)
-                                    values, block_max = _load_bf16x32_to_f32(
-                                        a_input,
-                                        token_idx * Int32(a_input.shape[1])
-                                        + block_start,
-                                    )
-                                    if cutlass.const_expr(self.w4a8_trellis):
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                _w4a8_trellis_permute_k32(
-                                                    values
-                                                ),
-                                                block_max,
                                             )
-                                        )
-                                    else:
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                values, block_max
+                                        else:
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    values, block_max
+                                                )
                                             )
-                                        )
-                                    for payload_pair in cutlass.range_constexpr(4):
-                                        packed64 = (
-                                            Uint64(payload[payload_pair * 2 + 1])
-                                            << Uint64(32)
-                                        ) | Uint64(payload[payload_pair * 2])
+                                        for payload_pair in cutlass.range_constexpr(4):
+                                            packed64 = (
+                                                Uint64(payload[payload_pair * 2 + 1])
+                                                << Uint64(32)
+                                            ) | Uint64(payload[payload_pair * 2])
+                                            if cutlass.const_expr(
+                                                self.materialize_intermediate
+                                            ):
+                                                output_offset = (
+                                                    token_idx * output_bytes_per_row
+                                                    + block_start
+                                                    + Int32(payload_pair * 8)
+                                                )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage,
+                                                        output_offset,
+                                                    ),
+                                                    packed64,
+                                                )
+                                            else:
+                                                # CuTe loop-carried values must have
+                                                # a concrete type before entering a
+                                                # dynamic while.  Keep the address
+                                                # offset in rmem and update it for
+                                                # each routed copy below.
+                                                output_offset = Int32(0)
+                                                topk_slot = Int32(0)
+                                                while topk_slot < num_topk:
+                                                    slot = route_slot_base + topk_slot
+                                                    phys_row = _ld_shared_i32(
+                                                        route_phys_rows_addr
+                                                        + slot * Int32(4)
+                                                    )
+                                                    if phys_row >= Int32(0):
+                                                        output_offset = (
+                                                            phys_row * output_bytes_per_row
+                                                            + block_start
+                                                            + Int32(payload_pair * 8)
+                                                        )
+                                                        st_global_u64(
+                                                            get_ptr_as_int64(
+                                                                packed_a_storage,
+                                                                output_offset,
+                                                            ),
+                                                            packed64,
+                                                        )
+                                                    topk_slot += Int32(1)
                                         if cutlass.const_expr(
                                             self.materialize_intermediate
                                         ):
-                                            output_offset = (
-                                                token_idx * output_bytes_per_row
-                                                + block_start
-                                                + Int32(payload_pair * 8)
-                                            )
-                                            st_global_u64(
-                                                get_ptr_as_int64(
-                                                    packed_a_storage,
-                                                    output_offset,
-                                                ),
-                                                packed64,
-                                            )
+                                            scale_storage[
+                                                token_idx * mx_blocks_per_row + blk_idx
+                                            ] = Uint8(mx_scale_byte & Uint32(0xFF))
                                         else:
-                                            # CuTe loop-carried values must have
-                                            # a concrete type before entering a
-                                            # dynamic while.  Keep the address
-                                            # offset in rmem and update it for
-                                            # each routed copy below.
-                                            output_offset = Int32(0)
                                             topk_slot = Int32(0)
                                             while topk_slot < num_topk:
                                                 slot = route_slot_base + topk_slot
                                                 phys_row = _ld_shared_i32(
-                                                    route_phys_rows_addr
-                                                    + slot * Int32(4)
+                                                    route_phys_rows_addr + slot * Int32(4)
                                                 )
                                                 if phys_row >= Int32(0):
-                                                    output_offset = (
-                                                        phys_row * output_bytes_per_row
-                                                        + block_start
-                                                        + Int32(payload_pair * 8)
-                                                    )
-                                                    st_global_u64(
-                                                        get_ptr_as_int64(
-                                                            packed_a_storage,
-                                                            output_offset,
-                                                        ),
-                                                        packed64,
+                                                    scale_storage[
+                                                        phys_row * mx_blocks_per_row + blk_idx
+                                                    ] = Uint8(
+                                                        mx_scale_byte & Uint32(0xFF)
                                                     )
                                                 topk_slot += Int32(1)
-                                    if cutlass.const_expr(
-                                        self.materialize_intermediate
-                                    ):
-                                        scale_storage[
-                                            token_idx * mx_blocks_per_row + blk_idx
-                                        ] = Uint8(mx_scale_byte & Uint32(0xFF))
-                                    else:
+                                        blk_idx += Int32(self.input_warps_per_token * 32)
+                            else:
+                                gs_value = shared_input_gs_value
+                                if num_topk == Int32(8):
+                                    for cache_slot in cutlass.range_constexpr(8):
+                                        slot = route_slot_base + Int32(cache_slot)
+                                        phys_row = _ld_shared_i32(
+                                            route_phys_rows_addr + slot * Int32(4)
+                                        )
+                                        route_output_base[cache_slot] = Int32(-1)
+                                        route_scale_base[cache_slot] = Int32(-1)
+                                        if phys_row >= Int32(0):
+                                            route_output_base[cache_slot] = (
+                                                phys_row * output_bytes_per_row
+                                            )
+                                            # Scale storage is tiled in 128-row SF
+                                            # atoms, independently of the MMA tile.
+                                            sf_atom = phys_row >> Int32(7)
+                                            sf_row = phys_row & Int32(127)
+                                            route_scale_base[cache_slot] = (
+                                                sf_atom
+                                                * num_k_tiles
+                                                * Int32(32 * 4 * 4)
+                                                + (sf_row % Int32(32)) * Int32(4 * 4)
+                                                + (sf_row // Int32(32)) * Int32(4)
+                                            )
+
+                                    sf_idx = lane_id
+                                    while sf_idx < sf_blocks_per_row:
+                                        block_start = sf_idx * Int32(16)
+                                        values = cute.make_rmem_tensor(
+                                            (16,), cutlass.Float32
+                                        )
+                                        block_max = cutlass.Float32(0.0)
+                                        for elem_idx in cutlass.range_constexpr(16):
+                                            value = cutlass.Float32(
+                                                a_input[
+                                                    token_idx, block_start + Int32(elem_idx)
+                                                ]
+                                            )
+                                            values[elem_idx] = value
+                                            block_max = fmax_f32(block_max, fabs_f32(value))
+                                        packed64 = Uint64(0)
+                                        scale_byte = Uint8(0)
+                                        if self.is_gated and self.fast_math:
+                                            packed64, scale_byte = quantize_block_fp4_fast(
+                                                values, block_max, gs_value
+                                            )
+                                        else:
+                                            packed64, scale_byte = quantize_block_fp4(
+                                                values, block_max, gs_value
+                                            )
+
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        scale_k_base = (
+                                            k_tile_idx * Int32(32 * 4 * 4) + inner_k_idx
+                                        )
+                                        for cache_slot in cutlass.range_constexpr(8):
+                                            output_base = route_output_base[cache_slot]
+                                            if output_base >= Int32(0):
+                                                output_offset = output_base + sf_idx * Int32(
+                                                    8
+                                                )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage, output_offset
+                                                    ),
+                                                    packed64,
+                                                )
+                                                scale_storage[
+                                                    route_scale_base[cache_slot]
+                                                    + scale_k_base
+                                                ] = scale_byte
+                                        sf_idx += Int32(32)
+                                else:
+                                    sf_idx = lane_id
+                                    while sf_idx < sf_blocks_per_row:
+                                        block_start = sf_idx * Int32(16)
+                                        values = cute.make_rmem_tensor(
+                                            (16,), cutlass.Float32
+                                        )
+                                        block_max = cutlass.Float32(0.0)
+                                        for elem_idx in cutlass.range_constexpr(16):
+                                            value = cutlass.Float32(
+                                                a_input[
+                                                    token_idx, block_start + Int32(elem_idx)
+                                                ]
+                                            )
+                                            values[elem_idx] = value
+                                            block_max = fmax_f32(block_max, fabs_f32(value))
+                                        packed64 = Uint64(0)
+                                        scale_byte = Uint8(0)
+                                        if self.is_gated and self.fast_math:
+                                            packed64, scale_byte = quantize_block_fp4_fast(
+                                                values, block_max, gs_value
+                                            )
+                                        else:
+                                            packed64, scale_byte = quantize_block_fp4(
+                                                values, block_max, gs_value
+                                            )
+
                                         topk_slot = Int32(0)
                                         while topk_slot < num_topk:
                                             slot = route_slot_base + topk_slot
@@ -3329,201 +3484,86 @@ class MoEDynamicKernelBackend:
                                                 route_phys_rows_addr + slot * Int32(4)
                                             )
                                             if phys_row >= Int32(0):
-                                                scale_storage[
-                                                    phys_row * mx_blocks_per_row + blk_idx
-                                                ] = Uint8(
-                                                    mx_scale_byte & Uint32(0xFF)
+                                                output_offset = (
+                                                    phys_row * output_bytes_per_row
+                                                    + sf_idx * Int32(8)
                                                 )
+                                                st_global_u64(
+                                                    get_ptr_as_int64(
+                                                        packed_a_storage, output_offset
+                                                    ),
+                                                    packed64,
+                                                )
+
+                                                # Scale storage uses 128-row SF atoms,
+                                                # independently of the MMA tile.
+                                                k_tile_idx = sf_idx // Int32(4)
+                                                sf_atom = phys_row >> Int32(7)
+                                                sf_row = phys_row & Int32(127)
+                                                outer_m_idx = sf_row % Int32(32)
+                                                inner_m_idx = sf_row // Int32(32)
+                                                inner_k_idx = sf_idx % Int32(4)
+                                                scale_offset = (
+                                                    sf_atom
+                                                    * num_k_tiles
+                                                    * Int32(32 * 4 * 4)
+                                                    + k_tile_idx * Int32(32 * 4 * 4)
+                                                    + outer_m_idx * Int32(4 * 4)
+                                                    + inner_m_idx * Int32(4)
+                                                    + inner_k_idx
+                                                )
+                                                scale_storage[scale_offset] = scale_byte
                                             topk_slot += Int32(1)
-                                    blk_idx += Int32(self.input_warps_per_token * 32)
-                        else:
-                            gs_value = shared_input_gs_value
-                            if num_topk == Int32(8):
-                                for cache_slot in cutlass.range_constexpr(8):
-                                    slot = route_slot_base + Int32(cache_slot)
-                                    phys_row = _ld_shared_i32(
-                                        route_phys_rows_addr + slot * Int32(4)
-                                    )
-                                    route_output_base[cache_slot] = Int32(-1)
-                                    route_scale_base[cache_slot] = Int32(-1)
-                                    if phys_row >= Int32(0):
-                                        route_output_base[cache_slot] = (
-                                            phys_row * output_bytes_per_row
-                                        )
-                                        # Scale storage is tiled in 128-row SF
-                                        # atoms, independently of the MMA tile.
-                                        sf_atom = phys_row >> Int32(7)
-                                        sf_row = phys_row & Int32(127)
-                                        route_scale_base[cache_slot] = (
-                                            sf_atom
-                                            * num_k_tiles
-                                            * Int32(32 * 4 * 4)
-                                            + (sf_row % Int32(32)) * Int32(4 * 4)
-                                            + (sf_row // Int32(32)) * Int32(4)
-                                        )
+                                        sf_idx += Int32(32)
 
-                                sf_idx = lane_id
-                                while sf_idx < sf_blocks_per_row:
-                                    block_start = sf_idx * Int32(16)
-                                    values = cute.make_rmem_tensor(
-                                        (16,), cutlass.Float32
-                                    )
-                                    block_max = cutlass.Float32(0.0)
-                                    for elem_idx in cutlass.range_constexpr(16):
-                                        value = cutlass.Float32(
-                                            a_input[
-                                                token_idx, block_start + Int32(elem_idx)
-                                            ]
-                                        )
-                                        values[elem_idx] = value
-                                        block_max = fmax_f32(block_max, fabs_f32(value))
-                                    packed64 = Uint64(0)
-                                    scale_byte = Uint8(0)
-                                    if self.is_gated and self.fast_math:
-                                        packed64, scale_byte = quantize_block_fp4_fast(
-                                            values, block_max, gs_value
-                                        )
-                                    else:
-                                        packed64, scale_byte = quantize_block_fp4(
-                                            values, block_max, gs_value
-                                        )
+                            if cutlass.const_expr(self.work_is_streaming):
+                                cute.arch.sync_warp()
+                                _threadfence()
+                                cute.arch.sync_warp()
 
-                                    k_tile_idx = sf_idx // Int32(4)
-                                    inner_k_idx = sf_idx % Int32(4)
-                                    scale_k_base = (
-                                        k_tile_idx * Int32(32 * 4 * 4) + inner_k_idx
-                                    )
-                                    for cache_slot in cutlass.range_constexpr(8):
-                                        output_base = route_output_base[cache_slot]
-                                        if output_base >= Int32(0):
-                                            output_offset = output_base + sf_idx * Int32(
-                                                8
-                                            )
-                                            st_global_u64(
-                                                get_ptr_as_int64(
-                                                    packed_a_storage, output_offset
-                                                ),
-                                                packed64,
-                                            )
-                                            scale_storage[
-                                                route_scale_base[cache_slot]
-                                                + scale_k_base
-                                            ] = scale_byte
-                                    sf_idx += Int32(32)
-                            else:
-                                sf_idx = lane_id
-                                while sf_idx < sf_blocks_per_row:
-                                    block_start = sf_idx * Int32(16)
-                                    values = cute.make_rmem_tensor(
-                                        (16,), cutlass.Float32
-                                    )
-                                    block_max = cutlass.Float32(0.0)
-                                    for elem_idx in cutlass.range_constexpr(16):
-                                        value = cutlass.Float32(
-                                            a_input[
-                                                token_idx, block_start + Int32(elem_idx)
-                                            ]
-                                        )
-                                        values[elem_idx] = value
-                                        block_max = fmax_f32(block_max, fabs_f32(value))
-                                    packed64 = Uint64(0)
-                                    scale_byte = Uint8(0)
-                                    if self.is_gated and self.fast_math:
-                                        packed64, scale_byte = quantize_block_fp4_fast(
-                                            values, block_max, gs_value
-                                        )
-                                    else:
-                                        packed64, scale_byte = quantize_block_fp4(
-                                            values, block_max, gs_value
-                                        )
+                                publish_routes = Int32(1)
+                                if cutlass.const_expr(self.is_w4a8):
+                                    self._sync_input_warp_pair(token_owner_warp)
+                                    publish_routes = Int32(1) - token_partition
 
+                                if lane_id == Int32(0) and publish_routes > Int32(0):
                                     topk_slot = Int32(0)
                                     while topk_slot < num_topk:
                                         slot = route_slot_base + topk_slot
                                         phys_row = _ld_shared_i32(
                                             route_phys_rows_addr + slot * Int32(4)
                                         )
-                                        if phys_row >= Int32(0):
-                                            output_offset = (
-                                                phys_row * output_bytes_per_row
-                                                + sf_idx * Int32(8)
-                                            )
-                                            st_global_u64(
-                                                get_ptr_as_int64(
-                                                    packed_a_storage, output_offset
-                                                ),
-                                                packed64,
-                                            )
-
-                                            # Scale storage uses 128-row SF atoms,
-                                            # independently of the MMA tile.
-                                            k_tile_idx = sf_idx // Int32(4)
-                                            sf_atom = phys_row >> Int32(7)
-                                            sf_row = phys_row & Int32(127)
-                                            outer_m_idx = sf_row % Int32(32)
-                                            inner_m_idx = sf_row // Int32(32)
-                                            inner_k_idx = sf_idx % Int32(4)
-                                            scale_offset = (
-                                                sf_atom
-                                                * num_k_tiles
-                                                * Int32(32 * 4 * 4)
-                                                + k_tile_idx * Int32(32 * 4 * 4)
-                                                + outer_m_idx * Int32(4 * 4)
-                                                + inner_m_idx * Int32(4)
-                                                + inner_k_idx
-                                            )
-                                            scale_storage[scale_offset] = scale_byte
-                                        topk_slot += Int32(1)
-                                    sf_idx += Int32(32)
-
-                        if cutlass.const_expr(self.work_is_streaming):
-                            cute.arch.sync_warp()
-                            _threadfence()
-                            cute.arch.sync_warp()
-
-                            publish_routes = Int32(1)
-                            if cutlass.const_expr(self.is_w4a8):
-                                self._sync_input_warp_pair(token_owner_warp)
-                                publish_routes = Int32(1) - token_partition
-
-                            if lane_id == Int32(0) and publish_routes > Int32(0):
-                                topk_slot = Int32(0)
-                                while topk_slot < num_topk:
-                                    slot = route_slot_base + topk_slot
-                                    phys_row = _ld_shared_i32(
-                                        route_phys_rows_addr + slot * Int32(4)
-                                    )
-                                    expert_id = _ld_shared_i32(
-                                        route_expert_ids_addr + slot * Int32(4)
-                                    )
-                                    if phys_row >= Int32(0):
-                                        phys_tile = phys_row // Int32(
-                                            self.tile_shape_mnk[0]
+                                        expert_id = _ld_shared_i32(
+                                            route_expert_ids_addr + slot * Int32(4)
                                         )
-                                        completed = atomic_add_global_i32(
-                                            get_ptr_as_int64(
-                                                tile_write_count, phys_tile
-                                            ),
-                                            Int32(1),
-                                        ) + Int32(1)
-                                        if completed == Int32(
-                                            self.tile_shape_mnk[0]
-                                        ):
-                                            self._publish_ready_tasks(
-                                                task_tail,
-                                                task_ready,
-                                                task_expert,
-                                                task_m_tile,
-                                                task_slice_begin,
-                                                task_slice_count,
-                                                task_valid_rows,
-                                                route_gate_tile_cnt,
-                                                task_slice_chunk,
-                                                expert_id,
-                                                phys_tile,
-                                                Int32(self.tile_shape_mnk[0]),
+                                        if phys_row >= Int32(0):
+                                            phys_tile = phys_row // Int32(
+                                                self.tile_shape_mnk[0]
                                             )
-                                    topk_slot += Int32(1)
+                                            completed = atomic_add_global_i32(
+                                                get_ptr_as_int64(
+                                                    tile_write_count, phys_tile
+                                                ),
+                                                Int32(1),
+                                            ) + Int32(1)
+                                            if completed == Int32(
+                                                self.tile_shape_mnk[0]
+                                            ):
+                                                self._publish_ready_tasks(
+                                                    task_tail,
+                                                    task_ready,
+                                                    task_expert,
+                                                    task_m_tile,
+                                                    task_slice_begin,
+                                                    task_slice_count,
+                                                    task_valid_rows,
+                                                    route_gate_tile_cnt,
+                                                    task_slice_chunk,
+                                                    expert_id,
+                                                    phys_tile,
+                                                    Int32(self.tile_shape_mnk[0]),
+                                                )
+                                        topk_slot += Int32(1)
                 else:
                     warp_item = Int32(0)
                     while warp_item < Int32(_PRODUCER_PAIRS_PER_WARP):
@@ -3574,50 +3614,49 @@ class MoEDynamicKernelBackend:
                                 route_is_valid, Int32(0)
                             )
 
-                            safe_expert_id = expert_id
-                            if route_is_valid == Int32(0):
-                                safe_expert_id = Int32(0)
-                            gs_value = input_global_scale[safe_expert_id].to(
-                                cutlass.Float32
-                            )
-                            if cutlass.const_expr(self.is_w4a8):
-                                # w4a8: per-32 dynamic UE8M0 + E4M3 payload, no
-                                # global scale. Payload stored plain row-major;
-                                # scales stored plain [row, cols//32].
-                                phys_row = phys_tile * Int32(
-                                    self.tile_shape_mnk[0]
-                                ) + row % Int32(self.tile_shape_mnk[0])
-                                blk_idx = lane_id
-                                while blk_idx < mx_blocks_per_row:
-                                    block_start = blk_idx * Int32(32)
-                                    values = cute.make_rmem_tensor(
-                                        (32,), cutlass.Float32
+                            if route_is_valid > Int32(0):
+                                gs_value = cutlass.Float32(0.0)
+                                if cutlass.const_expr(not self.is_w4a8):
+                                    gs_value = input_global_scale[expert_id].to(
+                                        cutlass.Float32
                                     )
-                                    block_max = cutlass.Float32(0.0)
-                                    for elem_idx in cutlass.range_constexpr(32):
-                                        value = cutlass.Float32(
-                                            a_input[
-                                                token_idx, block_start + Int32(elem_idx)
-                                            ]
+                                if cutlass.const_expr(self.is_w4a8):
+                                    # w4a8: per-32 dynamic UE8M0 + E4M3 payload, no
+                                    # global scale. Payload stored plain row-major;
+                                    # scales stored plain [row, cols//32].
+                                    phys_row = phys_tile * Int32(
+                                        self.tile_shape_mnk[0]
+                                    ) + row % Int32(self.tile_shape_mnk[0])
+                                    blk_idx = lane_id
+                                    while blk_idx < mx_blocks_per_row:
+                                        block_start = blk_idx * Int32(32)
+                                        values = cute.make_rmem_tensor(
+                                            (32,), cutlass.Float32
                                         )
-                                        values[elem_idx] = value
-                                        block_max = fmax_f32(block_max, fabs_f32(value))
-                                    if cutlass.const_expr(self.w4a8_trellis):
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                _w4a8_trellis_permute_k32(
-                                                    values
-                                                ),
-                                                block_max,
+                                        block_max = cutlass.Float32(0.0)
+                                        for elem_idx in cutlass.range_constexpr(32):
+                                            value = cutlass.Float32(
+                                                a_input[
+                                                    token_idx, block_start + Int32(elem_idx)
+                                                ]
                                             )
-                                        )
-                                    else:
-                                        payload, mx_scale_byte = (
-                                            quantize_block_fp8_mx(
-                                                values, block_max
+                                            values[elem_idx] = value
+                                            block_max = fmax_f32(block_max, fabs_f32(value))
+                                        if cutlass.const_expr(self.w4a8_trellis):
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    _w4a8_trellis_permute_k32(
+                                                        values
+                                                    ),
+                                                    block_max,
+                                                )
                                             )
-                                        )
-                                    if route_is_valid > Int32(0):
+                                        else:
+                                            payload, mx_scale_byte = (
+                                                quantize_block_fp8_mx(
+                                                    values, block_max
+                                                )
+                                            )
                                         output_offset = (
                                             phys_row * output_bytes_per_row + block_start
                                         )
@@ -3636,39 +3675,38 @@ class MoEDynamicKernelBackend:
                                         scale_storage[
                                             phys_row * mx_blocks_per_row + blk_idx
                                         ] = Uint8(mx_scale_byte & Uint32(0xFF))
-                                    blk_idx += Int32(32)
-                            elif cutlass.const_expr(self.is_w6a8):
-                                # w6a8_mx: MXFP8-E4M3 K/32 byte-container
-                                # payload (same encoding as w4a8's activation
-                                # side, but WITH the calibrated per-expert
-                                # global scale folded in at quantize time),
-                                # stored row-major for the A TMA; scale bytes
-                                # go to the swizzled 128-row SF atoms exactly
-                                # like nvfp4 (sf_idx now indexes K/32 blocks).
-                                sf_idx = lane_id
-                                while sf_idx < sf_blocks_per_row:
-                                    block_start = sf_idx * quant_block_elems
-                                    values = cute.make_rmem_tensor(
-                                        (32,), cutlass.Float32
-                                    )
-                                    block_max = cutlass.Float32(0.0)
-                                    for elem_idx in cutlass.range_constexpr(32):
-                                        value = cutlass.Float32(
-                                            a_input[
-                                                token_idx, block_start + Int32(elem_idx)
-                                            ]
+                                        blk_idx += Int32(32)
+                                elif cutlass.const_expr(self.is_w6a8):
+                                    # w6a8_mx: MXFP8-E4M3 K/32 byte-container
+                                    # payload (same encoding as w4a8's activation
+                                    # side, but WITH the calibrated per-expert
+                                    # global scale folded in at quantize time),
+                                    # stored row-major for the A TMA; scale bytes
+                                    # go to the swizzled 128-row SF atoms exactly
+                                    # like nvfp4 (sf_idx now indexes K/32 blocks).
+                                    sf_idx = lane_id
+                                    while sf_idx < sf_blocks_per_row:
+                                        block_start = sf_idx * quant_block_elems
+                                        values = cute.make_rmem_tensor(
+                                            (32,), cutlass.Float32
                                         )
-                                        values[elem_idx] = value
-                                        block_max = fmax_f32(block_max, fabs_f32(value))
-                                    containers, scale_byte = (
-                                        moe_mxfp6_quantize_input_block_containers(
-                                            values,
-                                            block_max,
-                                            gs_value,
-                                            self.mxfp6_fmt_a,
+                                        block_max = cutlass.Float32(0.0)
+                                        for elem_idx in cutlass.range_constexpr(32):
+                                            value = cutlass.Float32(
+                                                a_input[
+                                                    token_idx, block_start + Int32(elem_idx)
+                                                ]
+                                            )
+                                            values[elem_idx] = value
+                                            block_max = fmax_f32(block_max, fabs_f32(value))
+                                        containers, scale_byte = (
+                                            moe_mxfp6_quantize_input_block_containers(
+                                                values,
+                                                block_max,
+                                                gs_value,
+                                                self.mxfp6_fmt_a,
+                                            )
                                         )
-                                    )
-                                    if route_is_valid > Int32(0):
                                         output_offset = (
                                             phys_tile * Int32(self.tile_shape_mnk[0])
                                             + row % Int32(self.tile_shape_mnk[0])
@@ -3700,35 +3738,34 @@ class MoEDynamicKernelBackend:
                                             + inner_k_idx
                                         )
                                         scale_storage[scale_offset] = scale_byte
-                                    sf_idx += Int32(32)
-                            else:
-                                sf_idx = lane_id
-                                while sf_idx < sf_blocks_per_row:
-                                    block_start = sf_idx * Int32(16)
-                                    values = cute.make_rmem_tensor(
-                                        (16,), cutlass.Float32
-                                    )
-                                    block_max = cutlass.Float32(0.0)
-                                    for elem_idx in cutlass.range_constexpr(16):
-                                        value = cutlass.Float32(
-                                            a_input[
-                                                token_idx, block_start + Int32(elem_idx)
-                                            ]
+                                        sf_idx += Int32(32)
+                                else:
+                                    sf_idx = lane_id
+                                    while sf_idx < sf_blocks_per_row:
+                                        block_start = sf_idx * Int32(16)
+                                        values = cute.make_rmem_tensor(
+                                            (16,), cutlass.Float32
                                         )
-                                        values[elem_idx] = value
-                                        block_max = fmax_f32(block_max, fabs_f32(value))
-                                    packed64 = Uint64(0)
-                                    scale_byte = Uint8(0)
-                                    if self.is_gated and self.fast_math:
-                                        packed64, scale_byte = quantize_block_fp4_fast(
-                                            values, block_max, gs_value
-                                        )
-                                    else:
-                                        packed64, scale_byte = quantize_block_fp4(
-                                            values, block_max, gs_value
-                                        )
+                                        block_max = cutlass.Float32(0.0)
+                                        for elem_idx in cutlass.range_constexpr(16):
+                                            value = cutlass.Float32(
+                                                a_input[
+                                                    token_idx, block_start + Int32(elem_idx)
+                                                ]
+                                            )
+                                            values[elem_idx] = value
+                                            block_max = fmax_f32(block_max, fabs_f32(value))
+                                        packed64 = Uint64(0)
+                                        scale_byte = Uint8(0)
+                                        if self.is_gated and self.fast_math:
+                                            packed64, scale_byte = quantize_block_fp4_fast(
+                                                values, block_max, gs_value
+                                            )
+                                        else:
+                                            packed64, scale_byte = quantize_block_fp4(
+                                                values, block_max, gs_value
+                                            )
 
-                                    if route_is_valid > Int32(0):
                                         output_offset = (
                                             phys_tile * Int32(self.tile_shape_mnk[0])
                                             + row % Int32(self.tile_shape_mnk[0])
@@ -3759,39 +3796,36 @@ class MoEDynamicKernelBackend:
                                             + inner_k_idx
                                         )
                                         scale_storage[scale_offset] = scale_byte
-                                    sf_idx += Int32(32)
+                                        sf_idx += Int32(32)
 
-                            if cutlass.const_expr(self.work_is_streaming):
-                                cute.arch.sync_warp()
-                                # When the whole launch has fewer than one M-tile of routed
-                                # rows, only the final partial-tile flush can publish work.
-                                # Skip the per-row fence/counter path in that common micro case.
-                                _threadfence()
-                                cute.arch.sync_warp()
+                                if cutlass.const_expr(self.work_is_streaming):
+                                    cute.arch.sync_warp()
+                                    # When the whole launch has fewer than one M-tile of routed
+                                    # rows, only the final partial-tile flush can publish work.
+                                    # Skip the per-row fence/counter path in that common micro case.
+                                    _threadfence()
+                                    cute.arch.sync_warp()
 
-                                if (
-                                    lane_id == Int32(0)
-                                    and route_is_valid > Int32(0)
-                                ):
-                                    completed = atomic_add_global_i32(
-                                        get_ptr_as_int64(tile_write_count, phys_tile),
-                                        Int32(1),
-                                    ) + Int32(1)
-                                    if completed == Int32(self.tile_shape_mnk[0]):
-                                        self._publish_ready_tasks(
-                                            task_tail,
-                                            task_ready,
-                                            task_expert,
-                                            task_m_tile,
-                                            task_slice_begin,
-                                            task_slice_count,
-                                            task_valid_rows,
-                                            route_gate_tile_cnt,
-                                            task_slice_chunk,
-                                            expert_id,
-                                            phys_tile,
-                                            Int32(self.tile_shape_mnk[0]),
-                                        )
+                                    if lane_id == Int32(0):
+                                        completed = atomic_add_global_i32(
+                                            get_ptr_as_int64(tile_write_count, phys_tile),
+                                            Int32(1),
+                                        ) + Int32(1)
+                                        if completed == Int32(self.tile_shape_mnk[0]):
+                                            self._publish_ready_tasks(
+                                                task_tail,
+                                                task_ready,
+                                                task_expert,
+                                                task_m_tile,
+                                                task_slice_begin,
+                                                task_slice_count,
+                                                task_valid_rows,
+                                                route_gate_tile_cnt,
+                                                task_slice_chunk,
+                                                expert_id,
+                                                phys_tile,
+                                                Int32(self.tile_shape_mnk[0]),
+                                            )
                         warp_item += Int32(1)
 
         if cutlass.const_expr(not self.w4a8_m1_materialized):

--- a/tests/moe/test_cute_migration_moe_standard_corpus.py
+++ b/tests/moe/test_cute_migration_moe_standard_corpus.py
@@ -202,6 +202,13 @@ def _nvfp4_oracle(
 ) -> torch.Tensor:
     # This is the pure-Torch GPU oracle; it does not instantiate or call a CuTe
     # kernel and consumes the original checkpoint layout directly.
+    active = (inputs.topk_ids >= 0) & (inputs.topk_ids < _E)
+    oracle_ids = torch.where(
+        active, inputs.topk_ids, torch.zeros_like(inputs.topk_ids)
+    ).contiguous()
+    oracle_weights = torch.where(
+        active, inputs.topk_weights, torch.zeros_like(inputs.topk_weights)
+    ).contiguous()
     return moe_reference_nvfp4(
         inputs.a,
         weights.w1_fp4,
@@ -212,8 +219,8 @@ def _nvfp4_oracle(
         weights.w2_alpha,
         weights.a1_scale,
         weights.a2_scale,
-        inputs.topk_ids,
-        inputs.topk_weights,
+        oracle_ids,
+        oracle_weights,
         _E,
         _K,
         _N,
@@ -376,8 +383,8 @@ def _run_live_graph_check(
         max_normalized_rmse=max_normalized_rmse,
     )
 
-    # Mutate every live serving input in place.  IDs remain in range and each
-    # token still selects two distinct experts with positive normalized weights.
+    # Mutate every live serving input in place. The replay may include inactive
+    # route IDs, which must remain graph-safe without changing the binding.
     initial.a.copy_(changed.a)
     initial.topk_ids.copy_(changed.topk_ids)
     initial.topk_weights.copy_(changed.topk_weights)
@@ -463,16 +470,17 @@ def test_standard_moe_micro_live_graph_oracle(
     )
 
 
-def test_standard_moe_dynamic_prefill_live_graph_oracle(
+def test_standard_moe_dynamic_inactive_route_live_graph_oracle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Reach ``integration.tp_moe.dynamic`` at a prefill-sized standard M."""
+    """Ignore inactive routes in the production NVFP4 dynamic graph path."""
 
     device = require_b12x()
     _reset_dispatch_environment(monkeypatch)
     weights = _make_nvfp4_weights(device, seed=201)
-    initial = _make_inputs(device, m=128, seed=202, route_shift=0)
-    changed = _make_inputs(device, m=128, seed=203, route_shift=2)
+    initial = _make_inputs(device, m=40, seed=202, route_shift=0)
+    changed = _make_inputs(device, m=40, seed=203, route_shift=2)
+    changed.topk_ids[-8:].fill_(-1)
     initial_reference = _nvfp4_oracle(weights, initial)
     changed_reference = _nvfp4_oracle(weights, changed)
     case = _prepare_and_bind(
@@ -484,7 +492,7 @@ def test_standard_moe_dynamic_prefill_live_graph_oracle(
     launch_plan = case.scratch_plan.launch_plan
     assert launch_plan.implementation == "dynamic"
     assert case.binding.implementation == "dynamic"
-    assert launch_plan.execution.tile_m == 64
+    assert launch_plan.execution.tile_m == 32
     assert launch_plan.execution.tile_n == 128
     _run_live_graph_check(
         case,
@@ -492,10 +500,12 @@ def test_standard_moe_dynamic_prefill_live_graph_oracle(
         changed=changed,
         initial_reference=initial_reference,
         changed_reference=changed_reference,
-        context="standard-moe-dynamic-prefill-m128",
+        context="standard-moe-dynamic-graph-m40",
         min_cos=0.999,
         max_normalized_rmse=0.03,
     )
+    assert case.binding.output is not None
+    assert torch.count_nonzero(case.binding.output[-8:]).item() == 0
 
 
 def test_standard_moe_tiny_decode_live_graph_oracle(

--- a/tests/moe/test_cute_migration_moe_standard_corpus.py
+++ b/tests/moe/test_cute_migration_moe_standard_corpus.py
@@ -470,6 +470,41 @@ def test_standard_moe_micro_live_graph_oracle(
     )
 
 
+def test_standard_moe_dynamic_prefill_live_graph_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reach ``integration.tp_moe.dynamic`` at a prefill-sized standard M."""
+
+    device = require_b12x()
+    _reset_dispatch_environment(monkeypatch)
+    weights = _make_nvfp4_weights(device, seed=201)
+    initial = _make_inputs(device, m=128, seed=202, route_shift=0)
+    changed = _make_inputs(device, m=128, seed=203, route_shift=2)
+    initial_reference = _nvfp4_oracle(weights, initial)
+    changed_reference = _nvfp4_oracle(weights, changed)
+    case = _prepare_and_bind(
+        weights,
+        initial,
+        quant_mode="nvfp4",
+        source_format="modelopt_nvfp4",
+    )
+    launch_plan = case.scratch_plan.launch_plan
+    assert launch_plan.implementation == "dynamic"
+    assert case.binding.implementation == "dynamic"
+    assert launch_plan.execution.tile_m == 64
+    assert launch_plan.execution.tile_n == 128
+    _run_live_graph_check(
+        case,
+        initial=initial,
+        changed=changed,
+        initial_reference=initial_reference,
+        changed_reference=changed_reference,
+        context="standard-moe-dynamic-prefill-m128",
+        min_cos=0.999,
+        max_normalized_rmse=0.03,
+    )
+
+
 def test_standard_moe_dynamic_inactive_route_live_graph_oracle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/moe/test_dynamic_w4a8_trellis.py
+++ b/tests/moe/test_dynamic_w4a8_trellis.py
@@ -98,6 +98,14 @@ def _run_trellis_dynamic(
         torch.randn(m, top_k, device=device), dim=-1
     ).float()
 
+    active_routes = (topk_ids >= 0) & (topk_ids < E)
+    reference_ids = torch.where(
+        active_routes, topk_ids, torch.zeros_like(topk_ids)
+    )
+    reference_weights = torch.where(
+        active_routes, topk_weights, torch.zeros_like(topk_weights)
+    )
+
     # ---- torch oracle in the kernel bases ----
     rot_cols = (6 if coupled else 3) * n
     rotations = (
@@ -118,8 +126,8 @@ def _run_trellis_dynamic(
         w13_ref,
         down_w,
         rotations,
-        topk_ids,
-        topk_weights,
+        reference_ids,
+        reference_weights,
         coupled=coupled,
     )
     torch.cuda.synchronize()
@@ -376,7 +384,7 @@ def test_dynamic_trellis_matches_scaffold(activation: str, m: int) -> None:
 def test_dynamic_w4a8_m1_direct_ignores_inactive_routes() -> None:
     """M=1 direct scheduling must skip every inactive expert route."""
 
-    got, _ = _run_trellis_dynamic(
+    got, want = _run_trellis_dynamic(
         activation="silu",
         E=4,
         m=1,
@@ -388,7 +396,8 @@ def test_dynamic_w4a8_m1_direct_ignores_inactive_routes() -> None:
         direct=True,
         topk_ids_override=torch.full((1, 2), -1, dtype=torch.int32),
     )
-    torch.testing.assert_close(got, torch.zeros_like(got), rtol=0, atol=0)
+    torch.testing.assert_close(want, torch.zeros_like(want), rtol=0, atol=0)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_dynamic_w4a8_trellis.py
+++ b/tests/moe/test_dynamic_w4a8_trellis.py
@@ -66,6 +66,8 @@ def _run_trellis_dynamic(
     split_materialized: bool = False,
     coupled: bool = False,
     direct_lut: bool = False,
+    direct: bool = False,
+    topk_ids_override: torch.Tensor | None = None,
 ):
     device = torch.device("cuda")
     torch.manual_seed(seed)
@@ -79,9 +81,19 @@ def _run_trellis_dynamic(
     w13_i16 = torch.stack((gate_payload, up_payload), dim=0).contiguous()
     w2_i16 = down_payload.contiguous()
     w13_ref = torch.stack((gate_w, up_w), dim=0)
-    topk_ids = torch.stack(
-        [torch.randperm(E, device=device)[:top_k] for _ in range(m)]
-    ).to(torch.int32)
+    if topk_ids_override is None:
+        topk_ids = torch.stack(
+            [torch.randperm(E, device=device)[:top_k] for _ in range(m)]
+        ).to(torch.int32)
+    else:
+        if tuple(topk_ids_override.shape) != (m, top_k):
+            raise ValueError(
+                "topk_ids_override must have shape "
+                f"{(m, top_k)}, got {tuple(topk_ids_override.shape)}"
+            )
+        topk_ids = topk_ids_override.to(
+            device=device, dtype=torch.int32
+        ).contiguous()
     topk_weights = torch.softmax(
         torch.randn(m, top_k, device=device), dim=-1
     ).float()
@@ -170,7 +182,7 @@ def _run_trellis_dynamic(
     flat_weights = topk_weights.reshape(-1).contiguous()
 
     import os as _os
-    _direct = _os.environ.get("BENCH_DIRECT", "0") == "1"
+    _direct = direct or _os.environ.get("BENCH_DIRECT", "0") == "1"
     _share = (
         split_materialized
         or _direct
@@ -358,6 +370,25 @@ def test_dynamic_trellis_matches_scaffold(activation: str, m: int) -> None:
             got[row : row + 1], want[row : row + 1]
         ).item()
         assert row_cos > 0.995, (row, row_cos)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_dynamic_w4a8_m1_direct_ignores_inactive_routes() -> None:
+    """M=1 direct scheduling must skip every inactive expert route."""
+
+    got, _ = _run_trellis_dynamic(
+        activation="silu",
+        E=4,
+        m=1,
+        K=256,
+        n=128,
+        top_k=2,
+        seed=20260815,
+        recipe="w4a8_mx",
+        direct=True,
+        topk_ids_override=torch.full((1, 2), -1, dtype=torch.int32),
+    )
+    torch.testing.assert_close(got, torch.zeros_like(got), rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_dynamic_w4a8_trellis.py
+++ b/tests/moe/test_dynamic_w4a8_trellis.py
@@ -384,6 +384,7 @@ def test_dynamic_trellis_matches_scaffold(activation: str, m: int) -> None:
 def test_dynamic_w4a8_m1_direct_ignores_inactive_routes() -> None:
     """M=1 direct scheduling must skip every inactive expert route."""
 
+    keepalive: list[dict[str, object]] = []
     got, want = _run_trellis_dynamic(
         activation="silu",
         E=4,
@@ -395,9 +396,38 @@ def test_dynamic_w4a8_m1_direct_ignores_inactive_routes() -> None:
         recipe="w4a8_mx",
         direct=True,
         topk_ids_override=torch.full((1, 2), -1, dtype=torch.int32),
+        keepalive=keepalive,
     )
     torch.testing.assert_close(want, torch.zeros_like(want), rtol=0, atol=0)
     torch.testing.assert_close(got, want, rtol=0, atol=0)
+    packed_a = keepalive[0]["packed_a"]
+    assert isinstance(packed_a, torch.Tensor)
+    assert torch.count_nonzero(packed_a).item() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_dynamic_w4a8_shared_input_ignores_inactive_routes() -> None:
+    """Shared-input scheduling must not materialize an inactive token."""
+
+    keepalive: list[dict[str, object]] = []
+    got, want = _run_trellis_dynamic(
+        activation="silu",
+        E=4,
+        m=3,
+        K=256,
+        n=128,
+        top_k=2,
+        seed=20260815,
+        recipe="w4a8_mx",
+        split_materialized=True,
+        topk_ids_override=torch.full((3, 2), -1, dtype=torch.int32),
+        keepalive=keepalive,
+    )
+    torch.testing.assert_close(want, torch.zeros_like(want), rtol=0, atol=0)
+    torch.testing.assert_close(got, want, rtol=0, atol=0)
+    packed_a = keepalive[0]["packed_a"]
+    assert isinstance(packed_a, torch.Tensor)
+    assert torch.count_nonzero(packed_a).item() == 0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a8_dynamic_kernel.py
+++ b/tests/moe/test_w4a8_dynamic_kernel.py
@@ -73,6 +73,19 @@ def _fake_f32(shape):
     return cute.runtime.make_fake_compact_tensor(cutlass.Float32, shape, assumed_align=16)
 
 
+def _active_route_reference_inputs(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Represent inactive routes with safe indices and zero oracle weights."""
+
+    active = (topk_ids >= 0) & (topk_ids < num_experts)
+    safe_ids = torch.where(active, topk_ids, torch.zeros_like(topk_ids))
+    active_weights = torch.where(active, topk_weights, torch.zeros_like(topk_weights))
+    return safe_ids, active_weights
+
+
 def _run_w4a8_dynamic(
     *,
     recipe: str,
@@ -115,8 +128,6 @@ def _run_w4a8_dynamic(
                 f"{(m, top_k)}, got {tuple(topk_ids_override.shape)}"
             )
         topk_ids = topk_ids_override.to(device=device, dtype=torch.int32).contiguous()
-        if int(topk_ids.min().item()) < 0 or int(topk_ids.max().item()) >= E:
-            raise ValueError("topk_ids_override contains an out-of-range expert")
     topk_weights = torch.softmax(torch.randn(m, top_k, device=device), dim=-1).float()
     if route_weight_slot is not None:
         if not 0 <= route_weight_slot < top_k:
@@ -154,11 +165,14 @@ def _run_w4a8_dynamic(
     w2_packed = torch.stack([q[0] for q in w2_q]).contiguous()
     ones = torch.ones(E, device=device)
 
+    reference_ids, reference_weights = _active_route_reference_inputs(
+        topk_ids, topk_weights, E
+    )
     reference = moe_reference_w4a8_mx(
         x.float(),
         w13_packed, w13_mx, ref_res_w13, ones,
         w2_packed, w2_mx, ref_res_w2, ones,
-        topk_ids, topk_weights, E, K, n,
+        reference_ids, reference_weights, E, K, n,
         activation=activation,
     )
 
@@ -597,8 +611,8 @@ def _run_w4a8_dynamic(
                     w2_mx,
                     fc2_residual,
                     ones,
-                    topk_ids,
-                    topk_weights,
+                    reference_ids,
+                    reference_weights,
                     E,
                     K,
                     n,
@@ -651,6 +665,9 @@ def _run_w4a8_dynamic(
 
         if return_state:
             def _current_reference():
+                live_ids, live_weights = _active_route_reference_inputs(
+                    flat_ids.view(m, top_k), flat_weights.view(m, top_k), E
+                )
                 return moe_reference_w4a8_mx(
                     x.float(),
                     w13_packed,
@@ -661,8 +678,8 @@ def _run_w4a8_dynamic(
                     w2_mx,
                     ref_res_w2,
                     ones,
-                    flat_ids.view(m, top_k),
-                    flat_weights.view(m, top_k),
+                    live_ids,
+                    live_weights,
                     E,
                     K,
                     n,
@@ -732,6 +749,46 @@ def test_w4a8_dynamic_matches_oracle(recipe: str, activation: str) -> None:
     assert metrics.cos > 0.999, metrics
     ref_rms = ref.float().square().mean().sqrt().item()
     assert metrics.rmse <= max(0.03 * ref_rms, 5e-3), (metrics, ref_rms)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("inactive_expert", [-1, 4])
+def test_w4a8_dynamic_ignores_inactive_routes(inactive_expert: int) -> None:
+    """Inactive routes must not enter expert storage or contribute output."""
+
+    require_b12x()
+    topk_ids = torch.tensor(
+        [
+            [inactive_expert, inactive_expert],
+            [0, inactive_expert],
+            [1, 2],
+            [inactive_expert, 3],
+            [2, inactive_expert],
+            [3, 0],
+            [inactive_expert, 1],
+            [0, 2],
+        ],
+        dtype=torch.int32,
+    )
+    out, ref, debug = _run_w4a8_dynamic(
+        recipe="w4a8_mx",
+        activation="silu",
+        E=4,
+        m=8,
+        K=256,
+        n=128,
+        top_k=2,
+        seed=211,
+        topk_ids_override=topk_ids,
+        return_debug=True,
+    )
+
+    active_routes = int(((topk_ids >= 0) & (topk_ids < 4)).sum().item())
+    assert int(debug["row_counts"].sum().item()) == active_routes
+    assert int(debug["expert_write_rows"].sum().item()) == active_routes
+    torch.testing.assert_close(out[0], torch.zeros_like(out[0]), rtol=0, atol=0)
+    metrics = compare_to_reference(out.float(), ref)
+    assert metrics.cos > 0.999, metrics
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
@@ -976,10 +1033,13 @@ def test_w4a8_dynamic_graph_replay_tracks_routing_updates() -> None:
         )
 
     def _oracle():
+        live_ids, live_weights = _active_route_reference_inputs(
+            flat_ids.view(m, top_k), flat_weights.view(m, top_k), E
+        )
         return moe_reference_w4a8_mx(
             x.float(), w13_packed, w13_mx, None, ones,
             w2_packed, w2_mx, None, ones,
-            flat_ids.view(m, top_k), flat_weights.view(m, top_k), E, K, n,
+            live_ids, live_weights, E, K, n,
             activation="silu",
         )
 
@@ -1000,6 +1060,10 @@ def test_w4a8_dynamic_graph_replay_tracks_routing_updates() -> None:
         new_ids = torch.stack(
             [torch.randperm(E, device=device)[:top_k] for _ in range(m)]
         ).to(torch.int32)
+        if round_idx == 1:
+            new_ids[-3:, 1] = -1
+        elif round_idx == 2:
+            new_ids.fill_(-1)
         new_w = torch.softmax(torch.randn(m, top_k, device=device), dim=-1).float()
         flat_ids.copy_(new_ids.reshape(-1))
         flat_weights.copy_(new_w.reshape(-1))
@@ -1007,6 +1071,11 @@ def test_w4a8_dynamic_graph_replay_tracks_routing_updates() -> None:
         graph.replay()
         torch.cuda.synchronize()
         ref = _oracle()
-        metrics = compare_to_reference(scatter_output.float(), ref)
-        assert scatter_output.abs().sum().item() > 0, round_idx
-        assert metrics.cos > 0.999, (round_idx, metrics)
+        if round_idx == 2:
+            torch.testing.assert_close(
+                scatter_output, torch.zeros_like(scatter_output), rtol=0, atol=0
+            )
+        else:
+            metrics = compare_to_reference(scatter_output.float(), ref)
+            assert scatter_output.abs().sum().item() > 0, round_idx
+            assert metrics.cos > 0.999, (round_idx, metrics)


### PR DESCRIPTION
## Status

Implemented at `321c24a`. Targeted GPU qualification passed; the full repository
test suite was not rerun.

## Resulting behavior

The dynamic MoE route contract treats every expert ID outside
`[0, num_experts)` as inactive.

- Grouped routing excludes inactive entries from expert histograms, compacted
  storage, and task publication.
- Direct routing retains its graph-stable arithmetic task domain, marks inactive
  slots with zero valid rows, and skips them before loading expert weights or
  scales.
- The materialized M=1 producer derives one warp-uniform active-route signal and
  skips activation loads, quantization, packed writes, and scale writes when no
  route is active.
- Shared-input producers derive one token-level active-route signal after route
  allocation and skip activation loads, quantization, packed writes, fences,
  counters, and task publication when the token has no active route.
- Route-private producers use the existing warp-uniform route-valid signal to
  guard the expert scale load and the complete activation producer body.
- Tokens with no active routes retain the kernel's zero-initialized output.
- CUDA graph replay may change between valid, partially padded, and fully padded
  routing without rebinding or allocating workspace.

## Technical reason

vLLM's skip-padding MoE path uses expert ID `-1` for zero-weight padding routes;
the option defaults to enabled after
[vLLM #48979](https://github.com/vllm-project/vllm/pull/48979). Directly using
that ID in B12X expert histograms or prepared-weight addressing violates the
route storage bounds.

[local-inference-lab/vllm #291](https://github.com/local-inference-lab/vllm/pull/291)
maps `-1` to expert zero at the integration boundary. That mapping avoids the
invalid address but converts padding into executable expert-zero work. Defining
inactive routes in B12X preserves the skip-padding optimization and keeps the
contract valid for every B12X caller.

## Efficiency evidence

The inactive checks surround producer work rather than only predicating its
stores.

- A zero-initialized packed-activation probe on `83e306f` produced 256 nonzero
  elements for the fully inactive M=1 case and 768 for the fully inactive
  shared-input case. The same probes on `321c24a` produced zero packed elements
  and exact-zero outputs in both cases.
- `nvdisasm` on the `321c24a` W4A8 objects shows a uniform M=1 branch at `0x840`
  jumping to `0x1250`, past the activation/quantization/store body, and a
  shared-input branch at `0x1c30` jumping to `0x3150`, past both cooperating
  warp partitions.
- A valid-route production-path diagnostic at
  `M40/E64/H1024/I256/top-k6`, warm CUDA graph replay, used five samples of
  100,000 replays per head. `83e306f` measured `32.770 us`; `321c24a` measured
  `32.786 us` (`+0.047%`). Allocated memory remained `62,860,288` bytes across
  replay in both arms. This Max-Q diagnostic indicates no material active-route
  regression; it is not formal release qualification.

## Compatibility

Valid expert IDs retain the same routing, quantization, task geometry, and
output math. Active M=1 and shared-input producers add a short lane-zero route
scan plus a warp shuffle. The implementation adds no allocation, workspace, or
binding changes. Negative and positive out-of-range IDs are both inactive.

## Validation

Source: `321c24a` on B12X `master` base `d3fc4bd`.

GPU: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition,
`GPU-ac6fcbb2-ae5f-231d-cc3e-e843c305baff`; Torch `2.12.0+cu130`, CUDA `13.0`,
CUTLASS DSL `4.6.0`.

- `7 passed`: materialized M=1, shared-input materialization, grouped W4A8,
  production NVFP4 inactive routing, graph mutation/replay, and both dynamic
  prefill corpus cases.
- The existing `M=128` production dynamic-prefill corpus remains present; the
  `M=40` inactive-route corpus is a separate test.
- `py_compile`, `ruff check --ignore F401`, and `git diff --check`: passed.

## Merge recommendation

Ready to merge based on targeted GPU qualification. The full repository suite was not run.