### PR TITLE
Expose a uniform PCIe all-reduce channel contract

### DIFF
--- a/b12x/comm/pcie/pcie_allreduce.py
+++ b/b12x/comm/pcie/pcie_allreduce.py
@@ -70,6 +70,7 @@ class PCIeAllReduce:
         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeAllReduce":
         world_size = dist.get_world_size(group=exchange_group)
         algorithm = _algorithm_for_world_size(world_size)
@@ -82,6 +83,7 @@ class PCIeAllReduce:
                 rank_data_bytes=rank_data_bytes,
                 ext_module=ext_module,
                 single_channel=single_channel,
+                max_concurrent_channels=max_concurrent_channels,
             )
         else:
             if max_size < torch.bfloat16.itemsize:
@@ -106,6 +108,7 @@ class PCIeAllReduce:
         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
         ext_module=None,
         single_channel: bool = False,
+        max_concurrent_channels: int = 1,
     ) -> "PCIeAllReduce":
         return cls.from_exchange_group(
             exchange_group=process_group,
@@ -117,6 +120,7 @@ class PCIeAllReduce:
             rank_data_bytes=rank_data_bytes,
             ext_module=ext_module,
             single_channel=single_channel,
+            max_concurrent_channels=max_concurrent_channels,
         )
 
     @property
@@ -125,7 +129,25 @@ class PCIeAllReduce:
 
         return self.algorithm == "oneshot"
 
-    def for_stream(self, stream: object = None):
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        """Prepare named owners when the selected runtime supports them.
+
+        The bounded-degree runtime is a single ordered channel whose device
+        generations are graph-capturable, so named owners require no separate
+        allocation.
+        """
+        prepare = getattr(self._runtime, "prepare_channels", None)
+        if prepare is not None:
+            prepare(channel_ids)
+
+    def for_stream(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ):
+        if self.algorithm == "oneshot":
+            return self._runtime.for_stream(stream, channel_id=channel_id)
         return self._runtime.for_stream(stream)
 
     def all_reduce(
@@ -136,6 +158,7 @@ class PCIeAllReduce:
         peer_input_ptrs: Optional[Sequence[int]] = None,
         blocks: Optional[int] = None,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> torch.Tensor:
         if self.algorithm == "hierarchical":
             if peer_input_ptrs is not None:
@@ -155,11 +178,22 @@ class PCIeAllReduce:
             out=out,
             peer_input_ptrs=peer_input_ptrs,
             stream=stream,
+            channel_id=channel_id,
         )
 
     @contextmanager
-    def capture(self, stream: object = None):
-        with self._runtime.capture(stream=stream) as runtime:
+    def capture(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ):
+        capture = (
+            self._runtime.capture(stream=stream, channel_id=channel_id)
+            if self.algorithm == "oneshot"
+            else self._runtime.capture(stream=stream)
+        )
+        with capture as runtime:
             yield runtime
 
     def close(self) -> None:

--- a/b12x/comm/pcie/pcie_allreduce.py
+++ b/b12x/comm/pcie/pcie_allreduce.py
@@ -86,6 +86,10 @@ class PCIeAllReduce:
                 max_concurrent_channels=max_concurrent_channels,
             )
         else:
+            if int(max_concurrent_channels) != 1:
+                raise ValueError(
+                    "hierarchical all-reduce supports exactly one concurrent channel"
+                )
             if max_size < torch.bfloat16.itemsize:
                 raise ValueError("max_size must hold at least one BF16 element")
             runtime = PCIeHierarchicalAllReduce(
@@ -130,15 +134,8 @@ class PCIeAllReduce:
         return self.algorithm == "oneshot"
 
     def prepare_channels(self, channel_ids: Sequence[str]) -> None:
-        """Prepare named owners when the selected runtime supports them.
-
-        The bounded-degree runtime is a single ordered channel whose device
-        generations are graph-capturable, so named owners require no separate
-        allocation.
-        """
-        prepare = getattr(self._runtime, "prepare_channels", None)
-        if prepare is not None:
-            prepare(channel_ids)
+        """Prepare the runtime's semantic channel owners."""
+        self._runtime.prepare_channels(channel_ids)
 
     def for_stream(
         self,
@@ -146,9 +143,7 @@ class PCIeAllReduce:
         *,
         channel_id: Optional[str] = None,
     ):
-        if self.algorithm == "oneshot":
-            return self._runtime.for_stream(stream, channel_id=channel_id)
-        return self._runtime.for_stream(stream)
+        return self._runtime.for_stream(stream, channel_id=channel_id)
 
     def all_reduce(
         self,
@@ -170,6 +165,7 @@ class PCIeAllReduce:
                 out=out,
                 blocks=blocks,
                 stream=stream,
+                channel_id=channel_id,
             )
         if blocks is not None:
             raise ValueError("blocks is only available for hierarchical all-reduce")
@@ -188,12 +184,10 @@ class PCIeAllReduce:
         *,
         channel_id: Optional[str] = None,
     ):
