### PR TITLE
Add bounded-degree vocabulary-parallel argmax

### DIFF
--- a/b12x/comm/pcie/__init__.py
+++ b/b12x/comm/pcie/__init__.py
@@ -18,8 +18,9 @@ pools via ``<Class>Pool``.
 - ``VocabParallelArgmax``: TP8/TP12/TP16 fused BF16 add and exact global
   greedy argmax.
 
-Device kernels are authored in Python with CuTe DSL. Host-side CUDA Runtime
-and Driver calls are made from Python.
+Every device kernel is authored in Python with CuTe DSL. Host-side CUDA
+Runtime/Driver calls are also made from Python; this package contains no
+repo-authored C++ or CUDA source and never invokes a native extension build.
 """
 
 from __future__ import annotations

--- a/b12x/comm/pcie/__init__.py
+++ b/b12x/comm/pcie/__init__.py
@@ -15,10 +15,11 @@ pools via ``<Class>Pool``.
   per-token FP8-e4m3 transport.
 - ``DcpAllToAll``: DCP attention exchange with fused LSE reduce-scatter.
 - ``DcpTopKOwnerExchange``: exact DCP candidate owner staging.
+- ``VocabParallelArgmax``: TP8/TP12/TP16 fused BF16 add and exact global
+  greedy argmax.
 
-Every device kernel is authored in Python with CuTe DSL.  Host-side CUDA
-Runtime/Driver calls are also made from Python; this package contains no
-repo-authored C++ or CUDA source and never invokes a native extension build.
+Device kernels are authored in Python with CuTe DSL. Host-side CUDA Runtime
+and Driver calls are made from Python.
 """
 
 from __future__ import annotations
@@ -40,13 +41,14 @@ META = OpMeta(
         "DcpAllToAll",
         "DcpAllToAllPool",
         "DcpTopKOwnerExchange",
+        "VocabParallelArgmax",
         "autotune_dma_crossovers",
         "parse_oneshot_max_size",
         "lse_reduce_scatter_reference",
         "owner_stage_reference",
         "is_supported",
     ),
