### PR TITLE
[II] Align W4A16 CUDA graph tests with buffer contracts

### DIFF
--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -146,6 +146,7 @@ def test_w4a16_small_m_direct_barrier_modes_eager_and_graph(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
         quant_mode="w4a16",
+        output=torch.empty_like(x),
     )
     expected = _reference_w4a16(
         x,
@@ -328,7 +329,10 @@ def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
         n=2048,
         activation="silu",
         trellis_bits=3,
+        trellis_codebook="mcg",
+        trellis_pair_kinds=None,
         trellis_tile_config=None,
+        coupled_hadamard=False,
     )
     fused_calls: list[dict[str, object]] = []
     resolved_fused = object()
@@ -736,6 +740,7 @@ def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
             block_expert_ids=buffers.block_expert_ids,
             packed_route_count=buffers.packed_route_count,
             expert_offsets=buffers.expert_offsets,
+            expert_counts=buffers.expert_counts,
             swiglu_limit=10.0 if activation == "silu" else None,
         )
 
@@ -3018,6 +3023,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
         block_expert_ids=buffers.block_expert_ids,
         packed_route_count=buffers.packed_route_count,
         expert_offsets=buffers.expert_offsets,
+        expert_counts=buffers.expert_counts,
         swiglu_limit=swiglu_limit,
     )
     torch.cuda.synchronize()
@@ -3042,6 +3048,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
             block_expert_ids=buffers.block_expert_ids,
             packed_route_count=buffers.packed_route_count,
             expert_offsets=buffers.expert_offsets,
+            expert_counts=buffers.expert_counts,
             swiglu_limit=swiglu_limit,
         )
     graph.replay()
@@ -3129,6 +3136,7 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
             block_expert_ids=buffers.block_expert_ids,
             packed_route_count=buffers.packed_route_count,
             expert_offsets=buffers.expert_offsets,
+            expert_counts=buffers.expert_counts,
             fused_launch=fused_launch,
             topk_sum_launch=topk_sum_launch,
         )


### PR DESCRIPTION
## Behavior

W4A16 CUDA graph tests provide caller-owned output and route-histogram storage, and the Trellis prewarm fixture declares every plan field read by launch compilation.

## Technical reason

Graph capture must not allocate output or route histogram tensors. The runtime binding already owns these buffers through `TPW4A16Workspace`; direct kernel tests must pass the equivalent `output` and `expert_counts` tensors explicitly. The prewarm fixture must also expose `trellis_codebook`, `trellis_pair_kinds`, and `coupled_hadamard`, which are part of the compile key.

## Compatibility

This PR changes tests only. Runtime dispatch, arithmetic, workspace sizing, and public APIs are unchanged.

## Validation

- Small-M barrier modes: 2 passed on SM120.
- FP4 E8M0 oracle parity: 2 passed on SM120.
- SwiGLU limit graph replay: 1 passed on SM120.
- Preplanned-capacity graph replay: 1 passed on SM120.
- Trellis prewarm compile-key fixture: 1 passed.
- `ruff check tests/moe/test_w4a16_e2e.py`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

W4A16 CUDA graph tests now provide caller-owned `output` and `expert_counts` buffers during graph capture. This keeps graph execution allocation-free and matches the runtime buffer contract.

The Trellis prewarm fixture now declares `trellis_codebook`, `trellis_pair_kinds`, and `coupled_hadamard` as compile-key fields. Runtime dispatch, arithmetic, workspace sizing, and public APIs are unchanged.

Validation passed for the listed SM120 graph tests, Trellis prewarm coverage, and Ruff checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->