-        capture = (
-            self._runtime.capture(stream=stream, channel_id=channel_id)
-            if self.algorithm == "oneshot"
-            else self._runtime.capture(stream=stream)
-        )
-        with capture as runtime:
+        with self._runtime.capture(
+            stream=stream,
+            channel_id=channel_id,
+        ) as runtime:
             yield runtime
 
     def close(self) -> None:

--- a/b12x/comm/pcie/pcie_hierarchical.py
+++ b/b12x/comm/pcie/pcie_hierarchical.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 import torch.distributed as dist
@@ -282,8 +282,9 @@ class PCIeHierarchicalAllReduce:
         out: Optional[torch.Tensor] = None,
         blocks: Optional[int] = None,
         stream: object = None,
+        channel_id: Optional[str] = None,
     ) -> torch.Tensor:
-        del stream
+        del stream, channel_id
         if not self.should_allreduce(inp):
             raise ValueError(
                 "input does not satisfy hierarchical all-reduce requirements "
@@ -337,7 +338,22 @@ class PCIeHierarchicalAllReduce:
             )
         return out
 
-    def for_stream(self, stream: object = None) -> "PCIeHierarchicalAllReduce":
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        """Accept semantic owner names without allocating additional channels.
+
+        The hierarchical runtime has one ordered channel. Owner names provide
+        API compatibility for callers that serialize TP12/TP16 collectives;
+        they do not permit overlapping collective streams.
+        """
+
+        del channel_ids
+
+    def for_stream(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ) -> "PCIeHierarchicalAllReduce":
         """Compatibility with the vLLM PCIe runtime interface.
 
         Synchronization generations live in device memory, so captured graphs
@@ -345,12 +361,17 @@ class PCIeHierarchicalAllReduce:
         single ordered channel; callers must not overlap collective streams.
         """
 
-        del stream
+        del stream, channel_id
         return self
 
     @contextmanager
-    def capture(self, stream: object = None):
-        del stream
+    def capture(
+        self,
+        stream: object = None,
+        *,
+        channel_id: Optional[str] = None,
+    ):
+        del stream, channel_id
         yield self
 
     def register_graph_buffers(self) -> None:

--- a/tests/comm/test_pcie_hierarchical.py
+++ b/tests/comm/test_pcie_hierarchical.py
@@ -14,6 +14,7 @@ from b12x.comm.pcie.pcie_allreduce import (
     _algorithm_for_world_size,
 )
 from b12x.comm.pcie.pcie_hierarchical import (
+    PCIeHierarchicalAllReduce,
     _buffer_modes_from_env,
     _make_layout,
     _pick_blocks,
@@ -105,6 +106,30 @@ def test_allreduce_factory_forwards_oneshot_channel_capacity(
     )
 
 
+@pytest.mark.parametrize("max_concurrent_channels", [0, 2])
+def test_allreduce_factory_rejects_hierarchical_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+    max_concurrent_channels: int,
+) -> None:
+    hierarchy_factory = MagicMock()
+    exchange_group = object()
+    monkeypatch.setattr(pcie_allreduce.dist, "get_world_size", lambda group: 16)
+    monkeypatch.setattr(
+        pcie_allreduce,
+        "PCIeHierarchicalAllReduce",
+        hierarchy_factory,
+    )
+
+    with pytest.raises(ValueError, match="exactly one concurrent channel"):
+        PCIeAllReduce.from_exchange_group(
+            exchange_group=exchange_group,  # type: ignore[arg-type]
+            device="cuda:0",
+            max_concurrent_channels=max_concurrent_channels,
+        )
+
+    hierarchy_factory.assert_not_called()
+
+
 def test_allreduce_oneshot_forwards_named_channel_contract() -> None:
     runtime = MagicMock()
     runtime.rank = 0
@@ -135,7 +160,15 @@ def test_allreduce_oneshot_forwards_named_channel_contract() -> None:
 
 def test_allreduce_hierarchy_accepts_named_channel_contract() -> None:
     runtime = MagicMock(
-        spec=["rank", "world_size", "device", "for_stream", "all_reduce", "capture"]
+        spec=[
+            "rank",
+            "world_size",
+            "device",
+            "prepare_channels",
+            "for_stream",
+            "all_reduce",
+            "capture",
+        ]
     )
     runtime.rank = 0
     runtime.world_size = 16
