### PR TITLE
[II] Fix mapped W4A16 route namespace planning

### DIFF
--- a/b12x/moe/fused_moe/_impl.py
+++ b/b12x/moe/fused_moe/_impl.py
@@ -2591,7 +2591,9 @@ def _plan_core_workspace(
         )
         requested_route_E = int(route_num_experts or weight_E)
         full_rotation = weight_layout == "trellis_t256"
-        route_E = requested_route_E if full_rotation else int(weight_E)
+        # Route metadata must address every physical weight and every global
+        # router ID accepted through route_expert_map.
+        route_E = max(int(weight_E), requested_route_E)
         if full_rotation:
             if source_format not in _TRELLIS_SOURCE_FORMATS:
                 raise ValueError(

--- a/tests/moe/test_fused_moe_planning.py
+++ b/tests/moe/test_fused_moe_planning.py
@@ -99,6 +99,27 @@ def _subset_router_caps() -> fused_moe.Caps:
     )
 
 
+def _mapped_packed_caps() -> fused_moe.Caps:
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
+        source_format="compressed_tensors",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=8,
+        hidden_size=128,
+        intermediate_size=128,
+        w13_layout="w13",
+    )
+    return fused_moe.Caps(
+        max_tokens=8,
+        num_topk=2,
+        route_num_experts=12,
+        device="cpu",
+        weight_plan=weight_plan,
+        quant_mode="w4a16",
+    )
+
+
 def test_required_nbytes_avoids_launch_prewarm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -157,6 +178,20 @@ def test_non_trellis_core_sizes_routes_for_weight_experts(
     assert specs["packed_route_indices"].shape == (512,)
     assert specs["block_expert_ids"].shape == (64,)
     assert specs["expert_offsets"].shape == (161,)
+
+
+def test_mapped_packed_plan_covers_global_route_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
+
+    plan = fused_moe.plan(_mapped_packed_caps())
+    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+
+    assert plan._core_workspace_plan.weight_E == 8
+    assert plan._core_workspace_plan.route_E == 12
+    assert specs["expert_offsets"].shape == (13,)
+    assert specs["expert_counts"].shape == (12,)
 
 
 def test_unpinned_small_capacity_matches_reachable_block_8(


### PR DESCRIPTION
## Behavior

W4A16 scratch planning sizes route metadata for both physical expert weights and the declared global router namespace. Packed projection tiers can therefore bind a contiguous `route_expert_map` whose length exceeds the number of locally stored expert weights.

## Technical reason

`route_expert_map` is indexed by global router IDs, while W4A16 kernels index physical weights after mapping. The route workspace must cover `max(weight_E, route_num_experts)`. Sizing packed plans only from `weight_E` rejects valid maps before execution; sizing only from `route_num_experts` can under-size plans whose declaration is narrower than their weight set.

## Compatibility

Plans without an expert map and plans with equal expert counts retain the same route dimensions. A wider declared namespace reserves the route metadata and launch geometry required by that map. For the GLM-5.2 shape (`H=6144`, `I=2048`, top-k 8), the measured scratch delta through 32 tokens is 0.001-0.021 MiB. At a 128-token capacity, route-block selection reduced scratch by 46.942 MiB for 32 local experts and 23.452 MiB for 64 local experts.

## Validation

- `tests/moe/test_fused_moe_planning.py`: 20 passed.
- `test_w4a16_scratch_plan_mapped_decode_is_graph_safe`: eager parity and CUDA graph replay passed on SM120.
- `ruff check b12x/moe/fused_moe/_impl.py tests/moe/test_fused_moe_planning.py`: passed.