-    dtypes=("bf16", "fp32", "fp8_e4m3", "int32"),
+    dtypes=("bf16", "fp32", "fp8_e4m3", "int32", "int64"),
     requires=("multi_gpu",),
     provenance=Provenance(
         repo="https://github.com/lukealonso/b12x",
@@ -68,6 +70,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
         OneshotAllReduce,
         OneshotAllReducePool,
         TwoShotReduceScatter,
+        VocabParallelArgmax,
         autotune_dma_crossovers,
         is_supported,
         lse_reduce_scatter_reference,

--- a/b12x/comm/pcie/_vocab_argmax_cute.py
+++ b/b12x/comm/pcie/_vocab_argmax_cute.py
@@ -195,7 +195,7 @@ def _warp_max_u64(value: Uint64, *, loc=None, ip=None) -> Uint64:
 @cute.jit
 def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
     observed = _load_acquire_sys_u32(address)
-    while observed < generation:
+    while observed != generation:
         if cutlass.const_expr(cycles > 0):
             _nanosleep(Uint32(cycles))
         observed = _load_acquire_sys_u32(address)

--- a/b12x/comm/pcie/_vocab_argmax_cute.py
+++ b/b12x/comm/pcie/_vocab_argmax_cute.py
@@ -1,0 +1,645 @@
+"""CuTeDSL kernel for bounded-degree vocabulary-parallel greedy sampling."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Sequence
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32, Uint64
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import current_cuda_stream, make_ptr
+
+
+ISLAND_SIZE = 4
+MAX_ISLANDS = 4
+MAX_WORLD_SIZE = ISLAND_SIZE * MAX_ISLANDS
+MAX_BATCH_SIZE = 8
+THREADS = 512
+SLOTS = 2
+
+# Every protocol flag occupies an independent 128-byte system-scope cache line.
+_GENERATION_OFFSET = 0
+_LOCAL_READY_OFFSET = 256
+_LOCAL_READY_BYTES = SLOTS * MAX_BATCH_SIZE * ISLAND_SIZE * 128
+_ISLAND_READY_OFFSET = _LOCAL_READY_OFFSET + _LOCAL_READY_BYTES
+_ISLAND_READY_BYTES = SLOTS * MAX_BATCH_SIZE * MAX_ISLANDS * 128
+_LOCAL_KEY_OFFSET = _ISLAND_READY_OFFSET + _ISLAND_READY_BYTES
+_ISLAND_KEY_OFFSET = _LOCAL_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
+SLAB_BYTES = _ISLAND_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
+
+
+@dsl_user_op
+def _atomic_add_global_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int64(address).ir_value(loc=loc, ip=ip),
+                Uint32(value).ir_value(loc=loc, ip=ip),
+            ],
+            "atom.global.add.u32 $0, [$1], $2;",
+            "=r,l,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(address).ir_value(loc=loc, ip=ip)],
+            "ld.acquire.sys.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _store_release_sys_u32(
+    address: Int64, value: Uint32, *, loc=None, ip=None
+) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            Int64(address).ir_value(loc=loc, ip=ip),
+            Uint32(value).ir_value(loc=loc, ip=ip),
+        ],
+        "st.release.sys.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _fence_sc_sys(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "fence.sc.sys;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
+        "nanosleep.u32 $0;",
+        "r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _score_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
+    """Map an FP32 score to the exact greedy-sampling comparison order.
+
+    NaNs dominate finite values, positive and negative zero compare equal, and
+    unsigned integer order matches numeric order for every remaining value.
+    """
+
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred is_nan, is_zero;
+                .reg .u32 bits, mask;
+                mov.b32 bits, $1;
+                shr.u32 mask, bits, 31;
+                mul.lo.u32 mask, mask, 0x7fffffff;
+                or.b32 mask, mask, 0x80000000;
+                xor.b32 $0, bits, mask;
+                setp.eq.f32 is_zero, $1, 0f00000000;
+                @is_zero mov.u32 $0, 0x80000000;
+                setp.nan.f32 is_nan, $1, $1;
+                @is_nan mov.u32 $0, 0xffffffff;
+            }
+            """,
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _warp_max_u64(value: Uint64, *, loc=None, ip=None) -> Uint64:
+    """Return the warp-wide unsigned maximum of a packed 64-bit key."""
+
+    return Uint64(
+        llvm.inline_asm(
+            T.i64(),
+            [Uint64(value).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .pred high_matches;
+                .reg .u32 low, high, max_high, candidate_low, max_low;
+                mov.b64 {low, high}, $1;
+                redux.sync.max.u32 max_high, high, 0xffffffff;
+                setp.eq.u32 high_matches, high, max_high;
+                selp.u32 candidate_low, low, 0, high_matches;
+                redux.sync.max.u32 max_low, candidate_low, 0xffffffff;
+                mov.b64 $0, {max_low, max_high};
+            }
+            """,
+            "=l,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
+    observed = _load_acquire_sys_u32(address)
+    while observed < generation:
+        if cutlass.const_expr(cycles > 0):
+            _nanosleep(Uint32(cycles))
+        observed = _load_acquire_sys_u32(address)
+
+
+@cute.jit
+def _flag_address(
+    base: Int64,
+    region: int,
+    slot: Int32,
+    row: Int32,
+    index: Int32,
+) -> Int64:
+    return (
+        base
+        + Int64(region)
+        + (
+            (
+                Int64(slot) * Int64(MAX_BATCH_SIZE)
+                + Int64(row)
+            )
+            * Int64(ISLAND_SIZE)
+            + Int64(index)
+        )
+        * Int64(128)
+    )
+
+
+@cute.jit
+def _key_address(base: Int64, region: int, slot: Int32, row: Int32) -> Int64:
+    return (
+        base
+        + Int64(region)
+        + (
+            Int64(slot) * Int64(MAX_BATCH_SIZE) + Int64(row)
+        )
+        * Int64(8)
+    )
+
+
+@cute.jit
+def _pack_key(score: Float32, global_index: Int32) -> Uint64:
+    return (
+        Uint64(_score_order_key(score)) << Uint64(32)
+    ) | (Uint64(0xFFFFFFFF) - Uint64(global_index))
+
+
+@cute.jit
+def _key_index(key: Uint64) -> Int64:
+    return Int64(Uint64(0xFFFFFFFF) - (key & Uint64(0xFFFFFFFF)))
+
+
+class _VocabArgmaxLaunch:
+    def __init__(
+        self,
+        world_size: int,
+        rank: int,
+        *,
+        wait_nanosleep_cycles: int,
+    ) -> None:
+        self._world_size = int(world_size)
+        self._num_islands = self._world_size // ISLAND_SIZE
+        self._rank = int(rank)
+        self._island = self._rank // ISLAND_SIZE
+        self._local_rank = self._rank % ISLAND_SIZE
+        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
+        if self._world_size not in (8, 12, 16):
+            raise ValueError(f"unsupported world size {self._world_size}")
+        if not 0 <= self._rank < self._world_size:
+            raise ValueError(
+                f"invalid rank {self._rank} for world size {self._world_size}"
+            )
+        if not 0 <= self._wait_nanosleep_cycles <= 1024:
+            raise ValueError("wait_nanosleep_cycles must be in [0, 1024]")
+
+    @cute.jit
+    def __call__(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        base: cute.Pointer,
+        bias: cute.Pointer,
+        output: cute.Pointer,
+        local_elements: Int64,
+        base_row_stride: Int64,
+        bias_row_stride: Int64,
+        batch: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            slab0,
+            slab1,
+            slab2,
+            slab3,
+            slab4,
+            slab5,
+            slab6,
+            slab7,
+            slab8,
+            slab9,
+            slab10,
+            slab11,
+            slab12,
+            slab13,
+            slab14,
+            slab15,
+            base,
+            bias,
+            output,
+            local_elements,
+            base_row_stride,
+            bias_row_stride,
+        ).launch(
+            grid=(batch, 1, 1),
+            block=(THREADS, 1, 1),
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        slab9: cute.Pointer,
+        slab10: cute.Pointer,
+        slab11: cute.Pointer,
+        slab12: cute.Pointer,
+        slab13: cute.Pointer,
+        slab14: cute.Pointer,
+        slab15: cute.Pointer,
+        base: cute.Pointer,
+        bias: cute.Pointer,
+        output: cute.Pointer,
+        local_elements: Int64,
+        base_row_stride: Int64,
+        bias_row_stride: Int64,
+    ) -> None:
+        slabs = (
+            slab0,
+            slab1,
+            slab2,
+            slab3,
+            slab4,
+            slab5,
+            slab6,
+            slab7,
+            slab8,
+            slab9,
+            slab10,
+            slab11,
+            slab12,
+            slab13,
+            slab14,
+            slab15,
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+        lane = Int32(tidx) % Int32(32)
+        warp = Int32(tidx) // Int32(32)
+
+        initial = Uint64(_score_order_key(Float32(float("-inf")))) << Uint64(32)
+        best = initial
+        index = Int64(tidx)
+        base_offset = Int64(row) * base_row_stride
+        bias_offset = Int64(row) * bias_row_stride
+        while index < local_elements:
+            value = Float32(
+                cutlass.BFloat16(
+                    Float32(base[base_offset + index])
+                    + Float32(bias[bias_offset + index])
+                )
+            )
+            global_index = (
+                Int64(self._rank) * local_elements + index
+            )
+            candidate = _pack_key(value, Int32(global_index))
+            best = cutlass.max(best, candidate)
+            index += Int64(THREADS)
+        best = _warp_max_u64(best)
+
+        allocator = cutlass.utils.SmemAllocator()
+        warp_keys = allocator.allocate_tensor(
+            element_type=Uint64,
+            layout=cute.make_layout((THREADS // 32,)),
+            byte_alignment=16,
+        )
+        shared_generation = allocator.allocate_tensor(
+            element_type=Uint32,
+            layout=cute.make_layout((1,)),
+            byte_alignment=4,
+        )
+        if lane == Int32(0):
+            warp_keys[warp] = best
+        cute.arch.barrier()
+
+        block_key = initial
+        if warp == Int32(0):
+            if lane < Int32(THREADS // 32):
+                block_key = warp_keys[lane]
+            block_key = _warp_max_u64(block_key)
+        self_base = Int64(slabs[self._rank].toint())
+        if tidx == Int32(0):
+            generation = _atomic_add_global_u32(
+                self_base + Int64(row) * Int64(4), Uint32(1)
+            ) + Uint32(1)
+            shared_generation[0] = generation
+        cute.arch.barrier()
+
+        if tidx == Int32(0):
+            generation = Uint32(shared_generation[0])
+            slot = Int32(generation & Uint32(1))
+            local_key_ptr = cute.make_ptr(
+                Uint64,
+                _key_address(self_base, _LOCAL_KEY_OFFSET, slot, Int32(row)),
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            )
+            local_key_ptr[0] = block_key
+            _fence_sc_sys()
+
+            island_base_rank = self._island * ISLAND_SIZE
+            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
+                if cutlass.const_expr(peer_local != self._local_rank):
+                    peer_rank = island_base_rank + peer_local
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[peer_rank].toint()),
+                            _LOCAL_READY_OFFSET,
+                            slot,
+                            Int32(row),
+                            Int32(self._local_rank),
+                        ),
+                        generation,
+                    )
+            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
+                if cutlass.const_expr(peer_local != self._local_rank):
+                    _wait_for(
+                        _flag_address(
+                            self_base,
+                            _LOCAL_READY_OFFSET,
+                            slot,
+                            Int32(row),
+                            Int32(peer_local),
+                        ),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+
+            island_key = initial
+            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
+                peer_rank = island_base_rank + peer_local
+                peer_key_ptr = cute.make_ptr(
+                    Uint64,
+                    _key_address(
+                        Int64(slabs[peer_rank].toint()),
+                        _LOCAL_KEY_OFFSET,
+                        slot,
+                        Int32(row),
+                    ),
+                    cute.AddressSpace.gmem,
+                    assumed_align=8,
+                )
+                island_key = cutlass.max(island_key, peer_key_ptr[0])
+            island_key_ptr = cute.make_ptr(
+                Uint64,
+                _key_address(self_base, _ISLAND_KEY_OFFSET, slot, Int32(row)),
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            )
+            island_key_ptr[0] = island_key
+            _fence_sc_sys()
+
+            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
+                if cutlass.const_expr(peer_island < self._num_islands):
+                    if cutlass.const_expr(peer_island != self._island):
+                        peer_rank = peer_island * ISLAND_SIZE + self._local_rank
+                        _store_release_sys_u32(
+                            _flag_address(
+                                Int64(slabs[peer_rank].toint()),
+                                _ISLAND_READY_OFFSET,
+                                slot,
+                                Int32(row),
+                                Int32(self._island),
+                            ),
+                            generation,
+                        )
+            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
+                if cutlass.const_expr(peer_island < self._num_islands):
+                    if cutlass.const_expr(peer_island != self._island):
+                        _wait_for(
+                            _flag_address(
+                                self_base,
+                                _ISLAND_READY_OFFSET,
+                                slot,
+                                Int32(row),
+                                Int32(peer_island),
+                            ),
+                            generation,
+                            self._wait_nanosleep_cycles,
+                        )
+
+            global_key = initial
+            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
+                if cutlass.const_expr(peer_island < self._num_islands):
+                    peer_rank = peer_island * ISLAND_SIZE + self._local_rank
+                    peer_key_ptr = cute.make_ptr(
+                        Uint64,
+                        _key_address(
+                            Int64(slabs[peer_rank].toint()),
+                            _ISLAND_KEY_OFFSET,
+                            slot,
+                            Int32(row),
+                        ),
+                        cute.AddressSpace.gmem,
+                        assumed_align=8,
+                    )
+                    global_key = cutlass.max(global_key, peer_key_ptr[0])
+            output[Int64(row)] = _key_index(global_key)
+
+
+@functools.cache
+def get_vocab_argmax_launcher(
+    world_size: int,
+    rank: int,
+    device_index: int,
+    *,
+    wait_nanosleep_cycles: int,
+) -> Callable[..., None]:
+    """Return a rank-specialized launcher for TP8, TP12, or TP16."""
+
+    del device_index  # retained in the process-local cache key
+    launch = _VocabArgmaxLaunch(
+        world_size,
+        rank,
+        wait_nanosleep_cycles=wait_nanosleep_cycles,
+    )
+    cache_key = (
+        int(world_size),
+        int(rank),
+        int(wait_nanosleep_cycles),
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=launch, cache_key=cache_key
+    )
+    slab_placeholder = make_ptr(
+        cutlass.Uint8,
+        256,
+        cute.AddressSpace.gmem,
+        assumed_align=256,
+    )
+    raw = b12x_compile(
+        launch,
+        *(slab_placeholder for _ in range(MAX_WORLD_SIZE)),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        make_ptr(cutlass.Int64, 16, cute.AddressSpace.gmem, assumed_align=8),
+        1,
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "comm.pcie.vocab_argmax.bf16",
+            1,
+            cache_key,
+            labels=("world_size", "rank", "wait_nanosleep_cycles"),
+        ),
+    )
+
+    def run(
+        slab_addresses: Sequence[int],
+        base_address: int,
+        bias_address: int,
+        output_address: int,
+        local_elements: int,
+        base_row_stride: int,
+        bias_row_stride: int,
+        batch: int,
+    ) -> None:
+        if len(slab_addresses) != world_size:
+            raise ValueError(
+                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
+            )
+        padded_slabs = tuple(int(address) for address in slab_addresses) + (
+            0,
+        ) * (MAX_WORLD_SIZE - world_size)
+        raw(
+            *(
+                make_ptr(
+                    cutlass.Uint8,
+                    address,
+                    cute.AddressSpace.gmem,
+                    assumed_align=256,
+                )
+                for address in padded_slabs
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                base_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                bias_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            make_ptr(
+                cutlass.Int64,
+                output_address,
+                cute.AddressSpace.gmem,
+                assumed_align=8,
+            ),
+            local_elements,
+            base_row_stride,
+            bias_row_stride,
+            batch,
+            current_cuda_stream(),
+        )
+
+    return run
+
+
+__all__ = ["SLAB_BYTES", "get_vocab_argmax_launcher"]

--- a/b12x/comm/pcie/api.py
+++ b/b12x/comm/pcie/api.py
@@ -37,13 +37,15 @@ from .pcie_oneshot import (
 from .pcie_twoshot import (
     PCIeTwoShotSP as TwoShotReduceScatter,
 )
+from .pcie_vocab_argmax import (
+    PCIeVocabParallelArgmax as VocabParallelArgmax,
+)
 
 
 def is_supported(device=None) -> bool:
     """True on SM120/SM121 with >= 2 visible CUDA devices.
 
-    Device kernels are compiled from the Python CuTe DSL sources on first use;
-    no repo-authored C++/CUDA extension or runtime nvcc build is involved.
+    Device kernels compile from Python CuTeDSL sources.
     """
     import torch
 
@@ -59,6 +61,7 @@ __all__ = [
     "DcpAllToAll",
     "DcpAllToAllPool",
     "DcpTopKOwnerExchange",
+    "VocabParallelArgmax",
     "autotune_dma_crossovers",
     "parse_oneshot_max_size",
     "lse_reduce_scatter_reference",

--- a/b12x/comm/pcie/api.py
+++ b/b12x/comm/pcie/api.py
@@ -45,7 +45,8 @@ from .pcie_vocab_argmax import (
 def is_supported(device=None) -> bool:
     """True on SM120/SM121 with >= 2 visible CUDA devices.
 
-    Device kernels compile from Python CuTeDSL sources.
+    Device kernels are compiled from the Python CuTe DSL sources on first use;
+    no repo-authored C++/CUDA extension or runtime nvcc build is involved.
     """
     import torch
 

--- a/b12x/comm/pcie/pcie_oneshot.py
+++ b/b12x/comm/pcie/pcie_oneshot.py
@@ -279,12 +279,15 @@ def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
             backend = dist.get_backend(group)
     except Exception as exc:
         raise RuntimeError(
-            "PCIe oneshot IPC exchange requires a CUDA/NCCL process group"
+            "PCIe object exchange requires a valid process group"
         ) from exc
     backend_name = str(backend).lower()
+    if "gloo" in backend_name:
+        return torch.device("cpu")
     if "nccl" not in backend_name:
         raise RuntimeError(
-            f"PCIe oneshot IPC exchange requires an NCCL process group, got {backend}"
+            "PCIe object exchange requires an NCCL or Gloo process group, "
+            f"got {backend}"
         )
     if not torch.cuda.is_available():
         raise RuntimeError("PCIe oneshot IPC exchange requires CUDA")
@@ -2331,8 +2334,21 @@ class PCIeOneshotAllReduce:
         *,
         zero_fill: bool,
         ipc: CudaRTLibrary,
+        peer_ranks: Optional[Sequence[int]] = None,
     ) -> _OwnedSharedBuffer:
         _require_no_retained_ipc_setup(exchange_group)
+        world_size = dist.get_world_size(group=exchange_group)
+        rank = dist.get_rank(group=exchange_group)
+        selected_peers = (
+            set(range(world_size)) - {rank}
+            if peer_ranks is None
+            else {int(peer) for peer in peer_ranks}
+        )
+        if rank in selected_peers or any(
+            not 0 <= peer < world_size for peer in selected_peers
+        ):
+            raise ValueError("peer_ranks must contain valid remote group ranks")
+
         local_ptr: int | None = None
         local_handle: bytes | None = None
         prepare_error: BaseException | None = None
@@ -2435,8 +2451,6 @@ class PCIeOneshotAllReduce:
         peer_ptrs: list[int] = []
         remote_ptrs: list[int] = []
         try:
-            world_size = dist.get_world_size(group=exchange_group)
-            rank = dist.get_rank(group=exchange_group)
             handles = _broadcast_gather_object(local_handle, exchange_group)
         except Exception as exchange_error:
             # No rank has opened an import before handle exchange completes.
@@ -2459,6 +2473,9 @@ class PCIeOneshotAllReduce:
         for idx, handle in enumerate(handles):
             if idx == rank:
                 peer_ptrs.append(local_ptr)
+                continue
+            if idx not in selected_peers:
+                peer_ptrs.append(0)
                 continue
             try:
                 remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)

--- a/b12x/comm/pcie/pcie_vocab_argmax.py
+++ b/b12x/comm/pcie/pcie_vocab_argmax.py
@@ -1,0 +1,367 @@
+"""Bounded-degree vocabulary-parallel argmax runtime."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager, suppress
+from typing import Iterator, Optional
+from warnings import warn
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from ._cuda_ipc import CudaRTLibrary
+from ._vocab_argmax_cute import SLAB_BYTES, get_vocab_argmax_launcher
+from .pcie_oneshot import _broadcast_gather_object
+
+
+ISLAND_SIZE = 4
+MAX_BATCH_SIZE = 8
+SUPPORTED_WORLD_SIZES = (8, 12, 16)
+
+
+def _exchange_ipc_handles(
+    local_handle: object,
+    group: ProcessGroup,
+) -> list[object]:
+    """Exchange CUDA IPC handles over NCCL or a metadata-only Gloo group."""
+
+    backend = str(dist.get_backend(group=group)).lower()
+    if "nccl" in backend:
+        return _broadcast_gather_object(local_handle, group)
+    if "gloo" not in backend:
+        raise ValueError(
+            "vocabulary argmax IPC exchange requires an NCCL or Gloo group, "
+            f"got {backend}"
+        )
+
+    world_size = dist.get_world_size(group=group)
+    handles: list[object | None] = [None] * world_size
+    dist.all_gather_object(handles, local_handle, group=group)
+    if any(handle is None for handle in handles):
+        raise RuntimeError("vocabulary argmax IPC exchange returned an empty handle")
+    return list(handles)
+
+
+def _require_uniform_geometry(
+    local_vocab_size: int,
+    max_batch_size: int,
+    group: ProcessGroup,
+) -> None:
+    """Reject rank-local geometry before allocating collective resources."""
+    geometry = (int(local_vocab_size), int(max_batch_size))
+    # vLLM supplies its metadata-only Gloo TP group here so initialization does
+    # not allocate an NCCL object-collective workspace.  Geometry validation
+    # must preserve the same NCCL-or-Gloo contract as CUDA IPC handle exchange.
+    peer_geometry = _exchange_ipc_handles(geometry, group)
+    if any(candidate != geometry for candidate in peer_geometry):
+        raise RuntimeError(
+            f"vocabulary argmax geometry differs across ranks: {peer_geometry}"
+        )
+
+
+def _wait_nanosleep_cycles_from_env() -> int:
+    raw = os.getenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", "24")
+    try:
+        cycles = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be an integer"
+        ) from exc
+    if not 0 <= cycles <= 1024:
+        raise ValueError("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]")
+    return cycles
+
+
+def _selected_peers(rank: int, world_size: int = 16) -> tuple[int, ...]:
+    """Return three island peers plus the same lane in other islands."""
+
+    if world_size not in SUPPORTED_WORLD_SIZES:
+        raise ValueError(
+            "vocabulary argmax requires "
+            f"{SUPPORTED_WORLD_SIZES}, got TP{world_size}"
+        )
+    if not 0 <= rank < world_size:
+        raise ValueError(f"invalid rank {rank} for TP{world_size}")
+    island = rank // ISLAND_SIZE
+    lane = rank % ISLAND_SIZE
+    local = set(range(island * ISLAND_SIZE, (island + 1) * ISLAND_SIZE))
+    cross_island = set(range(lane, world_size, ISLAND_SIZE))
+    return tuple(sorted((local | cross_island) - {rank}))
+
+
+class PCIeVocabParallelArgmax:
+    """Fuse BF16 add and exact global greedy sampling across TP shards.
+
+    Every TP rank must invoke ``fused_add_argmax`` once per logical step with
+    the same batch size. Tensor-parallel schedulers satisfy this collective
+    ordering invariant; callers that cannot guarantee it must not use this
+    runtime. Construction verifies that local vocabulary and capacity geometry
+    match on all ranks.
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = (
+            device
+            if isinstance(device, torch.device)
+            else torch.device(f"cuda:{device}" if isinstance(device, int) else device)
+        )
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                "vocabulary argmax requires "
+                f"{SUPPORTED_WORLD_SIZES}, got TP{self.world_size}"
+            )
+        if self.device.type != "cuda":
+            raise ValueError("vocabulary argmax requires a CUDA device")
+        device_index = self.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+            self.device = torch.device("cuda", device_index)
+        if local_vocab_size <= 0 or local_vocab_size * self.world_size >= 1 << 31:
+            raise ValueError("global vocabulary must fit a positive int32 index")
+        if not 0 < max_batch_size <= MAX_BATCH_SIZE:
+            raise ValueError(f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]")
+
+        self.local_vocab_size = int(local_vocab_size)
+        self.max_batch_size = int(max_batch_size)
+        _require_uniform_geometry(
+            self.local_vocab_size,
+            self.max_batch_size,
+            exchange_group,
+        )
+        self._ipc = CudaRTLibrary()
+        self._slab_ptrs: tuple[int, ...] = ()
+        self._launcher = None
+        self._local_ptr = 0
+        self._remote_ptrs: list[int] = []
+        self._closed = False
+
+        peer_ptrs = [0] * self.world_size
+        try:
+            with self._cuda_runtime_device():
+                self._local_ptr = self._ipc.cudaMalloc(SLAB_BYTES)
+                self._ipc.cudaMemset(self._local_ptr, 0, SLAB_BYTES)
+                local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
+                handles = _exchange_ipc_handles(local_handle, exchange_group)
+                peer_ptrs[self.rank] = self._local_ptr
+                for peer in _selected_peers(self.rank, self.world_size):
+                    remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
+                    peer_ptrs[peer] = remote_ptr
+                    self._remote_ptrs.append(remote_ptr)
+                self._slab_ptrs = tuple(peer_ptrs)
+                self._launcher = get_vocab_argmax_launcher(
+                    self.world_size,
+                    self.rank,
+                    self.device.index or 0,
+                    wait_nanosleep_cycles=_wait_nanosleep_cycles_from_env(),
+                )
+        except Exception:
+            # Construction cleanup is rank-local. Mark the object closed so
+            # garbage collection cannot enter the collective close protocol.
+            self._closed = True
+            with suppress(Exception), self._cuda_runtime_device():
+                for ptr in self._remote_ptrs:
+                    with suppress(Exception):
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                self._remote_ptrs.clear()
+                if self._local_ptr:
+                    with suppress(Exception):
+                        self._ipc.cudaFree(self._local_ptr)
+                    self._local_ptr = 0
+            raise
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+    ) -> "PCIeVocabParallelArgmax":
+        return cls(
+            exchange_group=exchange_group,
+            device=device,
+            local_vocab_size=local_vocab_size,
+            max_batch_size=max_batch_size,
+        )
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        local_vocab_size: int,
+        max_batch_size: int = MAX_BATCH_SIZE,
+    ) -> "PCIeVocabParallelArgmax":
+        return cls.from_exchange_group(
+            exchange_group=process_group,
+            device=device,
+            local_vocab_size=local_vocab_size,
+            max_batch_size=max_batch_size,
+        )
+
+    @property
+    def mapped_peer_count(self) -> int:
+        return len(self._remote_ptrs)
+
+    @contextmanager
+    def _cuda_runtime_device(self) -> Iterator[None]:
+        """Select this runtime's CUDA device and restore the caller's device."""
+        if self.device.type != "cuda" or self.device.index is None:
+            yield
+            return
+        previous_device: int | None
+        try:
+            previous_device = torch.cuda.current_device()
+        except Exception:
+            previous_device = None
+        self._ipc.cudaSetDevice(self.device.index)
+        try:
+            yield
+        finally:
+            if previous_device is not None and previous_device != self.device.index:
+                self._ipc.cudaSetDevice(previous_device)
+
+    def fused_add_argmax(
+        self,
+        base: torch.Tensor,
+        bias: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Return exact global argmax of the BF16-rounded local sum."""
+
+        if self._closed:
+            raise RuntimeError("vocabulary argmax runtime is closed")
+        if base.device != self.device or bias.device != self.device:
+            raise ValueError("inputs must be on the runtime device")
+        if base.dtype != torch.bfloat16 or bias.dtype != torch.bfloat16:
+            raise ValueError("inputs must be BF16")
+        if base.ndim != 2 or base.shape != bias.shape:
+            raise ValueError("inputs must have matching [batch, local_vocab] shapes")
+        batch, local_vocab = (int(value) for value in base.shape)
+        if not 0 < batch <= self.max_batch_size:
+            raise ValueError(
+                f"batch size {batch} exceeds capacity {self.max_batch_size}"
+            )
+        if local_vocab != self.local_vocab_size:
+            raise ValueError(
+                f"local vocabulary must be {self.local_vocab_size}, got {local_vocab}"
+            )
+        if base.stride(1) != 1 or bias.stride(1) != 1:
+            raise ValueError("input last dimensions must be contiguous")
+        if base.stride(0) <= 0 or bias.stride(0) <= 0:
+            raise ValueError("input row strides must be positive")
+        if out is None:
+            out = torch.empty(batch, dtype=torch.int64, device=self.device)
+        if (
+            out.device != self.device
+            or out.dtype != torch.int64
+            or out.shape != (batch,)
+            or not out.is_contiguous()
+        ):
+            raise ValueError("output must be contiguous int64 [batch] on the device")
+        if self._launcher is None:
+            raise RuntimeError("vocabulary argmax launcher is unavailable")
+        with self._cuda_runtime_device():
+            self._launcher(
+                self._slab_ptrs,
+                base.data_ptr(),
+                bias.data_ptr(),
+                out.data_ptr(),
+                self.local_vocab_size,
+                base.stride(0),
+                bias.stride(0),
+                batch,
+            )
+        return out
+
+    def for_stream(self, stream: object = None) -> "PCIeVocabParallelArgmax":
+        del stream
+        return self
+
+    @contextmanager
+    def capture(self, stream: object = None):
+        del stream
+        yield self
+
+    def register_graph_buffers(self) -> None:
+        return None
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        with self._cuda_runtime_device():
+            torch.cuda.synchronize(self.device)
+            dist.barrier(group=self.group)
+            try:
+                self._launcher = None
+                self._slab_ptrs = ()
+            finally:
+                try:
+                    for ptr in self._remote_ptrs:
+                        self._ipc.cudaIpcCloseMemHandle(ptr)
+                finally:
+                    self._remote_ptrs.clear()
+                    dist.barrier(group=self.group)
+                    try:
+                        if self._local_ptr:
+                            self._ipc.cudaFree(self._local_ptr)
+                    finally:
+                        self._local_ptr = 0
+                        dist.barrier(group=self.group)
+
+    def __enter__(self) -> "PCIeVocabParallelArgmax":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        if getattr(self, "_closed", True):
+            return
+
+        # Python garbage collection is not ordered across distributed ranks.
+        # Calling close() here could deadlock on its collective barriers, so
+        # finalization releases only resources owned by this rank. Callers
+        # must use close() or the context manager for coordinated teardown.
+        self._closed = True
+        with suppress(Exception):
+            warn(
+                "PCIeVocabParallelArgmax was garbage-collected without close(); "
+                "releasing rank-local CUDA resources without collective teardown",
+                ResourceWarning,
+                stacklevel=2,
+            )
+
+        with suppress(Exception), self._cuda_runtime_device():
+            self._launcher = None
+            self._slab_ptrs = ()
+
+            remote_ptrs = list(getattr(self, "_remote_ptrs", ()))
+            self._remote_ptrs = []
+            for ptr in remote_ptrs:
+                with suppress(Exception):
+                    self._ipc.cudaIpcCloseMemHandle(ptr)
+
+            local_ptr = getattr(self, "_local_ptr", 0)
+            self._local_ptr = 0
+            if local_ptr:
+                with suppress(Exception):
+                    self._ipc.cudaFree(local_ptr)
+
+
+__all__ = ["PCIeVocabParallelArgmax"]

--- a/b12x/comm/pcie/pcie_vocab_argmax.py
+++ b/b12x/comm/pcie/pcie_vocab_argmax.py
@@ -13,7 +13,11 @@ from torch.distributed import ProcessGroup
 
 from ._cuda_ipc import CudaRTLibrary
 from ._vocab_argmax_cute import SLAB_BYTES, get_vocab_argmax_launcher
-from .pcie_oneshot import _broadcast_gather_object
+from .pcie_oneshot import (
+    PCIeOneshotAllReduce,
+    _broadcast_gather_object,
+    _run_collective_preallocation_setup,
+)
 
 
 ISLAND_SIZE = 4
@@ -112,74 +116,91 @@ class PCIeVocabParallelArgmax:
         self.group = exchange_group
         self.rank = dist.get_rank(group=exchange_group)
         self.world_size = dist.get_world_size(group=exchange_group)
-        self.device = (
-            device
-            if isinstance(device, torch.device)
-            else torch.device(f"cuda:{device}" if isinstance(device, int) else device)
-        )
-        if self.world_size not in SUPPORTED_WORLD_SIZES:
-            raise ValueError(
-                "vocabulary argmax requires "
-                f"{SUPPORTED_WORLD_SIZES}, got TP{self.world_size}"
-            )
-        if self.device.type != "cuda":
-            raise ValueError("vocabulary argmax requires a CUDA device")
-        device_index = self.device.index
-        if device_index is None:
-            device_index = torch.cuda.current_device()
-            self.device = torch.device("cuda", device_index)
-        if local_vocab_size <= 0 or local_vocab_size * self.world_size >= 1 << 31:
-            raise ValueError("global vocabulary must fit a positive int32 index")
-        if not 0 < max_batch_size <= MAX_BATCH_SIZE:
-            raise ValueError(f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]")
 
-        self.local_vocab_size = int(local_vocab_size)
-        self.max_batch_size = int(max_batch_size)
+        def normalize_and_validate():
+            device_obj = (
+                device
+                if isinstance(device, torch.device)
+                else torch.device(
+                    f"cuda:{device}" if isinstance(device, int) else device
+                )
+            )
+            if self.world_size not in SUPPORTED_WORLD_SIZES:
+                raise ValueError(
+                    "vocabulary argmax requires "
+                    f"{SUPPORTED_WORLD_SIZES}, got TP{self.world_size}"
+                )
+            if device_obj.type != "cuda":
+                raise ValueError("vocabulary argmax requires a CUDA device")
+            if device_obj.index is None:
+                device_obj = torch.device("cuda", torch.cuda.current_device())
+            normalized_local_vocab_size = int(local_vocab_size)
+            normalized_max_batch_size = int(max_batch_size)
+            if (
+                normalized_local_vocab_size <= 0
+                or normalized_local_vocab_size * self.world_size >= 1 << 31
+            ):
+                raise ValueError("global vocabulary must fit a positive int32 index")
+            if not 0 < normalized_max_batch_size <= MAX_BATCH_SIZE:
+                raise ValueError(
+                    f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]"
+                )
+            return (
+                device_obj,
+                normalized_local_vocab_size,
+                normalized_max_batch_size,
+                _wait_nanosleep_cycles_from_env(),
+            )
+
+        (
+            self.device,
+            self.local_vocab_size,
+            self.max_batch_size,
+            wait_nanosleep_cycles,
+        ) = _run_collective_preallocation_setup(
+            owner="PCIe vocabulary argmax argument validation",
+            exchange_group=exchange_group,
+            setup=normalize_and_validate,
+        )
         _require_uniform_geometry(
             self.local_vocab_size,
             self.max_batch_size,
             exchange_group,
         )
-        self._ipc = CudaRTLibrary()
         self._slab_ptrs: tuple[int, ...] = ()
         self._launcher = None
         self._local_ptr = 0
         self._remote_ptrs: list[int] = []
-        self._closed = False
+        self._closed = True
 
-        peer_ptrs = [0] * self.world_size
-        try:
+        def prepare_runtime():
+            self._ipc = CudaRTLibrary()
             with self._cuda_runtime_device():
-                self._local_ptr = self._ipc.cudaMalloc(SLAB_BYTES)
-                self._ipc.cudaMemset(self._local_ptr, 0, SLAB_BYTES)
-                local_handle = self._ipc.cudaIpcGetMemHandleBytes(self._local_ptr)
-                handles = _exchange_ipc_handles(local_handle, exchange_group)
-                peer_ptrs[self.rank] = self._local_ptr
-                for peer in _selected_peers(self.rank, self.world_size):
-                    remote_ptr = self._ipc.cudaIpcOpenMemHandleBytes(handles[peer])
-                    peer_ptrs[peer] = remote_ptr
-                    self._remote_ptrs.append(remote_ptr)
-                self._slab_ptrs = tuple(peer_ptrs)
-                self._launcher = get_vocab_argmax_launcher(
+                launcher = get_vocab_argmax_launcher(
                     self.world_size,
                     self.rank,
                     self.device.index or 0,
-                    wait_nanosleep_cycles=_wait_nanosleep_cycles_from_env(),
+                    wait_nanosleep_cycles=wait_nanosleep_cycles,
                 )
-        except Exception:
-            # Construction cleanup is rank-local. Mark the object closed so
-            # garbage collection cannot enter the collective close protocol.
-            self._closed = True
-            with suppress(Exception), self._cuda_runtime_device():
-                for ptr in self._remote_ptrs:
-                    with suppress(Exception):
-                        self._ipc.cudaIpcCloseMemHandle(ptr)
-                self._remote_ptrs.clear()
-                if self._local_ptr:
-                    with suppress(Exception):
-                        self._ipc.cudaFree(self._local_ptr)
-                    self._local_ptr = 0
-            raise
+            return self._ipc, launcher
+
+        self._ipc, self._launcher = _run_collective_preallocation_setup(
+            owner="PCIe vocabulary argmax runtime preparation",
+            exchange_group=exchange_group,
+            setup=prepare_runtime,
+        )
+        with self._cuda_runtime_device():
+            shared = PCIeOneshotAllReduce._allocate_shared_buffer(
+                exchange_group,
+                SLAB_BYTES,
+                zero_fill=True,
+                ipc=self._ipc,
+                peer_ranks=_selected_peers(self.rank, self.world_size),
+            )
+        self._local_ptr = shared.local_ptr
+        self._slab_ptrs = shared.peer_ptrs
+        self._remote_ptrs = list(shared.remote_ptrs)
+        self._closed = False
 
     @classmethod
     def from_exchange_group(

--- a/benchmarks/benchmark_vocab_parallel_argmax.py
+++ b/benchmarks/benchmark_vocab_parallel_argmax.py
@@ -1,0 +1,278 @@
+"""Validate and benchmark vocabulary-parallel greedy sampling."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import statistics
+import time
+from contextlib import suppress
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from b12x.comm.pcie.pcie_vocab_argmax import PCIeVocabParallelArgmax
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _inputs(
+    rank: int,
+    world_size: int,
+    local_vocab_size: int,
+    batch: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device).manual_seed(12000 + rank)
+    base = torch.randn(
+        (batch, local_vocab_size),
+        generator=generator,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    bias = torch.randn(
+        (batch, local_vocab_size),
+        generator=generator,
+        device=device,
+        dtype=torch.bfloat16,
+    ).mul_(0.02)
+
+    if batch > 1:
+        base[1:].fill_(-1.0)
+        bias[1:].zero_()
+    if rank == 0 and batch > 1:
+        base[1, 0] = 0.0
+    if rank == 0 and batch > 2:
+        base[2, 3] = float("nan")
+    if rank == 0 and batch > 3:
+        base[3, 0] = -0.0
+    elif rank != 0 and batch > 1:
+        base[1, 0] = 0.0
+    if rank == world_size - 1 and batch > 2:
+        base[2, local_vocab_size - 1] = float("nan")
+    if rank == world_size - 1 and batch > 3:
+        base[3, local_vocab_size - 1] = 0.0
+
+    local_scores = (base.float() + bias.float()).bfloat16()
+    gathered = [torch.empty_like(local_scores) for _ in range(world_size)]
+    dist.all_gather(gathered, local_scores)
+    expected = torch.cat(gathered, dim=1).argmax(dim=1).to(torch.int64)
+    if batch > 1:
+        expected[1] = 0
+    if batch > 2:
+        expected[2] = 3
+    if batch > 3:
+        expected[3] = 0
+    return base, bias, expected
+
+
+def _measure(
+    graph: torch.cuda.CUDAGraph,
+    *,
+    device: torch.device,
+    warmup: int,
+    iterations: int,
+    samples: int,
+) -> float:
+    timings: list[float] = []
+    for _ in range(samples):
+        dist.barrier()
+        for _ in range(warmup):
+            graph.replay()
+        torch.cuda.synchronize(device)
+        start = time.perf_counter()
+        for _ in range(iterations):
+            graph.replay()
+        torch.cuda.synchronize(device)
+        elapsed_us = (time.perf_counter() - start) * 1e6 / iterations
+        maximum = torch.tensor(elapsed_us, dtype=torch.float64, device=device)
+        dist.all_reduce(maximum, op=dist.ReduceOp.MAX)
+        timings.append(float(maximum.item()))
+    return statistics.median(timings)
+
+
+def _validate_random_inputs(
+    runtime: PCIeVocabParallelArgmax,
+    *,
+    rank: int,
+    world_size: int,
+    local_vocab_size: int,
+    batch: int,
+    cases: int,
+    device: torch.device,
+) -> None:
+    output = torch.empty(batch, dtype=torch.int64, device=device)
+    for case in range(cases):
+        generator = torch.Generator(device=device).manual_seed(
+            20000 + case * world_size + rank
+        )
+        base = torch.randn(
+            (batch, local_vocab_size),
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        bias = torch.randn(
+            (batch, local_vocab_size),
+            generator=generator,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        local_scores = (base.float() + bias.float()).bfloat16()
+        gathered = [torch.empty_like(local_scores) for _ in range(world_size)]
+        dist.all_gather(gathered, local_scores)
+        expected = torch.cat(gathered, dim=1).argmax(dim=1).to(torch.int64)
+        runtime.fused_add_argmax(base, bias, output)
+        torch.cuda.synchronize(device)
+        if not torch.equal(output, expected):
+            raise AssertionError(
+                f"rank {rank}, random case {case}: expected "
+                f"{expected.tolist()}, got {output.tolist()}"
+            )
+
+
+def _worker(
+    rank: int,
+    world_size: int,
+    local_vocab_size: int,
+    batch: int,
+    port: int,
+    warmup: int,
+    iterations: int,
+    samples: int,
+    random_cases: int,
+) -> None:
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    runtime: PCIeVocabParallelArgmax | None = None
+    try:
+        runtime = PCIeVocabParallelArgmax.from_process_group(
+            process_group=dist.group.WORLD,
+            device=device,
+            local_vocab_size=local_vocab_size,
+            max_batch_size=batch,
+        )
+        _validate_random_inputs(
+            runtime,
+            rank=rank,
+            world_size=world_size,
+            local_vocab_size=local_vocab_size,
+            batch=batch,
+            cases=random_cases,
+            device=device,
+        )
+        base, bias, expected = _inputs(
+            rank,
+            world_size,
+            local_vocab_size,
+            batch,
+            device,
+        )
+        output = torch.empty(batch, dtype=torch.int64, device=device)
+        for _ in range(3):
+            runtime.fused_add_argmax(base, bias, output)
+        torch.cuda.synchronize(device)
+        if not torch.equal(output, expected):
+            raise AssertionError(
+                f"rank {rank}: expected {expected.tolist()}, got {output.tolist()}"
+            )
+
+        graph = torch.cuda.CUDAGraph()
+        with runtime.capture(), torch.cuda.graph(graph):
+            runtime.fused_add_argmax(base, bias, output)
+        for _ in range(100):
+            graph.replay()
+        torch.cuda.synchronize(device)
+        if not torch.equal(output, expected):
+            raise AssertionError(
+                "CUDA graph replay changed vocabulary argmax output"
+            )
+
+        if batch > 1:
+            one_output = torch.empty(1, dtype=torch.int64, device=device)
+            one_graph = torch.cuda.CUDAGraph()
+            with runtime.capture(), torch.cuda.graph(one_graph):
+                runtime.fused_add_argmax(base[:1], bias[:1], one_output)
+            for _ in range(100):
+                one_graph.replay()
+                graph.replay()
+            torch.cuda.synchronize(device)
+            if not torch.equal(one_output, expected[:1]):
+                raise AssertionError(
+                    "alternating batch-one graph replay changed argmax output"
+                )
+            if not torch.equal(output, expected):
+                raise AssertionError(
+                    "alternating full-batch graph replay changed argmax output"
+                )
+
+        latency_us = _measure(
+            graph,
+            device=device,
+            warmup=warmup,
+            iterations=iterations,
+            samples=samples,
+        )
+        if rank == 0:
+            print(
+                "world_size,batch,local_vocab_size,latency_us\n"
+                f"{world_size},{batch},{local_vocab_size},{latency_us:.6f}",
+                flush=True,
+            )
+    finally:
+        if runtime is not None:
+            with suppress(Exception):
+                runtime.close()
+        if dist.is_initialized():
+            with suppress(Exception):
+                dist.destroy_process_group()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--world-size", type=int, default=16)
+    parser.add_argument("--local-vocab-size", type=int)
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("--random-cases", type=int, default=32)
+    args = parser.parse_args()
+    if args.world_size not in (8, 12, 16):
+        raise SystemExit("world size must be 8, 12, or 16")
+    if not 1 <= args.batch <= 8:
+        raise SystemExit("batch must be in [1, 8]")
+    local_vocab_size = args.local_vocab_size
+    if local_vocab_size is None:
+        global_vocab_size = 163840 if args.world_size in (8, 16) else 163968
+        local_vocab_size = global_vocab_size // args.world_size
+    mp.spawn(
+        _worker,
+        args=(
+            args.world_size,
+            local_vocab_size,
+            args.batch,
+            _free_port(),
+            args.warmup,
+            args.iterations,
+            args.samples,
+            args.random_cases,
+        ),
+        nprocs=args.world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_vocab_parallel_argmax.py
+++ b/benchmarks/benchmark_vocab_parallel_argmax.py
@@ -57,6 +57,12 @@ def _inputs(
         base[2, local_vocab_size - 1] = float("nan")
     if rank == world_size - 1 and batch > 3:
         base[3, local_vocab_size - 1] = 0.0
+    if rank == 0 and batch > 4:
+        base[4, 5] = float("inf")
+    if rank == world_size - 1 and batch > 4:
+        base[4, local_vocab_size - 1] = float("inf")
+    if batch > 5:
+        base[5].fill_(float("-inf"))
 
     local_scores = (base.float() + bias.float()).bfloat16()
     gathered = [torch.empty_like(local_scores) for _ in range(world_size)]
@@ -68,6 +74,10 @@ def _inputs(
         expected[2] = 3
     if batch > 3:
         expected[3] = 0
+    if batch > 4:
+        expected[4] = 5
+    if batch > 5:
+        expected[5] = 0
     return base, bias, expected
 
 

--- a/tests/comm/test_pcie_oneshot.py
+++ b/tests/comm/test_pcie_oneshot.py
@@ -15,6 +15,7 @@ from b12x.comm.pcie.pcie_oneshot import (
     _compute_crossover_size,
     _finish_collective_runtime_setup,
     _group_ranks,
+    _object_broadcast_device,
     _OwnedSharedBuffer,
     _require_no_retained_ipc_setup,
     _require_full_grid_residency,
@@ -1323,6 +1324,8 @@ def test_retained_generation_blocks_second_setup_before_cuda_allocation(monkeypa
     monkeypatch.setattr(
         "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
     )
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
 
     with pytest.raises(RuntimeError, match="preparation status") as exc:
         PCIeOneshotAllReduce._allocate_shared_buffer(
@@ -1416,6 +1419,55 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
     )
 
 
+def test_shared_buffer_maps_only_selected_peers(monkeypatch):
+    class FakeIPC:
+        def __init__(self):
+            self.opened = []
+
+        def cudaMalloc(self, size):
+            return 1000
+
+        def cudaMemset(self, ptr, value, size):
+            pass
+
+        def cudaIpcGetMemHandleBytes(self, ptr):
+            return b"local"
+
+        def cudaIpcOpenMemHandleBytes(self, handle):
+            ptr = {
+                b"remote-1": 2001,
+                b"remote-2": 2002,
+                b"remote-3": 2003,
+            }[handle]
+            self.opened.append(ptr)
+            return ptr
+
+    ipc = FakeIPC()
+    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 4)
+    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object",
+        lambda local_object, group: (
+            [local_object, (), (), ()]
+            if isinstance(local_object, tuple)
+            else [local_object, b"remote-1", b"remote-2", b"remote-3"]
+        ),
+    )
+
+    shared = PCIeOneshotAllReduce._allocate_shared_buffer(
+        object(),
+        256,
+        zero_fill=True,
+        ipc=ipc,
+        peer_ranks=(1, 3),
+    )
+
+    assert ipc.opened == [2001, 2003]
+    assert shared.local_ptr == 1000
+    assert shared.peer_ptrs == (1000, 2001, 0, 2003)
+    assert shared.remote_ptrs == (2001, 2003)
+
+
 def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
     class FakeIPC:
         def __init__(self):
@@ -1495,6 +1547,15 @@ def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
     assert ext.register_graph_buffers_calls == [
         (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
     ]
+
+
+def test_object_broadcast_uses_cpu_for_gloo(monkeypatch):
+    group = object()
+    monkeypatch.setattr(
+        "torch.distributed.get_backend", lambda group=None: "gloo"
+    )
+
+    assert _object_broadcast_device(group) == torch.device("cpu")
 
 
 def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(

--- a/tests/comm/test_pcie_vocab_argmax.py
+++ b/tests/comm/test_pcie_vocab_argmax.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -175,9 +176,18 @@ def test_vocab_argmax_resolves_implicit_cuda_device(
     group = MagicMock()
     launcher = MagicMock()
     ipc = MagicMock()
-    ipc.cudaMalloc.return_value = 1000
-    ipc.cudaIpcGetMemHandleBytes.return_value = b"local"
-    ipc.cudaIpcOpenMemHandleBytes.side_effect = range(2000, 2006)
+    shared = SimpleNamespace(
+        local_ptr=1000,
+        peer_ptrs=tuple(range(16)),
+        remote_ptrs=tuple(range(2000, 2006)),
+    )
+    allocate_shared_buffer = MagicMock(return_value=shared)
+    setup_owners = []
+
+    def run_collective_setup(*, owner, exchange_group, setup):
+        assert exchange_group is group
+        setup_owners.append(owner)
+        return setup()
 
     monkeypatch.setattr(torch.distributed, "get_rank", lambda group: 0)
     monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 16)
@@ -195,8 +205,13 @@ def test_vocab_argmax_resolves_implicit_cuda_device(
     )
     monkeypatch.setattr(
         vocab_argmax_module,
-        "_exchange_ipc_handles",
-        lambda local_handle, group: [local_handle] * 16,
+        "_run_collective_preallocation_setup",
+        run_collective_setup,
+    )
+    monkeypatch.setattr(
+        vocab_argmax_module.PCIeOneshotAllReduce,
+        "_allocate_shared_buffer",
+        allocate_shared_buffer,
     )
 
     runtime = PCIeVocabParallelArgmax(
@@ -206,7 +221,20 @@ def test_vocab_argmax_resolves_implicit_cuda_device(
     )
 
     assert runtime.device == torch.device("cuda:7")
-    ipc.cudaSetDevice.assert_called_once_with(7)
+    assert setup_owners == [
+        "PCIe vocabulary argmax argument validation",
+        "PCIe vocabulary argmax runtime preparation",
+    ]
+    allocate_shared_buffer.assert_called_once_with(
+        group,
+        vocab_argmax_module.SLAB_BYTES,
+        zero_fill=True,
+        ipc=ipc,
+        peer_ranks=(1, 2, 3, 4, 8, 12),
+    )
+    assert ipc.cudaSetDevice.call_count == 2
+    assert runtime._slab_ptrs == tuple(range(16))
+    assert runtime._remote_ptrs == list(range(2000, 2006))
     runtime._closed = True
 
 

--- a/tests/comm/test_pcie_vocab_argmax.py
+++ b/tests/comm/test_pcie_vocab_argmax.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from b12x.comm.pcie import pcie_vocab_argmax as vocab_argmax_module
+from b12x.comm.pcie.pcie_hierarchical import (
+    _selected_peers as _allreduce_peers,
+)
+from b12x.comm.pcie.pcie_vocab_argmax import (
+    PCIeVocabParallelArgmax,
+    _exchange_ipc_handles,
+    _require_uniform_geometry,
+    _selected_peers,
+    _wait_nanosleep_cycles_from_env,
+)
+
+
+@pytest.mark.parametrize(
+    ("world_size", "rank", "expected"),
+    [
+        (8, 0, (1, 2, 3, 4)),
+        (12, 6, (2, 4, 5, 7, 10)),
+        (16, 0, (1, 2, 3, 4, 8, 12)),
+        (16, 15, (3, 7, 11, 12, 13, 14)),
+    ],
+)
+def test_vocab_argmax_uses_bounded_lane_topology(
+    world_size: int,
+    rank: int,
+    expected: tuple[int, ...],
+) -> None:
+    assert _selected_peers(rank, world_size) == expected
+
+
+@pytest.mark.parametrize("world_size", (12, 16))
+def test_vocab_argmax_and_hierarchical_allreduce_union_stays_bounded(
+    world_size: int,
+) -> None:
+    expected_bound = world_size // 4 + 2
+    for rank in range(world_size):
+        peers = set(_selected_peers(rank, world_size)) | set(
+            _allreduce_peers(rank, world_size)
+        )
+        assert len(peers) <= expected_bound
+
+
+@pytest.mark.parametrize("world_size", (8, 12, 16))
+def test_vocab_argmax_peer_graph_is_reciprocal_and_connected(
+    world_size: int,
+) -> None:
+    peer_sets = {
+        rank: set(_selected_peers(rank, world_size))
+        for rank in range(world_size)
+    }
+    for rank, peers in peer_sets.items():
+        for peer in peers:
+            assert rank in peer_sets[peer]
+
+    reached = {0}
+    frontier = [0]
+    while frontier:
+        rank = frontier.pop()
+        for peer in peer_sets[rank] - reached:
+            reached.add(peer)
+            frontier.append(peer)
+    assert reached == set(range(world_size))
+
+
+def test_vocab_argmax_exchanges_metadata_over_gloo(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+    exchanges = []
+
+    def fake_all_gather(objects, local_handle, group):
+        exchanges.append((objects, local_handle, group))
+        objects[:] = [b"rank-0", b"rank-1"]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather)
+
+    assert _exchange_ipc_handles(b"rank-0", group) == [b"rank-0", b"rank-1"]
+    assert exchanges == [([b"rank-0", b"rank-1"], b"rank-0", group)]
+
+
+def test_vocab_argmax_rejects_missing_gloo_handle(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+
+    def fake_all_gather(objects, local_handle, group):
+        objects[:] = [local_handle, None]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather)
+
+    with pytest.raises(RuntimeError, match="empty handle"):
+        _exchange_ipc_handles(b"rank-0", group)
+
+
+def test_vocab_argmax_rejects_mismatched_rank_geometry(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(
+        vocab_argmax_module,
+        "_exchange_ipc_handles",
+        lambda geometry, group: [geometry] * 15 + [(2048, 4)],
+    )
+
+    with pytest.raises(RuntimeError, match="geometry differs across ranks"):
+        _require_uniform_geometry(1024, 4, group)
+
+
+def test_vocab_argmax_validates_uniform_geometry_over_gloo(monkeypatch) -> None:
+    group = MagicMock()
+    monkeypatch.setattr(torch.distributed, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+
+    def fake_all_gather(objects, geometry, group):
+        objects[:] = [geometry, geometry]
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", fake_all_gather)
+
+    _require_uniform_geometry(1024, 4, group)
+
+
+@pytest.mark.parametrize(("rank", "world_size"), [(-1, 8), (8, 8), (16, 16)])
+def test_vocab_argmax_rejects_invalid_rank(rank: int, world_size: int) -> None:
+    with pytest.raises(ValueError, match="invalid rank"):
+        _selected_peers(rank, world_size)
+
+
+@pytest.mark.parametrize("world_size", [1, 2, 4, 20, 32])
+def test_vocab_argmax_rejects_unsupported_world(world_size: int) -> None:
+    with pytest.raises(ValueError, match="requires"):
+        _selected_peers(0, world_size)
+
+
+@pytest.mark.parametrize("value", ["0", "24", "1024"])
+def test_vocab_argmax_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    assert _wait_nanosleep_cycles_from_env() == int(value)
+
+
+@pytest.mark.parametrize("value", ["-1", "1025", "bad"])
+def test_vocab_argmax_rejects_invalid_wait_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", value)
+    with pytest.raises(ValueError):
+        _wait_nanosleep_cycles_from_env()
+
+
+def _fake_runtime() -> PCIeVocabParallelArgmax:
+    runtime = PCIeVocabParallelArgmax.__new__(PCIeVocabParallelArgmax)
+    runtime.device = torch.device("cpu")
+    runtime.local_vocab_size = 16
+    runtime.max_batch_size = 8
+    runtime._closed = False
+    runtime._launcher = MagicMock()
+    runtime._slab_ptrs = tuple(range(16))
+    runtime._ipc = MagicMock()
+    runtime._remote_ptrs = [456]
+    runtime._local_ptr = 789
+    return runtime
+
+
+def test_vocab_argmax_resolves_implicit_cuda_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    group = MagicMock()
+    launcher = MagicMock()
+    ipc = MagicMock()
+    ipc.cudaMalloc.return_value = 1000
+    ipc.cudaIpcGetMemHandleBytes.return_value = b"local"
+    ipc.cudaIpcOpenMemHandleBytes.side_effect = range(2000, 2006)
+
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group: 0)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 16)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 7)
+    monkeypatch.setattr(vocab_argmax_module, "CudaRTLibrary", lambda: ipc)
+    monkeypatch.setattr(
+        vocab_argmax_module,
+        "get_vocab_argmax_launcher",
+        lambda *args, **kwargs: launcher,
+    )
+    monkeypatch.setattr(
+        vocab_argmax_module,
+        "_require_uniform_geometry",
+        lambda *args: None,
+    )
+    monkeypatch.setattr(
+        vocab_argmax_module,
+        "_exchange_ipc_handles",
+        lambda local_handle, group: [local_handle] * 16,
+    )
+
+    runtime = PCIeVocabParallelArgmax(
+        exchange_group=group,
+        device="cuda",
+        local_vocab_size=16,
+    )
+
+    assert runtime.device == torch.device("cuda:7")
+    ipc.cudaSetDevice.assert_called_once_with(7)
+    runtime._closed = True
+
+
+def test_vocab_argmax_destructor_never_enters_collective_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _fake_runtime()
+    runtime.group = MagicMock()
+    barrier = MagicMock()
+    monkeypatch.setattr(torch.distributed, "barrier", barrier)
+
+    with pytest.warns(ResourceWarning, match="without close"):
+        runtime.__del__()
+
+    barrier.assert_not_called()
+    runtime._ipc.cudaIpcCloseMemHandle.assert_called_once_with(456)
+    runtime._ipc.cudaFree.assert_called_once_with(789)
+    assert runtime._closed
+    assert runtime._launcher is None
+    assert runtime._slab_ptrs == ()
+    assert runtime._remote_ptrs == []
+    assert runtime._local_ptr == 0
+
+
+def test_vocab_argmax_close_reaches_all_barriers_after_ipc_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _fake_runtime()
+    runtime.group = MagicMock()
+    runtime._ipc.cudaIpcCloseMemHandle.side_effect = RuntimeError(
+        "IPC close failed"
+    )
+    barrier = MagicMock()
+    monkeypatch.setattr(torch.cuda, "synchronize", MagicMock())
+    monkeypatch.setattr(torch.distributed, "barrier", barrier)
+
+    with pytest.raises(RuntimeError, match="IPC close failed"):
+        runtime.close()
+
+    assert barrier.call_count == 3
+    runtime._ipc.cudaFree.assert_called_once_with(789)
+    assert runtime._launcher is None
+    assert runtime._slab_ptrs == ()
+    assert runtime._remote_ptrs == []
+    assert runtime._local_ptr == 0
+
+
+def test_vocab_argmax_allocates_int64_output_and_dispatches() -> None:
+    runtime = _fake_runtime()
+    base = torch.randn(4, 16, dtype=torch.bfloat16)
+    bias = torch.randn_like(base)
+
+    output = runtime.fused_add_argmax(base, bias)
+
+    assert output.shape == (4,)
+    assert output.dtype == torch.int64
+    runtime._launcher.assert_called_once_with(
+        tuple(range(16)),
+        base.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr(),
+        16,
+        base.stride(0),
+        bias.stride(0),
+        4,
+    )
+
+
+def test_vocab_argmax_accepts_row_strided_inputs() -> None:
+    runtime = _fake_runtime()
+    base_storage = torch.randn(4, 3, 16, dtype=torch.bfloat16)
+    bias_storage = torch.randn(4, 5, 16, dtype=torch.bfloat16)
+    base = base_storage[:, 1]
+    bias = bias_storage[:, 3]
+
+    assert not base.is_contiguous()
+    assert not bias.is_contiguous()
+    output = runtime.fused_add_argmax(base, bias)
+
+    runtime._launcher.assert_called_once_with(
+        tuple(range(16)),
+        base.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr(),
+        16,
+        base.stride(0),
+        bias.stride(0),
+        4,
+    )
+
+
+def test_vocab_argmax_rejects_noncontiguous_last_dimension() -> None:
+    base = torch.zeros(1, 32, dtype=torch.bfloat16)[:, ::2]
+    bias = torch.zeros_like(base)
+
+    with pytest.raises(ValueError, match="last dimensions"):
+        _fake_runtime().fused_add_argmax(base, bias)
+
+
+@pytest.mark.parametrize(
+    ("base", "bias", "error"),
+    [
+        (
+            torch.zeros(1, 16, dtype=torch.float32),
+            torch.zeros(1, 16, dtype=torch.float32),
+            "BF16",
+        ),
+        (
+            torch.zeros(1, 15, dtype=torch.bfloat16),
+            torch.zeros(1, 15, dtype=torch.bfloat16),
+            "local vocabulary",
+        ),
+        (
+            torch.zeros(9, 16, dtype=torch.bfloat16),
+            torch.zeros(9, 16, dtype=torch.bfloat16),
+            "capacity",
+        ),
+        (
+            torch.zeros(1, 16, dtype=torch.bfloat16),
+            torch.zeros(2, 16, dtype=torch.bfloat16),
+            "matching",
+        ),
+    ],
+)
+def test_vocab_argmax_validates_inputs(
+    base: torch.Tensor,
+    bias: torch.Tensor,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _fake_runtime().fused_add_argmax(base, bias)


### PR DESCRIPTION
## Status

Implemented.

## Behavior

Adds `VocabParallelArgmax`, a CuTeDSL PCIe collective for sharded greedy sampling. Each invocation:

1. adds matching BF16 base-logit and bias shards in FP32;
2. rounds each sum to BF16;
3. selects the exact global argmax across tensor-parallel ranks;
4. writes the global token ID as `int64` without gathering the vocabulary.

The runtime supports TP8, TP12, and TP16 with batch sizes from one through eight. Equal scores select the lower global token ID. NaNs dominate non-NaNs, multiple NaNs select the lower global token ID, and positive and negative zero compare equal.

This change adds a library primitive only; it does not add serving-framework dispatch or integration.

## Technical reason

A full-vocabulary all-gather transfers approximately 320 KiB per request for a 163,840-element BF16 vocabulary before greedy sampling. `VocabParallelArgmax` reduces each local shard first, then exchanges one packed score/token key through contiguous four-GPU PCIe islands. Each rank maps four peers at TP8, five at TP12, or six at TP16.

Rank-specialized launchers resolve during runtime construction, so CUDA graph capture and replay do not compile or load kernels. Device-resident unsigned 32-bit generation counters and two protocol slots give eager calls and graph replays the same collective ordering contract. Wait loops compare the exact generation for wrap safety; this changes the comparison predicate without adding a load, predicate, or loop branch.

Fallible validation, launcher resolution, CUDA IPC allocation, handle import, and rollback use coordinated rank-wide setup. A rank-local setup failure therefore cannot leave successful peers blocked behind an allocation or import phase.

The implementation adds no dependency, `.cu` source, native extension, or separate kernel route outside the existing Python/CuTeDSL PCIe package.

## Compatibility

- Existing PCIe collective interfaces and default shared-buffer allocation behavior are unchanged.
- Callers must invoke the collective in identical order and with identical batch size on every tensor-parallel rank.
- The global padded vocabulary must fit an `int32` token index.
- TP2 and TP4 are unsupported; the runtime has specializations only for TP8, TP12, and TP16.

## Validation

Current head `e264349d6`:

- `/home/luke/projects/b12x/.venv/bin/python -m pytest -q tests/comm`: 439 passed, 25 skipped.
- `git diff --check`: passed.
- `py_compile` passed for the changed runtime, kernel, benchmark, and tests.
- The benchmark defines randomized BF16-reference checks, exact ties, signed zero, positive and negative infinity, multiple NaNs, 100 same-shape graph replays, and 100 alternating batch-one/batch-eight graph replays.

GPU measurements were collected for PR revision `a01cd5634` on 16 NVIDIA RTX PRO 6000 Blackwell GPUs with PyTorch 2.13.0 and CUDA 13.3:

- TP16 batch one: CuTeDSL 10.927 us; native CUDA prototype 12.302 us (1.126x).
- TP16 batch four: CuTeDSL 11.589 us; native CUDA prototype 12.999 us (1.122x).
- TP16 batch eight: CuTeDSL 11.989 us; native CUDA prototype 13.592 us (1.134x).
- CuTeDSL batch-eight latency: TP8 12.440 us, TP12 12.327 us, TP16 11.968 us.

The native CUDA prototype, exact invocation, and raw timing samples are not checked into this repository. Those figures are supporting measurements rather than reproducible release evidence. No multi-GPU benchmark was rerun for `e264349d6`; relative to the measured kernel, its only steady-state kernel change is the generation comparison predicate. The remaining corrections affect construction and teardown only.