### PR TITLE
[II] Fuse Kimi paired projection gather and expert selection

### DIFF
--- a/b12x/comm/pcie/_cute_intrinsics.py
+++ b/b12x/comm/pcie/_cute_intrinsics.py
@@ -501,3 +501,57 @@ def rsqrt_approx_f32(value: Float32, *, loc=None, ip=None) -> Float32:
             ip=ip,
         )
     )
+
+
+@dsl_user_op
+def float_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Map a float onto a u32 whose unsigned order matches float order.
+
+    Lets a (score, expert) pair be packed into one integer key, so "better
+    candidate" becomes a plain integer max and the tie-break stops costing a
+    second comparison.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .u32 bits, mask;
+                mov.b32 bits, $1;
+                shr.u32 mask, bits, 31;
+                mul.lo.u32 mask, mask, 0x7fffffff;
+                or.b32 mask, mask, 0x80000000;
+                xor.b32 $0, bits, mask;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def redux_max_u32(value: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Warp-wide unsigned max in one instruction.
+
+    ``cute.arch.warp_redux_sync`` exposes the float variant, which libNVVM
+    rejects for sm_120a; the integer one is what the kernel actually needs.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(value).ir_value(loc=loc, ip=ip)],
+            "redux.sync.max.u32 $0, $1, 0xffffffff;",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )

--- a/b12x/comm/pcie/_dcp_a2a_cute.py
+++ b/b12x/comm/pcie/_dcp_a2a_cute.py
@@ -17,12 +17,15 @@ from b12x._lib.intrinsics import (
     fmax_f32,
     ld_global_v4_u32,
     st_global_v4_u32,
+    u32_as_f32,
 )
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
 
 from ._dcp_cute_common import block_pair_barrier
 from ._cute_intrinsics import (
+    float_order_key,
+    redux_max_u32,
     ld_generic_f32,
     ld_relaxed_gpu_u32,
     pack_f32x2_to_bf16x2,
@@ -107,6 +110,89 @@ def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
 
 
 @dsl_user_op
+def _select_if_eq_u32(
+    lhs: Uint32,
+    rhs: Uint32,
+    on_equal: Uint32,
+    otherwise: Uint32,
+    *,
+    loc=None,
+    ip=None,
+) -> Uint32:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select."""
+
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Uint32(lhs).ir_value(loc=loc, ip=ip),
+                Uint32(rhs).ir_value(loc=loc, ip=ip),
+                Uint32(on_equal).ir_value(loc=loc, ip=ip),
+                Uint32(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u32 p, $1, $2; selp.b32 $0, $3, $4, p; }",
+            "=r,r,r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _select_if_eq_u64(
+    lhs: cutlass.Uint64,
+    rhs: cutlass.Uint64,
+    on_equal: cutlass.Uint64,
+    otherwise: cutlass.Uint64,
+    *,
+    loc=None,
+    ip=None,
+) -> cutlass.Uint64:
+    """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
+
+    A Python ``if`` on a runtime condition becomes a branch region. The top-16
+    rounds update a register-held key array, so a divergent branch can spill the
+    array to local memory. A ternary chain emits straight-line predicated code
+    and lets ptxas fold repeated ``setp`` operations.
+    """
+
+    return cutlass.Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [
+                cutlass.Uint64(lhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(rhs).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(on_equal).ir_value(loc=loc, ip=ip),
+                cutlass.Uint64(otherwise).ir_value(loc=loc, ip=ip),
+            ],
+            "{ .reg .pred p; setp.eq.u64 p, $1, $2; selp.b64 $0, $3, $4, p; }",
+            "=l,l,l,l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def _copy_16b_addr(source: Int64, destination: Int64) -> None:
+    """Copy 16B between two byte addresses already resolved by the caller.
+
+    The gather loops pick their source rank at runtime.  Selecting the address
+    first and issuing one copy keeps a single load in flight per thread; cloning
+    the copy once per peer inside a constexpr chain makes a warp that straddles
+    two source ranks issue its loads in two serialised batches.
+    """
+    values = ld_global_v4_u32(source)
+    st_global_v4_u32(destination, *values)
+
+
+@dsl_user_op
 def _fma_rn_f32(
     a: Float32,
     b: Float32,
@@ -168,7 +254,7 @@ def _add_u64_opaque(
     loc=None,
     ip=None,
 ) -> Int64:
-    """Add a payload offset without CSE into the earlier LSE address phase."""
+    """Add a payload offset without CSE into the LSE-address calculation."""
 
     return Int64(
         llvm.inline_asm(
@@ -187,6 +273,70 @@ def _add_u64_opaque(
         )
     )
 
+
+
+_KIMI_NEG_INF = float("-inf")
+
+
+@cute.jit
+def _kimi_pack_key(score: Float32, expert: Int32) -> cutlass.Uint64:
+    """Pack (score, expert) so that a plain integer max picks the winner.
+
+    The expert index goes in complemented, so a tie on score resolves to the
+    lower index -- the same order the native reference produces, without a
+    second comparison at every step.
+    """
+    return (cutlass.Uint64(float_order_key(score)) << cutlass.Uint64(32)) | (
+        cutlass.Uint64(0xFFFF) - cutlass.Uint64(expert)
+    )
+
+
+@cute.jit
+def _kimi_key_expert(key: cutlass.Uint64) -> Int32:
+    return Int32(cutlass.Uint64(0xFFFF) - (key & cutlass.Uint64(0xFFFF)))
+
+
+@cute.jit
+def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
+    """Warp-wide max of a 64-bit key in two instructions.
+
+    Reduces the high words, then only the low words of the lanes that tied on
+    the high word, which is cheaper than carrying a 64-bit value through a
+    shuffle chain.
+    """
+    hi = cutlass.Uint32(key >> cutlass.Uint64(32))
+    lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
+    max_hi = redux_max_u32(hi)
+    contribution = _select_if_eq_u32(hi, max_hi, lo, Uint32(0))
+    max_lo = redux_max_u32(contribution)
+    return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
+
+
+def _kimi_sort_desc(keys, count: int) -> None:
+    """Descending bitonic sort over a compile-time number of packed keys.
+
+    Every index is a Python constant, so the whole network unrolls and the
+    per-round selection can just read ``keys[0]``.
+    """
+    width = 2
+    while width <= count:
+        stride = width // 2
+        while stride > 0:
+            for index in range(count):
+                peer = index ^ stride
+                if peer <= index:
+                    continue
+                descending = (index & width) == 0
+                lower = keys[index]
+                upper = keys[peer]
+                if descending:
+                    keys[index] = cutlass.max(lower, upper)
+                    keys[peer] = cutlass.min(lower, upper)
+                else:
+                    keys[index] = cutlass.min(lower, upper)
+                    keys[peer] = cutlass.max(lower, upper)
+            stride //= 2
+        width *= 2
 
 class _DCPA2ABase:
     def __init__(
@@ -902,23 +1052,31 @@ class _AllGatherHeadsLaunch(_DCPA2ABase):
                 * Int64(packs_per_head)
             )
             output_base = Int64(row) * Int64(packs_per_head)
+            # Resolve the peer's base address first and copy once. Cloning the
+            # whole pack loop into all sixteen arms of the constexpr chain
+            # bloats the kernel and pays the chain on every row.
+            source_address = Int64(
+                (local_input + source_base * Int64(4)).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
                         source_words = local_input
                     else:
                         source_words = self._staging_words(staging[source])
-                    pack = lane
-                    while pack < packs_per_head:
-                        _copy_16b(
-                            source_words
-                            + source_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                            output
-                            + output_base * Int64(4)
-                            + Int64(pack) * Int64(4),
-                        )
-                        pack += Int32(32)
+                    source_address = Int64(
+                        (source_words + source_base * Int64(4)).toint()
+                    )
+            output_address = Int64(
+                (output + output_base * Int64(4)).toint()
+            )
+            pack = lane
+            while pack < packs_per_head:
+                _copy_16b_addr(
+                    source_address + Int64(pack) * Int64(16),
+                    output_address + Int64(pack) * Int64(16),
+                )
+                pack += Int32(32)
             row += warp_stride
 
         if cutlass.const_expr(self._device_slot_selection):
@@ -1188,6 +1346,19 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             )
             source_rank = row_pack // first_packs
             pack = row_pack - source_rank * first_packs
+            # Default to this rank's own slice so the address is always
+            # mappable; the chain below always overwrites it, because
+            # source_rank is derived from row_pack and is in range.
+            source_address = Int64(
+                (
+                    local_first
+                    + (
+                        Int64(batch_index) * Int64(first_packs)
+                        + Int64(pack)
+                    )
+                    * Int64(4)
+                ).toint()
+            )
             for source in cutlass.range_constexpr(self._world_size):
                 if source_rank == Int32(source):
                     if cutlass.const_expr(source == self._rank):
@@ -1200,11 +1371,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                         source_base = (
                             Int64(batch_index) * Int64(combined_packs)
                         )
-                    _copy_16b(
-                        source_words
-                        + (source_base + Int64(pack)) * Int64(4),
-                        output_first + Int64(linear) * Int64(4),
+                    source_address = Int64(
+                        (
+                            source_words
+                            + (source_base + Int64(pack)) * Int64(4)
+                        ).toint()
                     )
+            _copy_16b_addr(
+                source_address,
+                Int64((output_first + Int64(linear) * Int64(4)).toint()),
+            )
             linear += Int32(self._threads)
 
         if cutlass.const_expr(not self._kimi_topk):
@@ -1221,6 +1397,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 )
                 source_rank = row_pack // second_packs
                 pack = row_pack - source_rank * second_packs
+                source_address = Int64(
+                    (
+                        local_second
+                        + (
+                            Int64(batch_index) * Int64(second_packs)
+                            + Int64(pack)
+                        )
+                        * Int64(4)
+                    ).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
@@ -1236,11 +1422,18 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                                 Int64(batch_index) * Int64(combined_packs)
                                 + Int64(first_packs)
                             )
-                        _copy_16b(
-                            source_words
-                            + (source_base + Int64(pack)) * Int64(4),
-                            output_second + Int64(linear) * Int64(4),
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                _copy_16b_addr(
+                    source_address,
+                    Int64(
+                        (output_second + Int64(linear) * Int64(4)).toint()
+                    ),
+                )
                 linear += Int32(self._threads)
         else:
             smem_alloc = cutlass.utils.SmemAllocator()
@@ -1253,6 +1446,10 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 unbiased_scores: cute.struct.Align[
                     cute.struct.MemRange[Float32, 896], 16
                 ]
+                # The 64 survivors of the warp-local rounds, as packed keys.
+                reduce_keys: cute.struct.Align[
+                    cute.struct.MemRange[cutlass.Uint64, 64], 16
+                ]
 
             storage = smem_alloc.allocate(SharedStorage)
             selection_scores = storage.selection_scores.get_tensor(
@@ -1261,30 +1458,52 @@ class _AllGatherPairLaunch(_DCPA2ABase):
             unbiased_scores = storage.unbiased_scores.get_tensor(
                 cute.make_layout((896,), stride=(1,))
             )
+            reduce_keys = storage.reduce_keys.get_tensor(
+                cute.make_layout((64,), stride=(1,))
+            )
 
-            expert = Int32(tidx)
-            while expert < Int32(896):
-                source_rank = expert // Int32(56)
-                local_expert = expert - source_rank * Int32(56)
-                router_value = Float32(0.0)
+            # Pull the 3,584-byte router row in 16-byte packs. This uses 224
+            # peer transactions instead of 896 scalar transactions; PCIe
+            # transaction count dominates router-row transfer time.
+            router_pack = Int32(tidx)
+            router_packs_total = Int32(self._world_size) * second_packs
+            while router_pack < router_packs_total:
+                source_rank = router_pack // second_packs
+                pack = router_pack - source_rank * second_packs
+                source_address = Int64(
+                    (local_second + Int64(pack) * Int64(4)).toint()
+                )
                 for source in cutlass.range_constexpr(self._world_size):
                     if source_rank == Int32(source):
                         if cutlass.const_expr(source == self._rank):
-                            source_router = cute.recast_ptr(
-                                local_second.align(4), dtype=Float32
-                            )
+                            source_words = local_second
+                            source_base = Int64(0)
                         else:
-                            source_router = cute.recast_ptr(
-                                (
-                                    staging[source]
-                                    + slot_offset
-                                    + Int64(first_packs) * Int64(16)
-                                ).align(4),
-                                dtype=Float32,
+                            source_words = self._staging_words(
+                                staging[source] + slot_offset
                             )
-                        router_value = cute.arch.load(
-                            source_router + Int64(local_expert), Float32
+                            source_base = Int64(first_packs)
+                        source_address = Int64(
+                            (
+                                source_words
+                                + (source_base + Int64(pack)) * Int64(4)
+                            ).toint()
                         )
+                word0, word1, word2, word3 = ld_global_v4_u32(source_address)
+                # router_pack counts packs in rank-major order, so multiplying
+                # it by four yields the first global expert index in the pack
+                # for every supported world size.
+                base_expert = router_pack * Int32(4)
+                selection_scores[base_expert] = u32_as_f32(word0)
+                selection_scores[base_expert + Int32(1)] = u32_as_f32(word1)
+                selection_scores[base_expert + Int32(2)] = u32_as_f32(word2)
+                selection_scores[base_expert + Int32(3)] = u32_as_f32(word3)
+                router_pack += Int32(self._threads)
+            cute.arch.sync_threads()
+
+            expert = Int32(tidx)
+            while expert < Int32(896):
+                router_value = selection_scores[expert]
                 bias = cute.arch.load(
                     correction_bias + Int64(expert), Float32
                 )
@@ -1306,43 +1525,89 @@ class _AllGatherPairLaunch(_DCPA2ABase):
                 expert += Int32(self._threads)
             cute.arch.sync_threads()
 
-            if Int32(tidx) == Int32(0):
-                selected_ids = cute.make_rmem_tensor((16,), Int32)
-                selected_weights = cute.make_rmem_tensor((16,), Float32)
+            # Two-level top-16 over packed (score, expert) keys. Four warps each
+            # reduce 256 experts held in registers (8 per lane); warp 0 then
+            # merges the 64 survivors.
+            # A round costs one warp reduction -- two instructions -- because the
+            # tie-break lives in the key rather than in a second comparison.
+            lane = Int32(tidx) % Int32(32)
+            warp = Int32(tidx) // Int32(32)
+            lane_key = cutlass.Uint64(0)
+            keys = cute.make_rmem_tensor((8,), cutlass.Uint64)
+            if warp < Int32(4):
+                for item in cutlass.range_constexpr(8):
+                    expert_id = warp * Int32(256) + Int32(item * 32) + lane
+                    value = Float32(_KIMI_NEG_INF)
+                    if expert_id < Int32(896):
+                        value = selection_scores[expert_id]
+                    keys[item] = _kimi_pack_key(value, expert_id)
+                _kimi_sort_desc(keys, 8)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    selected_ids[selected] = Int32(-1)
-                    selected_weights[selected] = Float32(0.0)
-                weight_sum = Float32(0.0)
+                    if cutlass.const_expr(selected > 0):
+                        # Hold the head before the shift overwrites it, so
+                        # every element selects on the same condition.
+                        head = keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF), _kimi_key_expert(keys[7])
+                        )
+                        for item in cutlass.range_constexpr(7):
+                            keys[item] = _select_if_eq_u64(
+                                previous, head, keys[item + 1], keys[item]
+                            )
+                        keys[7] = _select_if_eq_u64(
+                            previous, head, tail_key, keys[7]
+                        )
+                    previous = _kimi_warp_max_key(keys[0])
+                    lane_key = _select_if_eq_u64(
+                        cutlass.Uint64(lane),
+                        cutlass.Uint64(selected),
+                        previous,
+                        lane_key,
+                    )
+                if lane < Int32(16):
+                    reduce_keys[warp * Int32(16) + lane] = lane_key
+            cute.arch.sync_threads()
+            selected_ids = cute.make_rmem_tensor((16,), Int32)
+            selected_weights = cute.make_rmem_tensor((16,), Float32)
+            weight_sum = Float32(0.0)
+            if warp == Int32(0):
+                merge_keys = cute.make_rmem_tensor((2,), cutlass.Uint64)
+                for item in cutlass.range_constexpr(2):
+                    merge_keys[item] = reduce_keys[Int32(item * 32) + lane]
+                _kimi_sort_desc(merge_keys, 2)
+                previous = cutlass.Uint64(0)
                 for selected in cutlass.range_constexpr(16):
-                    best_score = Float32(float("-inf"))
-                    best_expert = Int32(-1)
-                    candidate = Int32(0)
-                    while candidate < Int32(896):
-                        already_selected = False
-                        for prior in cutlass.range_constexpr(selected):
-                            if selected_ids[prior] == candidate:
-                                already_selected = True
-                        score = selection_scores[candidate]
-                        if not already_selected:
-                            if (
-                                score > best_score
-                                or (
-                                    score == best_score
-                                    and (
-                                        best_expert < Int32(0)
-                                        or candidate < best_expert
-                                    )
-                                )
-                            ):
-                                best_score = score
-                                best_expert = candidate
-                        candidate += Int32(1)
-                    selected_ids[selected] = best_expert
-                    weight = Float32(0.0)
-                    if best_expert >= Int32(0):
-                        weight = unbiased_scores[best_expert]
+                    if cutlass.const_expr(selected > 0):
+                        head = merge_keys[0]
+                        tail_key = _kimi_pack_key(
+                            Float32(_KIMI_NEG_INF),
+                            _kimi_key_expert(merge_keys[1]),
+                        )
+                        merge_keys[0] = _select_if_eq_u64(
+                            previous, head, merge_keys[1], merge_keys[0]
+                        )
+                        merge_keys[1] = _select_if_eq_u64(
+                            previous, head, tail_key, merge_keys[1]
+                        )
+                    previous = _kimi_warp_max_key(merge_keys[0])
+                    # The reduction broadcasts, so every lane agrees here.
+                    final_expert = _kimi_key_expert(previous)
+                    selected_ids[selected] = final_expert
+                    weight = unbiased_scores[final_expert]
                     selected_weights[selected] = weight
-                    weight_sum += weight
+                # The native kernel renormalises with cg::reduce over the warp,
+                # which folds by halves (lane l adds lane l+stride, stride
+                # halving from 16). Summing left to right instead lands a ULP
+                # away, so fold in the same order. Same fifteen adds.
+                eight = [
+                    selected_weights[item] + selected_weights[item + 8]
+                    for item in range(8)
+                ]
+                four = [eight[item] + eight[item + 4] for item in range(4)]
+                two = [four[item] + four[item + 2] for item in range(2)]
+                weight_sum = two[0] + two[1]
+            if Int32(tidx) == Int32(0):
                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
                 for selected in cutlass.range_constexpr(16):
                     cute.arch.store(
@@ -1928,6 +2193,7 @@ def all_gather_pair(
 
 def all_gather_pair_kimi_topk(
     *,
+    world_size: int,
     rank: int,
     local_down_ptr: int,
     local_router_ptr: int,
@@ -1942,14 +2208,16 @@ def all_gather_pair_kimi_topk(
 ) -> None:
     slot_delta_256b = _slot_delta_256b(slot_delta_bytes)
     launcher = _get_compiled_all_gather_pair(
-        16,
+        world_size,
         rank,
         512,
         device_slot_selection,
         True,
     )
     if not device_slot_selection:
-        _get_compiled_all_gather_pair(16, rank, 512, True, True)
+        _get_compiled_all_gather_pair(
+            world_size, rank, 512, True, True
+        )
     launcher(
         local_down_ptr,
         local_router_ptr,
@@ -1960,8 +2228,8 @@ def all_gather_pair_kimi_topk(
         staging_ptrs,
         signal_ptrs,
         1,
-        28,
-        14,
+        448 // world_size,
+        224 // world_size,
         slot_delta_256b,
     )
 

--- a/b12x/comm/pcie/pcie_dcp_a2a.py
+++ b/b12x/comm/pcie/pcie_dcp_a2a.py
@@ -753,10 +753,13 @@ class PCIeDCPA2A:
             )
 
     def prepare_graph_all_gather_pair_kimi_topk(self) -> None:
-        """Compile/load the TP16 Kimi fused launcher before graph capture."""
+        """Compile/load the Kimi fused launcher before graph capture."""
 
-        if self.world_size != 16:
-            raise ValueError("Kimi paired gather+top-k requires TP16")
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                "Kimi paired gather+top-k requires a supported PCIe DCP "
+                f"world size, got {self.world_size}"
+            )
         if _is_current_stream_capturing(self.device):
             raise RuntimeError(
                 "prepare_graph_all_gather_pair_kimi_topk() must run before capture"
@@ -764,7 +767,13 @@ class PCIeDCPA2A:
         from ._dcp_a2a_cute import _get_compiled_all_gather_pair
 
         with torch.cuda.device(self.device):
-            _get_compiled_all_gather_pair(16, self.rank, 512, True, True)
+            _get_compiled_all_gather_pair(
+                self.world_size,
+                self.rank,
+                512,
+                True,
+                True,
+            )
 
     def _validate(
         self,
@@ -1270,15 +1279,30 @@ class PCIeDCPA2A:
         topk_weights: Optional[torch.Tensor] = None,
         topk_ids: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Gather Kimi-K3's TP16 latent row and select its 16 experts."""
+        """Gather Kimi-K3's sharded latent row and select its 16 experts."""
         self._check_stream()
         if self._closed:
             raise RuntimeError("PCIeDCPA2A is closed")
-        if self.world_size != 16:
-            raise ValueError("Kimi paired gather+top-k requires TP16")
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                "Kimi paired gather+top-k requires a supported PCIe DCP "
+                f"world size, got TP{self.world_size}"
+            )
+        local_down_width = 3584 // self.world_size
+        local_router_width = 896 // self.world_size
         expected = (
-            (local_down, (1, 224), torch.bfloat16, "local_down"),
-            (local_router, (1, 56), torch.float32, "local_router"),
+            (
+                local_down,
+                (1, local_down_width),
+                torch.bfloat16,
+                "local_down",
+            ),
+            (
+                local_router,
+                (1, local_router_width),
+                torch.float32,
+                "local_router",
+            ),
             (correction_bias, (896,), torch.float32, "correction_bias"),
         )
         for value, shape, dtype, name in expected:
