### PR TITLE
[II] Ignore inactive MoE routes in tiny decode

### DIFF
--- a/b12x/moe/_shared/kernels/tiny_decode.py
+++ b/b12x/moe/_shared/kernels/tiny_decode.py
@@ -231,7 +231,14 @@ class MoETinyDecodeKernelBackend:
             rem = bidx % fc1_per_rt
             nt = rem // Int32(c["fc1_ktg"])
             ktg = rem % Int32(c["fc1_ktg"])
-            eid = Int64(Int32(topk_ids[rt_idx]))
+            route_eid = Int32(topk_ids[rt_idx])
+            route_active = route_eid >= Int32(0) and route_eid < Int32(c["weight_E"])
+            # vLLM represents CUDA-graph padding and non-local EP routes with
+            # an expert id outside [0, weight_E). Keep every address in range;
+            # inactive routes retain the pre-zeroed intermediate and output.
+            eid = Int64(0)
+            if route_active:
+                eid = Int64(route_eid)
             tok = rt_idx // Int32(c["num_topk"])
             we_base = w13_base + eid * Int64(c["w13_words"] * 4)
             se_base = sfb13_base + eid * Int64(c["sfb13_bytes"])
@@ -292,7 +299,7 @@ class MoETinyDecodeKernelBackend:
             acc1 = warp_reduce(acc1, lambda a, b: a + b, width=4)
             acc2 = warp_reduce(acc2, lambda a, b: a + b, width=4)
             acc3 = warp_reduce(acc3, lambda a, b: a + b, width=4)
-            if cgrp == Int32(0):
+            if route_active and cgrp == Int32(0):
                 ibase_rt = inter_base + Int64(rt_idx) * Int64(c["two_n"] * 4)
                 accs = (acc0, acc1, acc2, acc3)
                 for v in cutlass.range_constexpr(4):
@@ -326,7 +333,11 @@ class MoETinyDecodeKernelBackend:
             rem = bidx % fc2_per_rt
             nt = rem // Int32(c["fc2_ktg"])
             ktg = rem % Int32(c["fc2_ktg"])
-            eid = Int64(Int32(topk_ids[rt_idx]))
+            route_eid = Int32(topk_ids[rt_idx])
+            route_active = route_eid >= Int32(0) and route_eid < Int32(c["weight_E"])
+            eid = Int64(0)
+            if route_active:
+                eid = Int64(route_eid)
             tok = rt_idx // Int32(c["num_topk"])
             rw = Float32(topk_weights[rt_idx])
             we_base = w2_base + eid * Int64(c["w2_words"] * 4)
@@ -433,7 +444,7 @@ class MoETinyDecodeKernelBackend:
             o1 = cute.arch.shuffle_sync_bfly(acc1, offset=4)
             o2 = cute.arch.shuffle_sync_bfly(acc2, offset=4)
             o3 = cute.arch.shuffle_sync_bfly(acc3, offset=4)
-            if cgrp == Int32(0):
+            if route_active and cgrp == Int32(0):
                 if (r8 % Int32(2)) == Int32(0):
                     ob = out_base + Int64(tok) * Int64(c["k"] * 2)
                     accs = (acc0, acc1, acc2, acc3)

--- a/tests/moe/test_cute_migration_moe_standard_corpus.py
+++ b/tests/moe/test_cute_migration_moe_standard_corpus.py
@@ -135,12 +135,8 @@ def _make_mxfp4_weights(device: torch.device, *, seed: int) -> _Weights:
     )
     # E8M0 byte 122 is exactly 2^-5.  These are checkpoint-native logical
     # K/32 grids; production preparation repacks them for tiny decode.
