### PR TITLE
fix(moe): reuse fixed route arenas for prefill tails

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
+++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
@@ -289,22 +289,49 @@ def pack_topk_routes_by_expert(
         int(num_experts),
         topk=topk,
     )
-    if packed_route_indices is not None and block_expert_ids is not None:
+    provided_routes = (
+        None if packed_route_indices is None else int(packed_route_indices.numel())
+    )
+    provided_blocks = (
+        None if block_expert_ids is None else int(block_expert_ids.numel())
+    )
+    if (
+        provided_routes is not None
+        and provided_blocks is not None
+        and (
+            provided_routes < capacity_packed_routes
+            or provided_blocks < capacity_route_blocks
+        )
+    ):
+        (
+            exact_numel_capacity,
+            exact_packed_routes,
+            exact_route_blocks,
+        ) = route_pack_capacity(
+            numel,
+            int(block_size),
+            int(num_experts),
+            topk=topk,
+            bucket_tokens=False,
+        )
         if (
-            int(packed_route_indices.numel()) < capacity_packed_routes
-            or int(block_expert_ids.numel()) < capacity_route_blocks
+            provided_routes >= exact_packed_routes
+            and provided_blocks >= exact_route_blocks
         ):
-            (
-                numel_capacity,
-                capacity_packed_routes,
-                capacity_route_blocks,
-            ) = route_pack_capacity(
-                numel,
-                int(block_size),
-                int(num_experts),
-                topk=topk,
-                bucket_tokens=False,
-            )
+            # A serving caller can own one fixed arena sized for its configured
+            # maximum while a live prefill tail belongs to a larger power-of-two
+            # bucket. Reuse the full caller capacity instead of specializing the
+            # post-prefix kernel for every exact tail length. The kernel
+            # sentinel-fills unused route slots/blocks, so this preserves output
+            # semantics and lets startup warmup cover runtime tails without
+            # increasing the arena allocation.
+            numel_capacity = exact_numel_capacity
+            capacity_packed_routes = provided_routes
+            capacity_route_blocks = provided_blocks
+        else:
+            numel_capacity = exact_numel_capacity
+            capacity_packed_routes = exact_packed_routes
+            capacity_route_blocks = exact_route_blocks
     max_packed_routes = capacity_packed_routes
     max_route_blocks = capacity_route_blocks
     max_packed_routes = max(max_packed_routes, 1)

--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
+++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
@@ -77,6 +77,22 @@ def _next_power_of_2(x: int) -> int:
     return 1 << (int(x) - 1).bit_length()
 
 
