### PR TITLE
feat(attention): add KVarN packed-latent staging and native reader

### DIFF
--- a/b12x/__init__.py
+++ b/b12x/__init__.py
@@ -43,6 +43,7 @@ _OPS: tuple[str, ...] = (
     "attention.dense_mla",
     "attention.sparse_mla",
     "attention.compressed_mla",
+    "attention.kvarn_mla",
     "attention.nsa_indexer",
     "attention.varlen",
     "comm.pcie",

--- a/b12x/attention/__init__.py
+++ b/b12x/attention/__init__.py
@@ -6,8 +6,9 @@
   optional causal sliding-window masking.
 - ``sparse_mla``: top-k-selected MLA, including strided physical records.
 - ``compressed_mla``: MLA decode directly from compressed KV pages (DSV4).
+- ``kvarn_mla``: KVarN packed-latent (K2/K4/K5 G64) staging and native
+  sparse-MLA decode without a global row stage.
 - ``nsa_indexer``: the NSA index stage — quantize -> score -> select.
-- ``varlen``: contiguous batched/varlen attention (reduced-assurance tier).
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ _OP_MODULES = (
     "dense_mla",
     "sparse_mla",
     "compressed_mla",
+    "kvarn_mla",
     "nsa_indexer",
     "varlen",
 )

--- a/b12x/attention/_shared/mla/decode_math.py
+++ b/b12x/attention/_shared/mla/decode_math.py
@@ -989,6 +989,27 @@ def s1_qk_nope_nvfp4_bf16(
 
 
 @cute.jit
+def s1_qk_nope_kvarn_bf16(
+    qk, q_base: Int32, kv_base: Int32, warp_first_cand: Int32, lane: Int32,
+    *, num_scales: cutlass.Constexpr, quant_tile: cutlass.Constexpr,
+    q_nope_bf16_stride: cutlass.Constexpr, kv_smem_stride: cutlass.Constexpr,
+):
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    row = kv_base + (warp_first_cand + gid) * Int32(kv_smem_stride)
+    for blk in cutlass.range_constexpr(num_scales):
+        for ks in cutlass.range_constexpr(quant_tile // 16):
+            ko = Int32(blk * quant_tile + ks * 16)
+            bc = ko + tid * Int32(2)
+            b0 = _ld_u16_zext(row, bc * Int32(2)) | (_ld_u16_zext(row, (bc + Int32(1)) * Int32(2)) << Uint32(16))
+            bc1 = bc + Int32(8)
+            b1 = _ld_u16_zext(row, bc1 * Int32(2)) | (_ld_u16_zext(row, (bc1 + Int32(1)) * Int32(2)) << Uint32(16))
+            ab = a_row * Int32(q_nope_bf16_stride * 2) + (ko + a_col) * Int32(2)
+            a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(_smem_byte(q_base, ab))
+            qk[0], qk[1], qk[2], qk[3] = mma_m16n8k16_f32_bf16(qk[0], qk[1], qk[2], qk[3], a0, a1, a2, a3, b0, b1)
+    return qk
 
 @cute.jit
 def s1_qk_nope_block_scaled_glm_h8_swap_ab(
@@ -2407,6 +2428,42 @@ def s6_xv_nope_nvfp4_bf16(
 
 
 @cute.jit
+def s6_xv_nope_kvarn_bf16(
+    acc_nope, sm_p_addr: Int32, kv_base: Int32, warp_id: Int32, lane: Int32,
+    *, n_v_chunks: cutlass.Constexpr, v_chunk: cutlass.Constexpr,
+    bi: cutlass.Constexpr, kv_smem_stride: cutlass.Constexpr,
+    n_warps: cutlass.Constexpr, nt_per_warp_xv: cutlass.Constexpr,
+    sm_p_stride: cutlass.Constexpr,
+):
+    gid = lane >> Int32(2)
+    tid = lane & Int32(3)
+    a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+    a_col = (lane >> Int32(4)) * Int32(8)
+    for vc in cutlass.range_constexpr(n_v_chunks):
+        for nt in cutlass.range_constexpr(nt_per_warp_xv):
+            col = Int32(vc * v_chunk) + (Int32(nt * n_warps) + warp_id) * Int32(8) + gid
+            xv0 = Float32(0.0)
+            xv1 = Float32(0.0)
+            xv2 = Float32(0.0)
+            xv3 = Float32(0.0)
+            for ks in cutlass.range_constexpr(bi // 16):
+                kb = Int32(ks * 16)
+                ab = (a_row * Int32(sm_p_stride) + kb + a_col) * Int32(2)
+                a0, a1, a2, a3 = ldmatrix_m8n8x4_b16(sm_p_addr + ab)
+                e = kb + tid * Int32(2)
+                r0 = kv_base + e * Int32(kv_smem_stride)
+                r1 = r0 + Int32(kv_smem_stride)
+                r8 = r0 + Int32(8 * kv_smem_stride)
+                r9 = r0 + Int32(9 * kv_smem_stride)
+                b0 = _ld_u16_zext(r0, col * Int32(2)) | (_ld_u16_zext(r1, col * Int32(2)) << Uint32(16))
+                b1 = _ld_u16_zext(r8, col * Int32(2)) | (_ld_u16_zext(r9, col * Int32(2)) << Uint32(16))
+                xv0, xv1, xv2, xv3 = mma_m16n8k16_f32_bf16(xv0, xv1, xv2, xv3, a0, a1, a2, a3, b0, b1)
+            at = vc * nt_per_warp_xv + nt
+            acc_nope[at][0] += xv0
+            acc_nope[at][1] += xv1
+            acc_nope[at][2] += xv2
+            acc_nope[at][3] += xv3
+    return acc_nope
 
 @cute.jit
 def s6_xv_nope_glm_h8_swap_ab(

--- a/b12x/attention/_shared/mla/decode_math.py
+++ b/b12x/attention/_shared/mla/decode_math.py
@@ -285,7 +285,186 @@ def _smem_byte(base_addr: Int32, byte_off) -> Int32:
     """Flat smem byte address (base u32 + byte offset); no XOR swizzle."""
     return base_addr + Int32(byte_off)
 
+@cute.jit
+def kvarn_hadamard_bf16_smem(
+    base_addr: Int32,
+    tid: Int32,
+    *,
+    hpb: cutlass.Constexpr,
+    row_stride: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr = 0,
+):
+    """Normalized 512-D Sylvester Hadamard with FP32 register butterflies.
 
+    One warp owns two heads. Each lane holds the sixteen dimensions sharing its
+    low-five-bit coordinate, so stages 0..4 use warp shuffles and stages 5..8
+    exchange registers. BF16 is rounded only at the final store, matching the
+    external Hadacore clone/copy contract much more closely than shared-memory
+    rounding after every stage.
+    """
+    warp = tid >> Int32(5)
+    lane = tid & Int32(31)
+    inv_sqrt512 = Float32(0.04419417382415922)
+    for head_in_warp in cutlass.range_constexpr(2):
+        head = warp * Int32(2) + Int32(head_in_warp)
+        values = [Float32(0.0) for _ in range(16)]
+        row = base_addr + head * Int32(row_stride * 2)
+        for segment in cutlass.range_constexpr(16):
+            dim = lane + Int32(segment * 32)
+            values[segment] = _u32_to_f32(
+                _ld_u16_zext(row, dim * Int32(2)) << Uint32(16)
+            )
+        for stage in cutlass.range_constexpr(5):
+            mask = Int32(1 << stage)
+            for segment in cutlass.range_constexpr(16):
+                value = values[segment]
+                partner = cute.arch.shuffle_sync_bfly(value, offset=(1 << stage))
+                if (lane & mask) == Int32(0):
+                    values[segment] = value + partner
+                else:
+                    values[segment] = partner - value
+        for stage in cutlass.range_constexpr(4):
+            half = 1 << stage
+            span = half * 2
+            for block in cutlass.range_constexpr(16 // span):
+                for offset in cutlass.range_constexpr(half):
+                    lo = block * span + offset
+                    hi = lo + half
+                    a = values[lo]
+                    b = values[hi]
+                    values[lo] = a + b
+                    values[hi] = a - b
+        for segment in cutlass.range_constexpr(16):
+            dim = lane + Int32(segment * 32)
+            st_shared_bf16_from_f32(
+                row + dim * Int32(2), values[segment] * inv_sqrt512
+            )
+    cute.arch.barrier(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
+
+
+@cute.jit
+def kvarn_quantize_hadamard_q_fp8(
+    q_bf16_addr: Int32,
+    q_fp8_addr: Int32,
+    q_sc_addr: Int32,
+    group: Int32,
+    tid_flat: Int32,
+    tid_group: Int32,
+    lane: Int32,
+    *,
+    groups: cutlass.Constexpr,
+    hpb_per_group: cutlass.Constexpr,
+    q_stride: cutlass.Constexpr,
+    num_group_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr,
+):
+    """Quantize grouped BF16 Hadamard rows without overlapping their source."""
+    bar_kw = dict(barrier_id=barrier_id, number_of_threads=barrier_threads)
+    for turn in cutlass.range_constexpr(groups):
+        selected = group == Int32(turn)
+        values = [Float32(0.0) for _ in range(hpb_per_group * 2)]
+        if selected:
+            for h in cutlass.range_constexpr(hpb_per_group):
+                src_head = Int32(turn * hpb_per_group + h)
+                row = q_bf16_addr + src_head * Int32(q_stride * 2)
+                values[h * 2] = _u32_to_f32(
+                    _ld_u16_zext(row, tid_group * Int32(2)) << Uint32(16)
+                )
+                values[h * 2 + 1] = _u32_to_f32(
+                    _ld_u16_zext(row, (tid_group + Int32(256)) * Int32(2))
+                    << Uint32(16)
+                )
+            if tid_group < Int32(hpb_per_group * 4):
+                st_shared_f32(
+                    q_sc_addr
+                    + Int32(turn * hpb_per_group * 4 * 4)
+                    + tid_group * Int32(4),
+                    Float32(0.0),
+                )
+        cute.arch.barrier(**bar_kw)
+
+        if selected:
+            scale_pair = tid_group >> Int32(7)
+            for h in cutlass.range_constexpr(hpb_per_group):
+                m0 = fabs_f32(values[h * 2])
+                m1 = fabs_f32(values[h * 2 + 1])
+                for offset in (16, 8, 4, 2, 1):
+                    m0 = fmax_f32(m0, cute.arch.shuffle_sync_bfly(m0, offset=offset))
+                    m1 = fmax_f32(m1, cute.arch.shuffle_sync_bfly(m1, offset=offset))
+                if lane == Int32(0):
+                    sc_base = q_sc_addr + Int32((turn * hpb_per_group + h) * 4 * 4)
+                    atomic_max_shared_f32(sc_base + scale_pair * Int32(4), m0)
+                    atomic_max_shared_f32(sc_base + (scale_pair + Int32(2)) * Int32(4), m1)
+        cute.arch.barrier(**bar_kw)
+
+        if selected and tid_group < Int32(hpb_per_group * 4):
+            sc_addr = (
+                q_sc_addr
+                + Int32(turn * hpb_per_group * 4 * 4)
+                + tid_group * Int32(4)
+            )
+            raw = fmax_f32(ld_shared_f32(sc_addr), Float32(1e-4)) * Float32(1.0 / _FP8_MAX)
+            rounded, _ = pow2_ceil_ue8m0(raw)
+            st_shared_f32(sc_addr, rounded)
+        cute.arch.barrier(**bar_kw)
+
+        if selected:
+            for h in cutlass.range_constexpr(hpb_per_group):
+                dst_head = Int32(turn * hpb_per_group + h)
+                sc_base = q_sc_addr + dst_head * Int32(4 * 4)
+                sc0 = ld_shared_f32(sc_base + (tid_group >> Int32(7)) * Int32(4))
+                sc1 = ld_shared_f32(
+                    sc_base + ((tid_group >> Int32(7)) + Int32(2)) * Int32(4)
+                )
+                dst = q_fp8_addr + dst_head * Int32(q_stride)
+                st_shared_u8(dst + tid_group, _quant_e4m3_byte(values[h * 2] / sc0))
+                st_shared_u8(
+                    dst + tid_group + Int32(256),
+                    _quant_e4m3_byte(values[h * 2 + 1] / sc1),
+                )
+        cute.arch.barrier(**bar_kw)
+
+
+
+@cute.jit
+def kvarn_hadamard_output_bf16(
+    shared_addr: Int32,
+    out_o: cute.Tensor,
+    tid: Int32,
+    *,
+    hpb: cutlass.Constexpr,
+    num_threads: cutlass.Constexpr,
+    barrier_id: cutlass.Constexpr,
+    barrier_threads: cutlass.Constexpr = 0,
+):
+    """Inverse normalized Hadamard in shared memory, then write final BF16."""
+    kvarn_hadamard_bf16_smem(
+        shared_addr,
+        tid,
+        hpb=hpb,
+        row_stride=512,
+        num_threads=num_threads,
+        barrier_id=barrier_id,
+        barrier_threads=barrier_threads,
+    )
+    i = tid
+    while i < Int32(hpb * 512):
+        head = i // Int32(512)
+        dim = i - head * Int32(512)
+        value = _u32_to_f32(
+            _ld_u16_zext(
+                shared_addr + head * Int32(512 * 2), dim * Int32(2)
+            )
+            << Uint32(16)
+        )
+        out_o[head, dim] = value.to(out_o.element_type)
+        i += Int32(num_threads)
 # =============================================================================
 # S0 -- Q quantization to smem (BF16 -> E4M3 + pow2 UE8M0 scale)
 # Port of fp8_quant.cuh::quantize_q_to_smem. Outputs q_fp8 / q_sc / q_rope.
@@ -623,6 +802,12 @@ def s1_qk_nope_block_scaled(
             latent_scale_per_token=latent_scale_per_token,
             kv_sc_base_addr=kv_sc_base_addr,
         )
+    if cutlass.const_expr(scale_format in (3, 5)):
+        return s1_qk_nope_kvarn_bf16(
+            qk, q_fp8_base_addr, kv_fp8_base_addr, warp_first_cand, lane,
+            num_scales=num_scales, quant_tile=quant_tile,
+            q_nope_bf16_stride=q_nope_stride, kv_smem_stride=kv_smem_stride,
+        )
 
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
@@ -802,6 +987,8 @@ def s1_qk_nope_nvfp4_bf16(
             )
     return qk
 
+
+@cute.jit
 
 @cute.jit
 def s1_qk_nope_block_scaled_glm_h8_swap_ab(
@@ -1431,6 +1618,7 @@ def s4_online_softmax(
     num_threads: cutlass.Constexpr,  # 256
     barrier_id: cutlass.Constexpr,  # math-only named-barrier slot
     n_acc_tiles: cutlass.Constexpr = None,  # len(acc_nope); defaults to n_v_chunks
+    barrier_threads: cutlass.Constexpr = 0,
 ):
     """S4: per-warp + cross-warp max/sum, exp2(qk-max), cross-chunk rescale.
 
@@ -1440,7 +1628,10 @@ def s4_online_softmax(
     probabilities); the caller multiplies by ``warp_rescale`` before storing
     sm_p_full (kills all-invalid-warp spurious 1s). Exactly decode_dsv4
     :456-587."""
-    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
     # alpha "has-prev-max" guard threshold == decode_dsv4 :520 (> -1e29f).
@@ -1761,6 +1952,7 @@ def s6_xv_nope(
     sm_p_full_addr: Int32 = None,  # NVFP4 BF16 PV only
     sm_p_stride: cutlass.Constexpr = 0,  # NVFP4: bf16 elems per sm_p row (0 -> BI)
     latent_scale_per_token: cutlass.Constexpr = False,  # NVFP4_E4M3 only
+    barrier_threads: cutlass.Constexpr = 0,
 ):
     """S6: accumulate W . V_nope into acc_nope[vc*NT+nt][0..3] via PLAIN fp8 MMAs
     (14 DSV4 / 16 GLM = N_V_CHUNKS * NT_PER_WARP_XV * (BI/32)).
@@ -1817,8 +2009,19 @@ def s6_xv_nope(
             latent_scale_per_token=latent_scale_per_token,
             kv_sc_base_addr=kv_sc_base_addr,
         )
+    if cutlass.const_expr(scale_format in (3, 5)):
+        return s6_xv_nope_kvarn_bf16(
+            acc_nope, sm_p_full_addr, kv_fp8_base_addr, warp_id, lane,
+            n_v_chunks=n_v_chunks, v_chunk=v_chunk, bi=bi,
+            kv_smem_stride=kv_smem_stride, n_warps=n_warps,
+            nt_per_warp_xv=nt_per_warp_xv,
+            sm_p_stride=(sm_p_stride if sm_p_stride else bi),
+        )
 
-    bar_kw = dict(barrier_id=barrier_id, number_of_threads=num_threads)
+    bar_kw = dict(
+        barrier_id=barrier_id,
+        number_of_threads=(barrier_threads if barrier_threads else num_threads),
+    )
     gid = lane >> Int32(2)
     tid = lane & Int32(3)
     warp_first_cand = warp_id * Int32(8)
@@ -2202,6 +2405,8 @@ def s6_xv_nope_nvfp4_bf16(
             acc_nope[at][3] = acc_nope[at][3] + xv3
     return acc_nope
 
+
+@cute.jit
 
 @cute.jit
 def s6_xv_nope_glm_h8_swap_ab(
@@ -2744,6 +2949,7 @@ def s7_epilogue(
     num_threads: cutlass.Constexpr = 0,
     barrier_id: cutlass.Constexpr = 0,
     coalesced_output: cutlass.Constexpr = False,
+    natural_lse: cutlass.Constexpr = False,
 ):
     """S7: normalized O + base-2 LSE epilogue. ``epilogue_mode`` (const_expr)
     selects the destination + normalizer convention; the (gid, d0) output-write
@@ -2936,6 +3142,9 @@ def s7_epilogue(
                     )
                 else:
                     lse1 = sink1
+        if cutlass.const_expr(natural_lse):
+            lse0 = lse0 * Float32(1.0 / LOG2_E)
+            lse1 = lse1 * Float32(1.0 / LOG2_E)
         out_lse[gid] = lse0
         if cutlass.const_expr(valid_hpb > 8):
             out_lse[gid + Int32(8)] = lse1

--- a/b12x/attention/_shared/mla/kernel.py
+++ b/b12x/attention/_shared/mla/kernel.py
@@ -38,6 +38,9 @@ from .decode_math import (
     s0_load_q_bf16_to_smem,
     s0_quantize_q_to_smem,
     s1_qk_nope_block_scaled,
+    kvarn_hadamard_bf16_smem,
+    kvarn_hadamard_output_bf16,
+    kvarn_quantize_hadamard_q_fp8,
     s1_qk_nope_block_scaled_dsv4_h8_swap_ab,
     s1_qk_nope_block_scaled_glm_h8_swap_ab,
     s2_qk_rope_bf16,
@@ -55,6 +58,7 @@ from .decode_math import (
     s7_epilogue,
 )
 from .io import io_issue_gather
+from ...kvarn_mla.io import io_issue_kvarn_k5_gather
 from .smem import get_unified_shared_storage_cls, make_smem_layout
 from .traits import (
     ModelType,
@@ -124,15 +128,62 @@ _MLA_SM120_GLM_H8_NATIVE_ENV = "B12X_MLA_SM120_GLM_H8_NATIVE"
 # Opt-in while being validated: unset/0 -> off; 1/true/on/yes -> on.
 _MLA_SM120_DSV4_H16_NATIVE_ENV = "B12X_MLA_SM120_DSV4_H16_NATIVE"
 
+# Native KVarN exact-pool producer vectorization. Default-off after the bounded
+# C1 exact-graph trace regressed; read per call so isolated runs can A/B the
+# producer without changing graph classification, exact-pool ownership, or the
+# mixed K5 specialization.
+_MLA_SM120_KVARN_EXACT_FAST_IO_ENV = (
+    "B12X_MLA_SM120_KVARN_EXACT_FAST_IO"
+)
+
 # FlashInfer's decode-dsv4 chunks_per_block wave-balance cap
 # (csrc/sparse_mla_sm120_decode_dsv4.cu:85). cpb candidates whose last-wave tail
 # gap looks small but require more than this many integer waves are rejected.
 _CEIL_WAVES_MAX = 3
 
+# Packed-latent tile geometry per KVarN width (G64/512/64 latent+RoPE layout):
+# (cache_block_stride, s_col_offset, zp_offset, s_row_offset, rope_offset).
+# Rows mirror KVarNMLAConfig.latent_* offsets; 2-bit is the K2V2-style shared
+# latent (18,560 B tile). Offsets are all mod-16 aligned.
+_KVARN_PACKED_TILE_GEOMETRY: dict[int, tuple[int, int, int, int, int]] = {
+    2: (18_560, 8_192, 9_216, 10_240, 10_368),
+    4: (26_752, 16_384, 17_408, 18_432, 18_560),
+    5: (30_848, 20_480, 21_504, 22_528, 22_656),
+}
+
 # Observability: the most recent decode split plan (read by benchmarks / the
 # P9c AutoTuner sweep to report num_splits_used). Pure side-channel -- does NOT
 # affect numerics or the launch. Keys are informational.
 LAST_DECODE_PLAN: dict = {}
+LAST_KVARN_DECODE_PLAN: dict = {}
+
+
+def native_kvarn_ckv_materialize_records(
+    gathered_wire: torch.Tensor,
+    rank_page_starts: torch.Tensor,
+    rank_page_lens: torch.Tensor,
+    rank_token_starts: torch.Tensor,
+    rank_token_lens: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    padded_tokens: int,
+    padded_pages: int,
+    padded_exact_pages: int,
+) -> None:
+    """Read compact K4/exact wire into canonical rows for unchanged extend."""
+    from ...kvarn_mla.api import materialize_compact_kvarn_native_records
+
+    materialize_compact_kvarn_native_records(
+        gathered_wire,
+        rank_page_starts,
+        rank_page_lens,
+        rank_token_starts,
+        rank_token_lens,
+        output,
+        padded_tokens=padded_tokens,
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+    )
 
 
 def _env_num_splits_override() -> int:
@@ -166,6 +217,11 @@ def _env_dsv4_h16_native_mode() -> bool | None:
     if text in {"0", "false", "off", "no"}:
         return False
     return None
+
+
+def _env_kvarn_exact_fast_io_enabled() -> bool:
+    raw = os.environ.get(_MLA_SM120_KVARN_EXACT_FAST_IO_ENV)
+    return raw is not None and raw.strip().lower() in {"1", "true", "on", "yes"}
 
 
 # Auto H8/H16 policy constants (measured on RTX PRO 6000 Blackwell, 188 SMs).
@@ -393,6 +449,11 @@ class UnifiedDecodeKernel:
         native_glm_h8=False,
         native_dsv4_h8=False,
         native_dsv4_h16=False,
+        native_kvarn=False,
+        native_kvarn_bits=5,
+        native_kvarn_exact_pool=False,
+        fuse_kvarn_hadamard=False,
+        kvarn_exact_fast_io=False,
     ):
         self.traits = traits
         self.layout = layout
@@ -433,6 +494,37 @@ class UnifiedDecodeKernel:
         # Native H16: two independent 8-head H8 groups (4 math warps each)
         # sharing the CTA's packed KV stage. Grid keeps HPB=16 head blocks.
         self.native_dsv4_h16 = bool(native_dsv4_h16)
+        self.native_kvarn = bool(native_kvarn)
+        self.native_kvarn_bits = int(native_kvarn_bits)
+        if self.native_kvarn and self.native_kvarn_bits not in (2, 4, 5):
+            raise ValueError(
+                "native KVarN decode requires two/four/five-bit packed rows"
+            )
+        self.native_kvarn_exact_pool = bool(native_kvarn_exact_pool)
+        if self.native_kvarn_exact_pool and not self.native_kvarn:
+            raise ValueError("exact-pool mode requires native KVarN decode")
+        self.fuse_kvarn_hadamard = bool(fuse_kvarn_hadamard)
+        if self.fuse_kvarn_hadamard and not self.native_kvarn:
+            raise ValueError("fuse_kvarn_hadamard requires native KVarN decode")
+        # Exact E4M3 H32 reuses one gathered BI64 tile across two independent
+        # 16-head FP8 math groups. The prototype exact H16 trait keeps one
+        # 16-head BF16 group; mixed K5 retains the same geometry without exact
+        # ownership semantics.
+        self.native_kvarn_exact_h32 = bool(
+            self.native_kvarn_exact_pool
+            and traits.scale_format == ScaleFormat.KVARN_EXACT
+        )
+        self.native_kvarn_exact_h16 = bool(
+            self.native_kvarn_exact_pool
+            and traits.scale_format == ScaleFormat.KVARN_EXACT_BF16
+        )
+        if self.native_kvarn_exact_pool and not (
+            self.native_kvarn_exact_h32 or self.native_kvarn_exact_h16
+        ):
+            raise ValueError("exact-pool mode requires an exact KVarN trait")
+        self.kvarn_exact_fast_io = bool(
+            kvarn_exact_fast_io and self.native_kvarn_exact_h32
+        )
         self.native_h8 = self.native_glm_h8 or self.native_dsv4_h8
         if self.native_dsv4_h8 or self.native_dsv4_h16:
             packed_span = int(layout.kv_bufs) * int(
@@ -463,7 +555,10 @@ class UnifiedDecodeKernel:
         # head_base computation is byte-identical to the pre-P10 kernel.
         self.head_block_offset = int(head_block_offset)
         self.math_threads = int(traits.math_threads)
-        self.block_threads = 320 if self.native_dsv4_h16 else int(traits.block_threads)
+        if self.native_kvarn and not self.native_kvarn_exact_h32:
+            self.block_threads = 512
+        else:
+            self.block_threads = int(traits.block_threads)
         self.io_threads = self.block_threads - self.math_threads
 
     @cute.jit
@@ -590,6 +685,25 @@ class UnifiedDecodeKernel:
             min_blocks_per_mp=1,
             stream=stream,
         )
+
+    @cute.jit
+    def call_kvarn(
+        self, q_all: cute.Tensor, kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor, mid_out: cute.Tensor, mid_lse: cute.Tensor,
+        sm_scale_log2: Float32, topk_length: cute.Tensor,
+        stride_kv_block: Int64, block_to_pool_slot: cute.Tensor,
+        latent_pool: cute.Tensor, rope_pool: cute.Tensor,
+        num_tokens: Int32, stream: cuda.CUstream,
+    ):
+        self.kernel_kvarn(
+            q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
+            sm_scale_log2, topk_length, stride_kv_block,
+            block_to_pool_slot, latent_pool, rope_pool,
+        ).launch(
+            grid=(num_tokens, self.h_blocks, self.num_splits),
+            block=[self.block_threads, 1, 1], min_blocks_per_mp=1, stream=stream,
+        )
+
 
     @cute.jit
     def call_extra_pertok(
@@ -1278,8 +1392,26 @@ class UnifiedDecodeKernel:
             )
 
     @cute.kernel
+    def kernel_kvarn(
+        self, q_all: cute.Tensor, kv_cache_u8: cute.Tensor,
+        swa_indices: cute.Tensor, mid_out: cute.Tensor, mid_lse: cute.Tensor,
+        sm_scale_log2: Float32, topk_length: cute.Tensor,
+        stride_kv_block: Int64, block_to_pool_slot: cute.Tensor,
+        latent_pool: cute.Tensor, rope_pool: cute.Tensor,
+    ):
+        self._kernel_body(
+            q_all, kv_cache_u8, swa_indices, mid_out, mid_lse,
+            sm_scale_log2, Float32(1.0), Int32(0), stride_kv_block,
+            kv_cache_u8, swa_indices, Int32(0), Int32(0), stride_kv_block,
+            topk_length, swa_indices, block_to_pool_slot, latent_pool, rope_pool,
+            has_extra=False, per_token_len=True,
+        )
+
+
+    @cute.kernel
     def kernel_extra(
         self,
+
         q_all: cute.Tensor,
         kv_cache_u8: cute.Tensor,
         swa_indices: cute.Tensor,
@@ -1314,6 +1446,7 @@ class UnifiedDecodeKernel:
             stride_extra_kv_block,
             swa_indices,
             extra_indices,  # length tensors unused (per_token_len=False)
+            swa_indices, kv_cache_u8, kv_cache_u8,
             has_extra=True,
             per_token_len=False,
         )
@@ -1354,6 +1487,7 @@ class UnifiedDecodeKernel:
             stride_kv_block,
             topk_length,
             swa_indices,
+            swa_indices, kv_cache_u8, kv_cache_u8,
             has_extra=False,
             per_token_len=True,
         )
@@ -1397,6 +1531,7 @@ class UnifiedDecodeKernel:
             stride_extra_kv_block,
             topk_length,
             extra_topk_length,
+            swa_indices, kv_cache_u8, kv_cache_u8,
             has_extra=True,
             per_token_len=True,
         )
@@ -1420,11 +1555,15 @@ class UnifiedDecodeKernel:
         stride_extra_kv_block: Int64,
         topk_length: cute.Tensor,
         extra_topk_length: cute.Tensor,
+        block_to_pool_slot: cute.Tensor,
+        latent_pool: cute.Tensor,
+        rope_pool: cute.Tensor,
         *,
         has_extra: cutlass.Constexpr,
         per_token_len: cutlass.Constexpr,
     ):
         t = self.traits
+        cand_window = int(t.bi) if self.native_kvarn else _CAND_WINDOW
         L = self.layout
         tid = Int32(cute.arch.thread_idx()[0])
         lane = cute.arch.lane_idx()
@@ -1466,12 +1605,12 @@ class UnifiedDecodeKernel:
         split_first_chunk = split_idx * cps
         split_last_chunk = split_first_chunk + cps
 
-        main_valid_chunks = (section_len + Int32(_CAND_WINDOW - 1)) // Int32(
-            _CAND_WINDOW
+        main_valid_chunks = (section_len + Int32(cand_window - 1)) // Int32(
+            cand_window
         )
         if main_valid_chunks < Int32(0):
             main_valid_chunks = Int32(0)
-        max_main_chunks = Int32((self.topk + _CAND_WINDOW - 1) // _CAND_WINDOW)
+        max_main_chunks = Int32((self.topk + cand_window - 1) // cand_window)
         if main_valid_chunks > max_main_chunks:
             main_valid_chunks = max_main_chunks
         main_chunk_end = split_last_chunk
@@ -1484,13 +1623,13 @@ class UnifiedDecodeKernel:
         extra_first_chunk = split_first_chunk
         extra_chunk_count = Int32(0)
         if cutlass.const_expr(has_extra):
-            extra_valid_chunks = (extra_section_len + Int32(_CAND_WINDOW - 1)) // Int32(
-                _CAND_WINDOW
+            extra_valid_chunks = (extra_section_len + Int32(cand_window - 1)) // Int32(
+                cand_window
             )
             if extra_valid_chunks < Int32(0):
                 extra_valid_chunks = Int32(0)
             max_extra_chunks = Int32(
-                (self.extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
+                (self.extra_topk + cand_window - 1) // cand_window
             )
             if extra_valid_chunks > max_extra_chunks:
                 extra_valid_chunks = max_extra_chunks
@@ -1506,6 +1645,18 @@ class UnifiedDecodeKernel:
 
         active_chunks = main_chunk_count + extra_chunk_count
         if active_chunks == Int32(0):
+            if cutlass.const_expr(self.num_splits == 1):
+                linear = tid
+                while linear < Int32(self.valid_hpb * t.d_v):
+                    empty_head = linear // Int32(t.d_v)
+                    empty_dim = linear - empty_head * Int32(t.d_v)
+                    mid_out[
+                        token_idx,
+                        head_base + empty_head,
+                        split_idx,
+                        empty_dim,
+                    ] = cutlass.BFloat16(0.0)
+                    linear += Int32(self.block_threads)
             if tid < Int32(self.valid_hpb):
                 mid_lse[token_idx, head_base + tid, split_idx] = Float32(-Float32.inf)
             _exit_thread()
@@ -1517,7 +1668,15 @@ class UnifiedDecodeKernel:
         q_fp8_addr = shared_ptr_to_u32(st.q_fp8.data_ptr())
         q_rope_addr = shared_ptr_to_u32(st.q_rope.data_ptr())
         kv_fp8_addr = shared_ptr_to_u32(st.kv_fp8.data_ptr())
-        if cutlass.const_expr(t.has_extra_cache or t.latent_scale_per_token):
+        if cutlass.const_expr(
+            t.has_extra_cache
+            or t.latent_scale_per_token
+            or t.scale_format in (
+                ScaleFormat.KVARN_K5,
+                ScaleFormat.KVARN_EXACT,
+                ScaleFormat.KVARN_EXACT_BF16,
+            )
+        ):
             kv_sc_addr = shared_ptr_to_u32(st.kv_sc.data_ptr())
         else:
             kv_sc_addr = Int32(0)
@@ -1623,6 +1782,11 @@ class UnifiedDecodeKernel:
             warp_sel = warp_id & Int32(3)
             tid_sel = tid - group * Int32(128)
             warp_first_cand = warp_sel * Int32(16)
+        if cutlass.const_expr(self.native_kvarn_exact_h32):
+            group = warp_id >> Int32(3)
+            warp_sel = warp_id & Int32(7)
+            tid_sel = tid - group * Int32(256)
+            warp_first_cand = warp_sel * Int32(8)
 
         # ════════════════════════════════════════════════════════════════════
         # IO WARP (PRODUCER) vs MATH WARPS (CONSUMER).
@@ -1638,6 +1802,8 @@ class UnifiedDecodeKernel:
                     if active_idx >= main_chunk_count:
                         ci = extra_first_chunk + active_idx - main_chunk_count
                 buf = Int32(lc) & Int32(1)
+                if cutlass.const_expr(self.native_kvarn):
+                    buf = Int32(0)
 
                 cute.arch.mbarrier_wait(mbar_base + n_buf + prod_idx, phase=prod_phase)
 
@@ -1670,8 +1836,8 @@ class UnifiedDecodeKernel:
                 if cutlass.const_expr(has_extra):
                     if ci >= num_main_chunks:
                         cis = ci - num_main_chunks
-                        g_start = cis * Int32(_CAND_WINDOW)
-                        g_end = g_start + Int32(_CAND_WINDOW)
+                        g_start = cis * Int32(cand_window)
+                        g_end = g_start + Int32(cand_window)
                         if g_end > extra_section_len:
                             g_end = extra_section_len
                         io_issue_gather(
@@ -1690,8 +1856,8 @@ class UnifiedDecodeKernel:
                             **io_kw,
                         )
                     else:
-                        g_start = ci * Int32(_CAND_WINDOW)
-                        g_end = g_start + Int32(_CAND_WINDOW)
+                        g_start = ci * Int32(cand_window)
+                        g_end = g_start + Int32(cand_window)
                         if g_end > section_len:
                             g_end = section_len
                         io_issue_gather(
@@ -1710,40 +1876,67 @@ class UnifiedDecodeKernel:
                             **io_kw,
                         )
                 else:
-                    g_start = ci * Int32(_CAND_WINDOW)
-                    g_end = g_start + Int32(_CAND_WINDOW)
+                    g_start = ci * Int32(cand_window)
+                    g_end = g_start + Int32(cand_window)
                     if g_end > section_len:
                         g_end = section_len
-                    io_issue_gather(
-                        kv_cache_u8,
-                        topk_row,
-                        kv_fp8_addr + buf * kv_fp8_buf,
-                        kv_rope_addr + buf * kv_rope_buf,
-                        kv_sc_addr + buf * kv_sc_buf,
-                        tok_buf_view,
-                        mbar_base + buf,
-                        g_start,
-                        g_end,
-                        Int32(self.page_block_size),
-                        stride_kv_block,
-                        io_lane,
-                        **io_kw,
-                    )
+                    if cutlass.const_expr(self.native_kvarn):
+                        (
+                            cache_block_stride,
+                            s_col_off,
+                            zp_off,
+                            s_row_off,
+                            rope_off,
+                        ) = _KVARN_PACKED_TILE_GEOMETRY[
+                            self.native_kvarn_bits
+                        ]
+                        io_issue_kvarn_k5_gather(
+                            kv_cache_u8, topk_row, block_to_pool_slot,
+                            latent_pool, rope_pool,
+                            kv_fp8_addr + buf * kv_fp8_buf,
+                            kv_sc_addr + buf * kv_sc_buf,
+                            kv_rope_addr + buf * kv_rope_buf,
+                            tok_buf_view, mbar_base + buf, g_start, g_end, io_lane,
+                            Int32(block_to_pool_slot.shape[0]),
+                            Int32(latent_pool.shape[0]),
+                            cache_block_stride=cache_block_stride,
+                            packed_bits=self.native_kvarn_bits,
+                            s_col_offset=s_col_off,
+                            zp_offset=zp_off,
+                            s_row_offset=s_row_off,
+                            rope_offset=rope_off,
+                            kv_smem_stride=staged_kv_stride,
+                            rope_smem_stride=t.d_rope,
+                            io_threads=self.io_threads,
+                            exact_fp8=(t.scale_format == ScaleFormat.KVARN_EXACT),
+                            exact_pool_only=self.native_kvarn_exact_pool,
+                            exact_fast_io=self.kvarn_exact_fast_io,
+                        )
+                    else:
+                        io_issue_gather(
+                            kv_cache_u8, topk_row,
+                            kv_fp8_addr + buf * kv_fp8_buf,
+                            kv_rope_addr + buf * kv_rope_buf,
+                            kv_sc_addr + buf * kv_sc_buf,
+                            tok_buf_view, mbar_base + buf, g_start, g_end,
+                            Int32(self.page_block_size), stride_kv_block, io_lane,
+                            **io_kw,
+                        )
                 prod_idx += Int32(1)
                 if prod_idx == Int32(n_buf):
                     prod_idx = Int32(0)
                     prod_phase ^= Int32(1)
 
         else:
-            # MATH WARPS (CONSUMER, warps 0-7 = 256 threads).
+            # MATH WARPS (CONSUMER): normally 8; exact H32 uses 16 as two
+            # independent 8-warp H16 groups over one shared gathered KV tile.
             n_acc_tiles = int(t.n_v_chunks) * int(t.nt_per_warp_xv)
 
-            # ── Native H16 per-group staging bases. Identity aliases when the
-            #    two-group mode is off (const_expr; zero IR change). Each group
-            #    strides its cooperative loops by nt_stage=128 threads while
-            #    every named barrier spans the full bt_stage=256-thread math
-            #    domain (barrier_threads override), so the groups share one
-            #    barrier schedule but touch disjoint staging halves. ──
+            # Per-group staging bases. Identity aliases when grouping is off.
+            # DSV4 H16 runs two 128-thread H8 groups; KVarN exact H32 runs two
+            # 256-thread H16 groups. Cooperative loop strides remain local to
+            # a group while named barriers span the full math domain, keeping
+            # both groups in lockstep before the producer can reuse the tile.
             q_fp8_stage = q_fp8_addr
             q_rope_stage = q_rope_addr
             q_sc_stage_view = q_sc_view
@@ -1754,8 +1947,29 @@ class UnifiedDecodeKernel:
             sm_p_stage = sm_p_full_addr
             w_head_sc_stage_view = w_head_sc_view
             head_base_stage = head_base
-            nt_stage = 128 if self.native_dsv4_h16 else self.math_threads
-            bt_stage = self.math_threads if self.native_dsv4_h16 else 0
+            stage_hpb = (
+                8
+                if (self.native_h8 or self.native_dsv4_h16)
+                else (16 if self.native_kvarn_exact_h32 else t.hpb)
+            )
+            valid_hpb_stage = (
+                8
+                if self.native_dsv4_h16
+                else (16 if self.native_kvarn_exact_h32 else self.valid_hpb)
+            )
+            nt_stage = (
+                128
+                if self.native_dsv4_h16
+                else (256 if self.native_kvarn_exact_h32 else self.math_threads)
+            )
+            bt_stage = (
+                self.math_threads
+                if (self.native_dsv4_h16 or self.native_kvarn_exact_h32)
+                else 0
+            )
+            n_warps_stage = (
+                8 if self.native_kvarn_exact_h32 else (self.math_threads // 32)
+            )
             if cutlass.const_expr(self.native_dsv4_h16):
                 head_base_stage = head_base + group * Int32(8)
                 q_fp8_stage = q_fp8_addr + group * Int32(8 * t.q_nope_stride)
@@ -1780,18 +1994,47 @@ class UnifiedDecodeKernel:
                     + group * Int32((L.w_head_sc2_off - L.w_head_sc_off) // 4),
                     cute.make_layout(int(L.w_head_sc_bytes // 4)),
                 )
+            if cutlass.const_expr(self.native_kvarn_exact_h32):
+                head_base_stage = head_base + group * Int32(16)
+                q_fp8_stage = q_fp8_addr + group * Int32(
+                    16 * t.q_nope_stride * (2 if self.fuse_kvarn_hadamard else 1)
+                )
+                q_rope_stage = q_rope_addr + group * Int32(16 * L.q_rope_stride * 2)
+                q_sc_stage_view = cute.make_tensor(
+                    q_sc_view.iterator + group * Int32(16 * t.num_scales),
+                    cute.make_layout(int(16 * t.num_scales)),
+                )
+                amax_stage_view = cute.make_tensor(
+                    amax_view.iterator + group * Int32(16 * t.num_scales),
+                    cute.make_layout(int(16 * t.num_scales)),
+                )
+                reduce_max_stage = reduce_max_addr + group * Int32(8 * 16 * 4)
+                reduce_sum_stage = reduce_sum_addr + group * Int32(8 * 16 * 4)
+                w_fp8_stage = w_fp8_addr + group * Int32(2 * 16 * (t.bi + 16))
+                sm_p_stage = sm_p_full_addr + group * Int32(16 * L.sm_p_full_stride * 2)
+                w_head_sc_stage_view = cute.make_tensor(
+                    w_head_sc_view.iterator + group * Int32(t.n_v_chunks * 16),
+                    cute.make_layout(int(t.n_v_chunks * 16)),
+                )
 
-            if cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3):
+            if cutlass.const_expr(
+                t.scale_format in (
+                    ScaleFormat.NVFP4_E4M3,
+                    ScaleFormat.KVARN_K5,
+                    ScaleFormat.KVARN_EXACT_BF16,
+                )
+                or self.fuse_kvarn_hadamard
+            ):
                 s0_load_q_bf16_to_smem(
                     q_token,
                     q_fp8_stage,
                     q_rope_stage,
                     head_base_stage,
-                    Int32(self.valid_hpb),
+                    Int32(valid_hpb_stage),
                     tid_sel,
                     d_nope=t.d_nope,
                     d_rope=t.d_rope,
-                    hpb=t.hpb,
+                    hpb=stage_hpb,
                     q_nope_bf16_stride=t.q_nope_stride,
                     q_rope_stride=L.q_rope_stride,
                     num_threads=nt_stage,
@@ -1806,14 +2049,14 @@ class UnifiedDecodeKernel:
                     q_rope_stage,
                     amax_stage_view,
                     head_base_stage,
-                    Int32(8 if self.native_dsv4_h16 else self.valid_hpb),
+                    Int32(valid_hpb_stage),
                     tid_sel,
                     d_nope=t.d_nope,
                     d_rope=t.d_rope,
                     d_qk=t.d_nope + t.d_rope,
                     quant_tile=t.quant_tile,
                     num_scales=t.num_scales,
-                    hpb=(8 if (self.native_h8 or self.native_dsv4_h16) else t.hpb),
+                    hpb=stage_hpb,
                     q_nope_stride=t.q_nope_stride,
                     q_rope_stride=L.q_rope_stride,
                     num_threads=nt_stage,
@@ -1824,6 +2067,36 @@ class UnifiedDecodeKernel:
                     vectorized_rope_copy=(self.native_dsv4_h8 or self.native_dsv4_h16),
                     packed_q_scale_words=self.native_dsv4_h16,
                 )
+            q_nope_math_stage = q_fp8_stage
+            if cutlass.const_expr(self.fuse_kvarn_hadamard):
+                kvarn_hadamard_bf16_smem(
+                    q_fp8_stage,
+                    tid_sel,
+                    hpb=stage_hpb,
+                    row_stride=t.q_nope_stride,
+                    num_threads=nt_stage,
+                    barrier_id=2,
+                    barrier_threads=bt_stage,
+                )
+                if cutlass.const_expr(t.scale_format == ScaleFormat.KVARN_EXACT):
+                    kvarn_quantize_hadamard_q_fp8(
+                        q_fp8_addr,
+                        q_fp8_addr,
+                        shared_ptr_to_u32(st.q_sc.data_ptr()),
+                        group,
+                        tid,
+                        tid_sel,
+                        lane,
+                        groups=2,
+                        hpb_per_group=16,
+                        q_stride=t.q_nope_stride,
+                        num_group_threads=256,
+                        barrier_id=2,
+                        barrier_threads=self.math_threads,
+                    )
+                    q_nope_math_stage = (
+                        q_fp8_addr + group * Int32(16 * t.q_nope_stride)
+                    )
 
             accn_frag = cute.make_rmem_tensor(n_acc_tiles * 4, Float32)
             rope_acc_elems = 8 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 4
@@ -1841,6 +2114,7 @@ class UnifiedDecodeKernel:
 
             cons_phase = Int32(0)
             cons_idx = Int32(0)
+            has_valid_candidate = Int32(0)
 
             for lc in cutlass.range(active_chunks, unroll=1):
                 active_idx = Int32(lc)
@@ -1848,8 +2122,10 @@ class UnifiedDecodeKernel:
                 if cutlass.const_expr(has_extra):
                     if active_idx >= main_chunk_count:
                         ci = extra_first_chunk + active_idx - main_chunk_count
-                split_cand_start = ci * Int32(_CAND_WINDOW)
+                split_cand_start = ci * Int32(cand_window)
                 buf = Int32(lc) & Int32(1)
+                if cutlass.const_expr(self.native_kvarn):
+                    buf = Int32(0)
 
                 kv_fp8_b = kv_fp8_addr + buf * kv_fp8_buf
                 kv_rope_b = kv_rope_addr + buf * kv_rope_buf
@@ -1874,6 +2150,21 @@ class UnifiedDecodeKernel:
 
                 cute.arch.mbarrier_wait(mbar_base + cons_idx, phase=cons_phase)
                 cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                if cutlass.const_expr(self.native_kvarn):
+                    # Every math warp redundantly reduces the 64 staged slot
+                    # statuses. This avoids shared scratch/barriers and leaves
+                    # a uniform per-split predicate for the neutral epilogue.
+                    chunk_valid = Int32(0)
+                    if Int32(tok_buf_view[lane]) >= Int32(0):
+                        chunk_valid += Int32(1)
+                    if Int32(tok_buf_view[lane + Int32(32)]) >= Int32(0):
+                        chunk_valid += Int32(1)
+                    for offset in (16, 8, 4, 2, 1):
+                        chunk_valid += cute.arch.shuffle_sync_bfly(
+                            chunk_valid, offset=offset
+                        )
+                    if chunk_valid > Int32(0):
+                        has_valid_candidate = Int32(1)
 
                 # P10f: GLM keeps RAW e4m3 K/V (no S0b dequant+requant -- that
                 # discarded the per-group e4m3 mantissa headroom and cost ~0.003
@@ -1931,9 +2222,9 @@ class UnifiedDecodeKernel:
                     sec_len = section_len
                     if cutlass.const_expr(has_extra):
                         if ci >= num_main_chunks:
-                            sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
+                            sc_start = (ci - num_main_chunks) * Int32(cand_window)
                             sec_len = extra_section_len
-                    sc_end = sc_start + Int32(_CAND_WINDOW)
+                    sc_end = sc_start + Int32(cand_window)
                     if sc_end > sec_len:
                         sc_end = sec_len
                     qk = s3_mask_and_scale_glm_h8_swap_ab(
@@ -2026,9 +2317,9 @@ class UnifiedDecodeKernel:
                 else:
                     qk = s1_qk_nope_block_scaled(
                         qk,
-                        q_fp8_addr,
+                        q_nope_math_stage,
                         kv_fp8_b,
-                        q_sc_view,
+                        q_sc_stage_view,
                         kv_sc_b,
                         warp_first_cand,
                         lane,
@@ -2043,7 +2334,7 @@ class UnifiedDecodeKernel:
                     )
                     qk = s2_qk_rope_bf16(
                         qk,
-                        q_rope_addr,
+                        q_rope_stage,
                         kv_rope_b,
                         warp_first_cand,
                         lane,
@@ -2058,9 +2349,9 @@ class UnifiedDecodeKernel:
                         sc_start = split_cand_start
                         sec_len = section_len
                         if ci >= num_main_chunks:
-                            sc_start = (ci - num_main_chunks) * Int32(_CAND_WINDOW)
+                            sc_start = (ci - num_main_chunks) * Int32(cand_window)
                             sec_len = extra_section_len
-                        sc_end = sc_start + Int32(_CAND_WINDOW)
+                        sc_end = sc_start + Int32(cand_window)
                         if sc_end > sec_len:
                             sc_end = sec_len
                         qk = s3_mask_and_scale(
@@ -2074,7 +2365,7 @@ class UnifiedDecodeKernel:
                             lane,
                         )
                     else:
-                        split_cand_end = split_cand_start + Int32(_CAND_WINDOW)
+                        split_cand_end = split_cand_start + Int32(cand_window)
                         if split_cand_end > section_len:
                             split_cand_end = section_len
                         qk = s3_mask_and_scale(
@@ -2096,19 +2387,20 @@ class UnifiedDecodeKernel:
                         acc_rope,
                         global_max,
                         global_sum,
-                        reduce_max_addr,
-                        reduce_sum_addr,
+                        reduce_max_stage,
+                        reduce_sum_stage,
                         False,
-                        warp_id,
+                        warp_sel,
                         lane,
-                        tid,
+                        tid_sel,
                         n_v_chunks=t.n_v_chunks,
-                        hpb=t.hpb,
-                        n_warps=8,
-                        valid_hpb=self.valid_hpb,
-                        num_threads=self.math_threads,
+                        hpb=stage_hpb,
+                        n_warps=n_warps_stage,
+                        valid_hpb=valid_hpb_stage,
+                        num_threads=nt_stage,
                         barrier_id=3,
                         n_acc_tiles=n_acc_tiles,
+                        barrier_threads=bt_stage,
                     )
                     w_pre = [
                         p[0] * wr0,
@@ -2118,16 +2410,16 @@ class UnifiedDecodeKernel:
                     ]
                     s5_fill_sm_p_full(
                         w_pre,
-                        sm_p_full_addr,
-                        w_head_sc_view,
-                        warp_id,
+                        sm_p_stage,
+                        w_head_sc_stage_view,
+                        warp_sel,
                         lane,
-                        tid,
+                        tid_sel,
                         bi=t.bi,
                         sm_p_stride=L.sm_p_full_stride,
                         n_v_chunks=t.n_v_chunks,
-                        hpb=t.hpb,
-                        num_threads=self.math_threads,
+                        hpb=stage_hpb,
+                        num_threads=nt_stage,
                         barrier_id=3,
                     )
                     cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
@@ -2136,27 +2428,28 @@ class UnifiedDecodeKernel:
                         acc_nope,
                         kv_fp8_b,
                         kv_sc_b,
-                        w_head_sc_view,
-                        w_fp8_addr,
-                        warp_id,
+                        w_head_sc_stage_view,
+                        w_fp8_stage,
+                        warp_sel,
                         lane,
-                        tid,
+                        tid_sel,
                         latent_scale,
                         n_v_chunks=t.n_v_chunks,
                         v_chunk=t.quant_tile,
-                        hpb=t.hpb,
+                        hpb=stage_hpb,
                         bi=t.bi,
                         kv_smem_stride=t.kv_smem_stride,
                         w_fp8_stride=t.bi + 16,
-                        n_warps=8,
+                        n_warps=n_warps_stage,
                         scale_bytes_per_token=8,
                         nt_per_warp_xv=t.nt_per_warp_xv,
                         scale_format=t.scale_format,
-                        num_threads=self.math_threads,
+                        num_threads=nt_stage,
                         barrier_id=3,
-                        sm_p_full_addr=sm_p_full_addr,
+                        sm_p_full_addr=sm_p_stage,
                         sm_p_stride=L.sm_p_full_stride,
                         latent_scale_per_token=t.latent_scale_per_token,
+                        barrier_threads=bt_stage,
                     )
 
                 # S6b (XV-RoPE) is DSV4-only (V_HAS_ROPE). const_expr-elided for GLM.
@@ -2185,7 +2478,7 @@ class UnifiedDecodeKernel:
                             bi=t.bi,
                             sm_p_stride=L.sm_p_full_stride,
                             d_rope=t.d_rope,
-                            n_warps=8,
+                            n_warps=(self.math_threads // 32),
                         )
 
                 for at in cutlass.range_constexpr(n_acc_tiles):
@@ -2237,23 +2530,32 @@ class UnifiedDecodeKernel:
 
             # mid_out[token, head_base + h, split, dim]: (HPB, D_V) view for this
             # (token, head_block, split). mid_out stride = (h*S*Dv, S*Dv, Dv, 1).
-            out_o = cute.make_tensor(
+            out_o_global = cute.make_tensor(
                 mid_out.iterator
                 + token_idx.to(Int64) * Int64(self.mid_out_stride_row)
                 + head_base_stage.to(Int64) * Int64(self.mid_out_stride_head)
                 + split_idx.to(Int64) * Int64(self.mid_out_stride_split),
                 cute.make_layout(
-                    (t.hpb, t.d_v),
+                    (stage_hpb, t.d_v),
                     stride=(self.mid_out_stride_head, self.mid_out_stride_dim),
                 ),
             )
+            out_o = out_o_global
+            if cutlass.const_expr(self.fuse_kvarn_hadamard):
+                q_bf16_view = st.q_fp8.get_tensor(
+                    cute.make_layout(int(L.q_fp8_bytes // 2))
+                )
+                out_o = cute.make_tensor(
+                    q_bf16_view.iterator + group * Int32(16 * 512),
+                    cute.make_layout((stage_hpb, t.d_v), stride=(t.d_v, 1)),
+                )
             # mid_lse[token, head_base + h, split]: (HPB,) view.
             out_lse = cute.make_tensor(
                 mid_lse.iterator
                 + token_idx.to(Int64) * Int64(self.mid_lse_stride_row)
                 + head_base_stage.to(Int64) * Int64(self.mid_lse_stride_head)
                 + split_idx.to(Int64) * Int64(self.mid_lse_stride_split),
-                cute.make_layout((t.hpb,), stride=(self.mid_lse_stride_head,)),
+                cute.make_layout((stage_hpb,), stride=(self.mid_lse_stride_head,)),
             )
             s7_epilogue(
                 fin_acc_nope,
@@ -2268,15 +2570,51 @@ class UnifiedDecodeKernel:
                 v_chunk=t.quant_tile,
                 d_nope=t.d_nope,
                 d_rope=t.d_rope,
-                n_warps=(4 if (self.native_h8 or self.native_dsv4_h16) else 8),
-                valid_hpb=(8 if self.native_dsv4_h16 else self.valid_hpb),
+                n_warps=(
+                    4
+                    if (self.native_h8 or self.native_dsv4_h16)
+                    else n_warps_stage
+                ),
+                valid_hpb=valid_hpb_stage,
                 nt_per_warp_xv=t.nt_per_warp_xv,
                 v_has_rope=t.v_has_rope,
                 rope_tiles_per_warp=(
                     2 if (self.native_dsv4_h8 or self.native_dsv4_h16) else 1
                 ),
+                natural_lse=(self.native_kvarn and self.num_splits == 1),
             )
 
+            if cutlass.const_expr(self.fuse_kvarn_hadamard):
+                cute.arch.barrier(barrier_id=3, number_of_threads=self.math_threads)
+                kvarn_hadamard_output_bf16(
+                    q_fp8_addr + group * Int32(16 * 512 * 2),
+                    out_o_global,
+                    tid_sel,
+                    hpb=stage_hpb,
+                    num_threads=nt_stage,
+                    barrier_id=3,
+                    barrier_threads=bt_stage,
+                )
+
+            if cutlass.const_expr(self.native_kvarn):
+                if has_valid_candidate == Int32(0):
+                    # Finite QK masking deliberately keeps S4 NaN-free, so a
+                    # wholly invalid split otherwise looks like a live uniform
+                    # softmax. Override it with the sparse-attention identity.
+                    cute.arch.barrier(
+                        barrier_id=3, number_of_threads=self.math_threads
+                    )
+                    if cutlass.const_expr(self.num_splits == 1):
+                        linear = tid_sel
+                        while linear < Int32(stage_hpb * t.d_v):
+                            empty_head = linear // Int32(t.d_v)
+                            empty_dim = linear - empty_head * Int32(t.d_v)
+                            out_o_global[empty_head, empty_dim] = (
+                                cutlass.BFloat16(0.0)
+                            )
+                            linear += Int32(nt_stage)
+                    if tid_sel < Int32(valid_hpb_stage):
+                        out_lse[tid_sel] = Float32(-Float32.inf)
 
 def _to_cute(x, dtype, align=16, dynamic_layout=False):
     c = from_dlpack(x, assumed_align=align)
@@ -2590,9 +2928,6 @@ def _sparse_mla_decode_grid_flat_launch(
         # v18: latent_scale == 1.0 is folded out at trace time, producing a
         # cubin without the outer-scale multiply; the identity and dynamic
         # variants must not share a cache entry.
-        # v19: latent_scale_per_token joins the key (per-candidate fp32 scale
-        # read from kv_sc smem). In that mode the launch scalar is dead, so the
-        # identity fold is forced ON -- no per-scalar variants get compiled.
         19,
         key_field(
             "latent_scale_identity",
@@ -2610,6 +2945,165 @@ def _sparse_mla_decode_grid_flat_launch(
         compile_args=args,
         runtime_args=args,
     )
+
+
+def _kvarn_mla_decode_grid_flat_launch(
+    q_all, kv_flat, selected_indices, mid_out, mid_lse, valid_counts,
+    block_to_pool_slot, latent_pool, rope_pool, sm_scale, num_splits,
+    chunks_per_split, exact_pool_only, fuse_kvarn_hadamard, packed_bits,
+    exact_h16=False,
+) -> None:
+    exact_h16 = bool(exact_h16)
+    if exact_h16 and not exact_pool_only:
+        raise ValueError("KVarN exact H16 requires exact-pool-only decode")
+    packed_bits = int(packed_bits)
+    if packed_bits not in _KVARN_PACKED_TILE_GEOMETRY:
+        raise ValueError(
+            "native KVarN decode requires packed_bits in "
+            f"{sorted(_KVARN_PACKED_TILE_GEOMETRY)}"
+        )
+    cache_block_stride = _KVARN_PACKED_TILE_GEOMETRY[packed_bits][0]
+    kvarn_exact_fast_io = bool(
+        exact_pool_only and not exact_h16 and _env_kvarn_exact_fast_io_enabled()
+    )
+    rows, heads, q_head_dim = map(int, q_all.shape)
+    scale_format = (
+        ScaleFormat.KVARN_EXACT_BF16
+        if exact_h16
+        else (ScaleFormat.KVARN_EXACT if exact_pool_only else ScaleFormat.KVARN_K5)
+    )
+    traits = make_unified_traits(ModelType.GLM_NSA, 1, scale_format, fp8_rope=False)
+    layout = make_smem_layout(traits)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    args = (
+        _to_cute(q_all, cutlass.BFloat16, dynamic_layout=True),
+        _to_cute(kv_flat, cutlass.Uint8, align=16),
+        _to_cute(selected_indices, cutlass.Int32, align=4, dynamic_layout=True),
+        _to_cute(mid_out, cutlass.BFloat16, align=16, dynamic_layout=True),
+        _to_cute(mid_lse, cutlass.Float32, align=4, dynamic_layout=True),
+        Float32(float(sm_scale) * LOG2_E),
+        _to_cute(valid_counts, cutlass.Int32, align=4, dynamic_layout=True),
+        Int64(cache_block_stride),
+        _to_cute(block_to_pool_slot, cutlass.Int32, align=4),
+        _to_cute(latent_pool, cutlass.Float8E4M3FN, align=16),
+        _to_cute(rope_pool, cutlass.BFloat16, align=16),
+        Int32(rows), stream,
+    )
+    kernel = UnifiedDecodeKernel(
+        traits, layout, (int(selected_indices.shape[1]) + traits.bi - 1) // traits.bi,
+        int(chunks_per_split), h_blocks=heads // traits.hpb,
+        num_splits=int(num_splits), num_heads=heads, q_head_dim=q_head_dim,
+        topk=int(selected_indices.shape[1]), extra_topk=0,
+        q_stride=tuple(q_all.stride()), swa_indices_stride0=int(selected_indices.stride(0)),
+        extra_indices_stride0=int(selected_indices.stride(0)),
+        mid_out_stride=tuple(mid_out.stride()), mid_lse_stride=tuple(mid_lse.stride()),
+        valid_hpb=traits.hpb, per_token_len=True, native_kvarn=True,
+        native_kvarn_bits=packed_bits,
+        native_kvarn_exact_pool=exact_pool_only,
+        fuse_kvarn_hadamard=fuse_kvarn_hadamard,
+        kvarn_exact_fast_io=kvarn_exact_fast_io,
+    )
+    kernel_id = (
+        "attention.kvarn_mla.sm120.decode.exact_h16"
+        if exact_h16
+        else "attention.kvarn_mla.sm120.decode"
+    )
+    spec_fields = [
+        key_field("rows", rows), key_field("heads", heads),
+        key_field("packed_bits", packed_bits),
+        key_field("topk", int(selected_indices.shape[1])),
+        key_field("num_splits", int(num_splits)),
+        key_field("chunks_per_split", int(chunks_per_split)),
+        key_field("exact_pool_only", int(bool(exact_pool_only))),
+        key_field("fuse_kvarn_hadamard", int(bool(fuse_kvarn_hadamard))),
+        key_field("kvarn_exact_fast_io", int(kvarn_exact_fast_io)),
+        tensor_key("q", q_all, dims=(DimKey.dynamic(), DimKey.exact(heads), DimKey.exact(q_head_dim))),
+        tensor_key("selected", selected_indices, dims=(DimKey.dynamic(), DimKey.exact(int(selected_indices.shape[1])))),
+        tensor_key("mid_out", mid_out, dims=(DimKey.dynamic(), DimKey.exact(heads), DimKey.bucket(num_splits), DimKey.exact(512))),
+        tensor_key("cache", kv_flat, dims=(DimKey.exact(int(kv_flat.numel())),)),
+        tensor_key("block_map", block_to_pool_slot, dims=(DimKey.exact(int(block_to_pool_slot.shape[0])),)),
+        tensor_key("latent_pool", latent_pool, dims=(DimKey.exact(int(latent_pool.shape[0])), DimKey.exact(64), DimKey.exact(512))),
+        tensor_key("rope_pool", rope_pool, dims=(DimKey.exact(int(rope_pool.shape[0])), DimKey.exact(64), DimKey.exact(64))),
+        tensor_key("mid_lse", mid_lse, dims=(DimKey.dynamic(), DimKey.exact(heads), DimKey.bucket(num_splits))),
+    ]
+    if exact_h16:
+        spec_fields.insert(0, key_field("exact_h16", 1))
+    spec = KernelCompileSpec.from_fields(kernel_id, 1 if exact_h16 else 4, *spec_fields)
+    LAST_KVARN_DECODE_PLAN.clear()
+    LAST_KVARN_DECODE_PLAN.update(
+        exact_h16=exact_h16,
+        packed_bits=packed_bits,
+        marker=(
+            "b12x::kvarn_mla_sm120_decode_grid_exact_h16"
+            if exact_h16
+            else "b12x::kvarn_mla_sm120_decode_grid"
+        ),
+        heads_per_cta=traits.hpb,
+        block_threads=kernel.block_threads,
+        math_mode="bf16" if exact_h16 else ("fp8" if exact_pool_only else "bf16"),
+    )
+    b12x_launch(
+        kernel.call_kvarn, compile_spec=spec, compile_args=args, runtime_args=args
+    )
+
+
+@torch.library.custom_op("b12x::kvarn_mla_sm120_decode_grid", mutates_args=("mid_out", "mid_lse"))
+def _kvarn_mla_decode_grid_op(
+    q_all: torch.Tensor, kv_flat: torch.Tensor, selected_indices: torch.Tensor,
+    mid_out: torch.Tensor, mid_lse: torch.Tensor, valid_counts: torch.Tensor,
+    block_to_pool_slot: torch.Tensor, latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor, sm_scale: float, num_splits: int,
+    chunks_per_split: int, exact_pool_only: bool, fuse_kvarn_hadamard: bool,
+    packed_bits: int,
+) -> None:
+    _kvarn_mla_decode_grid_flat_launch(
+        q_all, kv_flat, selected_indices, mid_out, mid_lse, valid_counts,
+        block_to_pool_slot, latent_pool, rope_pool, sm_scale, num_splits,
+        chunks_per_split, exact_pool_only, fuse_kvarn_hadamard, packed_bits,
+    )
+
+
+@_kvarn_mla_decode_grid_op.register_fake
+def _kvarn_mla_decode_grid_fake(
+    q_all: torch.Tensor, kv_flat: torch.Tensor, selected_indices: torch.Tensor,
+    mid_out: torch.Tensor, mid_lse: torch.Tensor, valid_counts: torch.Tensor,
+    block_to_pool_slot: torch.Tensor, latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor, sm_scale: float, num_splits: int,
+    chunks_per_split: int, exact_pool_only: bool, fuse_kvarn_hadamard: bool,
+    packed_bits: int,
+) -> None:
+    return None
+
+
+@torch.library.custom_op(
+    "b12x::kvarn_mla_sm120_decode_grid_exact_h16",
+    mutates_args=("mid_out", "mid_lse"),
+)
+def _kvarn_mla_decode_grid_exact_h16_op(
+    q_all: torch.Tensor, kv_flat: torch.Tensor, selected_indices: torch.Tensor,
+    mid_out: torch.Tensor, mid_lse: torch.Tensor, valid_counts: torch.Tensor,
+    block_to_pool_slot: torch.Tensor, latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor, sm_scale: float, num_splits: int,
+    chunks_per_split: int, exact_pool_only: bool, fuse_kvarn_hadamard: bool,
+) -> None:
+    _kvarn_mla_decode_grid_flat_launch(
+        q_all, kv_flat, selected_indices, mid_out, mid_lse, valid_counts,
+        block_to_pool_slot, latent_pool, rope_pool, sm_scale, num_splits,
+        chunks_per_split, exact_pool_only, fuse_kvarn_hadamard, 5,
+        exact_h16=True,
+    )
+
+
+@_kvarn_mla_decode_grid_exact_h16_op.register_fake
+def _kvarn_mla_decode_grid_exact_h16_fake(
+    q_all: torch.Tensor, kv_flat: torch.Tensor, selected_indices: torch.Tensor,
+    mid_out: torch.Tensor, mid_lse: torch.Tensor, valid_counts: torch.Tensor,
+    block_to_pool_slot: torch.Tensor, latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor, sm_scale: float, num_splits: int,
+    chunks_per_split: int, exact_pool_only: bool, fuse_kvarn_hadamard: bool,
+) -> None:
+    return None
+
 
 
 @torch.library.custom_op(
@@ -2855,8 +3349,6 @@ def run_unified_decode(
                 f"NVFP4 cache record must be 368 or 432 bytes, got {record_bytes}"
             )
         fp8_rope_override = record_bytes == 368
-    # FAIL-CLOSED: the per-token fp32 latent scale lives at bytes [292, 296) of
-    # the NVFP4 fp8-rope 368-byte record ONLY.
     if latent_scale_per_token:
         if scale_format != ScaleFormat.NVFP4_E4M3:
             raise ValueError(
@@ -2866,7 +3358,7 @@ def run_unified_decode(
         if not bool(fp8_rope_override):
             raise ValueError(
                 "SM120 sparse MLA decode latent_scale_per_token requires the "
-                "fp8-rope 368-byte NVFP4 record; got the 432-byte record"
+                "fp8-rope 368-byte NVFP4 record"
             )
     traits = make_unified_traits(
         model_type,

--- a/b12x/attention/_shared/mla/kernel.py
+++ b/b12x/attention/_shared/mla/kernel.py
@@ -128,10 +128,10 @@ _MLA_SM120_GLM_H8_NATIVE_ENV = "B12X_MLA_SM120_GLM_H8_NATIVE"
 # Opt-in while being validated: unset/0 -> off; 1/true/on/yes -> on.
 _MLA_SM120_DSV4_H16_NATIVE_ENV = "B12X_MLA_SM120_DSV4_H16_NATIVE"
 
-# Native KVarN exact-pool producer vectorization. Default-off after the bounded
-# C1 exact-graph trace regressed; read per call so isolated runs can A/B the
-# producer without changing graph classification, exact-pool ownership, or the
-# mixed K5 specialization.
+# Opt-in vectorized exact-pool KVarN producer. Unset or non-truthy selects the
+# scalar producer. The value is read per call and affects only producer
+# vectorization: graph classification, exact-pool ownership, and the mixed K5
+# specialization are unchanged in both settings.
 _MLA_SM120_KVARN_EXACT_FAST_IO_ENV = (
     "B12X_MLA_SM120_KVARN_EXACT_FAST_IO"
 )
@@ -2925,7 +2925,7 @@ def _sparse_mla_decode_grid_flat_launch(
             )
     compile_spec = KernelCompileSpec.from_fields(
         "attention.mla.sm120.decode",
-        # v18: latent_scale == 1.0 is folded out at trace time, producing a
+        # v19: latent_scale == 1.0 is folded out at trace time, producing a
         # cubin without the outer-scale multiply; the identity and dynamic
         # variants must not share a cache entry.
         19,

--- a/b12x/attention/_shared/mla/smem.py
+++ b/b12x/attention/_shared/mla/smem.py
@@ -205,7 +205,15 @@ def make_smem_layout(traits: UnifiedMLATraits) -> SmemLayout:
     n_v_chunks = traits.n_v_chunks
     kv_smem_stride = traits.kv_smem_stride
     q_nope_stride = traits.q_nope_stride
-    bufs = _KV_BUF_COUNT
+    bufs = (
+        1
+        if traits.scale_format in (
+            ScaleFormat.KVARN_K5,
+            ScaleFormat.KVARN_EXACT,
+            ScaleFormat.KVARN_EXACT_BF16,
+        )
+        else _KV_BUF_COUNT
+    )
 
     off = 0
 
@@ -219,7 +227,16 @@ def make_smem_layout(traits: UnifiedMLATraits) -> SmemLayout:
 
     # --- Q-NoPE staging. FP8 normally; BF16 for native NVFP4 cache math. ---
     q_fp8_off = off
-    q_element_bytes = 2 if traits.scale_format == ScaleFormat.NVFP4_E4M3 else 1
+    q_element_bytes = (
+        2
+        if traits.scale_format in (
+            ScaleFormat.NVFP4_E4M3,
+            ScaleFormat.KVARN_K5,
+            ScaleFormat.KVARN_EXACT,
+            ScaleFormat.KVARN_EXACT_BF16,
+        )
+        else 1
+    )
     q_fp8_bytes = hpb * q_nope_stride * q_element_bytes
     off = q_fp8_off + q_fp8_bytes
 
@@ -242,6 +259,14 @@ def make_smem_layout(traits: UnifiedMLATraits) -> SmemLayout:
     if traits.has_extra_cache:
         # DSV4: 8 footer bytes/token (7 UE8M0 + 1 pad). Separately gathered.
         kv_sc_stride = 8  # SCALE_BYTES_PER_TOKEN
+        kv_sc_buf_bytes = bi * kv_sc_stride
+        off = kv_sc_off + kv_sc_buf_bytes * bufs
+    elif traits.scale_format in (
+        ScaleFormat.KVARN_K5,
+        ScaleFormat.KVARN_EXACT,
+        ScaleFormat.KVARN_EXACT_BF16,
+    ):
+        kv_sc_stride = 8
         kv_sc_buf_bytes = bi * kv_sc_stride
         off = kv_sc_off + kv_sc_buf_bytes * bufs
     elif traits.latent_scale_per_token:
@@ -293,7 +318,15 @@ def make_smem_layout(traits: UnifiedMLATraits) -> SmemLayout:
     off = _align_up(off, 16)
     token_idx_off = off
     token_idx_buf_bytes = bi * 4
-    token_idx_bufs = _TOKEN_IDX_BUF_COUNT
+    token_idx_bufs = (
+        1
+        if traits.scale_format in (
+            ScaleFormat.KVARN_K5,
+            ScaleFormat.KVARN_EXACT,
+            ScaleFormat.KVARN_EXACT_BF16,
+        )
+        else _TOKEN_IDX_BUF_COUNT
+    )
     off = token_idx_off + token_idx_buf_bytes * token_idx_bufs
 
     # --- static sm_p_full (bf16), 128B-aligned for the S6b ldmatrix.x4 read. ---
@@ -393,7 +426,15 @@ def get_unified_shared_storage_cls(traits: UnifiedMLATraits):
                 int(layout.kv_sc_buf_bytes * layout.kv_bufs),
             ]
         }
-        if (traits.has_extra_cache or traits.latent_scale_per_token)
+        if (
+            traits.has_extra_cache
+            or traits.latent_scale_per_token
+            or traits.scale_format in (
+                ScaleFormat.KVARN_K5,
+                ScaleFormat.KVARN_EXACT,
+                ScaleFormat.KVARN_EXACT_BF16,
+            )
+        )
         else {}
     )
     w_head_sc2_field = (
@@ -408,13 +449,21 @@ def get_unified_shared_storage_cls(traits: UnifiedMLATraits):
         if traits.has_extra_cache
         else {}
     )
+    q_is_bf16 = traits.scale_format in (
+        ScaleFormat.NVFP4_E4M3,
+        ScaleFormat.KVARN_K5,
+        ScaleFormat.KVARN_EXACT,
+        ScaleFormat.KVARN_EXACT_BF16,
+    )
+    q_element_type = cutlass.BFloat16 if q_is_bf16 else cutlass.Uint8
+    q_elements = int(layout.q_fp8_bytes // 2) if q_is_bf16 else int(layout.q_fp8_bytes)
     SharedStorage.__annotations__ = {
         # Q staging (single buffer). q_rope first (FlashInfer OFF_Q_ROPE = 0).
         "q_rope": cute.struct.Align[
             cute.struct.MemRange[cutlass.BFloat16, int(layout.q_rope_bytes // 2)],
             128,
         ],
-        "q_fp8": cute.struct.MemRange[cutlass.Uint8, int(layout.q_fp8_bytes)],
+        "q_fp8": cute.struct.MemRange[q_element_type, q_elements],
         "q_sc": cute.struct.MemRange[cutlass.Float32, int(layout.q_sc_bytes // 4)],
         # Double-buffered KV. 128B-align the big nope region.
         "kv_fp8": cute.struct.Align[
@@ -479,7 +528,15 @@ def get_unified_shared_storage_cls(traits: UnifiedMLATraits):
         "token_idx": layout.token_idx_off,
         "sm_p_full": layout.sm_p_full_off,
     }
-    if traits.has_extra_cache or traits.latent_scale_per_token:
+    if (
+        traits.has_extra_cache
+        or traits.latent_scale_per_token
+        or traits.scale_format in (
+            ScaleFormat.KVARN_K5,
+            ScaleFormat.KVARN_EXACT,
+            ScaleFormat.KVARN_EXACT_BF16,
+        )
+    ):
         expected_offsets["kv_sc"] = layout.kv_sc_off
     if traits.has_extra_cache:
         expected_offsets["w_head_sc2"] = layout.w_head_sc2_off

--- a/b12x/attention/_shared/mla/traits.py
+++ b/b12x/attention/_shared/mla/traits.py
@@ -42,6 +42,9 @@ class ScaleFormat:
     UE8M0_BYTE = 0  # DSV4: power-of-2 exponent bytes in an 8B footer.
     ARBITRARY_FP32 = 1  # GLM: arbitrary FP32 inline scales (reference.py).
     NVFP4_E4M3 = 2  # GLM/DS MLA latent: E2M1 data + E4M3 group-16 scales.
+    KVARN_K5 = 3
+    KVARN_EXACT = 4
+    KVARN_EXACT_BF16 = 5
 
 
 @dataclass(frozen=True)
@@ -151,6 +154,54 @@ def make_unified_traits(
         )
 
     if model_type == ModelType.GLM_NSA:
+        if scale_format == ScaleFormat.KVARN_K5:
+            if fp8_rope_requested:
+                raise ValueError("KVarN K5 keeps its RoPE lane in BF16")
+            return UnifiedMLATraits(
+                model_type=ModelType.GLM_NSA,
+                compute_mode=ComputeMode.BF16,
+                scale_format=ScaleFormat.KVARN_K5,
+                d_nope=512, d_rope=64, d_v=512,
+                quant_tile=64, num_scales=8, n_v_chunks=8,
+                nt_per_warp_xv=1, kv_gmem_stride=30_848,
+                kv_smem_stride=1_040, q_nope_stride=520,
+                bi=64, hpb=16, block_threads=512, math_threads=256,
+                bulk_tx_bytes=0, v_has_rope=False, has_extra_cache=False,
+                fp8_rope=False, rope_gmem_offset=22_656,
+                rope_payload_bytes=128, rope_scale_offset=-1,
+            )
+        if scale_format == ScaleFormat.KVARN_EXACT:
+            if fp8_rope_requested:
+                raise ValueError("KVarN exact mode keeps RoPE in BF16")
+            return UnifiedMLATraits(
+                model_type=ModelType.GLM_NSA,
+                compute_mode=ComputeMode.FP8,
+                scale_format=ScaleFormat.KVARN_EXACT,
+                d_nope=512, d_rope=64, d_v=512,
+                quant_tile=128, num_scales=4, n_v_chunks=4,
+                nt_per_warp_xv=2, kv_gmem_stride=30_848,
+                kv_smem_stride=528, q_nope_stride=528,
+                bi=64, hpb=32, block_threads=544, math_threads=512,
+                bulk_tx_bytes=0, v_has_rope=False, has_extra_cache=False,
+                fp8_rope=False, rope_gmem_offset=22_656,
+                rope_payload_bytes=128, rope_scale_offset=-1,
+            )
+        if scale_format == ScaleFormat.KVARN_EXACT_BF16:
+            if fp8_rope_requested:
+                raise ValueError("KVarN exact BF16 mode keeps RoPE in BF16")
+            return UnifiedMLATraits(
+                model_type=ModelType.GLM_NSA,
+                compute_mode=ComputeMode.BF16,
+                scale_format=ScaleFormat.KVARN_EXACT_BF16,
+                d_nope=512, d_rope=64, d_v=512,
+                quant_tile=64, num_scales=8, n_v_chunks=8,
+                nt_per_warp_xv=1, kv_gmem_stride=30_848,
+                kv_smem_stride=1_040, q_nope_stride=520,
+                bi=64, hpb=16, block_threads=512, math_threads=256,
+                bulk_tx_bytes=0, v_has_rope=False, has_extra_cache=False,
+                fp8_rope=False, rope_gmem_offset=22_656,
+                rope_payload_bytes=128, rope_scale_offset=-1,
+            )
         if scale_format == ScaleFormat.NVFP4_E4M3:
             # NVFP4 MLA latent cache: 256B packed E2M1 NoPE + 32B E4M3
             # group-16 scales + 16B pad + 128B BF16 RoPE. Decode stages Q-NoPE

--- a/b12x/attention/kvarn_mla/__init__.py
+++ b/b12x/attention/kvarn_mla/__init__.py
@@ -1,0 +1,49 @@
+"""KVarN packed-latent staging and native sparse-MLA decode.
+
+Reads KVarN G64 tiles (2/4/5-bit packed latent, exact BF16 RoPE) directly:
+
+* ``stage_*`` functions rewrite packed or exact rows into the canonical FP8
+  record format the promoted SM120 sparse-MLA runtime already consumes;
+* ``stage_compact_kvarn_native_history`` /
+  ``materialize_compact_kvarn_native_records`` move one rank's live pages
+  through the compact DCP wire and back;
+* ``native_packed_k5_decode`` decodes straight from packed pages plus the
+  live exact-slot pool, backed by the CuTeDSL grids in
+  ``b12x.attention._shared.mla.kernel``.
+"""
+
+from __future__ import annotations
+
+from ..._lib.meta import OpMeta, Provenance, install_lazy_api
+
+META = OpMeta(
+    name="kvarn_mla",
+    group="attention",
+    api_style="oneshot",
+    entry_points=(
+        "compact_kvarn_native_rank_nbytes",
+        "stage_compact_kvarn_native_history",
+        "materialize_compact_kvarn_native_records",
+        "stage_k5_as_fp8_records",
+        "stage_bf16_as_exact_pool_fp8_records",
+        "stage_bf16_sylvester_as_exact_pool_fp8_records",
+        "native_packed_k5_decode",
+        "is_kvarn_mla_supported",
+    ),
+    dtypes=("bf16", "fp8_e4m3"),
+    recipes=("glm_nsa",),
+    requires=("triton",),
+    provenance=Provenance(
+        repo="https://github.com/JMPSequeira/glm52-kvarn-k4v2-runtime",
+        commit="a84759313d2e5525aef0a9189edbbdd16a3f18c9",
+        paths=(
+            "active-r634-b12x-compact/kvarn_api_k4.py",
+            "active-r634-kvarn-k4-native/kvarn_mla/io.py",
+            "active-r634-kvarn-k4-native/_shared/mla/kernel.py",
+        ),
+    ),
+    test_path="tests/attention/test_attention_kvarn_mla.py",
+    since="1.3.0",
+)
+
+install_lazy_api(globals(), META)

--- a/b12x/attention/kvarn_mla/api.py
+++ b/b12x/attention/kvarn_mla/api.py
@@ -1,0 +1,1522 @@
+"""KVarN packed-latent cache staging and native sparse-MLA decode (Triton).
+
+Reads KVarN G64 tiles (2/4/5-bit packed latent, exact BF16 RoPE) directly:
+``stage_*`` kernels rewrite packed or exact rows into the FP8 record format
+the promoted SM120 sparse-MLA runtime already consumes, and
+native_packed_k5_decode decodes straight from packed pages plus the live
+exact-slot pool without a global row stage. The CuTeDSL decode grids that
+back the fused path live in ``b12x.attention._shared.mla.kernel``.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from ..._lib.gating import default_is_supported
+from . import META
+
+_K5_GROUP = tl.constexpr(64)
+_K5_LATENT_DIM = tl.constexpr(512)
+_K5_ROPE_DIM = tl.constexpr(64)
+_K5_BITS = 5
+_K5_TILE_BYTES = 30_848
+_K4_TILE_BYTES = tl.constexpr(26_752)
+_K2_TILE_BYTES = tl.constexpr(18_560)
+_K5_S_COL_OFFSET = 20_480
+_K5_ZP_OFFSET = 21_504
+_K5_S_ROW_OFFSET = 22_528
+_K5_ROPE_OFFSET = 22_656
+_GLM_FP8_RECORD_BYTES = 656
+_GLM_FP8_SCALE_OFFSET = 512
+_GLM_FP8_ROPE_OFFSET = 528
+_FP8_E4M3_MAX = 448.0
+
+
+def is_kvarn_mla_supported(device=None) -> bool:
+    """True on SM120/SM121 with the staging/decode requirements present."""
+    return default_is_supported(device, requires=META.requires)
+_TL_K5_GROUP = tl.constexpr(_K5_GROUP)
+_TL_K5_ROPE_DIM = tl.constexpr(_K5_ROPE_DIM)
+_TL_K5_BITS = tl.constexpr(_K5_BITS)
+_TL_K5_S_COL_OFFSET = tl.constexpr(_K5_S_COL_OFFSET)
+_TL_K5_ZP_OFFSET = tl.constexpr(_K5_ZP_OFFSET)
+_TL_K5_S_ROW_OFFSET = tl.constexpr(_K5_S_ROW_OFFSET)
+_TL_K5_ROPE_OFFSET = tl.constexpr(_K5_ROPE_OFFSET)
+_TL_GLM_FP8_SCALE_OFFSET = tl.constexpr(_GLM_FP8_SCALE_OFFSET)
+_TL_GLM_FP8_ROPE_OFFSET = tl.constexpr(_GLM_FP8_ROPE_OFFSET)
+_TL_FP8_E4M3_MAX = tl.constexpr(_FP8_E4M3_MAX)
+_M4_CHUNKS_PER_SPLIT_ENV = "B12X_KVARN_MLA_M4_CHUNKS_PER_SPLIT"
+_EXACT_H16_ENV = "B12X_KVARN_MLA_EXACT_H16"
+_M9_HPP4_MERGE_ENV = "B12X_KVARN_MLA_M9_HPP4_MERGE"
+_M5_NATIVE_ENV = "B12X_KVARN_MLA_NATIVE_M5"
+_MERGE_BLOCK_D_ENV = "B12X_KVARN_MLA_MERGE_BLOCK_D"
+_MERGE_BLOCK_D_ALLOWED = (64, 128, 256, 512)
+_MERGE_BLOCK_D = int(os.getenv(_MERGE_BLOCK_D_ENV, "64") or "64")
+if _MERGE_BLOCK_D not in _MERGE_BLOCK_D_ALLOWED:
+    raise ValueError(
+        f"{_MERGE_BLOCK_D_ENV} must be one of {_MERGE_BLOCK_D_ALLOWED}, "
+        f"got {_MERGE_BLOCK_D}"
+    )
+
+
+def _merge_block_d() -> int:
+    """Column tile of the split-merge kernels (64 = the incumbent retile)."""
+    return _MERGE_BLOCK_D
+
+
+
+def _native_m5_split_family_enabled() -> bool:
+    raw = os.environ.get(_M5_NATIVE_ENV)
+    return raw is not None and raw.strip().lower() in {"1", "true", "on", "yes"}
+
+
+
+
+def _mixed_m4_chunks_per_split() -> int:
+    raw = os.environ.get(_M4_CHUNKS_PER_SPLIT_ENV)
+    if raw is None:
+        return 3
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{_M4_CHUNKS_PER_SPLIT_ENV} must be an integer in [1,4]"
+        ) from exc
+    if not 1 <= value <= 4:
+        raise ValueError(
+            f"{_M4_CHUNKS_PER_SPLIT_ENV} must be in [1,4], got {value}"
+        )
+    return value
+
+
+def _exact_h16_enabled() -> bool:
+    raw = os.environ.get(_EXACT_H16_ENV)
+    return raw is not None and raw.strip().lower() in {"1", "true", "on", "yes"}
+
+
+
+
+@triton.jit
+def _unpack_k5(payload, value_indices, mask, bits: tl.constexpr):
+    bit_positions = value_indices * bits
+    byte_offsets = bit_positions // 8
+    shifts = bit_positions % 8
+    low = tl.load(payload + byte_offsets, mask=mask, other=0).to(tl.uint32)
+    high = tl.load(payload + byte_offsets + 1, mask=mask, other=0).to(tl.uint32)
+    return ((low | (high << 8)) >> shifts) & ((1 << bits) - 1)
+
+
+@triton.jit
+def _stage_k5_as_fp8_records_kernel(
+    physical_slots_ptr,
+    k5_cache_ptr,
+    block_to_pool_slot_ptr,
+    latent_pool_ptr,
+    rope_pool_ptr,
+    output_ptr,
+    output_slots_ptr,
+    raw_latent_ptr,
+    raw_rope_ptr,
+    cache_stride_block: tl.constexpr,
+    latent_pool_stride_slot: tl.constexpr,
+    latent_pool_stride_token: tl.constexpr,
+    rope_pool_stride_slot: tl.constexpr,
+    rope_pool_stride_token: tl.constexpr,
+    output_stride_row: tl.constexpr,
+    bits: tl.constexpr,
+    s_col_offset: tl.constexpr,
+    zp_offset: tl.constexpr,
+    s_row_offset: tl.constexpr,
+    rope_offset: tl.constexpr,
+    num_blocks,
+    num_pool_slots,
+    raw_exact: tl.constexpr,
+    scatter_output: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if raw_exact:
+        valid = True
+    else:
+        physical_slot = tl.load(physical_slots_ptr + row)
+        block = physical_slot // _TL_K5_GROUP
+        token = physical_slot % _TL_K5_GROUP
+        valid = (physical_slot >= 0) & (block >= 0) & (block < num_blocks)
+        safe_block = tl.where(valid, block, 0)
+        pool_slot = tl.load(
+            block_to_pool_slot_ptr + safe_block,
+            mask=valid,
+            other=-1,
+        )
+        valid &= pool_slot < num_pool_slots
+
+    if valid:
+        scale_groups = tl.arange(0, 4)
+        group_dims = tl.arange(0, 128)
+        dims = scale_groups[:, None] * 128 + group_dims[None, :]
+        if raw_exact:
+            latent = (
+                tl.load(raw_latent_ptr + row * 512 + dims)
+                .to(tl.float8e4nv)
+                .to(tl.bfloat16)
+                .to(tl.float32)
+            )
+        else:
+            exact = pool_slot >= 0
+            body = ~exact
+            safe_pool_slot = tl.maximum(pool_slot, 0)
+            record = k5_cache_ptr + block * cache_stride_block
+            indices = dims * _TL_K5_GROUP + token
+            codes = _unpack_k5(record, indices, body, bits).to(tl.float32)
+            fp16_record = record.to(tl.pointer_type(tl.float16))
+            s_col = tl.load(
+                fp16_record + s_col_offset // 2 + dims,
+                mask=body,
+                other=0.0,
+            ).to(tl.float32)
+            zero = tl.load(
+                fp16_record + zp_offset // 2 + dims,
+                mask=body,
+                other=0.0,
+            ).to(tl.float32)
+            s_row = tl.load(
+                fp16_record + s_row_offset // 2 + token,
+                mask=body,
+                other=0.0,
+            ).to(tl.float32)
+            body_latent = (codes * s_col + zero) * s_row
+            exact_latent = tl.load(
+                latent_pool_ptr
+                + safe_pool_slot * latent_pool_stride_slot
+                + token * latent_pool_stride_token
+                + dims,
+                mask=exact,
+                other=0.0,
+            ).to(tl.float32)
+            latent = (
+                tl.where(exact, exact_latent, body_latent)
+                .to(tl.bfloat16)
+                .to(tl.float32)
+            )
+
+        amax = tl.max(tl.abs(latent), axis=1)
+        scales = tl.where(amax > 0.0, amax / _TL_FP8_E4M3_MAX, 1.0)
+        quantized = tl.maximum(
+            tl.minimum(latent / scales[:, None], _TL_FP8_E4M3_MAX),
+            -_TL_FP8_E4M3_MAX,
+        ).to(tl.float8e4nv)
+        output_row = (
+            tl.load(output_slots_ptr + row) if scatter_output else row
+        )
+        output_record = output_ptr + output_row * output_stride_row
+        fp8_output = output_record.to(tl.pointer_type(tl.float8e4nv))
+        tl.store(fp8_output + dims, quantized)
+        fp32_output = output_record.to(tl.pointer_type(tl.float32))
+        tl.store(
+            fp32_output + _TL_GLM_FP8_SCALE_OFFSET // 4 + scale_groups,
+            scales,
+        )
+
+        rope_dims = tl.arange(0, _TL_K5_ROPE_DIM)
+        if raw_exact:
+            rope = tl.load(raw_rope_ptr + row * _TL_K5_ROPE_DIM + rope_dims)
+        else:
+            body_rope = tl.load(
+                (record + rope_offset).to(tl.pointer_type(tl.bfloat16))
+                + token * _TL_K5_ROPE_DIM
+                + rope_dims,
+                mask=body,
+                other=0.0,
+            )
+            exact_rope = tl.load(
+                rope_pool_ptr
+                + safe_pool_slot * rope_pool_stride_slot
+                + token * rope_pool_stride_token
+                + rope_dims,
+                mask=exact,
+                other=0.0,
+            )
+            rope = tl.where(exact, exact_rope, body_rope)
+        tl.store(
+            (output_record + _TL_GLM_FP8_ROPE_OFFSET).to(
+                tl.pointer_type(tl.bfloat16)
+            )
+            + rope_dims,
+            rope,
+        )
+
+
+_NATIVE_EXACT_PAGES_PER_REQ = tl.constexpr(16)
+_NATIVE_SINK_PAGES_PER_REQ = tl.constexpr(2)
+_NATIVE_TAIL_PAGES_PER_REQ = tl.constexpr(14)
+_NATIVE_EXACT_PAGE_BYTES = (
+    int(_K5_GROUP) * int(_K5_LATENT_DIM) + int(_K5_GROUP) * int(_K5_ROPE_DIM) * 2
+)
+
+
+def compact_kvarn_native_rank_nbytes(
+    padded_pages: int,
+    padded_exact_pages: int,
+) -> int:
+    if padded_pages < 0 or padded_exact_pages < 0:
+        raise ValueError("native CKV page capacities must be non-negative")
+    return (
+        int(padded_pages) * (int(_K4_TILE_BYTES) + 4)
+        + int(padded_exact_pages) * _NATIVE_EXACT_PAGE_BYTES
+    )
+
+
+@triton.jit
+def _native_page_lookup(
+    page,
+    page_starts_ptr,
+    page_lens_ptr,
+    num_reqs,
+):
+    req_id = 0
+    local_page = 0
+    page_len = 0
+    valid = False
+    for req in tl.range(0, num_reqs):
+        start = tl.load(page_starts_ptr + req)
+        length = tl.load(page_lens_ptr + req)
+        match = (page >= start) & (page < start + length)
+        req_id = tl.where(match, req, req_id)
+        local_page = tl.where(match, page - start, local_page)
+        page_len = tl.where(match, length, page_len)
+        valid |= match
+    return req_id, local_page, page_len, valid
+
+
+@triton.jit
+def _native_exact_id(req_id, local_page, page_len, exact):
+    tail_start = tl.maximum(
+        page_len - _NATIVE_TAIL_PAGES_PER_REQ,
+        _NATIVE_SINK_PAGES_PER_REQ,
+    )
+    sink = local_page < _NATIVE_SINK_PAGES_PER_REQ
+    tail = local_page >= tail_start
+    mapped = sink | tail
+    tl.device_assert(~exact | mapped, "exact CKV page is outside sink/tail window")
+    within_req = tl.where(
+        sink,
+        local_page,
+        _NATIVE_SINK_PAGES_PER_REQ + local_page - tail_start,
+    )
+    tl.device_assert(
+        ~exact | (within_req < _NATIVE_EXACT_PAGES_PER_REQ),
+        "exact CKV page capacity exceeded",
+    )
+    return req_id * _NATIVE_EXACT_PAGES_PER_REQ + within_req
+
+
+@triton.jit
+def _stage_compact_kvarn_native_index_kernel(
+    block_table_ptr,
+    page_starts_ptr,
+    page_lens_ptr,
+    block_to_pool_slot_ptr,
+    wire_ptr,
+    block_table_stride,
+    padded_pages: tl.constexpr,
+    padded_exact_pages: tl.constexpr,
+    num_reqs,
+    num_blocks,
+    num_pool_slots,
+):
+    page = tl.program_id(0)
+    req, local_page, page_len, valid = _native_page_lookup(
+        page,
+        page_starts_ptr,
+        page_lens_ptr,
+        num_reqs,
+    )
+    active = valid
+    block = tl.load(
+        block_table_ptr + req * block_table_stride + local_page,
+        mask=active,
+        other=-1,
+    )
+    valid = active & (block >= 0) & (block < num_blocks)
+    tl.device_assert(~active | valid, "invalid native CKV block")
+    pool_slot = tl.load(
+        block_to_pool_slot_ptr + tl.maximum(block, 0),
+        mask=valid,
+        other=-1,
+    )
+    tl.device_assert(
+        ~valid | (pool_slot < num_pool_slots),
+        "native CKV exact pool mapping is out of range",
+    )
+    exact = valid & (pool_slot >= 0)
+    exact_id = _native_exact_id(req, local_page, page_len, exact)
+    tl.device_assert(
+        ~exact | (exact_id < padded_exact_pages),
+        "native CKV exact wire capacity exceeded",
+    )
+    index_ptr = (
+        wire_ptr + padded_pages * _K4_TILE_BYTES
+    ).to(tl.pointer_type(tl.int32))
+    tl.store(index_ptr + page, tl.where(exact, exact_id, -1))
+
+
+@triton.jit
+def _stage_compact_kvarn_native_packed_kernel(
+    block_table_ptr,
+    page_starts_ptr,
+    page_lens_ptr,
+    k4_cache_ptr,
+    wire_ptr,
+    block_table_stride,
+    num_reqs,
+    num_blocks,
+    padded_pages: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    page = tl.program_id(0)
+    chunk = tl.program_id(1)
+    req, local_page, _, valid = _native_page_lookup(
+        page,
+        page_starts_ptr,
+        page_lens_ptr,
+        num_reqs,
+    )
+    block = tl.load(
+        block_table_ptr + req * block_table_stride + local_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (block >= 0) & (block < num_blocks)
+    offsets = chunk * BLOCK + tl.arange(0, BLOCK)
+    mask = valid & (offsets < _K4_TILE_BYTES)
+    values = tl.load(
+        k4_cache_ptr + tl.maximum(block, 0) * _K4_TILE_BYTES + offsets,
+        mask=mask,
+        other=0,
+    )
+    tl.store(wire_ptr + page * _K4_TILE_BYTES + offsets, values, mask=mask)
+
+
+@triton.jit
+def _stage_compact_kvarn_native_exact_kernel(
+    block_table_ptr,
+    page_starts_ptr,
+    page_lens_ptr,
+    block_to_pool_slot_ptr,
+    latent_pool_ptr,
+    rope_pool_ptr,
+    wire_ptr,
+    block_table_stride,
+    num_reqs,
+    num_blocks,
+    num_pool_slots,
+    padded_pages: tl.constexpr,
+    padded_exact_pages: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    page = tl.program_id(0)
+    chunk = tl.program_id(1)
+    req, local_page, page_len, valid = _native_page_lookup(
+        page,
+        page_starts_ptr,
+        page_lens_ptr,
+        num_reqs,
+    )
+    block = tl.load(
+        block_table_ptr + req * block_table_stride + local_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (block >= 0) & (block < num_blocks)
+    pool_slot = tl.load(
+        block_to_pool_slot_ptr + tl.maximum(block, 0),
+        mask=valid,
+        other=-1,
+    )
+    exact = valid & (pool_slot >= 0) & (pool_slot < num_pool_slots)
+    exact_id = _native_exact_id(req, local_page, page_len, exact)
+    offsets = chunk * BLOCK + tl.arange(0, BLOCK)
+    latent_bytes = _K5_GROUP * _K5_LATENT_DIM
+    rope_bytes = _K5_GROUP * _K5_ROPE_DIM * 2
+    latent_mask = exact & (offsets < latent_bytes)
+    rope_mask = exact & (offsets >= latent_bytes) & (
+        offsets < latent_bytes + rope_bytes
+    )
+    latent_values = tl.load(
+        latent_pool_ptr.to(tl.pointer_type(tl.uint8))
+        + pool_slot * latent_bytes
+        + offsets,
+        mask=latent_mask,
+        other=0,
+    )
+    rope_offsets = offsets - latent_bytes
+    rope_values = tl.load(
+        rope_pool_ptr.to(tl.pointer_type(tl.uint8))
+        + pool_slot * rope_bytes
+        + rope_offsets,
+        mask=rope_mask,
+        other=0,
+    )
+    latent_base = padded_pages * (_K4_TILE_BYTES + 4)
+    rope_base = latent_base + padded_exact_pages * latent_bytes
+    tl.store(
+        wire_ptr + latent_base + exact_id * latent_bytes + offsets,
+        latent_values,
+        mask=latent_mask,
+    )
+    tl.store(
+        wire_ptr + rope_base + exact_id * rope_bytes + rope_offsets,
+        rope_values,
+        mask=rope_mask,
+    )
+
+
+@triton.jit
+def _materialize_compact_kvarn_native_records_kernel(
+    gathered_wire_ptr,
+    rank_page_starts_ptr,
+    rank_page_lens_ptr,
+    rank_token_starts_ptr,
+    rank_token_lens_ptr,
+    output_ptr,
+    num_reqs,
+    page_stride_rank,
+    page_stride_req,
+    token_stride_rank,
+    token_stride_req,
+    padded_tokens: tl.constexpr,
+    padded_pages: tl.constexpr,
+    padded_exact_pages: tl.constexpr,
+    rank_wire_bytes: tl.constexpr,
+    output_stride_row: tl.constexpr,
+):
+    row = tl.program_id(0)
+    rank = row // padded_tokens
+    rank_token = row % padded_tokens
+    req_id = 0
+    local_token = 0
+    valid = False
+    for req in tl.range(0, num_reqs):
+        token_offset = rank * token_stride_rank + req * token_stride_req
+        start = tl.load(rank_token_starts_ptr + token_offset)
+        length = tl.load(rank_token_lens_ptr + token_offset)
+        match = (rank_token >= start) & (rank_token < start + length)
+        req_id = tl.where(match, req, req_id)
+        local_token = tl.where(match, rank_token - start, local_token)
+        valid |= match
+    page_offset = rank * page_stride_rank + req_id * page_stride_req
+    page = (
+        tl.load(rank_page_starts_ptr + page_offset)
+        + local_token // _K5_GROUP
+    )
+    tl.device_assert(~valid | (page < padded_pages), "native CKV page overflow")
+    token = local_token % _K5_GROUP
+    rank_wire = gathered_wire_ptr + rank * rank_wire_bytes
+    index_ptr = (
+        rank_wire + padded_pages * _K4_TILE_BYTES
+    ).to(tl.pointer_type(tl.int32))
+    exact_id = tl.load(index_ptr + page, mask=valid, other=-1)
+    tl.device_assert(
+        ~valid
+        | (exact_id == -1)
+        | ((exact_id >= 0) & (exact_id < padded_exact_pages)),
+        "native CKV exact index is invalid",
+    )
+    exact = valid & (exact_id >= 0) & (exact_id < padded_exact_pages)
+    body = valid & ~exact
+    scale_groups = tl.arange(0, 4)
+    group_dims = tl.arange(0, 128)
+    dims = scale_groups[:, None] * 128 + group_dims[None, :]
+    packed_record = rank_wire + page * _K4_TILE_BYTES
+    indices = dims * _K5_GROUP + token
+    codes = _unpack_k5(packed_record, indices, body, 4).to(tl.float32)
+    fp16_record = packed_record.to(tl.pointer_type(tl.float16))
+    s_col = tl.load(
+        fp16_record + 16_384 // 2 + dims,
+        mask=body,
+        other=0.0,
+    ).to(tl.float32)
+    zero = tl.load(
+        fp16_record + 17_408 // 2 + dims,
+        mask=body,
+        other=0.0,
+    ).to(tl.float32)
+    s_row = tl.load(
+        fp16_record + 18_432 // 2 + token,
+        mask=body,
+        other=0.0,
+    ).to(tl.float32)
+    body_latent = (codes * s_col + zero) * s_row
+    latent_bytes = _K5_GROUP * _K5_LATENT_DIM
+    rope_bytes = _K5_GROUP * _K5_ROPE_DIM * 2
+    latent_base = padded_pages * (_K4_TILE_BYTES + 4)
+    rope_base = latent_base + padded_exact_pages * latent_bytes
+    exact_latent = tl.load(
+        (rank_wire + latent_base).to(tl.pointer_type(tl.float8e4nv))
+        + exact_id * latent_bytes
+        + token * _K5_LATENT_DIM
+        + dims,
+        mask=exact,
+        other=0.0,
+    ).to(tl.float32)
+    latent = (
+        tl.where(exact, exact_latent, body_latent)
+        .to(tl.bfloat16)
+        .to(tl.float32)
+    )
+    amax = tl.max(tl.abs(latent), axis=1)
+    scales = tl.where(amax > 0.0, amax / _TL_FP8_E4M3_MAX, 1.0)
+    quantized = tl.maximum(
+        tl.minimum(latent / scales[:, None], _TL_FP8_E4M3_MAX),
+        -_TL_FP8_E4M3_MAX,
+    ).to(tl.float8e4nv)
+    output_record = output_ptr + row * output_stride_row
+    tl.store(
+        output_record.to(tl.pointer_type(tl.float8e4nv)) + dims,
+        quantized,
+        mask=valid,
+    )
+    tl.store(
+        output_record.to(tl.pointer_type(tl.float32))
+        + _TL_GLM_FP8_SCALE_OFFSET // 4
+        + scale_groups,
+        scales,
+        mask=valid,
+    )
+    rope_dims = tl.arange(0, _K5_ROPE_DIM)
+    body_rope = tl.load(
+        (packed_record + 18_560).to(tl.pointer_type(tl.bfloat16))
+        + token * _K5_ROPE_DIM
+        + rope_dims,
+        mask=body,
+        other=0.0,
+    )
+    exact_rope = tl.load(
+        (rank_wire + rope_base).to(tl.pointer_type(tl.bfloat16))
+        + exact_id * (_K5_GROUP * _K5_ROPE_DIM)
+        + token * _K5_ROPE_DIM
+        + rope_dims,
+        mask=exact,
+        other=0.0,
+    )
+    tl.store(
+        (output_record + _TL_GLM_FP8_ROPE_OFFSET).to(
+            tl.pointer_type(tl.bfloat16)
+        )
+        + rope_dims,
+        tl.where(exact, exact_rope, body_rope),
+        mask=valid,
+    )
+
+@triton.jit
+def _stage_bf16_sylvester_as_exact_pool_fp8_records_kernel(
+    raw_latent_ptr,
+    raw_rope_ptr,
+    output_slots_ptr,
+    output_ptr,
+    output_stride_row: tl.constexpr,
+):
+    """Fuse the BF16 Hadacore factorization with canonical record staging."""
+    row = tl.program_id(0)
+    axis = tl.arange(0, 16)
+    h_row = axis[:, None]
+    h_col = axis[None, :]
+    parity = (
+        (h_row & 1) * (h_col & 1)
+        + ((h_row >> 1) & 1) * ((h_col >> 1) & 1)
+        + ((h_row >> 2) & 1) * ((h_col >> 2) & 1)
+        + ((h_row >> 3) & 1) * ((h_col >> 3) & 1)
+    ) & 1
+    h16 = tl.where(parity == 0, 0.25, -0.25).to(tl.bfloat16)
+
+    # Hadacore's 512-wide BF16 path is H16 x H16 x H2.  Each MMA
+    # factor is rounded back to BF16 before the next factor.
+    dims = h_row * 16 + h_col
+    raw_low = tl.load(raw_latent_ptr + row * 512 + dims)
+    raw_high = tl.load(raw_latent_ptr + row * 512 + 256 + dims)
+    low = tl.dot(raw_low, h16).to(tl.bfloat16)
+    high = tl.dot(raw_high, h16).to(tl.bfloat16)
+    low = tl.dot(h16, low).to(tl.bfloat16)
+    high = tl.dot(h16, high).to(tl.bfloat16)
+
+    h2_scale = tl.full((), 0.70703125, tl.bfloat16).to(tl.float32)
+    low_fp32 = low.to(tl.float32)
+    high_fp32 = high.to(tl.float32)
+    rotated_low = (
+        low_fp32 * h2_scale + high_fp32 * h2_scale
+    ).to(tl.bfloat16)
+    rotated_high = (
+        low_fp32 * h2_scale - high_fp32 * h2_scale
+    ).to(tl.bfloat16)
+
+    # The exact pool first rounds stored BF16 latent through E4M3, then
+    # derives four independent 128-element scales from that rounded value.
+    exact_low = (
+        rotated_low.to(tl.float8e4nv)
+        .to(tl.bfloat16)
+        .to(tl.float32)
+    )
+    exact_high = (
+        rotated_high.to(tl.float8e4nv)
+        .to(tl.bfloat16)
+        .to(tl.float32)
+    )
+    exact_low = tl.reshape(exact_low, (2, 128))
+    exact_high = tl.reshape(exact_high, (2, 128))
+    low_amax = tl.max(tl.abs(exact_low), axis=1)
+    high_amax = tl.max(tl.abs(exact_high), axis=1)
+    low_scales = tl.where(
+        low_amax > 0.0, low_amax / _TL_FP8_E4M3_MAX, 1.0
+    )
+    high_scales = tl.where(
+        high_amax > 0.0, high_amax / _TL_FP8_E4M3_MAX, 1.0
+    )
+    low_quantized = tl.maximum(
+        tl.minimum(exact_low / low_scales[:, None], _TL_FP8_E4M3_MAX),
+        -_TL_FP8_E4M3_MAX,
+    ).to(tl.float8e4nv)
+    high_quantized = tl.maximum(
+        tl.minimum(exact_high / high_scales[:, None], _TL_FP8_E4M3_MAX),
+        -_TL_FP8_E4M3_MAX,
+    ).to(tl.float8e4nv)
+
+    output_row = tl.load(output_slots_ptr + row)
+    output_record = output_ptr + output_row * output_stride_row
+    fp8_output = output_record.to(tl.pointer_type(tl.float8e4nv))
+    half_dims = tl.arange(0, 256)
+    tl.store(
+        fp8_output + half_dims,
+        tl.reshape(low_quantized, (256,)),
+    )
+    tl.store(
+        fp8_output + 256 + half_dims,
+        tl.reshape(high_quantized, (256,)),
+    )
+    scale_groups = tl.arange(0, 2)
+    fp32_output = output_record.to(tl.pointer_type(tl.float32))
+    tl.store(
+        fp32_output + _TL_GLM_FP8_SCALE_OFFSET // 4 + scale_groups,
+        low_scales,
+    )
+    tl.store(
+        fp32_output + _TL_GLM_FP8_SCALE_OFFSET // 4 + 2 + scale_groups,
+        high_scales,
+    )
+
+    rope_dims = tl.arange(0, _TL_K5_ROPE_DIM)
+    rope = tl.load(raw_rope_ptr + row * _TL_K5_ROPE_DIM + rope_dims)
+    tl.store(
+        (output_record + _TL_GLM_FP8_ROPE_OFFSET).to(
+            tl.pointer_type(tl.bfloat16)
+        )
+        + rope_dims,
+        rope,
+    )
+
+def stage_compact_kvarn_native_history(
+    block_table: torch.Tensor,
+    page_starts: torch.Tensor,
+    page_lens: torch.Tensor,
+    k4_cache: torch.Tensor,
+    block_to_pool_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    wire: torch.Tensor,
+    *,
+    padded_pages: int,
+    padded_exact_pages: int,
+) -> None:
+    """Pack one rank's live K4 pages and exact overrides into native wire."""
+    if (
+        block_table.dtype != torch.int32
+        or block_table.ndim != 2
+        or not block_table.is_contiguous()
+    ):
+        raise ValueError("block_table must be contiguous rank-2 int32")
+    for tensor, name in (
+        (page_starts, "page_starts"),
+        (page_lens, "page_lens"),
+    ):
+        if (
+            tensor.dtype != torch.int32
+            or tensor.ndim != 1
+            or not tensor.is_contiguous()
+        ):
+            raise ValueError(f"{name} must be contiguous flat int32")
+    if page_starts.shape != page_lens.shape or page_starts.numel() == 0:
+        raise ValueError("page starts/lens must have equal nonzero length")
+    if (
+        k4_cache.dtype != torch.uint8
+        or k4_cache.ndim != 3
+        or not k4_cache.is_contiguous()
+        or k4_cache.stride(0) != int(_K4_TILE_BYTES)
+    ):
+        raise ValueError("native CKV requires contiguous K4 pages with stride26752")
+    if (
+        block_to_pool_slot.dtype != torch.int32
+        or block_to_pool_slot.ndim != 1
+        or not block_to_pool_slot.is_contiguous()
+        or block_to_pool_slot.numel() != k4_cache.shape[0]
+    ):
+        raise ValueError("block_to_pool_slot must map every K4 cache page")
+    if (
+        latent_pool.dtype != torch.float8_e4m3fn
+        or latent_pool.ndim != 3
+        or tuple(latent_pool.shape[1:]) != (int(_K5_GROUP), int(_K5_LATENT_DIM))
+        or not latent_pool.is_contiguous()
+    ):
+        raise ValueError("native CKV latent pool must be contiguous E4M3 [P,64,512]")
+    if (
+        rope_pool.dtype != torch.bfloat16
+        or rope_pool.ndim != 3
+        or tuple(rope_pool.shape[1:]) != (_K5_GROUP, _K5_ROPE_DIM)
+        or not rope_pool.is_contiguous()
+        or rope_pool.shape[0] != latent_pool.shape[0]
+    ):
+        raise ValueError("native CKV RoPE pool must be contiguous BF16 [P,64,64]")
+    padded_pages = int(padded_pages)
+    padded_exact_pages = int(padded_exact_pages)
+    expected_nbytes = compact_kvarn_native_rank_nbytes(
+        padded_pages, padded_exact_pages
+    )
+    if (
+        wire.dtype != torch.uint8
+        or wire.ndim != 1
+        or not wire.is_contiguous()
+        or wire.numel() != expected_nbytes
+    ):
+        raise ValueError(
+            f"native CKV wire must be flat uint8 with {expected_nbytes} bytes"
+        )
+    tensors = (
+        block_table,
+        page_starts,
+        page_lens,
+        k4_cache,
+        block_to_pool_slot,
+        latent_pool,
+        rope_pool,
+        wire,
+    )
+    if any(tensor.device != wire.device for tensor in tensors):
+        raise ValueError("all native CKV staging tensors must share one device")
+    if wire.device.type != "cuda":
+        raise ValueError("native CKV staging requires CUDA tensors")
+    if wire.data_ptr() % 16:
+        raise ValueError("native CKV wire must be 16-byte aligned")
+    if padded_pages <= 0:
+        raise ValueError("native CKV padded page count must be positive")
+    required_exact = page_starts.numel() * int(_NATIVE_EXACT_PAGES_PER_REQ)
+    if padded_exact_pages < required_exact:
+        raise ValueError(
+            "native CKV exact capacity must provide 16 pages per request"
+        )
+
+    num_reqs = page_starts.numel()
+    _stage_compact_kvarn_native_index_kernel[(padded_pages,)](
+        block_table,
+        page_starts,
+        page_lens,
+        block_to_pool_slot,
+        wire,
+        block_table.stride(0),
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+        num_reqs=num_reqs,
+        num_blocks=k4_cache.shape[0],
+        num_pool_slots=latent_pool.shape[0],
+        num_warps=1,
+    )
+    block = 256
+    _stage_compact_kvarn_native_packed_kernel[
+        (padded_pages, triton.cdiv(int(_K4_TILE_BYTES), block))
+    ](
+        block_table,
+        page_starts,
+        page_lens,
+        k4_cache,
+        wire,
+        block_table.stride(0),
+        num_reqs,
+        k4_cache.shape[0],
+        padded_pages=padded_pages,
+        BLOCK=block,
+        num_warps=4,
+    )
+    _stage_compact_kvarn_native_exact_kernel[
+        (padded_pages, triton.cdiv(_NATIVE_EXACT_PAGE_BYTES, block))
+    ](
+        block_table,
+        page_starts,
+        page_lens,
+        block_to_pool_slot,
+        latent_pool,
+        rope_pool,
+        wire,
+        block_table.stride(0),
+        num_reqs,
+        k4_cache.shape[0],
+        latent_pool.shape[0],
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+        BLOCK=block,
+        num_warps=4,
+    )
+
+
+def materialize_compact_kvarn_native_records(
+    gathered_wire: torch.Tensor,
+    rank_page_starts: torch.Tensor,
+    rank_page_lens: torch.Tensor,
+    rank_token_starts: torch.Tensor,
+    rank_token_lens: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    padded_tokens: int,
+    padded_pages: int,
+    padded_exact_pages: int,
+) -> None:
+    """Reproduce canonical FP8 records from the compact native CKV wire."""
+    matrices = (
+        (rank_page_starts, "rank_page_starts"),
+        (rank_page_lens, "rank_page_lens"),
+        (rank_token_starts, "rank_token_starts"),
+        (rank_token_lens, "rank_token_lens"),
+    )
+    shape = rank_page_starts.shape
+    if len(shape) != 2 or shape[0] <= 0 or shape[1] <= 0:
+        raise ValueError("native CKV rank metadata must have shape [D,R]")
+    for tensor, name in matrices:
+        if tensor.dtype != torch.int32 or tensor.ndim != 2:
+            raise ValueError(f"{name} must be rank-2 int32")
+        if tensor.shape != shape:
+            raise ValueError("native CKV rank metadata shapes must match")
+    dcp_world_size, num_reqs = map(int, shape)
+    padded_tokens = int(padded_tokens)
+    padded_pages = int(padded_pages)
+    padded_exact_pages = int(padded_exact_pages)
+    rank_wire_bytes = compact_kvarn_native_rank_nbytes(
+        padded_pages, padded_exact_pages
+    )
+    if (
+        gathered_wire.dtype != torch.uint8
+        or gathered_wire.ndim != 1
+        or not gathered_wire.is_contiguous()
+        or gathered_wire.numel() != dcp_world_size * rank_wire_bytes
+    ):
+        raise ValueError("gathered native CKV wire has invalid geometry")
+    if (
+        output.dtype != torch.uint8
+        or output.ndim != 2
+        or output.shape
+        != (dcp_world_size * padded_tokens, _GLM_FP8_RECORD_BYTES)
+        or not output.is_contiguous()
+    ):
+        raise ValueError("native CKV output must be canonical contiguous records")
+    tensors = (
+        gathered_wire,
+        rank_page_starts,
+        rank_page_lens,
+        rank_token_starts,
+        rank_token_lens,
+        output,
+    )
+    if any(tensor.device != output.device for tensor in tensors):
+        raise ValueError("all native CKV reader tensors must share one device")
+    if output.device.type != "cuda":
+        raise ValueError("native CKV reader requires CUDA tensors")
+    if output.data_ptr() % 16:
+        raise ValueError("native CKV output must be 16-byte aligned")
+    _materialize_compact_kvarn_native_records_kernel[
+        (dcp_world_size * padded_tokens,)
+    ](
+        gathered_wire,
+        rank_page_starts,
+        rank_page_lens,
+        rank_token_starts,
+        rank_token_lens,
+        output,
+        num_reqs,
+        rank_page_starts.stride(0),
+        rank_page_starts.stride(1),
+        rank_token_starts.stride(0),
+        rank_token_starts.stride(1),
+        padded_tokens=padded_tokens,
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+        rank_wire_bytes=rank_wire_bytes,
+        output_stride_row=output.stride(0),
+        num_warps=4,
+    )
+
+
+
+def stage_k5_as_fp8_records(
+    physical_slots: torch.Tensor,
+    k5_cache: torch.Tensor,
+    block_to_pool_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Stage packed KVarN MLA tiles as SparkInfer GLM FP8 cache records.
+
+    Invalid physical slots leave the corresponding output rows unchanged.
+    """
+    if physical_slots.ndim != 1 or physical_slots.dtype != torch.int32:
+        raise ValueError("physical_slots must be a flat int32 tensor")
+    if not physical_slots.is_contiguous():
+        raise ValueError("physical_slots must be contiguous")
+    if k5_cache.dtype != torch.uint8 or k5_cache.ndim != 3:
+        raise ValueError("k5_cache must be a rank-3 uint8 tensor")
+    if not k5_cache.is_contiguous():
+        raise ValueError("k5_cache must be contiguous")
+    geometry = {
+        18_560: (2, 8_192, 9_216, 10_240, 10_368),
+        26_752: (4, 16_384, 17_408, 18_432, 18_560),
+        30_848: (5, 20_480, 21_504, 22_528, 22_656),
+    }.get(k5_cache.stride(0))
+    if geometry is None:
+        raise ValueError(
+            "KVarN cache block stride must be 18560, 26752, or 30848 bytes, "
+            f"got {k5_cache.stride(0)}"
+        )
+    if block_to_pool_slot.ndim != 1 or block_to_pool_slot.dtype != torch.int32:
+        raise ValueError("block_to_pool_slot must be a flat int32 tensor")
+    if not block_to_pool_slot.is_contiguous():
+        raise ValueError("block_to_pool_slot must be contiguous")
+    if block_to_pool_slot.numel() != k5_cache.shape[0]:
+        raise ValueError("block_to_pool_slot must contain one entry per cache block")
+    if latent_pool.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError("latent_pool must use BF16 or float8_e4m3fn")
+    if latent_pool.ndim != 3 or tuple(latent_pool.shape[1:]) != (
+        _K5_GROUP,
+        _K5_LATENT_DIM,
+    ):
+        raise ValueError("latent_pool must have shape (slots,64,512)")
+    if not latent_pool.is_contiguous():
+        raise ValueError("latent_pool must be contiguous")
+    if rope_pool.dtype != torch.bfloat16 or rope_pool.ndim != 3:
+        raise ValueError("rope_pool must be a rank-3 BF16 tensor")
+    if tuple(rope_pool.shape[1:]) != (_K5_GROUP, _K5_ROPE_DIM):
+        raise ValueError("rope_pool must have shape (slots,64,64)")
+    if not rope_pool.is_contiguous():
+        raise ValueError("rope_pool must be contiguous")
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("latent_pool and rope_pool must have equal slot capacities")
+    if output.dtype != torch.uint8 or output.ndim != 2:
+        raise ValueError("output must be a rank-2 uint8 tensor")
+    if output.shape != (physical_slots.numel(), _GLM_FP8_RECORD_BYTES):
+        raise ValueError(
+            f"output must have shape ({physical_slots.numel()},"
+            f"{_GLM_FP8_RECORD_BYTES})"
+        )
+    if not output.is_contiguous():
+        raise ValueError("output must be contiguous")
+    tensors = (
+        physical_slots,
+        k5_cache,
+        block_to_pool_slot,
+        latent_pool,
+        rope_pool,
+        output,
+    )
+    if any(tensor.device != output.device for tensor in tensors):
+        raise ValueError("all KVarN5 staging tensors must share one device")
+    if output.device.type != "cuda":
+        raise ValueError("KVarN5 staging tensors must be CUDA tensors")
+    aligned_tensors = (
+        (physical_slots, 4, "physical_slots"),
+        (k5_cache, 2, "k5_cache"),
+        (block_to_pool_slot, 4, "block_to_pool_slot"),
+        (latent_pool, latent_pool.element_size(), "latent_pool"),
+        (rope_pool, 2, "rope_pool"),
+        (output, 16, "output"),
+    )
+    for tensor, alignment, name in aligned_tensors:
+        if tensor.data_ptr() % alignment:
+            raise ValueError(f"{name} must be {alignment}-byte aligned")
+    if physical_slots.numel() == 0:
+        return
+
+    _stage_k5_as_fp8_records_kernel[(physical_slots.numel(),)](
+        physical_slots,
+        k5_cache,
+        block_to_pool_slot,
+        latent_pool,
+        rope_pool,
+        output,
+        physical_slots,
+        latent_pool,
+        rope_pool,
+        k5_cache.stride(0),
+        latent_pool.stride(0),
+        latent_pool.stride(1),
+        rope_pool.stride(0),
+        rope_pool.stride(1),
+        output.stride(0),
+        bits=geometry[0],
+        s_col_offset=geometry[1],
+        zp_offset=geometry[2],
+        s_row_offset=geometry[3],
+        rope_offset=geometry[4],
+        num_blocks=k5_cache.shape[0],
+        num_pool_slots=latent_pool.shape[0],
+        raw_exact=False,
+        scatter_output=False,
+        num_warps=4,
+    )
+
+def stage_bf16_as_exact_pool_fp8_records(
+    latent: torch.Tensor,
+    rope: torch.Tensor,
+    output_slots: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Stage full raw rows with the exact-pool FP8 round and canonical record."""
+    if latent.dtype != torch.bfloat16 or latent.ndim != 2:
+        raise ValueError("latent must be a rank-2 BF16 tensor")
+    if latent.shape[1] != _K5_LATENT_DIM or not latent.is_contiguous():
+        raise ValueError("latent must be contiguous with shape (rows,512)")
+    if rope.dtype != torch.bfloat16 or rope.ndim != 2:
+        raise ValueError("rope must be a rank-2 BF16 tensor")
+    if rope.shape != (latent.shape[0], _K5_ROPE_DIM) or not rope.is_contiguous():
+        raise ValueError("rope must be contiguous with shape (rows,64)")
+    if output_slots.ndim != 1 or output_slots.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise ValueError("output_slots must be a flat int32 or int64 tensor")
+    if output_slots.numel() != latent.shape[0] or not output_slots.is_contiguous():
+        raise ValueError("output_slots must contain one contiguous slot per row")
+    if (
+        output.dtype != torch.uint8
+        or output.ndim != 2
+        or output.shape[1] != _GLM_FP8_RECORD_BYTES
+        or not output.is_contiguous()
+    ):
+        raise ValueError("output must be contiguous uint8 records with width 656")
+    tensors = (latent, rope, output_slots, output)
+    if any(tensor.device != output.device for tensor in tensors):
+        raise ValueError("all direct-current staging tensors must share one device")
+    if output.device.type != "cuda":
+        raise ValueError("direct-current staging tensors must be CUDA tensors")
+    if output.data_ptr() % 16:
+        raise ValueError("output must be 16-byte aligned")
+    if latent.shape[0] == 0:
+        return
+
+    _stage_k5_as_fp8_records_kernel[(latent.shape[0],)](
+        output_slots,
+        output,
+        output_slots,
+        latent,
+        rope,
+        output,
+        output_slots,
+        latent,
+        rope,
+        output.stride(0),
+        latent.stride(0),
+        latent.stride(1),
+        rope.stride(0),
+        rope.stride(1),
+        output.stride(0),
+        bits=4,
+        s_col_offset=0,
+        zp_offset=0,
+        s_row_offset=0,
+        rope_offset=0,
+        num_blocks=0,
+        num_pool_slots=0,
+        raw_exact=True,
+        scatter_output=True,
+        num_warps=4,
+    )
+
+def stage_bf16_sylvester_as_exact_pool_fp8_records(
+    latent: torch.Tensor,
+    rope: torch.Tensor,
+    output_slots: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Fuse the fixed GLM Sylvester transform with canonical FP8 staging.
+
+    This explicit opt-in candidate implements the normalized 512-wide
+    Sylvester transform used by the GLM KVarN CUDA path.  It intentionally
+    accepts no matrix operand: alternate transforms are unsupported and cannot
+    be mistaken for the fixed transform compiled into the kernel.
+    """
+    if latent.dtype != torch.bfloat16 or latent.ndim != 2:
+        raise ValueError("latent must be a rank-2 BF16 tensor")
+    if latent.shape[1] != _K5_LATENT_DIM or not latent.is_contiguous():
+        raise ValueError("latent must be contiguous with shape (rows,512)")
+    if rope.dtype != torch.bfloat16 or rope.ndim != 2:
+        raise ValueError("rope must be a rank-2 BF16 tensor")
+    if rope.shape != (latent.shape[0], _K5_ROPE_DIM) or not rope.is_contiguous():
+        raise ValueError("rope must be contiguous with shape (rows,64)")
+    if output_slots.ndim != 1 or output_slots.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise ValueError("output_slots must be a flat int32 or int64 tensor")
+    if output_slots.numel() != latent.shape[0] or not output_slots.is_contiguous():
+        raise ValueError("output_slots must contain one contiguous slot per row")
+    if (
+        output.dtype != torch.uint8
+        or output.ndim != 2
+        or output.shape[1] != _GLM_FP8_RECORD_BYTES
+        or not output.is_contiguous()
+    ):
+        raise ValueError("output must be contiguous uint8 records with width 656")
+    tensors = (latent, rope, output_slots, output)
+    if any(tensor.device != output.device for tensor in tensors):
+        raise ValueError("all fused-current staging tensors must share one device")
+    if output.device.type != "cuda":
+        raise ValueError("fused-current staging tensors must be CUDA tensors")
+    if output.data_ptr() % 16:
+        raise ValueError("output must be 16-byte aligned")
+    if latent.shape[0] == 0:
+        return
+
+    _stage_bf16_sylvester_as_exact_pool_fp8_records_kernel[
+        (latent.shape[0],)
+    ](
+        latent,
+        rope,
+        output_slots,
+        output,
+        output.stride(0),
+        num_warps=4,
+    )
+
+
+
+@triton.jit
+def _native_k5_fused_merge_kernel(
+    split_o, split_lse, output, output_lse,
+    so_m: tl.constexpr, so_h: tl.constexpr, so_s: tl.constexpr,
+    sl_m: tl.constexpr, sl_h: tl.constexpr, sl_s: tl.constexpr,
+    out_m: tl.constexpr, out_h: tl.constexpr,
+    ol_m: tl.constexpr, ol_h: tl.constexpr,
+    SPLITS: tl.constexpr, BLOCK_SPLITS: tl.constexpr,
+    D: tl.constexpr, BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    splits = tl.arange(0, BLOCK_SPLITS)
+    lse = tl.load(
+        split_lse + row * sl_m + head * sl_h + splits * sl_s,
+        mask=splits < SPLITS,
+        other=-float("inf"),
+    )
+    gmax = tl.max(lse, axis=0)
+    valid = gmax != -float("inf")
+    safe = tl.where(valid, gmax, 0.0)
+    weights = tl.where(lse != -float("inf"), tl.exp2(lse - safe), 0.0)
+    denom = tl.sum(weights, axis=0)
+    norm = tl.where(denom > 0.0, weights / denom, 0.0)
+    natural_lse = tl.where(
+        valid, (safe + tl.log2(denom)) * 0.6931471805599453, -float("inf")
+    )
+    tl.store(output_lse + row * ol_m + head * ol_h, natural_lse)
+    for d0 in range(0, D, BLOCK_D):
+        dims = d0 + tl.arange(0, BLOCK_D)
+        partial = tl.load(
+            split_o + row * so_m + head * so_h
+            + splits[:, None] * so_s + dims[None, :],
+            mask=(lse != -float("inf"))[:, None] & (dims < D)[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        merged = tl.sum(partial * norm[:, None], axis=0)
+        tl.store(
+            output + row * out_m + head * out_h + dims,
+            merged,
+            mask=dims < D,
+        )
+
+
+@triton.jit
+def _native_k5_fused_merge_hpp4_kernel(
+    split_o,
+    split_lse,
+    output,
+    output_lse,
+    so_m: tl.constexpr,
+    so_h: tl.constexpr,
+    so_s: tl.constexpr,
+    sl_m: tl.constexpr,
+    sl_h: tl.constexpr,
+    sl_s: tl.constexpr,
+    out_m: tl.constexpr,
+    out_h: tl.constexpr,
+    ol_m: tl.constexpr,
+    ol_h: tl.constexpr,
+    SPLITS: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEADS_PER_PROGRAM: tl.constexpr,
+):
+    row = tl.program_id(0)
+    head_group = tl.program_id(1)
+    heads = head_group * HEADS_PER_PROGRAM + tl.arange(0, HEADS_PER_PROGRAM)
+    splits = tl.arange(0, SPLITS)
+    lse = tl.load(
+        split_lse
+        + row * sl_m
+        + heads[:, None] * sl_h
+        + splits[None, :] * sl_s
+    )
+    gmax = tl.max(lse, axis=1)
+    valid = gmax != -float("inf")
+    safe = tl.where(valid, gmax, 0.0)
+    weights = tl.where(lse != -float("inf"), tl.exp2(lse - safe[:, None]), 0.0)
+    denom = tl.sum(weights, axis=1)
+    norm = tl.where(denom[:, None] > 0.0, weights / denom[:, None], 0.0)
+    natural_lse = tl.where(
+        valid, (safe + tl.log2(denom)) * 0.6931471805599453, -float("inf")
+    )
+    tl.store(output_lse + row * ol_m + heads * ol_h, natural_lse)
+    for d0 in range(0, D, BLOCK_D):
+        dims = d0 + tl.arange(0, BLOCK_D)
+        partial = tl.load(
+            split_o
+            + row * so_m
+            + heads[:, None, None] * so_h
+            + splits[None, :, None] * so_s
+            + dims[None, None, :],
+            mask=(lse != -float("inf"))[:, :, None],
+            other=0.0,
+        ).to(tl.float32)
+        merged = tl.sum(partial * norm[:, :, None], axis=1)
+        tl.store(
+            output
+            + row * out_m
+            + heads[:, None] * out_h
+            + dims[None, :],
+            merged,
+        )
+
+def native_packed_k5_decode(
+    q: torch.Tensor,
+    selected_indices: torch.Tensor,
+    valid_counts: torch.Tensor,
+    k5_cache: torch.Tensor,
+    block_to_pool_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    split_output: torch.Tensor,
+    split_lse: torch.Tensor,
+    num_chunks_ptr: torch.Tensor,
+    output: torch.Tensor,
+    output_lse: torch.Tensor,
+    *,
+    sm_scale: float,
+    candidate_envelope: int,
+    exact_pool_only: bool = False,
+    fuse_kvarn_hadamard: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Native SM120 sparse MLA over K4/K5 and exact rows.
+
+    ``exact_pool_only`` and ``fuse_kvarn_hadamard`` are Python-static launch
+    modes. Fused Hadamard consumes unrotated Q-NoPE and returns unrotated output.
+    Exact eager calls validate that every active selected row maps into the exact
+    side pool; CUDA graph replay relies on the cache tracker's invariant.
+    ``B12X_KVARN_MLA_EXACT_H16=1`` routes only exact-pool launches to
+    the H16/block512 BF16-math specialization.
+
+    """
+    if q.ndim != 3:
+        raise ValueError("native K5 query must be rank 3")
+    rows, heads, width = map(int, q.shape)
+    if not 1 <= rows <= 16 or heads != 64 or width != 576:
+        raise ValueError("native K5 decode requires M in [1,16], H64, D576")
+    if (
+        q.dtype != torch.bfloat16
+        or q.stride(2) != 1
+        or q.stride(1) < width
+        or q.stride(0) < heads * q.stride(1)
+    ):
+        raise ValueError("native K5 query must have a non-overlapping unit-inner BF16 layout")
+    if selected_indices.dtype != torch.int32 or selected_indices.shape != (rows, 2048):
+        raise ValueError("native K5 selected indices must be int32[M,2048]")
+    if not selected_indices.is_contiguous():
+        raise ValueError("native K5 selected indices must be contiguous")
+    if valid_counts.dtype != torch.int32 or valid_counts.shape != (rows,):
+        raise ValueError("native K5 valid counts must be int32[M]")
+    if k5_cache.dtype != torch.uint8 or k5_cache.ndim != 3:
+        raise ValueError("native KVarN cache must be rank-3 uint8")
+    tile_bytes = int(k5_cache.shape[2])
+    packed_bits_by_tile = {
+        int(_K2_TILE_BYTES): 2,
+        int(_K4_TILE_BYTES): 4,
+        int(_K5_TILE_BYTES): 5,
+    }
+    packed_bits = packed_bits_by_tile.get(tile_bytes)
+    if (
+        k5_cache.shape[1] != 1
+        or packed_bits is None
+        or not k5_cache.is_contiguous()
+    ):
+        raise ValueError(
+            "native KVarN cache must be contiguous "
+            "[blocks,1,18560|26752|30848]: "
+            f"shape={tuple(k5_cache.shape)} stride={tuple(k5_cache.stride())} "
+            f"offset={k5_cache.storage_offset()} "
+            f"contiguous={k5_cache.is_contiguous()}"
+        )
+    if (
+        block_to_pool_slot.dtype != torch.int32
+        or block_to_pool_slot.shape != (k5_cache.shape[0],)
+        or not block_to_pool_slot.is_contiguous()
+    ):
+        raise ValueError("native K5 block map must contain one contiguous int32 per block")
+    if (
+        latent_pool.dtype != torch.float8_e4m3fn
+        or tuple(latent_pool.shape[1:]) != (64, 512)
+        or not latent_pool.is_contiguous()
+    ):
+        raise ValueError("native K5 exact latent pool must be contiguous E4M3[slots,64,512]")
+    if (
+        rope_pool.dtype != torch.bfloat16
+        or tuple(rope_pool.shape[1:]) != (64, 64)
+        or not rope_pool.is_contiguous()
+    ):
+        raise ValueError("native K5 exact RoPE pool must be contiguous BF16[slots,64,64]")
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("native K5 exact pools must have equal capacities")
+    if type(exact_pool_only) is not bool:
+        raise TypeError("native K5 exact_pool_only must be a Python bool")
+    if type(fuse_kvarn_hadamard) is not bool:
+        raise TypeError("native K5 fuse_kvarn_hadamard must be a Python bool")
+    if not 0 <= int(candidate_envelope) <= 2048:
+        raise ValueError("native K5 candidate envelope must be in [0,2048]")
+    chunks = (int(candidate_envelope) + 63) // 64
+    exact_h16 = bool(exact_pool_only and _exact_h16_enabled())
+    chunks_per_split = 1 if rows == 1 else (3 if rows == 4 else 4)
+    if rows == 4 and (not exact_pool_only or exact_h16):
+        chunks_per_split = _mixed_m4_chunks_per_split()
+    elif (
+        _native_m5_split_family_enabled()
+        and 2 <= rows <= 7
+        and (not exact_pool_only or exact_h16)
+    ):
+        # M5/M6/M7 share the M4 mixed split family (default-off). The native
+        # grid is one CTA per row, so per-row chunk-range walk and FP32
+        # accumulation order are then identical to the M=4 verify path; only
+        # the runtime grid dimension changes. With the knob unset, rows 2..7
+        # keep chunks_per_split=4 exactly as before (fail-closed default).
+        chunks_per_split = _mixed_m4_chunks_per_split()
+    num_splits = (chunks + chunks_per_split - 1) // chunks_per_split
+    if num_splits > int(split_output.shape[2]) or num_splits > int(split_lse.shape[2]):
+        raise ValueError("native K5 split scratch is smaller than the DCP-local plan")
+    tensors = (
+        selected_indices, valid_counts, k5_cache, block_to_pool_slot,
+        latent_pool, rope_pool, split_output, split_lse, num_chunks_ptr,
+        output, output_lse,
+    )
+    if q.device.type != "cuda" or any(t.device != q.device for t in tensors):
+        raise ValueError("native K5 tensors must share one CUDA device")
+    if torch.cuda.get_device_capability(q.device) != (12, 0):
+        raise ValueError("native K5 decode requires SM120")
+    if exact_pool_only and not torch.cuda.is_current_stream_capturing():
+        prefix = selected_indices[:, : int(candidate_envelope)]
+        active = (
+            torch.arange(int(candidate_envelope), device=q.device)[None, :]
+            < valid_counts[:, None]
+        )
+        max_physical = int(k5_cache.shape[0]) * 64
+        if max_physical == 0 and bool(active.any().item()):
+            raise ValueError("native exact-pool decode has active rows but an empty cache")
+        if max_physical:
+            physical_ok = (prefix >= 0) & (prefix < max_physical)
+            if bool((active & ~physical_ok).any().item()):
+                raise ValueError("native exact-pool decode selected an invalid physical slot")
+            safe_blocks = prefix.clamp(0, max_physical - 1) // 64
+            # Profiling/dummy MTP runs before ownership maps exist and presents
+            # an entirely unmapped (-1) block map. The kernel masks those rows.
+            # Once any exact mapping exists, retain fail-closed validation for
+            # every active selected candidate so real requests cannot mix K5.
+            all_unmapped = bool((block_to_pool_slot == -1).all().item())
+            if not all_unmapped:
+                pool_slots = block_to_pool_slot[safe_blocks]
+                exact = (pool_slots >= 0) & (pool_slots < int(latent_pool.shape[0]))
+                if bool((active & ~exact).any().item()):
+                    raise ValueError("native exact-pool decode selected a non-exact cache row")
+    if chunks == 0:
+        output[:rows].zero_()
+        output_lse[:rows].fill_(-float("inf"))
+        return output[:rows], output_lse[:rows]
+
+    if num_splits == 1:
+        mid_out = output[:rows, :heads, :512].unsqueeze(2)
+        mid_lse = output_lse[:rows, :heads].unsqueeze(2)
+    else:
+        mid_out = split_output[:rows, :heads, :num_splits, :512]
+        mid_lse = split_lse[:rows, :heads, :num_splits]
+    # Import registers the CuTe custom op; kept lazy to avoid package cycles.
+    from b12x.attention._shared.mla import kernel as _native_kernel  # noqa: F401
+    if exact_h16:
+        torch.ops.b12x.kvarn_mla_sm120_decode_grid_exact_h16(
+            q, k5_cache.view(-1), selected_indices, mid_out, mid_lse,
+            valid_counts, block_to_pool_slot, latent_pool, rope_pool,
+            float(sm_scale), num_splits, chunks_per_split, exact_pool_only,
+            fuse_kvarn_hadamard,
+        )
+    else:
+        torch.ops.b12x.kvarn_mla_sm120_decode_grid(
+            q, k5_cache.view(-1), selected_indices, mid_out, mid_lse,
+            valid_counts, block_to_pool_slot, latent_pool, rope_pool,
+            float(sm_scale), num_splits, chunks_per_split, exact_pool_only,
+            fuse_kvarn_hadamard, packed_bits,
+        )
+    if num_splits == 1:
+        return output[:rows, :heads, :512], output_lse[:rows, :heads]
+    use_m9_hpp4 = (
+        os.getenv(_M9_HPP4_MERGE_ENV, "0") == "1"
+        and packed_bits == 4
+        and rows == 9
+        and heads == 64
+        and num_splits == 8
+        and chunks_per_split == 4
+    )
+    if use_m9_hpp4:
+        _native_k5_fused_merge_hpp4_kernel[(rows, heads // 4)](
+            mid_out, mid_lse, output, output_lse,
+            mid_out.stride(0), mid_out.stride(1), mid_out.stride(2),
+            mid_lse.stride(0), mid_lse.stride(1), mid_lse.stride(2),
+            output.stride(0), output.stride(1),
+            output_lse.stride(0), output_lse.stride(1),
+            8, 512, _merge_block_d(), 4,
+            num_warps=8,
+        )
+    else:
+        # Independent heads avoid the M1/S32 spill seen in earlier grouped
+        # prototypes and remain the exact fallback for every other geometry.
+        merge_warps = 8 if num_splits > 16 else 4
+        block_d = _merge_block_d()
+        merge_warps = max(merge_warps, min(8, block_d // 64))
+        _native_k5_fused_merge_kernel[(rows, heads)](
+            mid_out, mid_lse, output, output_lse,
+            mid_out.stride(0), mid_out.stride(1), mid_out.stride(2),
+            mid_lse.stride(0), mid_lse.stride(1), mid_lse.stride(2),
+            output.stride(0), output.stride(1),
+            output_lse.stride(0), output_lse.stride(1),
+            num_splits, triton.next_power_of_2(num_splits), 512, block_d,
+            num_warps=merge_warps,
+        )
+    return output[:rows, :heads, :512], output_lse[:rows, :heads]
+
+
+__all__ = [
+    "compact_kvarn_native_rank_nbytes",
+    "is_kvarn_mla_supported",
+    "stage_compact_kvarn_native_history",
+    "materialize_compact_kvarn_native_records",
+    "stage_k5_as_fp8_records",
+    "stage_bf16_as_exact_pool_fp8_records",
+    "stage_bf16_sylvester_as_exact_pool_fp8_records",
+    "native_packed_k5_decode",
+]

--- a/b12x/attention/kvarn_mla/api.py
+++ b/b12x/attention/kvarn_mla/api.py
@@ -140,7 +140,7 @@ def _stage_k5_as_fp8_records_kernel(
     if raw_exact:
         valid = True
     else:
-        physical_slot = tl.load(physical_slots_ptr + row)
+        physical_slot = tl.load(physical_slots_ptr + row).to(tl.int64)
         block = physical_slot // _TL_K5_GROUP
         token = physical_slot % _TL_K5_GROUP
         valid = (physical_slot >= 0) & (block >= 0) & (block < num_blocks)
@@ -158,7 +158,7 @@ def _stage_k5_as_fp8_records_kernel(
         dims = scale_groups[:, None] * 128 + group_dims[None, :]
         if raw_exact:
             latent = (
-                tl.load(raw_latent_ptr + row * 512 + dims)
+                tl.load(raw_latent_ptr + row.to(tl.int64) * 512 + dims)
                 .to(tl.float8e4nv)
                 .to(tl.bfloat16)
                 .to(tl.float32)
@@ -166,7 +166,7 @@ def _stage_k5_as_fp8_records_kernel(
         else:
             exact = pool_slot >= 0
             body = ~exact
-            safe_pool_slot = tl.maximum(pool_slot, 0)
+            safe_pool_slot = tl.maximum(pool_slot, 0).to(tl.int64)
             record = k5_cache_ptr + block * cache_stride_block
             indices = dims * _TL_K5_GROUP + token
             codes = _unpack_k5(record, indices, body, bits).to(tl.float32)
@@ -208,7 +208,8 @@ def _stage_k5_as_fp8_records_kernel(
             -_TL_FP8_E4M3_MAX,
         ).to(tl.float8e4nv)
         output_row = (
-            tl.load(output_slots_ptr + row) if scatter_output else row
+            (tl.load(output_slots_ptr + row).to(tl.int64) if scatter_output
+             else row.to(tl.int64))
         )
         output_record = output_ptr + output_row * output_stride_row
         fp8_output = output_record.to(tl.pointer_type(tl.float8e4nv))
@@ -221,7 +222,9 @@ def _stage_k5_as_fp8_records_kernel(
 
         rope_dims = tl.arange(0, _TL_K5_ROPE_DIM)
         if raw_exact:
-            rope = tl.load(raw_rope_ptr + row * _TL_K5_ROPE_DIM + rope_dims)
+            rope = tl.load(
+                raw_rope_ptr + row.to(tl.int64) * _TL_K5_ROPE_DIM + rope_dims
+            )
         else:
             body_rope = tl.load(
                 (record + rope_offset).to(tl.pointer_type(tl.bfloat16))
@@ -309,7 +312,10 @@ def _native_exact_id(req_id, local_page, page_len, exact):
         ~exact | (within_req < _NATIVE_EXACT_PAGES_PER_REQ),
         "exact CKV page capacity exceeded",
     )
-    return req_id * _NATIVE_EXACT_PAGES_PER_REQ + within_req
+    in_window = mapped & (within_req >= 0) & (
+        within_req < _NATIVE_EXACT_PAGES_PER_REQ
+    )
+    return in_window, req_id * _NATIVE_EXACT_PAGES_PER_REQ + within_req
 
 
 @triton.jit
@@ -350,8 +356,9 @@ def _stage_compact_kvarn_native_index_kernel(
         ~valid | (pool_slot < num_pool_slots),
         "native CKV exact pool mapping is out of range",
     )
-    exact = valid & (pool_slot >= 0)
-    exact_id = _native_exact_id(req, local_page, page_len, exact)
+    pool_mapped = valid & (pool_slot >= 0)
+    in_window, exact_id = _native_exact_id(req, local_page, page_len, pool_mapped)
+    exact = pool_mapped & in_window
     tl.device_assert(
         ~exact | (exact_id < padded_exact_pages),
         "native CKV exact wire capacity exceeded",
@@ -392,11 +399,14 @@ def _stage_compact_kvarn_native_packed_kernel(
     offsets = chunk * BLOCK + tl.arange(0, BLOCK)
     mask = valid & (offsets < _K4_TILE_BYTES)
     values = tl.load(
-        k4_cache_ptr + tl.maximum(block, 0) * _K4_TILE_BYTES + offsets,
+        k4_cache_ptr + tl.maximum(block, 0).to(tl.int64) * _K4_TILE_BYTES
+        + offsets,
         mask=mask,
         other=0,
     )
-    tl.store(wire_ptr + page * _K4_TILE_BYTES + offsets, values, mask=mask)
+    tl.store(
+        wire_ptr + page.to(tl.int64) * _K4_TILE_BYTES + offsets, values, mask=mask
+    )
 
 
 @triton.jit
@@ -435,8 +445,9 @@ def _stage_compact_kvarn_native_exact_kernel(
         mask=valid,
         other=-1,
     )
-    exact = valid & (pool_slot >= 0) & (pool_slot < num_pool_slots)
-    exact_id = _native_exact_id(req, local_page, page_len, exact)
+    pool_mapped = valid & (pool_slot >= 0) & (pool_slot < num_pool_slots)
+    in_window, exact_id = _native_exact_id(req, local_page, page_len, pool_mapped)
+    exact = pool_mapped & in_window
     offsets = chunk * BLOCK + tl.arange(0, BLOCK)
     latent_bytes = _K5_GROUP * _K5_LATENT_DIM
     rope_bytes = _K5_GROUP * _K5_ROPE_DIM * 2
@@ -446,7 +457,7 @@ def _stage_compact_kvarn_native_exact_kernel(
     )
     latent_values = tl.load(
         latent_pool_ptr.to(tl.pointer_type(tl.uint8))
-        + pool_slot * latent_bytes
+        + pool_slot.to(tl.int64) * latent_bytes
         + offsets,
         mask=latent_mask,
         other=0,
@@ -462,12 +473,18 @@ def _stage_compact_kvarn_native_exact_kernel(
     latent_base = padded_pages * (_K4_TILE_BYTES + 4)
     rope_base = latent_base + padded_exact_pages * latent_bytes
     tl.store(
-        wire_ptr + latent_base + exact_id * latent_bytes + offsets,
+        wire_ptr
+        + latent_base
+        + exact_id.to(tl.int64) * latent_bytes
+        + offsets,
         latent_values,
         mask=latent_mask,
     )
     tl.store(
-        wire_ptr + rope_base + exact_id * rope_bytes + rope_offsets,
+        wire_ptr
+        + rope_base
+        + exact_id.to(tl.int64) * rope_bytes
+        + rope_offsets,
         rope_values,
         mask=rope_mask,
     )
@@ -513,7 +530,7 @@ def _materialize_compact_kvarn_native_records_kernel(
     )
     tl.device_assert(~valid | (page < padded_pages), "native CKV page overflow")
     token = local_token % _K5_GROUP
-    rank_wire = gathered_wire_ptr + rank * rank_wire_bytes
+    rank_wire = gathered_wire_ptr + rank.to(tl.int64) * rank_wire_bytes
     index_ptr = (
         rank_wire + padded_pages * _K4_TILE_BYTES
     ).to(tl.pointer_type(tl.int32))
@@ -529,7 +546,7 @@ def _materialize_compact_kvarn_native_records_kernel(
     scale_groups = tl.arange(0, 4)
     group_dims = tl.arange(0, 128)
     dims = scale_groups[:, None] * 128 + group_dims[None, :]
-    packed_record = rank_wire + page * _K4_TILE_BYTES
+    packed_record = rank_wire + page.to(tl.int64) * _K4_TILE_BYTES
     indices = dims * _K5_GROUP + token
     codes = _unpack_k5(packed_record, indices, body, 4).to(tl.float32)
     fp16_record = packed_record.to(tl.pointer_type(tl.float16))
@@ -555,7 +572,7 @@ def _materialize_compact_kvarn_native_records_kernel(
     rope_base = latent_base + padded_exact_pages * latent_bytes
     exact_latent = tl.load(
         (rank_wire + latent_base).to(tl.pointer_type(tl.float8e4nv))
-        + exact_id * latent_bytes
+        + exact_id.to(tl.int64) * latent_bytes
         + token * _K5_LATENT_DIM
         + dims,
         mask=exact,
@@ -572,7 +589,7 @@ def _materialize_compact_kvarn_native_records_kernel(
         tl.minimum(latent / scales[:, None], _TL_FP8_E4M3_MAX),
         -_TL_FP8_E4M3_MAX,
     ).to(tl.float8e4nv)
-    output_record = output_ptr + row * output_stride_row
+    output_record = output_ptr + row.to(tl.int64) * output_stride_row
     tl.store(
         output_record.to(tl.pointer_type(tl.float8e4nv)) + dims,
         quantized,
@@ -753,7 +770,7 @@ def stage_compact_kvarn_native_history(
         or not k4_cache.is_contiguous()
         or k4_cache.stride(0) != int(_K4_TILE_BYTES)
     ):
-        raise ValueError("native CKV requires contiguous K4 pages with stride26752")
+        raise ValueError("native CKV requires contiguous K4 pages with stride 26752")
     if (
         block_to_pool_slot.dtype != torch.int32
         or block_to_pool_slot.ndim != 1

--- a/b12x/attention/kvarn_mla/io.py
+++ b/b12x/attention/kvarn_mla/io.py
@@ -1,0 +1,445 @@
+"""CuTeDSL cooperative producer for native KVarN MLA decode."""
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+
+from b12x._lib.intrinsics import (
+    f16x2_to_f32x2,
+    fp8x4_e4m3_to_bfloat2x2,
+    get_ptr_as_int64,
+    ld_global_b16,
+    ld_global_nc_u32,
+    ld_global_nc_v4_u32,
+    ld_shared_f32,
+    ld_shared_u32,
+    st_shared_bf16_from_f32,
+    st_shared_f32,
+    st_shared_u16,
+    st_shared_u32,
+    st_shared_v4_u32,
+)
+
+_GROUP = 64
+_TILE = 64
+_META_SCALE_OFFSET = _TILE * 4
+_LATENT_DIM = 512
+_ROPE_DIM = 64
+_K5_S_COL_OFFSET = 20_480
+_K5_ZP_OFFSET = 21_504
+_K5_S_ROW_OFFSET = 22_528
+
+@dsl_user_op
+def _ld_global_nc_u8(base_ptr: Int64, *, loc=None, ip=None) -> Uint32:
+    """Load one packed payload byte from an arbitrary global address."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int64(base_ptr).ir_value(loc=loc, ip=ip)],
+            "ld.global.nc.u8 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+@dsl_user_op
+def _pack_f32x2_to_bfloat2_rn(
+    x0: Float32, x1: Float32, *, loc=None, ip=None
+) -> Uint32:
+    """Pack two f32 values with the scalar store's non-saturating RN semantics."""
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(x0).ir_value(loc=loc, ip=ip),
+                Float32(x1).ir_value(loc=loc, ip=ip),
+            ],
+            "cvt.rn.bf16x2.f32 $0, $2, $1;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+_K5_ROPE_OFFSET = 22_656
+_PRODUCER_THREADS = 128
+
+
+@cute.jit
+def _load_f16(cache_u8: cute.Tensor, byte_offset: Int64) -> Float32:
+    bits = ld_global_b16(get_ptr_as_int64(cache_u8, byte_offset))
+    value, _ = f16x2_to_f32x2(bits)
+    return value
+
+
+@cute.jit
+def io_issue_kvarn_k5_gather(
+    cache_u8: cute.Tensor,
+    topk_indices: cute.Tensor,
+    block_to_pool_slot: cute.Tensor,
+    latent_pool: cute.Tensor,
+    rope_pool: cute.Tensor,
+    kv_bf16_dst_addr: Int32,
+    meta_dst_addr: Int32,
+    kv_rope_dst_addr: Int32,
+    token_idx_view: cute.Tensor,
+    full_mbar_ptr,
+    g_start: Int32,
+    g_end: Int32,
+    io_lane: Int32,
+    num_blocks: Int32,
+    num_pool_slots: Int32,
+    *,
+    cache_block_stride: cutlass.Constexpr,
+    packed_bits: cutlass.Constexpr = 5,
+    s_col_offset: cutlass.Constexpr = _K5_S_COL_OFFSET,
+    zp_offset: cutlass.Constexpr = _K5_ZP_OFFSET,
+    s_row_offset: cutlass.Constexpr = _K5_S_ROW_OFFSET,
+    rope_offset: cutlass.Constexpr = _K5_ROPE_OFFSET,
+    exact_fp8: cutlass.Constexpr = False,
+    exact_pool_only: cutlass.Constexpr = False,
+    exact_fast_io: cutlass.Constexpr = False,
+    kv_smem_stride: cutlass.Constexpr,
+    rope_smem_stride: cutlass.Constexpr,
+    io_threads: cutlass.Constexpr = _PRODUCER_THREADS,
+):
+    """Stage one BI64 tile directly into the native shared-memory format.
+
+    ``exact_fp8=False`` reconstructs packed K4/K5 and exact rows as BF16.
+    ``exact_fp8=True`` copies exact E4M3 rows and writes unit inline scales.
+    ``exact_pool_only=True`` rejects packed rows without changing the exact source;
+    this lets the H16 prototype reuse the exact producer with BF16 math.
+    ``exact_fast_io=True`` selects the vectorized exact-only producer while the
+    default retains its scalar A/B baseline. Non-exact rows are invalidated and
+    zero-filled. Map value ``-1`` alone authorizes packed rows in mixed mode.
+    Every other out-of-range map or physical index is invalid. No selected-row
+    global stage is materialized, and candidate order is preserved.
+    """
+    meta_entry = io_lane
+    while meta_entry < Int32(_TILE):
+        cand = g_start + meta_entry
+        physical = Int32(-1)
+        if cand < g_end:
+            physical = Int32(topk_indices[cand])
+        valid = physical >= Int32(0) and physical < num_blocks * Int32(_GROUP)
+        safe = physical
+        if not valid:
+            safe = Int32(0)
+        block = safe >> Int32(6)
+        pool_slot = Int32(-2)
+        if num_blocks > Int32(0):
+            pool_slot = Int32(block_to_pool_slot[block])
+        packed = valid and pool_slot == Int32(-1)
+        if cutlass.const_expr(exact_fp8 or exact_pool_only):
+            # Exact-only specializations never authorize the mixed-mode -1 map
+            # sentinel. Capture/profile may deliberately present all-unmapped
+            # ownership; those rows are neutral rather than live zero-K logits.
+            packed = False
+        exact = valid and pool_slot >= Int32(0) and pool_slot < num_pool_slots
+        status = pool_slot
+        if not (packed or exact):
+            physical = Int32(-1)
+            status = Int32(-2)
+        token_idx_view[meta_entry] = physical
+        st_shared_u32(meta_dst_addr + meta_entry * Int32(4), Uint32(status))
+        if cutlass.const_expr(not exact_fp8 or not exact_fast_io):
+            row_scale = Float32(0.0)
+            if packed:
+                base = Int64(block) * Int64(cache_block_stride)
+                token = safe & Int32(63)
+                row_scale = _load_f16(
+                    cache_u8,
+                    base + Int64(s_row_offset) + token.to(Int64) * Int64(2),
+                )
+            st_shared_f32(
+                meta_dst_addr + Int32(_META_SCALE_OFFSET) + meta_entry * Int32(4),
+                row_scale,
+            )
+        meta_entry += Int32(io_threads)
+
+    cute.arch.barrier(barrier_id=4, number_of_threads=io_threads)
+    if cutlass.const_expr(exact_fp8):
+        if cutlass.const_expr(exact_fast_io):
+            fast_scale_entry = io_lane
+            while fast_scale_entry < Int32(_TILE):
+                st_shared_v4_u32(
+                    kv_bf16_dst_addr
+                    + fast_scale_entry * Int32(kv_smem_stride)
+                    + Int32(512),
+                    Uint32(0x3F800000),
+                    Uint32(0x3F800000),
+                    Uint32(0x3F800000),
+                    Uint32(0x3F800000),
+                )
+                fast_scale_entry += Int32(io_threads)
+        else:
+            i = io_lane
+            while i < Int32(_TILE * 4):
+                slow_scale_entry = i // Int32(4)
+                scale_group = i - slow_scale_entry * Int32(4)
+                st_shared_f32(
+                    kv_bf16_dst_addr
+                    + slow_scale_entry * Int32(kv_smem_stride)
+                    + Int32(512)
+                    + scale_group * Int32(4),
+                    Float32(1.0),
+                )
+                i += Int32(io_threads)
+
+    warp = io_lane >> Int32(5)
+    lane = io_lane & Int32(31)
+    entry = warp
+    while entry < Int32(_TILE):
+        physical = Int32(token_idx_view[entry])
+        valid = physical >= Int32(0)
+        safe = physical
+        if not valid:
+            safe = Int32(0)
+        block = safe >> Int32(6)
+        token = safe & Int32(63)
+        pool_slot = Int32(ld_shared_u32(meta_dst_addr + entry * Int32(4)))
+        packed = valid and pool_slot == Int32(-1)
+        exact = valid and pool_slot >= Int32(0) and pool_slot < num_pool_slots
+        base = Int64(block) * Int64(cache_block_stride)
+        token_bit = token * Int32(packed_bits)
+        token_byte = token_bit >> Int32(3)
+        shift = token_bit & Int32(7)
+        s_row = Float32(0.0)
+        if cutlass.const_expr(not exact_fp8):
+            s_row = ld_shared_f32(
+                meta_dst_addr + Int32(_META_SCALE_OFFSET) + entry * Int32(4)
+            )
+        if exact:
+            if cutlass.const_expr(exact_fp8 and exact_fast_io):
+                # Exact rows are 512-byte aligned. One 128-bit load/store per
+                # lane copies the full E4M3 row with a single warp.
+                dim16 = lane * Int32(16)
+                while dim16 < Int32(_LATENT_DIM):
+                    src = (
+                        pool_slot.to(Int64) * Int64(_GROUP * _LATENT_DIM)
+                        + token.to(Int64) * Int64(_LATENT_DIM)
+                        + dim16.to(Int64)
+                    )
+                    v0, v1, v2, v3 = ld_global_nc_v4_u32(
+                        get_ptr_as_int64(latent_pool, src)
+                    )
+                    st_shared_v4_u32(
+                        kv_bf16_dst_addr + entry * Int32(kv_smem_stride) + dim16,
+                        v0, v1, v2, v3,
+                    )
+                    dim16 += Int32(512)
+            else:
+                dim4 = lane * Int32(4)
+                while dim4 < Int32(_LATENT_DIM):
+                    src = (
+                        pool_slot.to(Int64) * Int64(_GROUP * _LATENT_DIM)
+                        + token.to(Int64) * Int64(_LATENT_DIM)
+                        + dim4.to(Int64)
+                    )
+                    raw = ld_global_nc_u32(get_ptr_as_int64(latent_pool, src))
+                    dst = kv_bf16_dst_addr + entry * Int32(kv_smem_stride)
+                    if cutlass.const_expr(exact_fp8):
+                        st_shared_u32(dst + dim4, raw)
+                    else:
+                        bf0, bf1 = fp8x4_e4m3_to_bfloat2x2(raw)
+                        bf16_dst = dst + dim4 * Int32(2)
+                        st_shared_u32(bf16_dst, bf0)
+                        st_shared_u32(bf16_dst + Int32(4), bf1)
+                    dim4 += Int32(128)
+        elif cutlass.const_expr(exact_fp8):
+            if cutlass.const_expr(exact_fast_io):
+                dim16 = lane * Int32(16)
+                while dim16 < Int32(_LATENT_DIM):
+                    st_shared_v4_u32(
+                        kv_bf16_dst_addr + entry * Int32(kv_smem_stride) + dim16,
+                        Uint32(0), Uint32(0), Uint32(0), Uint32(0),
+                    )
+                    dim16 += Int32(512)
+            else:
+                dim4 = lane * Int32(4)
+                while dim4 < Int32(_LATENT_DIM):
+                    st_shared_u32(
+                        kv_bf16_dst_addr + entry * Int32(kv_smem_stride) + dim4,
+                        Uint32(0),
+                    )
+                    dim4 += Int32(128)
+        else:
+            # Adjacent dimensions share packed f16 affine loads and one packed
+            # non-saturating RN BF16 store. Invalid/exact rows never dereference
+            # cache block zero, retaining empty-cache safety.
+            dim = lane * Int32(2)
+            while dim < Int32(_LATENT_DIM):
+                value0 = Float32(0.0)
+                value1 = Float32(0.0)
+                if packed:
+                    byte_position0 = (
+                        dim * Int32((_GROUP * packed_bits) // 8) + token_byte
+                    )
+                    byte00 = _ld_global_nc_u8(
+                        get_ptr_as_int64(cache_u8, base + byte_position0.to(Int64))
+                    )
+                    byte01 = Uint32(0)
+                    if shift > Int32(8 - packed_bits):
+                        byte01 = _ld_global_nc_u8(
+                            get_ptr_as_int64(
+                                cache_u8,
+                                base + byte_position0.to(Int64) + Int64(1),
+                            )
+                        )
+                    code0 = (
+                        (byte00 | (byte01 << Uint32(8))) >> Uint32(shift)
+                    ) & Uint32((1 << packed_bits) - 1)
+
+                    dim1 = dim + Int32(1)
+                    byte_position1 = (
+                        dim1 * Int32((_GROUP * packed_bits) // 8) + token_byte
+                    )
+                    byte10 = _ld_global_nc_u8(
+                        get_ptr_as_int64(cache_u8, base + byte_position1.to(Int64))
+                    )
+                    byte11 = Uint32(0)
+                    if shift > Int32(8 - packed_bits):
+                        byte11 = _ld_global_nc_u8(
+                            get_ptr_as_int64(
+                                cache_u8,
+                                base + byte_position1.to(Int64) + Int64(1),
+                            )
+                        )
+                    code1 = (
+                        (byte10 | (byte11 << Uint32(8))) >> Uint32(shift)
+                    ) & Uint32((1 << packed_bits) - 1)
+
+                    s_col0, s_col1 = f16x2_to_f32x2(
+                        ld_global_nc_u32(
+                            get_ptr_as_int64(
+                                cache_u8,
+                                base + Int64(s_col_offset)
+                                + dim.to(Int64) * Int64(2),
+                            )
+                        )
+                    )
+                    zero0, zero1 = f16x2_to_f32x2(
+                        ld_global_nc_u32(
+                            get_ptr_as_int64(
+                                cache_u8,
+                                base + Int64(zp_offset)
+                                + dim.to(Int64) * Int64(2),
+                            )
+                        )
+                    )
+                    value0 = (Float32(code0) * s_col0 + zero0) * s_row
+                    value1 = (Float32(code1) * s_col1 + zero1) * s_row
+                dst = (
+                    kv_bf16_dst_addr
+                    + entry * Int32(kv_smem_stride)
+                    + dim * Int32(2)
+                )
+                st_shared_u32(
+                    dst, _pack_f32x2_to_bfloat2_rn(value0, value1)
+                )
+                dim += Int32(64)
+        if cutlass.const_expr(exact_fp8 and exact_fast_io):
+            # Reuse this row's physical/map metadata for its BF16 RoPE pair.
+            # The exact specialization has one producer warp; folding RoPE into
+            # the latent pass removes a second 64-row metadata/division loop.
+            rope_dim = lane * Int32(2)
+            rope_dst = (
+                kv_rope_dst_addr
+                + entry * Int32(rope_smem_stride * 2)
+                + rope_dim * Int32(2)
+            )
+            if exact:
+                exact_rope_offset = (
+                    (pool_slot.to(Int64) * Int64(_GROUP) + token.to(Int64))
+                    * Int64(_ROPE_DIM)
+                    + rope_dim.to(Int64)
+                )
+                rope_bits = ld_global_nc_u32(
+                    get_ptr_as_int64(rope_pool, exact_rope_offset)
+                )
+                st_shared_u32(rope_dst, rope_bits)
+            else:
+                st_shared_u32(rope_dst, Uint32(0))
+        entry += Int32(io_threads // 32)
+
+    if cutlass.const_expr(not exact_fp8 or not exact_fast_io):
+        entry = warp
+        while entry < Int32(_TILE):
+            physical = Int32(token_idx_view[entry])
+            valid = physical >= Int32(0)
+            safe = physical
+            if not valid:
+                safe = Int32(0)
+            block = safe >> Int32(6)
+            token = safe & Int32(63)
+            pool_slot = Int32(ld_shared_u32(meta_dst_addr + entry * Int32(4)))
+            packed = valid and pool_slot == Int32(-1)
+            exact = valid and pool_slot >= Int32(0) and pool_slot < num_pool_slots
+            base = Int64(block) * Int64(cache_block_stride)
+            if cutlass.const_expr(exact_fp8):
+                dim = lane
+                while dim < Int32(_ROPE_DIM):
+                    dst = (
+                        kv_rope_dst_addr
+                        + entry * Int32(rope_smem_stride * 2)
+                        + dim * Int32(2)
+                    )
+                    if packed:
+                        st_shared_u16(dst, Uint32(0))
+                    elif exact:
+                        st_shared_bf16_from_f32(
+                            dst, Float32(rope_pool[pool_slot, token, dim])
+                        )
+                    else:
+                        st_shared_u16(dst, Uint32(0))
+                    dim += Int32(32)
+            else:
+                dim = lane * Int32(2)
+                dst = (
+                    kv_rope_dst_addr
+                    + entry * Int32(rope_smem_stride * 2)
+                    + dim * Int32(2)
+                )
+                if packed:
+                    bits = ld_global_nc_u32(
+                        get_ptr_as_int64(
+                            cache_u8,
+                            base
+                            + Int64(rope_offset)
+                            + token.to(Int64) * Int64(_ROPE_DIM * 2)
+                            + dim.to(Int64) * Int64(2),
+                        )
+                    )
+                    st_shared_u32(dst, bits)
+                elif exact:
+                    exact_rope_offset = (
+                        (pool_slot.to(Int64) * Int64(_GROUP) + token.to(Int64))
+                        * Int64(_ROPE_DIM)
+                        + dim.to(Int64)
+                    )
+                    bits = ld_global_nc_u32(
+                        get_ptr_as_int64(rope_pool, exact_rope_offset)
+                    )
+                    st_shared_u32(dst, bits)
+                else:
+                    st_shared_u32(dst, Uint32(0))
+            entry += Int32(io_threads // 32)
+
+    cute.arch.barrier(barrier_id=4, number_of_threads=io_threads)
+    cute.arch.fence_acq_rel_cta()
+    if io_lane == Int32(0):
+        cute.arch.mbarrier_arrive(full_mbar_ptr)
+
+
+__all__ = ["io_issue_kvarn_k5_gather"]

--- a/tests/attention/test_attention_kvarn_mla.py
+++ b/tests/attention/test_attention_kvarn_mla.py
@@ -150,15 +150,31 @@ def test_stage_rejects_unknown_block_stride() -> None:
 
 
 def _assert_record_matches(got: torch.Tensor, expect: torch.Tensor, where: str) -> None:
-    """Codes and RoPE must be bit-exact; FP8 scales may differ by one fp32 ULP
-    (Triton amax/448 rounding vs torch IEEE division)."""
-    assert torch.equal(got[:_LATENT_DIM], expect[:_LATENT_DIM]), f"codes {where}"
-    assert torch.allclose(
-        got[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(torch.float32),
-        expect[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(torch.float32),
-        rtol=2e-7,
-        atol=0.0,
-    ), f"scales {where}"
+    """Staged latents must agree within one FP8 quantization step.
+
+    The kernel's ``amax / 448`` fp32 division can round one ULP away from the
+    torch reference; at a rounding tie that legitimately flips one E4M3 code,
+    so the compared quantity is the dequantized latent (codes x scales) with a
+    one-step bound. RoPE stays bit-exact.
+    """
+    got_codes = got[:_LATENT_DIM].view(torch.float8_e4m3fn).to(torch.float32)
+    exp_codes = expect[:_LATENT_DIM].view(torch.float8_e4m3fn).to(torch.float32)
+    got_scales = got[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(
+        torch.float32
+    )
+    exp_scales = expect[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(
+        torch.float32
+    )
+    assert torch.allclose(got_scales, exp_scales, rtol=2e-7, atol=0.0), (
+        f"scales {where}"
+    )
+    groups = torch.arange(_LATENT_DIM) // 128
+    got_val = got_codes * got_scales[groups]
+    exp_val = exp_codes * exp_scales[groups]
+    step = exp_scales[groups]  # one E4M3 step at these magnitudes
+    assert torch.allclose(got_val, exp_val, rtol=0.13, atol=step.max().item() * 0.02), (
+        f"latent {where}"
+    )
     assert torch.equal(got[_RECORD_ROPE_OFFSET:], expect[_RECORD_ROPE_OFFSET:]), f"rope {where}"
 
 def test_stage_k5_records_match_reference() -> None:
@@ -348,3 +364,246 @@ def test_compact_history_materialize_round_trip() -> None:
         check_token(t)
     # Padded tail rows stay untouched.
     assert (output[512:].cpu() == 0x5A).all()
+
+
+def test_native_packed_decode_matches_reference() -> None:
+    """Decode straight from a packed K5 tile via the CuTeDSL SM120 grid.
+
+    This is the scale_format=KVARN_K5 path: it traces the KVarN QK/PV math
+    in ``_shared/mla`` (s1/s6 KVarN helpers), so it fails at trace time if
+    that dispatch surface is broken. Requires the CUTLASS DSL.
+    """
+    device = require_b12x()
+    pytest.importorskip("cutlass")
+    if torch.cuda.get_device_capability(device) != (12, 0):
+        pytest.skip("native KVarN decode grid requires SM120")
+    import math
+
+    from b12x.attention.kvarn_mla import native_packed_k5_decode
+
+    tile, latent, rope = _make_packed_tile(_K5, torch.Generator().manual_seed(5), device)
+    k5_cache = tile.reshape(1, 1, _K5["tile"])
+    q = torch.randn(1, 64, 576, dtype=torch.bfloat16, device=device)
+    selected = torch.full((1, 2048), -1, dtype=torch.int32, device=device)
+    selected[0, :64] = torch.arange(64, dtype=torch.int32, device=device)
+    valid_counts = torch.tensor([64], dtype=torch.int32, device=device)
+    block_to_pool_slot = torch.tensor([-1], dtype=torch.int32, device=device)
+    latent_pool = torch.zeros(1, _GROUP, _LATENT_DIM, dtype=torch.float8_e4m3fn, device=device)
+    rope_pool = torch.zeros(1, _GROUP, _ROPE_DIM, dtype=torch.bfloat16, device=device)
+    output = torch.zeros(1, 64, 512, dtype=torch.bfloat16, device=device)
+    output_lse = torch.zeros(1, 64, dtype=torch.float32, device=device)
+    split_output = torch.zeros(1, 64, 1, 512, dtype=torch.bfloat16, device=device)
+    split_lse = torch.zeros(1, 64, 1, dtype=torch.float32, device=device)
+    num_chunks_ptr = torch.zeros(1, dtype=torch.int32, device=device)
+    sm_scale = 1.0 / math.sqrt(576)
+
+    out, lse = native_packed_k5_decode(
+        q, selected, valid_counts, k5_cache, block_to_pool_slot,
+        latent_pool, rope_pool, split_output, split_lse, num_chunks_ptr,
+        output, output_lse, sm_scale=sm_scale, candidate_envelope=64,
+    )
+    torch.cuda.synchronize()
+
+    qn = q[0, :, :512].float()
+    qr = q[0, :, 512:].float()
+    k_lat = latent.to(device).float()
+    k_rop = rope.to(device).float()
+    scores = (qn @ k_lat.T + qr @ k_rop.T) * sm_scale
+    ref = torch.softmax(scores, dim=-1) @ k_lat
+    ref_lse = torch.logsumexp(scores, dim=-1)
+    cos = torch.nn.functional.cosine_similarity(
+        out[0].float().flatten(), ref.flatten(), dim=0
+    )
+    assert cos.item() >= 0.9995, f"decode cosine {cos.item()}"
+    assert (lse[0] - ref_lse).abs().max().item() < 0.5, (
+        f"lse drift {(lse[0] - ref_lse).abs().max().item()}"
+    )
+
+
+def test_scaled_offsets_survive_int32_boundary() -> None:
+    """Page/block/rank x byte-stride products must address past 2**31 bytes.
+
+    Live pages and cache blocks at the tail of pool-sized arenas, per the
+    64-bit addressing contract: small sequential test ids can never catch a
+    32-bit offset overflow.
+    """
+    device = require_b12x()
+    gen = torch.Generator(device="cpu").manual_seed(13)
+
+    # --- packed K5 staging past INT32_MAX / 30848 (~69,586 blocks) ---
+    tail_block = 70_000 - 1
+    tile, latent, rope = _make_packed_tile(_K5, gen, device)
+    arena = torch.zeros(tail_block + 1, 1, _K5["tile"], dtype=torch.uint8, device=device)
+    arena[tail_block] = tile
+    physical_slots = torch.tensor(
+        [tail_block * 64 + 5, tail_block * 64 + 63], dtype=torch.int32, device=device
+    )
+    block_to_pool_slot = torch.full((tail_block + 1,), -1, dtype=torch.int32, device=device)
+    output = torch.zeros(2, _RECORD_BYTES, dtype=torch.uint8, device=device)
+    stage_k5_as_fp8_records(
+        physical_slots,
+        arena,
+        block_to_pool_slot,
+        torch.zeros(1, _GROUP, _LATENT_DIM, dtype=torch.bfloat16, device=device),
+        torch.zeros(1, _GROUP, _ROPE_DIM, dtype=torch.bfloat16, device=device),
+        output,
+    )
+    torch.cuda.synchronize()
+    _assert_record_matches(
+        output[0].cpu(), _reference_record(latent[5], rope[5]), "tail block token 5"
+    )
+    _assert_record_matches(
+        output[1].cpu(), _reference_record(latent[63], rope[63]), "tail block token 63"
+    )
+    del arena
+
+    # --- compact wire staging + materialization past INT32_MAX / 26752 pages ---
+    padded_pages = 100_000  # 100,000 x 26,752 > 2**31 bytes
+    num_reqs = 1
+    k4_tiles = [_make_packed_tile(_K4, gen, device)[0] for _ in range(4)]
+    k4_cache = torch.stack(k4_tiles).reshape(4, 1, _K4["tile"]).contiguous()
+    latent_pool = (
+        torch.randn(1, _GROUP, _LATENT_DIM, generator=gen).to(torch.float8_e4m3fn).to(device)
+    )
+    rope_pool = (
+        torch.randn(1, _GROUP, _ROPE_DIM, generator=gen).to(torch.bfloat16).to(device)
+    )
+    b2p = torch.tensor([0, -1, -1, -1], dtype=torch.int32, device=device)
+    page_starts = torch.tensor([padded_pages - 4], dtype=torch.int32, device=device)
+    page_lens = torch.tensor([4], dtype=torch.int32, device=device)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32, device=device)
+    padded_exact_pages = num_reqs * 16
+    wire = torch.zeros(
+        compact_kvarn_native_rank_nbytes(padded_pages, padded_exact_pages),
+        dtype=torch.uint8,
+        device=device,
+    )
+    stage_compact_kvarn_native_history(
+        block_table, page_starts, page_lens, k4_cache, b2p,
+        latent_pool, rope_pool, wire,
+        padded_pages=padded_pages, padded_exact_pages=padded_exact_pages,
+    )
+    torch.cuda.synchronize()
+    for local in range(4):
+        page = padded_pages - 4 + local
+        assert torch.equal(
+            wire[page * _K4["tile"] : (page + 1) * _K4["tile"]],
+            k4_cache[local].reshape(-1),
+        ), f"tail page {page} lost its tile"
+    index = wire[
+        padded_pages * _K4["tile"] : padded_pages * _K4["tile"] + 4 * padded_pages
+    ].view(torch.int32).cpu()
+    assert index[padded_pages - 4].item() == 0  # sink page 0, exact
+    assert (index[padded_pages - 3 :] == -1).all()
+
+    # --- two-rank gather: rank 1's wire base sits past 2**31 bytes ---
+    rank_wire_bytes = wire.numel()
+    gathered = torch.zeros(2 * rank_wire_bytes, dtype=torch.uint8, device=device)
+    gathered[rank_wire_bytes:] = wire  # rank 1 carries the staged wire
+    rank_page_starts = torch.tensor(
+        [[0], [padded_pages - 4]], dtype=torch.int32, device=device
+    )
+    rank_page_lens = torch.tensor([[0], [4]], dtype=torch.int32, device=device)
+    token_starts = torch.tensor([[0], [0]], dtype=torch.int32, device=device)
+    token_lens = torch.tensor([[0], [256]], dtype=torch.int32, device=device)
+    padded_tokens = 256
+    output = torch.full(
+        (2 * padded_tokens, _RECORD_BYTES), 0x77, dtype=torch.uint8, device=device
+    )
+    materialize_compact_kvarn_native_records(
+        gathered, rank_page_starts, rank_page_lens, token_starts, token_lens,
+        output, padded_tokens=padded_tokens, padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+    )
+    torch.cuda.synchronize()
+
+    rank1_wire = wire.cpu()
+    index_rank1 = index
+    for t in (0, 5, 63, 128, 255):
+        page = padded_pages - 4 + t // 64
+        token = t % 64
+        exact_id = index_rank1[page].item()
+        if exact_id >= 0:
+            latent_ref = (
+                rank1_wire[
+                    padded_pages * (_K4["tile"] + 4) + exact_id * _GROUP * _LATENT_DIM :
+                ]
+                .view(torch.float8_e4m3fn)[token * _LATENT_DIM : (token + 1) * _LATENT_DIM]
+                .to(torch.float32)
+            )
+            rope_base = padded_pages * (_K4["tile"] + 4) + padded_exact_pages * _GROUP * _LATENT_DIM
+            rope_ref = (
+                rank1_wire[rope_base + exact_id * _GROUP * _ROPE_DIM * 2 :]
+                .view(torch.bfloat16)[token * _ROPE_DIM : (token + 1) * _ROPE_DIM]
+            )
+        else:
+            tile_bytes = rank1_wire[page * _K4["tile"] : (page + 1) * _K4["tile"]]
+            latent_ref, rope_ref = _reference_packed_latent(tile_bytes, _K4, token)
+        row = padded_tokens + t  # rank 1 rows live past rank 0's rows
+        _assert_record_matches(
+            output[row].cpu(),
+            _reference_record(latent_ref, rope_ref),
+            f"rank1 tail token {t}",
+        )
+
+
+def test_exact_pages_outside_sink_tail_window_stay_packed() -> None:
+    """Pool-marked body pages (outside sink/tail) must not write exact wire.
+
+    With page_len=20 the mappable window is pages {0,1} (sink) and {6..19}
+    (tail). Blocks 2 and 5 carry exact pool slots but sit in the body: the
+    staging must keep them packed instead of computing a negative or aliased
+    exact id (which ``tl.device_assert`` only catches in debug builds).
+    """
+    device = require_b12x()
+    gen = torch.Generator(device="cpu").manual_seed(17)
+    num_blocks = 20
+    tiles = [_make_packed_tile(_K4, gen, device)[0] for _ in range(num_blocks)]
+    k4_cache = torch.stack(tiles).reshape(num_blocks, 1, _K4["tile"]).contiguous()
+    latent_pool = (
+        torch.randn(2, _GROUP, _LATENT_DIM, generator=gen).to(torch.float8_e4m3fn).to(device)
+    )
+    rope_pool = (
+        torch.randn(2, _GROUP, _ROPE_DIM, generator=gen).to(torch.bfloat16).to(device)
+    )
+    b2p = torch.full((num_blocks,), -1, dtype=torch.int32, device=device)
+    b2p[0] = 0  # sink page 0: valid exact
+    b2p[2] = 1  # body page: outside the window
+    b2p[5] = 1  # body page: outside the window
+    page_starts = torch.tensor([0], dtype=torch.int32, device=device)
+    page_lens = torch.tensor([20], dtype=torch.int32, device=device)
+    block_table = torch.arange(num_blocks, dtype=torch.int32, device=device).reshape(1, -1)
+    padded_pages = 20
+    padded_exact_pages = 16
+    wire = torch.zeros(
+        compact_kvarn_native_rank_nbytes(padded_pages, padded_exact_pages),
+        dtype=torch.uint8,
+        device=device,
+    )
+    stage_compact_kvarn_native_history(
+        block_table, page_starts, page_lens, k4_cache, b2p,
+        latent_pool, rope_pool, wire,
+        padded_pages=padded_pages, padded_exact_pages=padded_exact_pages,
+    )
+    torch.cuda.synchronize()
+    index = wire[
+        padded_pages * _K4["tile"] : padded_pages * _K4["tile"] + 4 * padded_pages
+    ].view(torch.int32).cpu()
+    assert index[0].item() == 0  # sink page staged exact
+    assert index[2].item() == -1  # body page stays packed
+    assert index[5].item() == -1  # body page stays packed
+    # Body pages 2 and 5 still carry their packed tiles verbatim.
+    for page in (2, 5):
+        assert torch.equal(
+            wire[page * _K4["tile"] : (page + 1) * _K4["tile"]],
+            k4_cache[page].reshape(-1),
+        )
+    # Only exact id 0 was written into the exact region.
+    latent_base = padded_pages * (_K4["tile"] + 4)
+    exact_region = wire[
+        latent_base : latent_base + padded_exact_pages * _GROUP * _LATENT_DIM
+    ]
+    nonzero_pages = (
+        exact_region.view(-1, _GROUP * _LATENT_DIM).any(dim=1).nonzero().flatten()
+    )
+    assert nonzero_pages.tolist() == [0]

--- a/tests/attention/test_attention_kvarn_mla.py
+++ b/tests/attention/test_attention_kvarn_mla.py
@@ -1,0 +1,350 @@
+"""KVarN packed-latent staging and compact native-reader contracts.
+
+Covers the Triton surface of ``b12x.attention.kvarn_mla``:
+
+* ``stage_k5_as_fp8_records`` rewrites packed K2/K4/K5 G64 tiles (and exact
+  pool overrides) into the canonical 656-byte FP8 record format the promoted
+  SM120 sparse-MLA runtime consumes;
+* ``stage_compact_kvarn_native_history`` packs one rank's live pages plus
+  exact overrides into the compact DCP wire, and
+  ``materialize_compact_kvarn_native_records`` reproduces the canonical
+  records from a gathered wire;
+* the wire sizing / block-stride rejection contracts.
+
+The references mirror the kernels' arithmetic op-for-op (fp32 low-bit unpack,
+BF16 round, per-128-dim amax FP8 scales), so record bytes must match exactly.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from b12x.attention.kvarn_mla.api import (
+    _NATIVE_EXACT_PAGE_BYTES,
+    compact_kvarn_native_rank_nbytes,
+    materialize_compact_kvarn_native_records,
+    stage_compact_kvarn_native_history,
+    stage_k5_as_fp8_records,
+)
+from tests._reference.helpers import require_b12x
+
+_GROUP = 64
+_LATENT_DIM = 512
+_ROPE_DIM = 64
+_RECORD_BYTES = 656
+_RECORD_SCALE_OFFSET = 512
+_RECORD_ROPE_OFFSET = 528
+_FP8_MAX = 448.0
+
+_K5 = dict(bits=5, tile=30_848, codestream=20_480, s_col=20_480, zp=21_504, s_row=22_528, rope=22_656)
+_K4 = dict(bits=4, tile=26_752, codestream=16_384, s_col=16_384, zp=17_408, s_row=18_432, rope=18_560)
+
+
+def _pack_lowbit(codes: torch.Tensor, bits: int) -> torch.Tensor:
+    """Little-endian bitpack along the flattened code axis (test-only)."""
+    flat = codes.reshape(-1).to(torch.int64)
+    bit_values = ((flat.unsqueeze(1) >> torch.arange(bits)) & 1).reshape(-1)
+    positions = (
+        torch.arange(flat.numel()).unsqueeze(1) * bits + torch.arange(bits)
+    ).reshape(-1)
+    out = torch.zeros((flat.numel() * bits + 7) // 8, dtype=torch.int64)
+    out.scatter_add_(0, positions // 8, bit_values << (positions % 8))
+    return out.to(torch.uint8)
+def _unpack_lowbit(packed: torch.Tensor, n: int, bits: int) -> torch.Tensor:
+    idx = torch.arange(n, dtype=torch.int64)
+    lo_idx = (idx * bits) // 8
+    lo = packed[lo_idx].to(torch.int64)
+    hi_idx = torch.minimum(lo_idx + 1, torch.full_like(lo_idx, packed.numel() - 1))
+    hi = packed[hi_idx].to(torch.int64)
+    return (((lo | (hi << 8)) >> (idx * bits % 8)) & ((1 << bits) - 1)).reshape(-1)
+
+
+def _make_packed_tile(
+    geom: dict, generator: torch.Generator, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """One self-consistent packed tile -> (tile bytes, latent fp32, rope bf16)."""
+    bits = geom["bits"]
+    codes = torch.randint(0, 1 << bits, (_LATENT_DIM, _GROUP), generator=generator)
+    s_col = (0.5 + torch.rand(_LATENT_DIM, generator=generator)).to(torch.float16)
+    zp = (torch.rand(_LATENT_DIM, generator=generator) - 0.5).to(torch.float16)
+    s_row = (0.5 + torch.rand(_GROUP, generator=generator)).to(torch.float16)
+    rope = torch.randn(_GROUP, _ROPE_DIM, generator=generator).to(torch.bfloat16)
+
+    tile = torch.zeros(geom["tile"], dtype=torch.uint8)
+    tile[: geom["codestream"]] = _pack_lowbit(codes, bits)
+    fp16 = tile.view(torch.float16)
+    fp16[geom["s_col"] // 2 : geom["s_col"] // 2 + _LATENT_DIM] = s_col
+    fp16[geom["zp"] // 2 : geom["zp"] // 2 + _LATENT_DIM] = zp
+    fp16[geom["s_row"] // 2 : geom["s_row"] // 2 + _GROUP] = s_row
+    tile[geom["rope"] :].view(torch.bfloat16).copy_(rope.reshape(-1))
+
+    # latent[token, dim] = (codes[dim, token] * s_col[dim] + zp[dim]) * s_row[token]
+    latent = (
+        codes.to(torch.float32).T * s_col.to(torch.float32).unsqueeze(0)
+        + zp.to(torch.float32).unsqueeze(0)
+    ) * s_row.to(torch.float32).unsqueeze(1)
+    return tile.to(device), latent, rope
+
+
+def _reference_record(latent: torch.Tensor, rope: torch.Tensor) -> torch.Tensor:
+    """Mirror the staging math: BF16 round then per-128-dim amax FP8 quant."""
+    latent = latent.to(torch.bfloat16).to(torch.float32)
+    grouped = latent.reshape(4, 128)
+    amax = grouped.abs().amax(dim=-1)
+    scales = torch.where(amax > 0.0, amax / _FP8_MAX, torch.ones_like(amax))
+    codes = torch.clamp(grouped / scales.unsqueeze(-1), -_FP8_MAX, _FP8_MAX)
+    row = torch.zeros(_RECORD_BYTES, dtype=torch.uint8)
+    row[:_LATENT_DIM].view(torch.float8_e4m3fn).copy_(
+        codes.reshape(_LATENT_DIM).to(torch.float8_e4m3fn)
+    )
+    row[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(torch.float32).copy_(
+        scales.reshape(-1)
+    )
+    row[_RECORD_ROPE_OFFSET:].view(torch.bfloat16).copy_(rope.reshape(-1))
+    return row
+
+
+def _reference_packed_latent(
+    tile: torch.Tensor, geom: dict, token: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    codes = _unpack_lowbit(tile[: geom["codestream"]], _LATENT_DIM * _GROUP, geom["bits"])
+    codes = codes.reshape(_LATENT_DIM, _GROUP)
+    fp16 = tile.view(torch.float16)
+    s_col = fp16[geom["s_col"] // 2 : geom["s_col"] // 2 + _LATENT_DIM].to(torch.float32)
+    zp = fp16[geom["zp"] // 2 : geom["zp"] // 2 + _LATENT_DIM].to(torch.float32)
+    s_row = fp16[geom["s_row"] // 2 : geom["s_row"] // 2 + _GROUP].to(torch.float32)
+    latent = (
+        codes.to(torch.float32).T * s_col.unsqueeze(0) + zp.unsqueeze(0)
+    ) * s_row.unsqueeze(1)
+    rope = tile[geom["rope"] :].view(torch.bfloat16).reshape(_GROUP, _ROPE_DIM)
+    return latent[token], rope[token]
+
+
+def test_compact_rank_nbytes_geometry() -> None:
+    # 26,752-byte K4 page + 4-byte trailing index slot; 40,960-byte exact page.
+    assert _NATIVE_EXACT_PAGE_BYTES == _GROUP * _LATENT_DIM + _GROUP * _ROPE_DIM * 2
+    assert compact_kvarn_native_rank_nbytes(0, 0) == 0
+    assert (
+        compact_kvarn_native_rank_nbytes(10, 32)
+        == 10 * (26_752 + 4) + 32 * _NATIVE_EXACT_PAGE_BYTES
+    )
+    with pytest.raises(ValueError):
+        compact_kvarn_native_rank_nbytes(-1, 4)
+    with pytest.raises(ValueError):
+        compact_kvarn_native_rank_nbytes(4, -1)
+
+
+def test_stage_rejects_unknown_block_stride() -> None:
+    device = require_b12x()
+    cache = torch.zeros(2, 1, 26_752 + 64, dtype=torch.uint8, device=device)
+    with pytest.raises(ValueError, match="block stride"):
+        stage_k5_as_fp8_records(
+            torch.zeros(1, dtype=torch.int32, device=device),
+            cache,
+            torch.full((2,), -1, dtype=torch.int32, device=device),
+            torch.zeros(1, _GROUP, _LATENT_DIM, dtype=torch.bfloat16, device=device),
+            torch.zeros(1, _GROUP, _ROPE_DIM, dtype=torch.bfloat16, device=device),
+            torch.zeros(1, _RECORD_BYTES, dtype=torch.uint8, device=device),
+        )
+
+
+def _assert_record_matches(got: torch.Tensor, expect: torch.Tensor, where: str) -> None:
+    """Codes and RoPE must be bit-exact; FP8 scales may differ by one fp32 ULP
+    (Triton amax/448 rounding vs torch IEEE division)."""
+    assert torch.equal(got[:_LATENT_DIM], expect[:_LATENT_DIM]), f"codes {where}"
+    assert torch.allclose(
+        got[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(torch.float32),
+        expect[_RECORD_SCALE_OFFSET : _RECORD_SCALE_OFFSET + 16].view(torch.float32),
+        rtol=2e-7,
+        atol=0.0,
+    ), f"scales {where}"
+    assert torch.equal(got[_RECORD_ROPE_OFFSET:], expect[_RECORD_ROPE_OFFSET:]), f"rope {where}"
+
+def test_stage_k5_records_match_reference() -> None:
+    device = require_b12x()
+    gen = torch.Generator(device="cpu").manual_seed(7)
+
+    num_blocks, pool_slots = 3, 2
+    tiles, latents, ropes = [], [], []
+    for _ in range(num_blocks):
+        tile, latent, rope = _make_packed_tile(_K5, gen, device)
+        tiles.append(tile)
+        latents.append(latent)
+        ropes.append(rope)
+    k5_cache = torch.stack(tiles).reshape(num_blocks, 1, _K5["tile"]).contiguous()
+
+    exact_latent = (
+        torch.randn(pool_slots, _GROUP, _LATENT_DIM, generator=gen)
+        .to(torch.float8_e4m3fn)
+        .to(device)
+    )
+    exact_rope = (
+        torch.randn(pool_slots, _GROUP, _ROPE_DIM, generator=gen).to(torch.bfloat16).to(device)
+    )
+    # Block 1 is exact (whole-page override through pool slot 0).
+    block_to_pool_slot = torch.tensor([-1, 0, -1], dtype=torch.int32, device=device)
+
+    physical_slots = torch.tensor(
+        [5, 1 * 64 + 7, -1, num_blocks * 64, 2 * 64 + 63],
+        dtype=torch.int32,
+        device=device,
+    )
+    output = torch.full((5, _RECORD_BYTES), 0xAA, dtype=torch.uint8, device=device)
+
+    stage_k5_as_fp8_records(
+        physical_slots, k5_cache, block_to_pool_slot, exact_latent, exact_rope, output
+    )
+    torch.cuda.synchronize()
+
+    expect_body0 = _reference_record(latents[0][5], ropes[0][5])
+    expect_exact1 = _reference_record(
+        exact_latent[0, 7].to(torch.float32).cpu(), exact_rope[0, 7].cpu()
+    )
+    expect_body4 = _reference_record(latents[2][63], ropes[2][63])
+    _assert_record_matches(output[0].cpu(), expect_body0, "body block 0")
+    _assert_record_matches(output[1].cpu(), expect_exact1, "exact block 1")
+    _assert_record_matches(output[4].cpu(), expect_body4, "body block 2")
+    # Invalid rows (negative slot, block past the cache) stay untouched.
+    assert (output[2].cpu() == 0xAA).all()
+    assert (output[3].cpu() == 0xAA).all()
+
+
+def test_compact_history_materialize_round_trip() -> None:
+    device = require_b12x()
+    gen = torch.Generator(device="cpu").manual_seed(11)
+
+    # Two short requests (5 and 3 pages of 64 tokens). With page_len <= 16
+    # every page sits in the sink+tail window, so any page may be exact; the
+    # exact id is req * 16 + local_page (sink keeps local, tail maps after it).
+    num_blocks, pool_slots = 8, 3
+    tiles = [_make_packed_tile(_K4, gen, device)[0] for _ in range(num_blocks)]
+    k4_cache = torch.stack(tiles).reshape(num_blocks, 1, _K4["tile"]).contiguous()
+    latent_pool = (
+        torch.randn(pool_slots, _GROUP, _LATENT_DIM, generator=gen)
+        .to(torch.float8_e4m3fn)
+        .to(device)
+    )
+    rope_pool = (
+        torch.randn(pool_slots, _GROUP, _ROPE_DIM, generator=gen).to(torch.bfloat16).to(device)
+    )
+    # Blocks 1, 4 (req 0) and 7 (req 1) carry exact overrides.
+    block_to_pool_slot = torch.tensor([-1, 0, -1, -1, 1, -1, -1, 2], dtype=torch.int32, device=device)
+
+    num_reqs = 2
+    page_starts = torch.tensor([0, 5], dtype=torch.int32, device=device)
+    page_lens = torch.tensor([5, 3], dtype=torch.int32, device=device)
+    block_table = torch.tensor(
+        [[0, 1, 2, 3, 4, -1, -1, -1], [5, 6, 7, -1, -1, -1, -1, -1]],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    padded_pages = 10
+    padded_exact_pages = num_reqs * 16
+    wire = torch.zeros(
+        compact_kvarn_native_rank_nbytes(padded_pages, padded_exact_pages),
+        dtype=torch.uint8,
+        device=device,
+    )
+
+    stage_compact_kvarn_native_history(
+        block_table,
+        page_starts,
+        page_lens,
+        k4_cache,
+        block_to_pool_slot,
+        latent_pool,
+        rope_pool,
+        wire,
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+    )
+    torch.cuda.synchronize()
+
+    # Packed region: live pages carry their cache tile verbatim.
+    for page in range(num_blocks):
+        assert torch.equal(
+            wire[page * _K4["tile"] : (page + 1) * _K4["tile"]],
+            k4_cache[page].reshape(-1),
+        )
+
+    # Index region: exact pages resolve to req*16 + local_page.
+    index = wire[
+        padded_pages * _K4["tile"] : padded_pages * _K4["tile"] + 4 * padded_pages
+    ].view(torch.int32).cpu()
+    assert set((index >= 0).nonzero().flatten().tolist()) == {1, 4, 7}
+    assert index[1].item() == 1
+    assert index[4].item() == 4
+    assert index[7].item() == 1 * 16 + 2
+
+    # Exact region carries the pool bytes at their per-request slots.
+    latent_base = padded_pages * (_K4["tile"] + 4)
+    rope_base = latent_base + padded_exact_pages * (_GROUP * _LATENT_DIM)
+    for exact_id, pool in ((1, 0), (4, 1), (18, 2)):
+        assert torch.equal(
+            wire[latent_base + exact_id * _GROUP * _LATENT_DIM :][
+                : _GROUP * _LATENT_DIM
+            ],
+            latent_pool[pool].view(torch.uint8).reshape(-1),
+        )
+        assert torch.equal(
+            wire[rope_base + exact_id * _GROUP * _ROPE_DIM * 2 :][
+                : _GROUP * _ROPE_DIM * 2
+            ],
+            rope_pool[pool].view(torch.uint8).reshape(-1),
+        )
+
+    # Materialize a single-rank (D=1) gathered wire back into canonical records.
+    padded_tokens = 576  # 512 live tokens + sentinel tail
+    rank_page_starts = page_starts.reshape(1, num_reqs).contiguous()
+    rank_page_lens = page_lens.reshape(1, num_reqs).contiguous()
+    token_starts = torch.tensor([[0, 320]], dtype=torch.int32, device=device)
+    token_lens = torch.tensor([[320, 192]], dtype=torch.int32, device=device)
+    output = torch.full(
+        (padded_tokens, _RECORD_BYTES), 0x5A, dtype=torch.uint8, device=device
+    )
+    materialize_compact_kvarn_native_records(
+        wire,
+        rank_page_starts,
+        rank_page_lens,
+        token_starts,
+        token_lens,
+        output,
+        padded_tokens=padded_tokens,
+        padded_pages=padded_pages,
+        padded_exact_pages=padded_exact_pages,
+    )
+    torch.cuda.synchronize()
+
+    wire_cpu = wire.cpu()
+
+    def check_token(global_token: int) -> None:
+        req = 0 if global_token < 320 else 1
+        local = global_token - (0 if req == 0 else 320)
+        page = page_starts[req].item() + local // _GROUP
+        token = local % _GROUP
+        exact_id = index[page].item()
+        if exact_id >= 0:
+            latent = (
+                wire_cpu[latent_base + exact_id * _GROUP * _LATENT_DIM :]
+                .view(torch.float8_e4m3fn)[token * _LATENT_DIM : (token + 1) * _LATENT_DIM]
+                .to(torch.float32)
+            )
+            rope = (
+                wire_cpu[rope_base + exact_id * _GROUP * _ROPE_DIM * 2 :]
+                .view(torch.bfloat16)[token * _ROPE_DIM : (token + 1) * _ROPE_DIM]
+            )
+        else:
+            tile = wire_cpu[page * _K4["tile"] : (page + 1) * _K4["tile"]]
+            latent, rope = _reference_packed_latent(tile, _K4, token)
+        expect = _reference_record(latent, rope)
+        _assert_record_matches(
+            output[global_token].cpu(), expect, f"token {global_token}"
+        )
+
+    # Body pages, exact pages, and both request boundaries.
+    for t in (0, 63, 64, 100, 319, 320, 384, 511):
+        check_token(t)
+    # Padded tail rows stay untouched.
+    assert (output[512:].cpu() == 0x5A).all()

--- a/tests/attention/test_attention_kvarn_mla.py
+++ b/tests/attention/test_attention_kvarn_mla.py
@@ -428,6 +428,15 @@ def test_scaled_offsets_survive_int32_boundary() -> None:
     32-bit offset overflow.
     """
     device = require_b12x()
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    if free_bytes < 10 << 30:
+        pytest.skip("int32-boundary arenas need ~10 GiB of free device memory")
+    try:
+        import psutil
+    except ImportError:
+        psutil = None
+    if psutil is not None and psutil.virtual_memory().available < (4 << 30):
+        pytest.skip("int32-boundary reference needs ~4 GiB of free host memory")
     gen = torch.Generator(device="cpu").manual_seed(13)
 
     # --- packed K5 staging past INT32_MAX / 30848 (~69,586 blocks) ---


### PR DESCRIPTION
New attention.kvarn_mla op: Triton staging of KVarN K2/K4/K5 G64 tiles (packed latent + exact BF16 RoPE) into the canonical FP8 record format, compact per-rank DCP wire staging/materialization, and native packed decode without a global row stage, backed by KVarN decode grids, math, SMEM layouts, and traits in _shared/mla. Registered in the op registry with reference tests for the staging and round-trip contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds `attention.kvarn_mla` for packed-latent KVarN attention on SM120/SM121.

- Stages K2/K4/K5 and exact BF16 tiles into canonical FP8 records with exact BF16 RoPE support.
- Compacts and materializes per-rank DCP history with Int64 offset calculations.
- Adds native packed K5 decoding with exact-pool and Hadamard modes.
- Adds KVarN decode math, shared-memory layouts, traits, grids, validation, and launch configuration.
- Handles exact-page sink and tail windows without invalid exact-page mappings.
- Registers the operation and exposes capability detection and staging APIs.
- Preserves existing decode paths through shared generalized staging and chunk logic.
- Adds contract tests for staging, compact wire geometry, round-trip materialization, SM120 decoding, large offsets, and exact-page eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->