-    w1_scale = torch.full(
-        (_E, 2 * _N, _K // 32), 122, dtype=torch.uint8, device=device
-    )
-    w2_scale = torch.full(
-        (_E, _K, _N // 32), 122, dtype=torch.uint8, device=device
-    )
+    w1_scale = torch.full((_E, 2 * _N, _K // 32), 122, dtype=torch.uint8, device=device)
+    w2_scale = torch.full((_E, _K, _N // 32), 122, dtype=torch.uint8, device=device)
     alpha = torch.ones(_E, dtype=torch.float32, device=device)
     unit = torch.ones(_E, dtype=torch.float32, device=device)
     return _Weights(
@@ -232,6 +228,13 @@ def _nvfp4_oracle(
 def _mxfp4_oracle(weights: _Weights, inputs: _Inputs) -> torch.Tensor:
     # No prepared/repacked tensor participates in this oracle.  It consumes the
     # checkpoint-native FP4 + E8M0 grids and emulates MXFP8 activation rounding.
+    active = (inputs.topk_ids >= 0) & (inputs.topk_ids < _E)
+    oracle_ids = torch.where(
+        active, inputs.topk_ids, torch.zeros_like(inputs.topk_ids)
+    ).contiguous()
+    oracle_weights = torch.where(
+        active, inputs.topk_weights, torch.zeros_like(inputs.topk_weights)
+    ).contiguous()
     return moe_reference_w4a8_mx(
         inputs.a.float(),
         weights.w1_fp4,
@@ -242,8 +245,8 @@ def _mxfp4_oracle(weights: _Weights, inputs: _Inputs) -> torch.Tensor:
         weights.w2_scale,
         None,
         weights.w2_alpha,
-        inputs.topk_ids,
-        inputs.topk_weights,
+        oracle_ids,
+        oracle_weights,
         _E,
         _K,
         _N,
@@ -576,6 +579,40 @@ def test_standard_moe_tiny_decode_live_graph_oracle(
         initial_reference=initial_reference,
         changed_reference=changed_reference,
         context="standard-moe-tiny-decode-phases-1-2",
+        min_cos=0.998,
+        max_normalized_rmse=0.05,
+    )
+
+
+def test_standard_moe_tiny_decode_inactive_route_live_graph_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ignore scheduler-padding routes during tiny-decode graph replay."""
+
+    device = require_b12x()
+    _reset_dispatch_environment(monkeypatch)
+    weights = _make_mxfp4_weights(device, seed=301)
+    initial = _make_inputs(device, m=2, seed=302, route_shift=0)
+    changed = _make_inputs(device, m=2, seed=303, route_shift=2)
+    changed.topk_ids[1, 1] = -1
+
+    initial_reference = _mxfp4_oracle(weights, initial)
+    changed_reference = _mxfp4_oracle(weights, changed)
+    case = _prepare_and_bind(
+        weights,
+        initial,
+        quant_mode="w4a8_mx",
+        source_format="fp4_e8m0_k32",
+    )
+    assert case.scratch_plan.launch_plan.implementation == "micro"
+    assert case.binding.implementation == "micro"
+    _run_live_graph_check(
+        case,
+        initial=initial,
+        changed=changed,
+        initial_reference=initial_reference,
+        changed_reference=changed_reference,
+        context="standard-moe-tiny-decode-inactive-route",
         min_cos=0.998,
         max_normalized_rmse=0.05,
     )


### PR DESCRIPTION
## Resulting behavior

The B12X W4A8 tiny-decode MoE kernel treats every route whose expert ID is outside `[0, weight_E)` as inactive. Inactive routes use an in-range address for speculative reads and contribute zero to the intermediate and output tensors.

This matches the existing dynamic-MoE contract and vLLM scheduler semantics: CUDA-graph padding and non-local expert-parallel routes may carry expert ID `-1`. The kernel must not dereference that ID even when the corresponding router weight is expected to be zero.

## Technical reason

The tiny-decode FC1 and FC2 kernels previously formed weight addresses directly from `topk_ids`. A padded `-1` route therefore addressed memory before the expert allocation. Native KV offloading changes the allocation layout enough to make the invalid read reproducible during PIECEWISE CUDA-graph memory profiling, but neither the offload transport nor its filesystem tier is causal.

The implementation now:

- validates the route ID before forming expert weight addresses;
- substitutes expert zero only as a safe read address for inactive routes;
- suppresses FC1 intermediate writes and FC2 output accumulation for inactive routes;
- preserves the launch geometry and arithmetic of every valid route.

## Validation

- `ruff check` and `ruff format --check`: pass.
- `git diff --check`: pass.
- `tests/moe/test_cute_migration_moe_standard_corpus.py`: 5 passed on SM120.
- Added CUDA-graph replay coverage with a nonzero router weight on expert ID `-1`; output is compared with an oracle that explicitly masks inactive routes.
- DeepSeek-V4-Flash-0731, TP2/DCP1, DSpark K5, B12X A8, `MAX_NUM_BATCHED_TOKENS=8192`, native KV offload: all PIECEWISE memory profiles and model/DSpark/context-KV graph captures complete without `CUDA_LAUNCH_BLOCKING`.
- The same server completed an 85,986-token request and a strict required-tool request.
- Filesystem-tier replay read 1.60 GB across 795 block hits with no promotion/cascade failure or residual temporary file.

Configurations whose declared context exceeds the available KV budget now fail at the explicit capacity check rather than inside the tiny-decode kernel. That capacity failure is expected and is not bypassed by this change.

## Compatibility

Valid expert IDs retain the existing code path and launch policy. The only semantic change is for IDs that are outside the local expert range, which are defined as inactive.