@@ -151,14 +184,26 @@ def test_allreduce_hierarchy_accepts_named_channel_contract() -> None:
     with allreduce.capture(stream, channel_id="target"):
         pass
 
-    runtime.for_stream.assert_called_once_with(stream)
+    runtime.prepare_channels.assert_called_once_with(("target", "draft"))
+    runtime.for_stream.assert_called_once_with(stream, channel_id="target")
     runtime.all_reduce.assert_called_once_with(
         inp,
         out=out,
         blocks=None,
         stream=stream,
+        channel_id="target",
     )
-    runtime.capture.assert_called_once_with(stream=stream)
+    runtime.capture.assert_called_once_with(stream=stream, channel_id="target")
+
+
+def test_hierarchical_named_channel_surface_remains_serial() -> None:
+    runtime = object.__new__(PCIeHierarchicalAllReduce)
+    stream = object()
+
+    runtime.prepare_channels(("target", "draft"))
+    assert runtime.for_stream(stream, channel_id="target") is runtime
+    with runtime.capture(stream, channel_id="draft") as captured:
+        assert captured is runtime
 
 
 @pytest.mark.parametrize("world_size", [1, 3, 10, 14, 20])

--- a/tests/comm/test_pcie_hierarchical.py
+++ b/tests/comm/test_pcie_hierarchical.py
@@ -69,6 +69,98 @@ def test_allreduce_factory_builds_tp16_hierarchy(
     )
 
 