+def _numel_capacity_for_route_workspace(
+    packed_routes: int,
+    route_blocks: int,
+    block_size: int,
+    num_experts: int,
+) -> int:
+    """Recover the largest live route count covered by a fixed workspace."""
+    block_size = int(block_size)
+    num_experts = int(num_experts)
+    padded_slots = min(int(packed_routes), int(route_blocks) * block_size)
+    fully_padded_experts = num_experts * block_size
+    if padded_slots <= fully_padded_experts:
+        return padded_slots // block_size
+    return padded_slots - num_experts * (block_size - 1)
+
+
 def _workspace_slice(
     tensor: torch.Tensor | None,
     *,
@@ -320,12 +336,17 @@ def pack_topk_routes_by_expert(
         ):
             # A serving caller can own one fixed arena sized for its configured
             # maximum while a live prefill tail belongs to a larger power-of-two
-            # bucket. Reuse the full caller capacity instead of specializing the
-            # post-prefix kernel for every exact tail length. The kernel
-            # sentinel-fills unused route slots/blocks, so this preserves output
-            # semantics and lets startup warmup cover runtime tails without
-            # increasing the arena allocation.
-            numel_capacity = exact_numel_capacity
+            # bucket. Reuse the full caller capacity instead of specializing each
+            # exact tail. The small-prefix and post-prefix kernels fill unused
+            # route slots with ``live_numel`` and unused blocks with ``-1``. The
+            # recovered live-route capacity also keeps the small-prefix loop bound
+            # stable without changing the caller's allocation or route semantics.
+            numel_capacity = _numel_capacity_for_route_workspace(
+                provided_routes,
+                provided_blocks,
+                int(block_size),
+                int(num_experts),
+            )
             capacity_packed_routes = provided_routes
             capacity_route_blocks = provided_blocks
         else:

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -5,6 +5,7 @@ import math
 import pytest
 import torch
 
+import b12x.moe._shared.kernels.w4a16.route_pack as route_pack_module
 from b12x.moe._shared.kernels.w4a16.kernel import pack_topk_routes_by_expert
 from b12x.moe._shared.kernels.w4a16.host import (
     route_block_sizes_for_capacity,
@@ -81,8 +82,8 @@ def _expected_route_pack(
 def test_route_pack_reuses_provided_fixed_capacity_for_prefill_tail() -> None:
     """A fixed-capacity serving arena must not specialize every tail length.
 
-    With a 1536-token serving capacity, top-k 16, and E=896, a 1177-token
-    prefill tail belongs to the 2048-token compile bucket. That bucket exceeds
+    With a 1536-token serving capacity, top-k 16, and 896 experts, a
+    1177-token prefill tail belongs to the 2048-token compile bucket. That bucket
     the fixed arena even though the arena safely covers the live tail. Reuse
     the caller's full capacity so startup warmup and runtime select the same
     Triton constexprs instead of compiling an exact tail specialization.
@@ -100,24 +101,108 @@ def test_route_pack_reuses_provided_fixed_capacity_for_prefill_tail() -> None:
         bucket_tokens=False,
     )
     device = torch.device("cuda")
+    topk_ids = (
+        torch.arange(tail_tokens * topk, dtype=torch.int32, device=device)
+        .reshape(tail_tokens, topk)
+        .remainder_(num_experts)
+    )
     packed_routes = torch.empty(max_routes, dtype=torch.int32, device=device)
     block_experts = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    packed_route_count = torch.empty(1, dtype=torch.int32, device=device)
 
-    returned_routes, returned_blocks, _ = pack_topk_routes_by_expert(
-        torch.zeros((tail_tokens, topk), dtype=torch.int32, device=device),
+    returned_routes, returned_blocks, returned_count = pack_topk_routes_by_expert(
+        topk_ids,
         block_size,
         num_experts,
         packed_route_indices=packed_routes,
         block_expert_ids=block_experts,
-        packed_route_count=torch.empty(1, dtype=torch.int32, device=device),
+        packed_route_count=packed_route_count,
         expert_offsets=torch.empty(num_experts + 1, dtype=torch.int32, device=device),
         expert_counts=torch.empty(num_experts, dtype=torch.int32, device=device),
     )
+    (
+        expected_ids,
+        expected_valid,
+        expected_count,
+        expected_blocks,
+    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+    sentinel = int(topk_ids.numel())
+    valid_routes = int(expected_count.item())
+    valid_blocks = valid_routes // block_size
 
     assert returned_routes.data_ptr() == packed_routes.data_ptr()
     assert returned_blocks.data_ptr() == block_experts.data_ptr()
+    assert returned_count.data_ptr() == packed_route_count.data_ptr()
     assert returned_routes.numel() == max_routes
     assert returned_blocks.numel() == max_blocks
+    assert torch.equal(returned_count.cpu(), expected_count)
+    assert torch.equal(returned_blocks[:valid_blocks].cpu(), expected_blocks)
+    assert bool(torch.all(returned_blocks[valid_blocks:] == -1).item())
+    assert bool(torch.all(returned_routes[valid_routes:] == sentinel).item())
+
+    host_routes = returned_routes[:valid_routes].cpu().to(torch.int64)
+    payload = host_routes[host_routes < sentinel]
+    assert payload.numel() == int(expected_valid.sum().item())
+    assert torch.equal(payload.sort().values, torch.arange(sentinel))
+    for block, expert in enumerate(expected_blocks.tolist()):
+        block_routes = host_routes[block * block_size : (block + 1) * block_size]
+        block_payload = block_routes[block_routes < sentinel]
+        if block_payload.numel() > 0:
+            assert bool(torch.all(expected_ids[block_payload] == expert).item())
+
+
+def test_small_prefix_reuses_fixed_arena_numel_capacity(monkeypatch) -> None:
+    """Fixed small-prefix arenas must not specialize on each live tail."""
+
+    class LaunchRecorder:
+        def __init__(self) -> None:
+            self.kwargs: list[dict[str, object]] = []
+
+        def __getitem__(self, _grid):
+            def launch(*_args, **kwargs) -> None:
+                self.kwargs.append(kwargs)
+
+            return launch
+
+    small_prefix = LaunchRecorder()
+    sort = LaunchRecorder()
+    monkeypatch.setattr(
+        route_pack_module,
+        "_pack_topk_routes_small_prefix_kernel",
+        small_prefix,
+    )
+    monkeypatch.setattr(route_pack_module, "_pack_topk_routes_sort_kernel", sort)
+
+    max_tokens = 24
+    topk = 1
+    block_size = 8
+    num_experts = 32
+    planned_numel, max_routes, max_blocks = route_pack_capacity(
+        max_tokens * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+        bucket_tokens=False,
+    )
+
+    observed = []
+    for tail_tokens in (17, 23):
+        route_pack_module.pack_topk_routes_by_expert(
+            torch.arange(tail_tokens * topk, dtype=torch.int32).reshape(
+                tail_tokens, topk
+            )
+            % num_experts,
+            block_size,
+            num_experts,
+            packed_route_indices=torch.empty(max_routes, dtype=torch.int32),
+            block_expert_ids=torch.empty(max_blocks, dtype=torch.int32),
+            packed_route_count=torch.empty(1, dtype=torch.int32),
+            expert_offsets=torch.empty(num_experts + 1, dtype=torch.int32),
+            expert_counts=torch.empty(num_experts, dtype=torch.int32),
+        )
+        observed.append(small_prefix.kwargs[-1]["NUMEL_CAPACITY"])
+
+    assert observed == [planned_numel, planned_numel]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -78,6 +78,49 @@ def _expected_route_pack(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_route_pack_reuses_provided_fixed_capacity_for_prefill_tail() -> None:
+    """A fixed-capacity serving arena must not specialize every tail length.
+
+    With a 1536-token serving capacity, top-k 16, and E=896, a 1177-token
+    prefill tail belongs to the 2048-token compile bucket. That bucket exceeds
+    the fixed arena even though the arena safely covers the live tail. Reuse
+    the caller's full capacity so startup warmup and runtime select the same
+    Triton constexprs instead of compiling an exact tail specialization.
+    """
+    max_tokens = 1536
+    tail_tokens = 1177
+    topk = 16
+    block_size = 8
+    num_experts = 896
+    _, max_routes, max_blocks = route_pack_capacity(
+        max_tokens * topk,
+        block_size,
+        num_experts,
+        topk=topk,
+        bucket_tokens=False,
+    )
+    device = torch.device("cuda")
+    packed_routes = torch.empty(max_routes, dtype=torch.int32, device=device)
+    block_experts = torch.empty(max_blocks, dtype=torch.int32, device=device)
+
+    returned_routes, returned_blocks, _ = pack_topk_routes_by_expert(
+        torch.zeros((tail_tokens, topk), dtype=torch.int32, device=device),
+        block_size,
+        num_experts,
+        packed_route_indices=packed_routes,
+        block_expert_ids=block_experts,
+        packed_route_count=torch.empty(1, dtype=torch.int32, device=device),
+        expert_offsets=torch.empty(num_experts + 1, dtype=torch.int32, device=device),
+        expert_counts=torch.empty(num_experts, dtype=torch.int32, device=device),
+    )
+
+    assert returned_routes.data_ptr() == packed_routes.data_ptr()
+    assert returned_blocks.data_ptr() == block_experts.data_ptr()
+    assert returned_routes.numel() == max_routes
+    assert returned_blocks.numel() == max_blocks
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_route_pack_capacity_error_reports_live_contract() -> None:
     topk_ids = torch.zeros((17, 8), dtype=torch.int32, device="cuda")
 


### PR DESCRIPTION
## Bug description

A serving caller can provide one fixed W4A16 route-pack arena sized for its configured maximum token count. For a shorter prefill tail, the power-of-two compile bucket can be larger than that arena even though the arena still covers every live route.

The prior fallback treated that case as if the arena were undersized and selected exact live-tail capacities. Since route capacities and the small-prefix loop bound are Triton constexprs, distinct tails could compile distinct route-pack variants instead of reusing the fixed-arena specialization.

A concrete boundary is:

- fixed capacity: 1536 tokens
- live prefill tail: 1177 tokens
- top-k: 16
- experts: 896
- block size: 8

The fixed arena holds 30,848 route slots and 3,856 route blocks. Before the fix, runtime sliced it to the exact tail's 25,104 slots and 3,138 blocks.

## Root cause

The fallback conflated two different states:

1. the caller arena is smaller than the power-of-two compile bucket but large enough for the live routes;
2. the caller arena is genuinely too small for the live routes.

It also retained the exact live route count as `NUMEL_CAPACITY` after reusing fixed route/block buffers, leaving small-prefix launches specialized per exact tail.

## Fix

- Compute exact live-route requirements when the caller arena is below the compile bucket.
- Reuse the caller's full fixed route/block capacities when they cover the exact requirement.
- Recover the largest live route count represented by that workspace and use it as the stable small-prefix loop bound.
- Preserve exact-capacity fallback and workspace-too-small errors for genuinely undersized buffers.

`_pack_topk_routes_small_prefix_kernel` and `_pack_topk_routes_post_prefix_kernel` already fill unused route slots with `live_numel` and unused route blocks with `-1`. The change preserves route math, ordering, and allocation ownership.

## Verification

- Clean `master` post-prefix RED:
  - expected fixed capacities: `30848 / 3856`
  - returned before fix: `25104 / 3138`
- Small-prefix RED:
  - planned `NUMEL_CAPACITY`: `[24, 24]`
  - observed before fix: `[17, 23]`
- Added CUDA output checks for nonuniform routes, packed count, expert blocks, route payload grouping, and both sentinel regions.
- Source-matched GPU suite: `77 passed` (`tests/moe/test_w4a16_route_pack.py`).
- `ruff check` and `git diff --check`: passed.

The first focused commit (`60269a7`) preserves the initially qualified post-prefix source. The follow-up (`8c6f5a3`) adds the stable small-prefix bound and strengthened regression coverage without rewriting that provenance.

## Risk assessment

Low. The changed selection applies only when both caller-provided workspace buffers cover the exact live requirement but are smaller than the compile bucket. Dynamic allocation and genuinely undersized-workspace behavior retain their existing paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

MoE W4A16 prefill-tail route packing now derives the live-route capacity supported by caller-provided fixed workspaces. When the workspaces cover all live routes, the implementation reuses their full capacities even below the power-of-two compile bucket and uses the derived capacity for small-prefix kernel bounds. This preserves reuse of the startup-warmed Triton specialization.

When the workspaces are insufficient, the existing exact-capacity fallback and undersized-workspace error behavior remain unchanged. No public declarations changed.

Regression tests cover fixed-arena reuse across tail lengths and route, block, count, grouping, payload, and sentinel behavior at the 1,536-capacity and 1,177-token boundary. The focused GPU suite passed 76 tests. `ruff check` and `git diff --check` also passed. Production qualification reported no inference-time JIT warnings or CUDA-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->