### PR TITLE
Fix route-packed W4A16 top-k scaling

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -4885,7 +4885,7 @@ class W4A16GemmKernel:
                     scale_bf2 = ld_shared_u32(
                         smem_base
                         + Int32(self.sh_topk_off * 16)
-                        + metadata_row * Int32(4)
+                        + row * Int32(4)
                     )
                     q0 = self._elem2_mul(q0, scale_bf2)
                     q1 = self._elem2_mul(q1, scale_bf2)
@@ -4952,7 +4952,7 @@ class W4A16GemmKernel:
                     scale_bf2 = ld_shared_u32(
                         smem_base
                         + Int32(self.sh_topk_off * 16)
-                        + metadata_row * Int32(4)
+                        + row * Int32(4)
                     )
                     q0 = self._elem2_mul(q0, scale_bf2)
                     q1 = self._elem2_mul(q1, scale_bf2)


### PR DESCRIPTION
## Status

Qualified.

## Behavior

Loads each route-packed W4A16 top-k scale from the shared-memory row that owns the corresponding output row. Both aligned and tail output epilogues use the same route-row index.

## Technical reason

The aligned and tail epilogues referenced an undefined `metadata_row` symbol. CuTeDSL therefore rejected every main route-packed W4A16 kernel specialization with `mul_topk_weights=True` during JIT compilation. The route-packed ABI stores one top-k scale per local route row, so `row` is the required index.

## Compatibility

The change affects only the main route-packed W4A16 epilogue when router weights are multiplied after GEMM accumulation. Direct small-M kernels and paths that do not multiply top-k weights are unchanged. The compile-time `mul_topk_weights` branch adds no runtime predicate to unaffected specializations.

## Validation

Conditions: CUDA 13.3, PyTorch 2.13, CuTeDSL 4.6.2, Blackwell GPU.

Results:

- `test_w4a16_e8m0_native_large_m_uses_main_gemm`: 4 passed.
- `test_w4a16_e8m0_native_compact_tail_uses_ceil_scale_grid` plus `test_w4a16_moe_matches_oracle`: 15 passed.
- The patched kernel compiled for aligned and logical-tail output shapes and matched the W4A16 oracle.