+def test_allreduce_factory_forwards_oneshot_channel_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = SimpleNamespace(
+        rank=0,
+        world_size=8,
+        device=torch.device("cuda:0"),
+    )
+    oneshot_factory = MagicMock(return_value=runtime)
+    exchange_group = object()
+    monkeypatch.setattr(pcie_allreduce.dist, "get_world_size", lambda group: 8)
+    monkeypatch.setattr(
+        pcie_allreduce.PCIeOneshotAllReducePool,
+        "from_exchange_group",
+        oneshot_factory,
+    )
+
+    allreduce = PCIeAllReduce.from_exchange_group(
+        exchange_group=exchange_group,  # type: ignore[arg-type]
+        device="cuda:0",
+        max_concurrent_channels=3,
+    )
+
+    assert allreduce.algorithm == "oneshot"
+    oneshot_factory.assert_called_once_with(
+        exchange_group=exchange_group,
+        device="cuda:0",
+        eager_buffer_bytes=8388608,
+        max_size=8388608,
+        rank_data_bytes=8388608,
+        ext_module=None,
+        single_channel=False,
+        max_concurrent_channels=3,
+    )
+
+
+def test_allreduce_oneshot_forwards_named_channel_contract() -> None:
+    runtime = MagicMock()
+    runtime.rank = 0
+    runtime.world_size = 8
+    runtime.device = torch.device("cuda:0")
+    allreduce = PCIeAllReduce(runtime, "oneshot")
+    stream = object()
+    inp = torch.randn(2, 4)
+    out = torch.empty_like(inp)
+
+    allreduce.prepare_channels(("target", "draft"))
+    allreduce.for_stream(stream, channel_id="target")
+    allreduce.all_reduce(inp, out=out, stream=stream, channel_id="target")
+    with allreduce.capture(stream, channel_id="target"):
+        pass
+
+    runtime.prepare_channels.assert_called_once_with(("target", "draft"))
+    runtime.for_stream.assert_called_once_with(stream, channel_id="target")
+    runtime.all_reduce.assert_called_once_with(
+        inp,
+        out=out,
+        peer_input_ptrs=None,
+        stream=stream,
+        channel_id="target",
+    )
+    runtime.capture.assert_called_once_with(stream=stream, channel_id="target")
+
+
+def test_allreduce_hierarchy_accepts_named_channel_contract() -> None:
+    runtime = MagicMock(
+        spec=["rank", "world_size", "device", "for_stream", "all_reduce", "capture"]
+    )
+    runtime.rank = 0
+    runtime.world_size = 16
+    runtime.device = torch.device("cuda:0")
+    allreduce = PCIeAllReduce(runtime, "hierarchical")
+    stream = object()
+    inp = torch.randn(2, 4)
+    out = torch.empty_like(inp)
+
+    allreduce.prepare_channels(("target", "draft"))
+    allreduce.for_stream(stream, channel_id="target")
+    allreduce.all_reduce(inp, out=out, stream=stream, channel_id="target")
+    with allreduce.capture(stream, channel_id="target"):
+        pass
+
+    runtime.for_stream.assert_called_once_with(stream)
+    runtime.all_reduce.assert_called_once_with(
+        inp,
+        out=out,
+        blocks=None,
+        stream=stream,
+    )
+    runtime.capture.assert_called_once_with(stream=stream)
+
+
 @pytest.mark.parametrize("world_size", [1, 3, 10, 14, 20])
 def test_allreduce_rejects_unsupported_or_peer_unsafe_worlds(
     world_size: int,
@@ -319,19 +411,20 @@ def test_hierarchical_slab_layout_matches_native_alignment(
     layout = _make_layout(max_elements)
     assert layout.stage[0] == 69_888
     for slot in range(2):
-        assert layout.partial[slot] == (
-            (layout.stage[slot] + max_elements * 2 + 255) // 256
-        ) * 256
-        assert layout.final[slot] == (
-            (layout.partial[slot] + max_elements * 4 + 255) // 256
-        ) * 256
+        assert (
+            layout.partial[slot]
+            == ((layout.stage[slot] + max_elements * 2 + 255) // 256) * 256
+        )
+        assert (
+            layout.final[slot]
+            == ((layout.partial[slot] + max_elements * 4 + 255) // 256) * 256
+        )
         if slot == 0:
-            assert layout.stage[1] == (
-                (layout.final[0] + max_elements * 2 + 255) // 256
-            ) * 256
-    assert layout.bytes == (
-        (layout.final[1] + max_elements * 2 + 255) // 256
-    ) * 256
+            assert (
+                layout.stage[1]
+                == ((layout.final[0] + max_elements * 2 + 255) // 256) * 256
+            )
+    assert layout.bytes == ((layout.final[1] + max_elements * 2 + 255) // 256) * 256
     assert all(
         value % 256 == 0
         for offsets in (layout.stage, layout.partial, layout.final)


### PR DESCRIPTION
## Behavior

`b12x.comm.pcie.PCIeAllReduce` exposes one channel-ownership interface across every supported tensor-parallel world size.

- TP2, TP4, TP6, and TP8 forward semantic channel identifiers and `max_concurrent_channels` to `PCIeOneshotAllReducePool`.
- TP12 and TP16 expose the same method signatures while retaining one ordered hierarchical channel. Construction rejects `max_concurrent_channels` values other than `1` instead of silently ignoring unsupported concurrency.
- `prepare_channels`, `for_stream`, and `capture` dispatch directly to both concrete runtimes without capability probes or per-call algorithm predicates.
- `all_reduce` retains its existing algorithm dispatch because the oneshot and hierarchical runtimes accept different data-path arguments.

## Technical reason

Callers can use the world-size dispatcher without depending on implementation-specific method signatures. Semantic channel identifiers select independently owned oneshot resources where concurrency is supported. The hierarchical runtime accepts the identifiers as ownership labels but allocates no additional channel resources and requires serialized collective streams.

## Compatibility

Calls that omit `channel_id` and `max_concurrent_channels` retain their behavior. TP2 through TP8 continue to use direct oneshot all-reduce; TP12 and TP16 continue to use bounded-degree four-GPU islands. Requests for concurrent TP12 or TP16 channels now fail during construction. CUDA kernels and launch geometry are unchanged.

## Validation

Status: **implemented**.

- `python -m pytest -q tests/comm/test_pcie_hierarchical.py tests/comm/test_pcie_preallocation_setup.py`: 104 passed.
- `python -m py_compile b12x/comm/pcie/pcie_allreduce.py b12x/comm/pcie/pcie_hierarchical.py tests/comm/test_pcie_hierarchical.py`: passed.
- `git diff --check`: passed.
- Validation is host-side API coverage; no GPU qualification was required because no kernel or launch behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

* **Unified API**
  * Added named-channel support to `PCIeAllReduce` operations.
  * Added `prepare_channels` for consistent channel setup.
  * Added `max_concurrent_channels` to both factory methods.
  * Forwarded channel IDs and capacity settings to the selected implementation.

* **Compatibility**
  * Preserved existing calls that omit the new arguments.
  * Kept hierarchical execution on one ordered channel.
  * Rejected hierarchical concurrency values other than `1`.
  * Preserved existing algorithm selection.

* **Tests**
  * Added coverage for channel forwarding, capacity validation, named-channel operations, and hierarchical interface compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->