@@ -1317,7 +1341,7 @@ class PCIeDCPA2A:
             from ._dcp_a2a_cute import is_all_gather_pair_prepared
 
             if not is_all_gather_pair_prepared(
-                16,
+                self.world_size,
                 self.rank,
                 512,
                 True,
@@ -1363,6 +1387,7 @@ class PCIeDCPA2A:
 
         with torch.cuda.device(self.device):
             all_gather_pair_kimi_topk(
+                world_size=self.world_size,
                 rank=self.rank,
                 local_down_ptr=local_down.data_ptr(),
                 local_router_ptr=local_router.data_ptr(),

--- a/benchmarks/benchmark_kimi_k3_pair_topk.py
+++ b/benchmarks/benchmark_kimi_k3_pair_topk.py
@@ -1,6 +1,16 @@
+"""Benchmark Kimi paired projection gathering with fused expert selection.
+
+The benchmark covers tensor-parallel worlds of two, four, eight, and sixteen
+ranks (TP2, TP4, TP8, and TP16). It compares a separate paired gather plus vLLM
+``grouped_topk`` against the fused B12X operation. Expert IDs and projection
+data must match exactly. Router weights may differ by at most one FP32 rounding
+step because the implementations use different parallel reduction orders.
+"""
+
 from __future__ import annotations
 
 import argparse
+import json
 import socket
 import statistics
 import time
@@ -42,7 +52,7 @@ def _measure(
     warmup: int,
     iterations: int,
     samples: int,
-) -> float:
+) -> list[float]:
     timings: list[float] = []
     for _ in range(samples):
         dist.barrier()
@@ -57,13 +67,14 @@ def _measure(
         maximum = torch.tensor(elapsed_us, dtype=torch.float64, device=device)
         dist.all_reduce(maximum, op=dist.ReduceOp.MAX)
         timings.append(float(maximum.item()))
-    return statistics.median(timings)
+    return timings
 
 
 def _case(
     name: str,
     *,
     rank: int,
+    world_size: int,
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if name == "random":
@@ -83,16 +94,24 @@ def _case(
         bias[33] = float("inf")
     else:
         raise ValueError(name)
-    local = logits[:, rank * 56 : (rank + 1) * 56].contiguous()
+    local_width = 896 // world_size
+    local = logits[
+        :, rank * local_width : (rank + 1) * local_width
+    ].contiguous()
     return local, bias.contiguous()
 
 
 def _equal_with_matching_nan(actual: torch.Tensor, expected: torch.Tensor) -> bool:
-    return bool(
-        torch.all(
-            torch.eq(actual, expected) | (torch.isnan(actual) & torch.isnan(expected))
-        )
+    finite = torch.isfinite(actual) & torch.isfinite(expected)
+    finite_close = torch.where(
+        finite,
+        torch.isclose(actual, expected, rtol=2.0**-23, atol=0.0),
+        torch.ones_like(finite),
     )
+    special_equal = torch.eq(actual, expected) | (
+        torch.isnan(actual) & torch.isnan(expected)
+    )
+    return bool(torch.all(finite_close & torch.where(finite, True, special_equal)))
 
 
 def _worker(
@@ -114,32 +133,34 @@ def _worker(
     reference_pool: PCIeDCPA2APool | None = None
     fused_pool: PCIeDCPA2APool | None = None
     try:
+        query_head_dim = 10752 // world_size
         reference_pool = PCIeDCPA2APool.from_process_group(
             process_group=dist.group.WORLD,
             device=device,
             max_batch_size=1,
             total_heads=world_size,
-            head_dim=672,
-            query_head_dim=672,
+            head_dim=query_head_dim,
+            query_head_dim=query_head_dim,
         )
         fused_pool = PCIeDCPA2APool.from_process_group(
             process_group=dist.group.WORLD,
             device=device,
             max_batch_size=1,
             total_heads=world_size,
-            head_dim=672,
-            query_head_dim=672,
+            head_dim=query_head_dim,
+            query_head_dim=query_head_dim,
         )
         reference_channel = "k3-pair-topk:reference"
         fused_channel = "k3-pair-topk:fused"
         reference_pool.prepare_channels((reference_channel,))
         fused_pool.prepare_channels((fused_channel,))
 
+        local_down_width = 3584 // world_size
         down_local = (
-            torch.arange(224, device=device, dtype=torch.float32)
-            .add_(rank * 224)
+            torch.arange(local_down_width, device=device, dtype=torch.float32)
+            .add_(rank * local_down_width)
             .to(torch.bfloat16)
-            .view(1, 224)
+            .view(1, local_down_width)
         )
         reference_down = torch.empty((1, 3584), device=device, dtype=torch.bfloat16)
         reference_router = torch.empty((1, 896), device=device, dtype=torch.float32)
@@ -160,11 +181,20 @@ def _worker(
 
     try:
         if rank == 0:
-            print("case,ids_exact,weights_exact,max_abs,down_exact", flush=True)
+            print(
+                "case,ids_exact,weights_exact,finite_mask_exact,"
+                "nonzero_mask_exact,max_abs,down_exact",
+                flush=True,
+            )
         benchmark_router: torch.Tensor | None = None
         benchmark_bias: torch.Tensor | None = None
         for name in ("random", "ties", "near_ties", "wide"):
-            local_router, bias = _case(name, rank=rank, device=device)
+            local_router, bias = _case(
+                name,
+                rank=rank,
+                world_size=world_size,
+                device=device,
+            )
             reference_pool.all_gather_pair(
                 down_local,
                 local_router,
@@ -194,22 +224,35 @@ def _worker(
             torch.cuda.synchronize(device)
             ids_exact = torch.equal(fused_ids, reference_ids)
             weights_exact = _equal_with_matching_nan(fused_weights, reference_weights)
+            finite_mask_exact = torch.equal(
+                torch.isfinite(fused_weights),
+                torch.isfinite(reference_weights),
+            )
+            nonzero_mask_exact = torch.equal(
+                fused_weights != 0,
+                reference_weights != 0,
+            )
             max_abs = float((fused_weights - reference_weights).abs().max().item())
             down_exact = torch.equal(fused_down, reference_down)
             if rank == 0:
                 print(
                     f"{name},{int(ids_exact)},{int(weights_exact)},"
+                    f"{int(finite_mask_exact)},{int(nonzero_mask_exact)},"
                     f"{max_abs:.9g},{int(down_exact)}",
                     flush=True,
                 )
             failures = torch.tensor(
-                int(not ids_exact) + int(not weights_exact) + int(not down_exact),
+                int(not ids_exact)
+                + int(not weights_exact)
+                + int(not finite_mask_exact)
+                + int(not nonzero_mask_exact)
+                + int(not down_exact),
                 device=device,
                 dtype=torch.int32,
             )
             dist.all_reduce(failures)
             if failures.item() != 0:
-                raise AssertionError(f"{name} differs from HH native reference")
+                raise AssertionError(f"{name} differs from the grouped_topk reference")
             if name == "random":
                 benchmark_router = local_router
                 benchmark_bias = bias
@@ -261,14 +304,14 @@ def _worker(
         if not torch.equal(fused_down, reference_down):
             raise AssertionError("captured down projection differs")
 
-        reference_us = _measure(
+        reference_samples_us = _measure(
             reference_graph,
             device=device,
             warmup=warmup,
             iterations=iterations,
             samples=samples,
         )
-        fused_us = _measure(
+        fused_samples_us = _measure(
             fused_graph,
             device=device,
             warmup=warmup,
@@ -276,6 +319,21 @@ def _worker(
             samples=samples,
         )
         if rank == 0:
+            reference_us = statistics.median(reference_samples_us)
+            fused_us = statistics.median(fused_samples_us)
+            print(
+                "reference_samples_us," + json.dumps(reference_samples_us),
+                flush=True,
+            )
+            print(
+                "fused_samples_us," + json.dumps(fused_samples_us),
+                flush=True,
+            )
+            print(
+                "speedup_definition,reference_median_us/fused_median_us; "
+                "values greater than one mean the fused path is faster",
+                flush=True,
+            )
             print(
                 "world_size,reference_us,fused_us,speedup,saved_us\n"
                 f"{world_size},{reference_us:.6f},{fused_us:.6f},"
@@ -300,8 +358,10 @@ def main() -> None:
     parser.add_argument("--iterations", type=int, default=1000)
     parser.add_argument("--samples", type=int, default=5)
     args = parser.parse_args()
-    if args.world_size != 16:
-        raise SystemExit("Kimi paired gather+top-k benchmark requires TP16")
+    if args.world_size not in (2, 4, 8, 16):
+        raise SystemExit(
+            "Kimi paired gather+top-k benchmark requires TP2, TP4, TP8, or TP16"
+        )
     mp.spawn(
         _worker,
         args=(

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from contextlib import nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -131,7 +133,7 @@ class _FakeKimiRuntime(PCIeDCPA2A):
         device_slot_selection,
     ):
         del local_router, correction_bias, slot, device_slot_selection
-        out_down.copy_(torch.cat((local_down,) * 16, dim=1))
+        out_down.copy_(torch.cat((local_down,) * self.world_size, dim=1))
         topk_weights.fill_(1.0 / 16.0)
         topk_ids.copy_(torch.arange(16, dtype=torch.int32).view(1, 16))
 
@@ -139,8 +141,10 @@ def _make_runtime() -> PCIeDCPA2A:
     return _FakeRuntime()
 
 
-def _make_kimi_tp16_runtime(ext: _FakeExt | None = None) -> PCIeDCPA2A:
-    world_size = 16
+def _make_kimi_runtime(
+    world_size: int, ext: _FakeExt | None = None
+) -> PCIeDCPA2A:
+    query_head_dim = 7168 // world_size + 3584 // world_size
     return _FakeKimiRuntime(
         rank=0,
         world_size=world_size,
@@ -150,11 +154,11 @@ def _make_kimi_tp16_runtime(ext: _FakeExt | None = None) -> PCIeDCPA2A:
         staging1_ptrs=tuple(range(300, 300 + world_size)),
         max_batch_size=1,
         total_heads=world_size,
-        head_dim=672,
-        output_capacity_elems=world_size * 672,
-        lse_offset=world_size * 672 * 2,
+        head_dim=query_head_dim,
+        output_capacity_elems=world_size * query_head_dim,
+        lse_offset=world_size * query_head_dim * 2,
         lse_capacity=world_size,
-        query_head_dim=672,
+        query_head_dim=query_head_dim,
         ext_module=ext or _FakeExt(),
     )
 
@@ -415,7 +419,9 @@ def test_lse_launch_preserves_native_launch_bounds_contract() -> None:
     assert "min_blocks_per_mp=1," in source
 
 
-def test_all_gather_uses_constexpr_direct_source_pointers() -> None:
+def test_all_gather_resolves_one_peer_address_before_each_copy() -> None:
+    """The peer selector must not clone the memory transaction per rank."""
+
     from b12x.comm.pcie import _dcp_a2a_cute as kernels
 
     kernel_source = inspect.getsource(kernels._AllGatherHeadsLaunch.kernel)
@@ -425,7 +431,8 @@ def test_all_gather_uses_constexpr_direct_source_pointers() -> None:
     assert "if cutlass.const_expr(source == self._rank):" in read_phase
     assert "source_words = local_input" in read_phase
     assert "source_words = self._staging_words(staging[source])" in read_phase
-    assert "source_address" not in read_phase
+    assert "source_address = Int64(" in read_phase
+    assert "_copy_16b_addr(" in read_phase
     assert "source_words = cute.make_ptr(" not in read_phase
 
 
@@ -629,11 +636,18 @@ def test_runtime_accepts_head_major_input_and_output():
     torch.testing.assert_close(actual, partial_output[:, :16])
 
 
-def test_kimi_tp16_pair_topk_dispatches_compact_outputs() -> None:
+@pytest.mark.parametrize("world_size", (2, 4, 8, 16))
+def test_kimi_pair_topk_dispatches_compact_outputs(world_size: int) -> None:
     ext = _FakeExt()
-    runtime = _make_kimi_tp16_runtime(ext)
-    local_down = torch.arange(224, dtype=torch.bfloat16).view(1, 224)
-    local_router = torch.arange(56, dtype=torch.float32).view(1, 56)
+    runtime = _make_kimi_runtime(world_size, ext)
+    local_down_width = 3584 // world_size
+    local_router_width = 896 // world_size
+    local_down = torch.arange(
+        local_down_width, dtype=torch.bfloat16
+    ).view(1, local_down_width)
+    local_router = torch.arange(
+        local_router_width, dtype=torch.float32
+    ).view(1, local_router_width)
     correction_bias = torch.zeros(896, dtype=torch.float32)
 
     down, weights, ids = runtime.all_gather_pair_kimi_topk(
@@ -647,6 +661,32 @@ def test_kimi_tp16_pair_topk_dispatches_compact_outputs() -> None:
     assert ids.shape == (1, 16)
     torch.testing.assert_close(weights, torch.full_like(weights, 1.0 / 16.0))
     assert torch.equal(ids, torch.arange(16, dtype=torch.int32).view(1, 16))
+    runtime.close()
+
+
+@pytest.mark.parametrize("world_size", (2, 4, 8, 16))
+def test_kimi_pair_topk_graph_prewarm_uses_runtime_world_size(
+    monkeypatch: pytest.MonkeyPatch,
+    world_size: int,
+) -> None:
+    runtime = _make_kimi_runtime(world_size)
+    compiled: list[tuple[int, int, int, bool, bool]] = []
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
+        lambda device: False,
+    )
+    monkeypatch.setattr(torch.cuda, "device", lambda device: nullcontext())
+    monkeypatch.setitem(
+        sys.modules,
+        "b12x.comm.pcie._dcp_a2a_cute",
+        SimpleNamespace(
+            _get_compiled_all_gather_pair=lambda *args: compiled.append(args)
+        ),
+    )
+
+    runtime.prepare_graph_all_gather_pair_kimi_topk()
+
+    assert compiled == [(world_size, 0, 512, True, True)]
     runtime.close()
 
 


### PR DESCRIPTION
## Status

**Implemented and GPU-qualified** at revision `df78ccb7ff48018bc0f4de428dc29450bf3be348`.

## Behavior

Adds a fused PCIe distributed-context-parallel operation for the Kimi-K3 decode projection pair. The operation:

- gathers the 3,584-element BF16 latent projection;
- gathers the 896-element FP32 router projection;
- applies the 896-element correction bias;
- selects and normalizes the exact top 16 routed experts;
- returns the latent row, normalized weights, and expert IDs without materializing the gathered router row in vLLM.

Local shard widths, graph-prewarm shapes, and CuTeDSL launch geometry are derived from the configured tensor-parallel world size. TP2, TP4, TP8, and TP16 are supported.

## Technical reason

A separate router all-gather followed by `grouped_topk` adds a collective launch and repeats global-memory traffic in every decode layer. The fused operation transfers the router row in 16-byte packs and performs deterministic two-level top-16 selection in the gather kernel. Packed score/expert keys preserve lower-expert-ID tie breaking.

The gather loops resolve one peer address before issuing each copy. This prevents a runtime-selected source from cloning the payload loop into every compile-time peer branch.

## Compatibility

- The existing `all_gather_pair` and `all_gather_heads` interfaces remain available.
- The fused operation accepts Kimi-K3's fixed global projection widths and batch size one.
- Unsupported world sizes and incompatible tensor shapes fail before launch.
- The implementation uses CuTeDSL and adds no native CUDA extension.
- vLLM can retain the separate gather plus `grouped_topk` path as a correctness fallback.

## Validation

Conditions: one 16-GPU NVIDIA RTX PRO 6000 Blackwell host, CUDA 13.3, PyTorch 2.13.0, CUDA graphs enabled, 100 warm-up iterations, 1,000 measured iterations per sample, and five samples per topology. The reported speedup is `reference median / fused median`, so values greater than one favor the fused operation. Raw samples, device state, source revision, logs, and SHA-256 checksums are stored under `b12x-pr216-qualification-20260816` in the qualification artifact set.

- CPU validation: `tests/comm/test_pcie_dcp_a2a.py` passed all 52 tests.
- GPU correctness: TP2, TP4, TP8, and TP16 matched the reference for exact expert IDs, exact normalized weights, finite-value masks, nonzero masks, and the gathered latent projection on random, tied, near-tied, and non-finite inputs.
- TP2: reference 8.239461 us; fused 8.194180 us; 1.005526x.
- TP4: reference 9.564035 us; fused 8.247089 us; 1.159686x.
- TP8: reference 10.930929 us; fused 10.106305 us; 1.081595x.
- TP16: reference 13.667556 us; fused 12.757422 us; 1.071342x.

Conclusion: the fused operation preserves the reference routing result across every supported topology and reduces the projection-gather-plus-routing latency for TP2, TP4, TP8, and TP16.

## AI assistance

Implementation and validation were performed with AI assistance. The committed tests and recorded GPU qualification results define the supported behavior.
