### PR TITLE
Add packed Qwen QSRT K5 dense inference

### DIFF
--- a/b12x/gemm/trellis_linear/__init__.py
+++ b/b12x/gemm/trellis_linear/__init__.py
@@ -7,8 +7,9 @@ views; execution performs input rotation, a W4A16 or direct E4M3-W4A8 GEMM,
 and output rotation. Optional additive rank-16 branches evaluate native BF16
 tensor-core stages while retaining the packed base weight. Equal-shaped
 gate/up factors share one projection launch and one output launch.
-Callers that need CUDA-graph capture can allocate all stable storage with
-:func:`make_buffers` or :func:`make_pair_buffers`.
+Callers allocate stable capacity with :func:`make_buffers` or
+:func:`make_pair_buffers` and obtain allocation-free exact-row views with
+:func:`view_buffers` or :func:`view_pair_buffers`.
 """
 
 from __future__ import annotations
@@ -36,6 +37,8 @@ META = OpMeta(
         "run",
         "run_additive",
         "run_additive_pair",
+        "view_buffers",
+        "view_pair_buffers",
         "is_supported",
         "clear_caches",
     ),
@@ -78,6 +81,8 @@ if TYPE_CHECKING:
         run,
         run_additive,
         run_additive_pair,
+        view_buffers,
+        view_pair_buffers,
     )
 
 install_lazy_api(globals(), META)

--- a/b12x/gemm/trellis_linear/__init__.py
+++ b/b12x/gemm/trellis_linear/__init__.py
@@ -1,12 +1,14 @@
 """Trellis-coded dense linear for SM12x.
 
 The operation consumes the checkpoint-native ``trellis_t256`` payload
-(MCG or SQG-XOR-Cheb-T12 codebooks) and
+(MCG, SQG-XOR-Cheb-T12, or SQG-FP16-D3L codebooks) and
 its two Hadamard sign vectors.  Preparation validates and records zero-copy
 views; execution performs input rotation, a W4A16 or direct E4M3-W4A8 GEMM,
-and output rotation.
-Callers that need CUDA-graph capture must provide stable ``output``,
-``gemm_output``, and ``c_tmp`` tensors to :func:`run`.
+and output rotation. Optional additive rank-16 branches evaluate native BF16
+tensor-core stages while retaining the packed base weight. Equal-shaped
+gate/up factors share one projection launch and one output launch.
+Callers that need CUDA-graph capture can allocate all stable storage with
+:func:`make_buffers` or :func:`make_pair_buffers`.
 """
 
 from __future__ import annotations
@@ -21,9 +23,19 @@ META = OpMeta(
     api_style="oneshot",
     entry_points=(
         "PreparedWeight",
+        "PreparedAdditiveWeight",
+        "PreparedAdditivePair",
+        "Buffers",
+        "PairBuffers",
         "prepare_weight",
+        "prepare_additive_weight",
+        "prepare_additive_pair",
         "prepare_pair_weight",
+        "make_buffers",
+        "make_pair_buffers",
         "run",
+        "run_additive",
+        "run_additive_pair",
         "is_supported",
         "clear_caches",
     ),
@@ -31,8 +43,10 @@ META = OpMeta(
     recipes=(
         "w4a16/trellis_mcg",
         "w4a16/trellis_sqg_e4m3",
+        "w4a16/trellis_sqg_fp16",
         "w4a8/trellis_sqg_e4m3",
     ),
+    requires=("triton",),
     provenance=Provenance(
         repo="https://github.com/local-inference-lab/b12x",
         commit="c58a381",
@@ -43,17 +57,27 @@ META = OpMeta(
     ),
     test_path="tests/gemm/test_trellis_linear.py",
     since="1.0.1",
-    notes="Trellis-coded dense W4A16 and direct E4M3-W4A8 linear.",
+    notes="Trellis-coded W4A16, single/paired BF16 rank-16, and direct E4M3-W4A8 linear.",
 )
 
 if TYPE_CHECKING:
     from .api import (  # noqa: F401
+        Buffers,
+        PairBuffers,
+        PreparedAdditivePair,
+        PreparedAdditiveWeight,
         PreparedWeight,
         clear_caches,
         is_supported,
+        make_buffers,
+        make_pair_buffers,
+        prepare_additive_pair,
+        prepare_additive_weight,
         prepare_weight,
         prepare_pair_weight,
         run,
+        run_additive,
+        run_additive_pair,
     )
 
 install_lazy_api(globals(), META)

--- a/b12x/gemm/trellis_linear/_low_rank.py
+++ b/b12x/gemm/trellis_linear/_low_rank.py
@@ -1,0 +1,538 @@
+"""Native BF16 low-rank correction for packed dense Trellis weights."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+_BLOCK_M = 16
+_BLOCK_N = 128
+_BLOCK_K = 64
+_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
+_WARMED_PAIR_PROJECT_SIGNATURES: set[tuple[int, int, int, int]] = set()
+_WARMED_PAIR_ADD_SIGNATURES: set[tuple[int, int, int, int]] = set()
+
+
+@triton.jit
+def _project_kernel(
+    x,
+    a_t,
+    hidden,
+    rows,
+    INPUT_FEATURES: tl.constexpr,
+    RANK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row_start = tl.program_id(0) * BLOCK_M
+    rows_offset = row_start + tl.arange(0, BLOCK_M)
+    rank_offset = tl.arange(0, RANK)
+    accumulator = tl.zeros((BLOCK_M, RANK), dtype=tl.float32)
+
+    for feature_start in tl.range(
+        0,
+        INPUT_FEATURES,
+        BLOCK_K,
+        num_stages=2,
+    ):
+        feature_offset = feature_start + tl.arange(0, BLOCK_K)
+        x_offsets = (
+            rows_offset[:, None].to(tl.int64) * INPUT_FEATURES + feature_offset[None, :]
+        )
+        a_offsets = (
+            rank_offset[None, :].to(tl.int64) * INPUT_FEATURES + feature_offset[:, None]
+        )
+        x_tile = tl.load(
+            x + x_offsets,
+            mask=(rows_offset[:, None] < rows)
+            & (feature_offset[None, :] < INPUT_FEATURES),
+            other=0.0,
+        )
+        a_tile = tl.load(
+            a_t + a_offsets,
+            mask=feature_offset[:, None] < INPUT_FEATURES,
+            other=0.0,
+        )
+        accumulator = tl.dot(x_tile, a_tile, accumulator)
+
+    hidden_offsets = rows_offset[:, None].to(tl.int64) * RANK + rank_offset[None, :]
+    tl.store(
+        hidden + hidden_offsets,
+        accumulator.to(tl.bfloat16),
+        mask=rows_offset[:, None] < rows,
+    )
+
+
+@triton.jit
+def _add_kernel(
+    hidden,
+    b,
+    output,
+    rows,
+    OUTPUT_FEATURES: tl.constexpr,
+    RANK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    rows_offset = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    output_offset = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    rank_offset = tl.arange(0, RANK)
+    hidden_offsets = rows_offset[:, None].to(tl.int64) * RANK + rank_offset[None, :]
+    factor_offsets = rank_offset[:, None] + output_offset[None, :].to(tl.int64) * RANK
+    hidden_tile = tl.load(
+        hidden + hidden_offsets,
+        mask=rows_offset[:, None] < rows,
+        other=0.0,
+    )
+    factor_tile = tl.load(
+        b + factor_offsets,
+        mask=output_offset[None, :] < OUTPUT_FEATURES,
+        other=0.0,
+    )
+    correction = tl.dot(hidden_tile, factor_tile).to(tl.bfloat16)
+    output_offsets = (
+        rows_offset[:, None].to(tl.int64) * OUTPUT_FEATURES + output_offset[None, :]
+    )
+    mask = (rows_offset[:, None] < rows) & (output_offset[None, :] < OUTPUT_FEATURES)
+    base = tl.load(output + output_offsets, mask=mask, other=0.0)
+    result = base.to(tl.float32) + correction.to(tl.float32)
+    tl.store(output + output_offsets, result, mask=mask)
+
+
+@triton.jit
+def _project_pair_kernel(
+    x,
+    a_t,
+    hidden,
+    rows,
+    INPUT_FEATURES: tl.constexpr,
+    RANK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row_start = tl.program_id(0) * BLOCK_M
+    rows_offset = row_start + tl.arange(0, BLOCK_M)
+    rank_offset = tl.arange(0, RANK)
+    accumulator_0 = tl.zeros((BLOCK_M, RANK), dtype=tl.float32)
+    accumulator_1 = tl.zeros((BLOCK_M, RANK), dtype=tl.float32)
+
+    for feature_start in tl.range(
+        0,
+        INPUT_FEATURES,
+        BLOCK_K,
+        num_stages=2,
+    ):
+        feature_offset = feature_start + tl.arange(0, BLOCK_K)
+        x_offsets = (
+            rows_offset[:, None].to(tl.int64) * INPUT_FEATURES + feature_offset[None, :]
+        )
+        a_offsets = (
+            rank_offset[None, :].to(tl.int64) * INPUT_FEATURES + feature_offset[:, None]
+        )
+        x_tile = tl.load(
+            x + x_offsets,
+            mask=(rows_offset[:, None] < rows)
+            & (feature_offset[None, :] < INPUT_FEATURES),
+            other=0.0,
+        )
+        a_tile_0 = tl.load(
+            a_t + a_offsets,
+            mask=feature_offset[:, None] < INPUT_FEATURES,
+            other=0.0,
+        )
+        a_tile_1 = tl.load(
+            a_t + RANK * INPUT_FEATURES + a_offsets,
+            mask=feature_offset[:, None] < INPUT_FEATURES,
+            other=0.0,
+        )
+        accumulator_0 = tl.dot(x_tile, a_tile_0, accumulator_0)
+        accumulator_1 = tl.dot(x_tile, a_tile_1, accumulator_1)
+
+    hidden_offsets = rows_offset[:, None].to(tl.int64) * RANK + rank_offset[None, :]
+    mask = rows_offset[:, None] < rows
+    tl.store(hidden + hidden_offsets, accumulator_0.to(tl.bfloat16), mask=mask)
+    tl.store(
+        hidden + rows * RANK + hidden_offsets,
+        accumulator_1.to(tl.bfloat16),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _add_pair_kernel(
+    hidden,
+    b,
+    output,
+    rows,
+    OUTPUT_FEATURES: tl.constexpr,
+    RANK: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    rows_offset = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    blocks_per_projection = OUTPUT_FEATURES // BLOCK_N
+    projection = tl.program_id(1) // blocks_per_projection
+    projection_block = tl.program_id(1) % blocks_per_projection
+    output_offset = projection_block * BLOCK_N + tl.arange(0, BLOCK_N)
+    rank_offset = tl.arange(0, RANK)
+    hidden_offsets = (
+        projection.to(tl.int64) * rows * RANK
+        + rows_offset[:, None].to(tl.int64) * RANK
+        + rank_offset[None, :]
+    )
+    factor_offsets = (
+        projection.to(tl.int64) * OUTPUT_FEATURES * RANK
+        + output_offset[None, :].to(tl.int64) * RANK
+        + rank_offset[:, None]
+    )
+    hidden_tile = tl.load(
+        hidden + hidden_offsets,
+        mask=rows_offset[:, None] < rows,
+        other=0.0,
+    )
+    factor_tile = tl.load(b + factor_offsets)
+    correction = tl.dot(hidden_tile, factor_tile).to(tl.bfloat16)
+    fused_width = 2 * OUTPUT_FEATURES
+    output_offsets = (
+        rows_offset[:, None].to(tl.int64) * fused_width
+        + projection.to(tl.int64) * OUTPUT_FEATURES
+        + output_offset[None, :]
+    )
+    mask = rows_offset[:, None] < rows
+    base = tl.load(output + output_offsets, mask=mask, other=0.0)
+    result = base.to(tl.float32) + correction.to(tl.float32)
+    tl.store(output + output_offsets, result, mask=mask)
+
+
+def _device_index(tensor: torch.Tensor) -> int:
+    index = tensor.device.index
+    return torch.cuda.current_device() if index is None else int(index)
+
+
+def _signature(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+) -> tuple[int, int, int, int]:
+    return (
+        _device_index(x),
+        int(x.shape[1]),
+        int(b.shape[0]),
+        int(a_t.shape[0]),
+    )
+
+
+def _launch(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    rows = int(x.shape[0])
+    input_features = int(x.shape[1])
+    output_features = int(b.shape[0])
+    rank = int(a_t.shape[0])
+    signature = _signature(x, a_t, b)
+    if torch.cuda.is_current_stream_capturing() and signature not in _WARMED_SIGNATURES:
+        raise RuntimeError(
+            "additive Trellis low-rank kernels are not initialized for CUDA "
+            "graph capture; run this exact factor geometry eagerly first"
+        )
+    _project_kernel[(triton.cdiv(rows, _BLOCK_M),)](
+        x,
+        a_t,
+        hidden,
+        rows,
+        INPUT_FEATURES=input_features,
+        RANK=rank,
+        BLOCK_M=_BLOCK_M,
+        BLOCK_K=_BLOCK_K,
+        num_warps=4,
+        num_stages=2,
+    )
+    _add_kernel[(triton.cdiv(rows, _BLOCK_M), triton.cdiv(output_features, _BLOCK_N))](
+        hidden,
+        b,
+        output,
+        rows,
+        OUTPUT_FEATURES=output_features,
+        RANK=rank,
+        BLOCK_M=_BLOCK_M,
+        BLOCK_N=_BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+    _WARMED_SIGNATURES.add(signature)
+
+
+def _launch_pair_project(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    hidden: torch.Tensor,
+) -> None:
+    rows = int(x.shape[0])
+    input_features = int(x.shape[1])
+    rank = int(a_t.shape[1])
+    signature = (_device_index(x), input_features, rank, rows)
+    if (
+        torch.cuda.is_current_stream_capturing()
+        and signature not in _WARMED_PAIR_PROJECT_SIGNATURES
+    ):
+        raise RuntimeError(
+            "paired additive Trellis projection is not initialized for CUDA "
+            "graph capture; run this exact factor geometry eagerly first"
+        )
+    _project_pair_kernel[(triton.cdiv(rows, _BLOCK_M),)](
+        x,
+        a_t,
+        hidden,
+        rows,
+        INPUT_FEATURES=input_features,
+        RANK=rank,
+        BLOCK_M=_BLOCK_M,
+        BLOCK_K=_BLOCK_K,
+        num_warps=4,
+        num_stages=2,
+    )
+    _WARMED_PAIR_PROJECT_SIGNATURES.add(signature)
+
+
+def _launch_pair_add(
+    hidden: torch.Tensor,
+    b: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    rows = int(hidden.shape[1])
+    output_features = int(b.shape[1])
+    rank = int(hidden.shape[2])
+    signature = (_device_index(hidden), output_features, rank, rows)
+    if (
+        torch.cuda.is_current_stream_capturing()
+        and signature not in _WARMED_PAIR_ADD_SIGNATURES
+    ):
+        raise RuntimeError(
+            "paired additive Trellis output is not initialized for CUDA graph "
+            "capture; run this exact factor geometry eagerly first"
+        )
+    _add_pair_kernel[
+        (
+            triton.cdiv(rows, _BLOCK_M),
+            2 * triton.cdiv(output_features, _BLOCK_N),
+        )
+    ](
+        hidden,
+        b,
+        output,
+        rows,
+        OUTPUT_FEATURES=output_features,
+        RANK=rank,
+        BLOCK_M=_BLOCK_M,
+        BLOCK_N=_BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+    _WARMED_PAIR_ADD_SIGNATURES.add(signature)
+
+
+@torch.library.custom_op(
+    "b12x::trellis_low_rank_additive",
+    mutates_args=("hidden", "output"),
+)
+def _low_rank_additive_op(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    _launch(x, a_t, b, hidden, output)
+
+
+@_low_rank_additive_op.register_fake
+def _low_rank_additive_fake(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    del x, a_t, b, hidden, output
+
+
+@torch.library.custom_op(
+    "b12x::trellis_low_rank_pair_project",
+    mutates_args=("hidden",),
+)
+def _low_rank_pair_project_op(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    hidden: torch.Tensor,
+) -> None:
+    _launch_pair_project(x, a_t, hidden)
+
+
+@_low_rank_pair_project_op.register_fake
+def _low_rank_pair_project_fake(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    hidden: torch.Tensor,
+) -> None:
+    del x, a_t, hidden
+
+
+@torch.library.custom_op(
+    "b12x::trellis_low_rank_pair_add",
+    mutates_args=("output",),
+)
+def _low_rank_pair_add_op(
+    hidden: torch.Tensor,
+    b: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    _launch_pair_add(hidden, b, output)
+
+
+@_low_rank_pair_add_op.register_fake
+def _low_rank_pair_add_fake(
+    hidden: torch.Tensor,
+    b: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    del hidden, b, output
+
+
+def run_low_rank_additive(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Project through BF16 rank factors and add into caller-owned output."""
+    if (
+        x.ndim != 2
+        or a_t.ndim != 2
+        or b.ndim != 2
+        or hidden.ndim != 2
+        or output.ndim != 2
+    ):
+        raise ValueError("additive low-rank tensors must all be rank two")
+    rows, input_features = (int(value) for value in x.shape)
+    rank = int(a_t.shape[0])
+    output_features = int(b.shape[0])
+    if (
+        tuple(a_t.shape) != (rank, input_features)
+        or tuple(b.shape) != (output_features, rank)
+        or tuple(hidden.shape) != (rows, rank)
+        or tuple(output.shape) != (rows, output_features)
+        or rows <= 0
+        or rank != 16
+        or input_features % _BLOCK_K != 0
+        or output_features % _BLOCK_N != 0
+    ):
+        raise ValueError(
+            "additive low-rank execution requires rank 16, K divisible by 64, "
+            "N divisible by 128, and mutually compatible tensor geometry"
+        )
+    tensors = (x, a_t, b, hidden, output)
+    if any(
+        tensor.dtype != torch.bfloat16
+        or not tensor.is_cuda
+        or tensor.device != x.device
+        or not tensor.is_contiguous()
+        or int(tensor.data_ptr()) % 16 != 0
+        for tensor in tensors
+    ):
+        raise ValueError(
+            "additive low-rank tensors must be contiguous, aligned BF16 CUDA storage"
+        )
+    torch.ops.b12x.trellis_low_rank_additive(x, a_t, b, hidden, output)
+
+
+def _validate_pair_storage(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> tuple[int, int, int, int]:
+    if (
+        x.ndim != 2
+        or a_t.ndim != 3
+        or b.ndim != 3
+        or hidden.ndim != 3
+        or output.ndim != 2
+    ):
+        raise ValueError("paired additive low-rank tensors have incompatible ranks")
+    rows, input_features = (int(value) for value in x.shape)
+    output_features = int(b.shape[1])
+    rank = int(a_t.shape[1])
+    if (
+        tuple(a_t.shape) != (2, rank, input_features)
+        or tuple(b.shape) != (2, output_features, rank)
+        or tuple(hidden.shape) != (2, rows, rank)
+        or tuple(output.shape) != (rows, 2 * output_features)
+        or rows <= 0
+        or rank != 16
+        or input_features % _BLOCK_K != 0
+        or output_features % _BLOCK_N != 0
+    ):
+        raise ValueError(
+            "paired additive execution requires rank 16, K divisible by 64, "
+            "N divisible by 128, and mutually compatible tensor geometry"
+        )
+    tensors = (x, a_t, b, hidden, output)
+    if any(
+        tensor.dtype != torch.bfloat16
+        or not tensor.is_cuda
+        or tensor.device != x.device
+        or not tensor.is_contiguous()
+        or int(tensor.data_ptr()) % 16 != 0
+        for tensor in tensors
+    ):
+        raise ValueError(
+            "paired additive tensors must be contiguous, aligned BF16 CUDA storage"
+        )
+    return rows, input_features, output_features, rank
+
+
+def run_low_rank_pair_project(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Project one input through two rank-16 A factors in one native launch."""
+    _validate_pair_storage(x, a_t, b, hidden, output)
+    torch.ops.b12x.trellis_low_rank_pair_project(x, a_t, hidden)
+
+
+def run_low_rank_pair_add(
+    x: torch.Tensor,
+    a_t: torch.Tensor,
+    b: torch.Tensor,
+    hidden: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Add two rank-16 B projections to one concatenated gate/up output."""
+    _validate_pair_storage(x, a_t, b, hidden, output)
+    torch.ops.b12x.trellis_low_rank_pair_add(hidden, b, output)
+
+
+def clear_low_rank_caches() -> None:
+    """Require an eager warmup before any later CUDA-graph capture."""
+    _WARMED_SIGNATURES.clear()
+    _WARMED_PAIR_PROJECT_SIGNATURES.clear()
+    _WARMED_PAIR_ADD_SIGNATURES.clear()
+
+
+__all__ = [
+    "clear_low_rank_caches",
+    "run_low_rank_additive",
+    "run_low_rank_pair_add",
+    "run_low_rank_pair_project",
+]

--- a/b12x/gemm/trellis_linear/_low_rank.py
+++ b/b12x/gemm/trellis_linear/_low_rank.py
@@ -15,6 +15,17 @@ _WARMED_PAIR_PROJECT_SIGNATURES: set[tuple[int, int, int, int]] = set()
 _WARMED_PAIR_ADD_SIGNATURES: set[tuple[int, int, int, int]] = set()
 
 
+def _has_16_byte_alignment(tensor: torch.Tensor) -> bool:
+    """Check storage alignment when a real tensor pointer is observable.
+
+    TorchDynamo traces with fake tensors whose storage pointer is intentionally
+    unavailable. PyTorch CUDA allocations satisfy the alignment contract, and
+    caller-owned buffers are checked during the required eager warmup before a
+    compiled or CUDA-graph execution.
+    """
+    return torch.compiler.is_compiling() or int(tensor.data_ptr()) % 16 == 0
+
+
 @triton.jit
 def _project_kernel(
     x,
@@ -412,6 +423,9 @@ def run_low_rank_additive(
     output: torch.Tensor,
 ) -> None:
     """Project through BF16 rank factors and add into caller-owned output."""
+    if torch.compiler.is_compiling():
+        torch.ops.b12x.trellis_low_rank_additive(x, a_t, b, hidden, output)
+        return
     if (
         x.ndim != 2
         or a_t.ndim != 2
@@ -443,7 +457,7 @@ def run_low_rank_additive(
         or not tensor.is_cuda
         or tensor.device != x.device
         or not tensor.is_contiguous()
-        or int(tensor.data_ptr()) % 16 != 0
+        or not _has_16_byte_alignment(tensor)
         for tensor in tensors
     ):
         raise ValueError(
@@ -459,6 +473,8 @@ def _validate_pair_storage(
     hidden: torch.Tensor,
     output: torch.Tensor,
 ) -> tuple[int, int, int, int]:
+    if torch.compiler.is_compiling():
+        return 0, 0, 0, 0
     if (
         x.ndim != 2
         or a_t.ndim != 3
@@ -490,7 +506,7 @@ def _validate_pair_storage(
         or not tensor.is_cuda
         or tensor.device != x.device
         or not tensor.is_contiguous()
-        or int(tensor.data_ptr()) % 16 != 0
+        or not _has_16_byte_alignment(tensor)
         for tensor in tensors
     ):
         raise ValueError(

--- a/b12x/gemm/trellis_linear/api.py
+++ b/b12x/gemm/trellis_linear/api.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 
 import torch
 
 from ..._lib.gating import default_is_supported
+from ...moe._shared.kernels.w4a16.host import (
+    _W4A16_ALLOWED_ROUTED_SIZES,
+    packed_gemm_scratch_elements,
+)
 from ...moe._shared.kernels.w4a16.kernel import (
     clear_w4a16_kernel_cache,
     run_trellis256_dense,
@@ -17,8 +22,279 @@ from ...moe._shared.kernels.w4a16.prepare import (
     prepare_trellis256_pair_dense_weight,
 )
 from . import META
+from ._low_rank import (
+    clear_low_rank_caches,
+    run_low_rank_additive,
+    run_low_rank_pair_add,
+    run_low_rank_pair_project,
+)
 
 PreparedWeight = PreparedTrellis256DenseWeight
+
+
+@dataclass(frozen=True)
+class PreparedAdditiveWeight:
+    """Packed Trellis weight plus an additive BF16 rank-16 correction.
+
+    ``a_t`` is the preparation-time rank-major copy of the checkpoint's
+    ``[in_features, rank]`` A factor. ``b`` retains the checkpoint's
+    ``[out_features, rank]`` B factor by reference. Execution evaluates
+    ``base(x) + (x @ a_t.T) @ b.T`` without materializing a decoded base matrix.
+    """
+
+    base: PreparedWeight
+    a_t: torch.Tensor
+    b: torch.Tensor
+    rank: int
+
+
+@dataclass(frozen=True)
+class PreparedAdditivePair:
+    """Two same-shaped packed weights with jointly executed rank-16 factors."""
+
+    left: PreparedWeight
+    right: PreparedWeight
+    a_t: torch.Tensor
+    b: torch.Tensor
+    rank: int
+
+
+@dataclass(frozen=True)
+class Buffers:
+    """Caller-owned storage for one fixed-shape dense Trellis execution."""
+
+    output: torch.Tensor
+    gemm_output: torch.Tensor
+    c_tmp: torch.Tensor
+    rotated_f16: torch.Tensor
+    input_f16: Optional[torch.Tensor] = None
+    rotated_compute: Optional[torch.Tensor] = None
+    gemm_output_f16: Optional[torch.Tensor] = None
+    output_f16: Optional[torch.Tensor] = None
+    low_rank_hidden: Optional[torch.Tensor] = None
+
+    def run_kwargs(self) -> dict[str, Optional[torch.Tensor]]:
+        """Return keyword arguments accepted by :func:`run`."""
+        return {
+            "output": self.output,
+            "gemm_output": self.gemm_output,
+            "c_tmp": self.c_tmp,
+            "input_f16": self.input_f16,
+            "rotated_f16": self.rotated_f16,
+            "rotated_compute": self.rotated_compute,
+            "gemm_output_f16": self.gemm_output_f16,
+            "output_f16": self.output_f16,
+        }
+
+
+@dataclass(frozen=True)
+class PairBuffers:
+    """Caller-owned storage for one fixed-shape paired dense execution."""
+
+    base: Buffers
+    output: torch.Tensor
+    low_rank_hidden: torch.Tensor
+
+
+def prepare_additive_weight(
+    base: PreparedWeight,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> PreparedAdditiveWeight:
+    """Bind BF16 factors and create the native rank-major A layout."""
+    if not isinstance(base, PreparedTrellis256DenseWeight):
+        raise TypeError("additive Trellis preparation requires a prepared dense weight")
+    rank = int(a.shape[1]) if isinstance(a, torch.Tensor) and a.ndim == 2 else 0
+    if (
+        not isinstance(a, torch.Tensor)
+        or not isinstance(b, torch.Tensor)
+        or a.ndim != 2
+        or b.ndim != 2
+        or tuple(a.shape) != (int(base.in_features), rank)
+        or tuple(b.shape) != (int(base.out_features), rank)
+        or rank != 16
+    ):
+        raise ValueError(
+            "low-rank factors must have shapes [in_features, 16] and [out_features, 16]"
+        )
+    if base.params_dtype != torch.bfloat16:
+        raise TypeError("native additive Trellis execution requires BF16 compute")
+    for name, factor in (("a", a), ("b", b)):
+        if (
+            factor.device != base.trellis.device
+            or factor.dtype != base.params_dtype
+            or not factor.is_contiguous()
+            or int(factor.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                f"low-rank factor {name} must be contiguous, 16-byte-aligned "
+                f"{base.params_dtype} storage on {base.trellis.device}"
+            )
+    a_t = a.T.contiguous()
+    if int(a_t.data_ptr()) % 16 != 0:
+        raise RuntimeError("rank-major low-rank factor storage is not aligned")
+    return PreparedAdditiveWeight(base=base, a_t=a_t, b=b, rank=rank)
+
+
+def prepare_additive_pair(
+    left: PreparedWeight,
+    right: PreparedWeight,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> PreparedAdditivePair:
+    """Bind two equal-geometry packed bases to stacked gate/up factors."""
+    if not isinstance(left, PreparedTrellis256DenseWeight) or not isinstance(
+        right, PreparedTrellis256DenseWeight
+    ):
+        raise TypeError("paired additive preparation requires two dense weights")
+    if (
+        left.in_features != right.in_features
+        or left.out_features != right.out_features
+        or left.params_dtype != torch.bfloat16
+        or right.params_dtype != torch.bfloat16
+        or left.trellis.device != right.trellis.device
+        or left.trellis_bits != right.trellis_bits
+        or left.trellis_codebook != right.trellis_codebook
+    ):
+        raise ValueError("paired additive bases must share BF16 geometry and device")
+    expected_a = (2, int(left.in_features), 16)
+    expected_b = (2, int(left.out_features), 16)
+    if (
+        not isinstance(a, torch.Tensor)
+        or not isinstance(b, torch.Tensor)
+        or tuple(a.shape) != expected_a
+        or tuple(b.shape) != expected_b
+    ):
+        raise ValueError(
+            f"paired factors must have shapes {expected_a} and {expected_b}"
+        )
+    for name, factor in (("a", a), ("b", b)):
+        if (
+            factor.device != left.trellis.device
+            or factor.dtype != torch.bfloat16
+            or not factor.is_contiguous()
+            or int(factor.data_ptr()) % 16 != 0
+        ):
+            raise ValueError(
+                f"paired low-rank factor {name} must be contiguous, aligned BF16 "
+                f"storage on {left.trellis.device}"
+            )
+    a_t = a.transpose(1, 2).contiguous()
+    if int(a_t.data_ptr()) % 16 != 0:
+        raise RuntimeError("paired rank-major factor storage is not aligned")
+    return PreparedAdditivePair(
+        left=left,
+        right=right,
+        a_t=a_t,
+        b=b,
+        rank=16,
+    )
+
+
+def make_buffers(
+    weight: PreparedWeight | PreparedAdditiveWeight,
+    *,
+    size_m: int,
+    input_dtype: torch.dtype,
+) -> Buffers:
+    """Allocate all storage needed by one fixed-shape eager or graph run."""
+    if isinstance(weight, PreparedAdditiveWeight):
+        base = weight.base
+        rank: int | None = weight.rank
+    elif isinstance(weight, PreparedTrellis256DenseWeight):
+        base = weight
+        rank = None
+    else:
+        raise TypeError("dense Trellis buffers require a prepared weight")
+    size_m = int(size_m)
+    if size_m <= 0:
+        raise ValueError(f"dense Trellis M must be positive, got {size_m}")
+    if input_dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"dense Trellis input must be fp16 or bf16, got {input_dtype}")
+    if rank is not None and input_dtype != torch.bfloat16:
+        raise TypeError(
+            "additive Trellis execution requires input and factor dtypes to match"
+        )
+    device = base.trellis.device
+    size_k = int(base.in_features)
+    size_n = int(base.out_features)
+    compute_dtype = base.params_dtype
+
+    def empty(shape: tuple[int, int], dtype: torch.dtype) -> torch.Tensor:
+        return torch.empty(shape, dtype=dtype, device=device)
+
+    sms = int(torch.cuda.get_device_properties(device).multi_processor_count)
+    c_tmp_elements = max(
+        packed_gemm_scratch_elements(
+            size_n=size_n,
+            route_slots=((size_m + block_size - 1) // block_size) * block_size,
+            moe_block_size=block_size,
+            sms=sms,
+        )
+        for block_size in _W4A16_ALLOWED_ROUTED_SIZES
+    )
+
+    return Buffers(
+        output=empty((size_m, size_n), input_dtype),
+        gemm_output=empty((size_m, size_n), compute_dtype),
+        c_tmp=torch.empty(
+            (c_tmp_elements,),
+            dtype=torch.float32,
+            device=device,
+        ),
+        input_f16=(
+            empty((size_m, size_k), torch.float16)
+            if input_dtype == torch.bfloat16
+            else None
+        ),
+        rotated_f16=empty((size_m, size_k), torch.float16),
+        rotated_compute=(
+            empty((size_m, size_k), torch.bfloat16)
+            if compute_dtype == torch.bfloat16
+            else None
+        ),
+        gemm_output_f16=(
+            empty((size_m, size_n), torch.float16)
+            if compute_dtype == torch.bfloat16
+            else None
+        ),
+        output_f16=(
+            empty((size_m, size_n), torch.float16)
+            if input_dtype == torch.bfloat16
+            else None
+        ),
+        low_rank_hidden=(
+            empty((size_m, rank), input_dtype) if rank is not None else None
+        ),
+    )
+
+
+def make_pair_buffers(
+    weight: PreparedAdditivePair,
+    *,
+    size_m: int,
+    input_dtype: torch.dtype,
+) -> PairBuffers:
+    """Allocate stable storage for one paired gate/up execution."""
+    if not isinstance(weight, PreparedAdditivePair):
+        raise TypeError("paired Trellis buffers require a prepared additive pair")
+    if input_dtype != torch.bfloat16:
+        raise TypeError("paired additive Trellis execution requires BF16 input")
+    base = make_buffers(weight.left, size_m=size_m, input_dtype=input_dtype)
+    device = weight.left.trellis.device
+    return PairBuffers(
+        base=base,
+        output=torch.empty(
+            (int(size_m), 2 * int(weight.left.out_features)),
+            dtype=input_dtype,
+            device=device,
+        ),
+        low_rank_hidden=torch.empty(
+            (2, int(size_m), weight.rank),
+            dtype=input_dtype,
+            device=device,
+        ),
+    )
 
 
 def prepare_weight(
@@ -107,14 +383,154 @@ def run(
     )
 
 
+def run_additive(
+    x: torch.Tensor,
+    weight: PreparedAdditiveWeight,
+    *,
+    low_rank_hidden: Optional[torch.Tensor] = None,
+    output: Optional[torch.Tensor] = None,
+    gemm_output: Optional[torch.Tensor] = None,
+    c_tmp: Optional[torch.Tensor] = None,
+    input_f16: Optional[torch.Tensor] = None,
+    rotated_f16: Optional[torch.Tensor] = None,
+    rotated_compute: Optional[torch.Tensor] = None,
+    gemm_output_f16: Optional[torch.Tensor] = None,
+    output_f16: Optional[torch.Tensor] = None,
+    hadamard_128=None,
+    _moe_block_size: int = 64,
+    _force_tile_config: tuple[int, int] | None = None,
+) -> torch.Tensor:
+    """Execute packed Trellis GEMM and add a fixed low-rank branch.
+
+    The operation is inference-only. Supplying the buffers returned by
+    :func:`make_buffers` avoids allocation and pointer changes during replay.
+    """
+    if not isinstance(weight, PreparedAdditiveWeight):
+        raise TypeError("run_additive requires a prepared additive weight")
+    if x.dtype != weight.a_t.dtype:
+        raise TypeError("additive Trellis input and factor dtypes must match")
+    expected_hidden = (int(x.shape[0]), weight.rank) if x.ndim == 2 else ()
+    if low_rank_hidden is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Trellis dense low_rank_hidden is not initialized for CUDA graph "
+                "capture; provide caller-owned storage"
+            )
+        low_rank_hidden = torch.empty(
+            expected_hidden,
+            dtype=x.dtype,
+            device=x.device,
+        )
+    elif (
+        tuple(low_rank_hidden.shape) != expected_hidden
+        or low_rank_hidden.dtype != x.dtype
+        or low_rank_hidden.device != x.device
+        or not low_rank_hidden.is_contiguous()
+        or int(low_rank_hidden.data_ptr()) % 16 != 0
+    ):
+        raise ValueError(
+            "low_rank_hidden must be contiguous, 16-byte-aligned storage with "
+            f"shape {expected_hidden}, dtype {x.dtype}, and device {x.device}"
+        )
+    result = run(
+        x,
+        weight.base,
+        output=output,
+        gemm_output=gemm_output,
+        c_tmp=c_tmp,
+        input_f16=input_f16,
+        rotated_f16=rotated_f16,
+        rotated_compute=rotated_compute,
+        gemm_output_f16=gemm_output_f16,
+        output_f16=output_f16,
+        hadamard_128=hadamard_128,
+        _moe_block_size=_moe_block_size,
+        _force_tile_config=_force_tile_config,
+    )
+    run_low_rank_additive(
+        x,
+        weight.a_t,
+        weight.b,
+        low_rank_hidden,
+        result,
+    )
+    return result
+
+
+def run_additive_pair(
+    x: torch.Tensor,
+    weight: PreparedAdditivePair,
+    *,
+    buffers: PairBuffers,
+    hadamard_128=None,
+    _moe_block_size: int = 64,
+    _force_tile_config: tuple[int, int] | None = None,
+) -> torch.Tensor:
+    """Execute two packed bases with a two-launch paired rank-16 branch."""
+    if not isinstance(weight, PreparedAdditivePair):
+        raise TypeError("run_additive_pair requires a prepared additive pair")
+    if not isinstance(buffers, PairBuffers):
+        raise TypeError("run_additive_pair requires caller-owned pair buffers")
+    if x.ndim != 2:
+        raise ValueError("paired additive input must be a matrix")
+    expected_output = (int(x.shape[0]), 2 * int(weight.left.out_features))
+    expected_hidden = (2, int(x.shape[0]), weight.rank)
+    if (
+        x.dtype != torch.bfloat16
+        or x.device != weight.left.trellis.device
+        or not x.is_contiguous()
+        or tuple(buffers.output.shape) != expected_output
+        or tuple(buffers.low_rank_hidden.shape) != expected_hidden
+    ):
+        raise ValueError(
+            "paired additive input or caller-owned storage is incompatible"
+        )
+    run_low_rank_pair_project(
+        x,
+        weight.a_t,
+        weight.b,
+        buffers.low_rank_hidden,
+        buffers.output,
+    )
+    kwargs = buffers.base.run_kwargs()
+    left = run(
+        x,
+        weight.left,
+        hadamard_128=hadamard_128,
+        _moe_block_size=_moe_block_size,
+        _force_tile_config=_force_tile_config,
+        **kwargs,
+    )
+    width = int(weight.left.out_features)
+    buffers.output[:, :width].copy_(left)
+    right = run(
+        x,
+        weight.right,
+        hadamard_128=hadamard_128,
+        _moe_block_size=_moe_block_size,
+        _force_tile_config=_force_tile_config,
+        **kwargs,
+    )
+    buffers.output[:, width:].copy_(right)
+    run_low_rank_pair_add(
+        x,
+        weight.a_t,
+        weight.b,
+        buffers.low_rank_hidden,
+        buffers.output,
+    )
+    return buffers.output
+
+
 def is_supported(device=None) -> bool:
     """True when the SM120/SM121 Trellis kernel stack is available."""
     return default_is_supported(device, requires=META.requires)
 
 
 def clear_caches() -> None:
-    """Clear compiled W4A16 specializations."""
+    """Clear compiled W4A16 and additive low-rank specializations."""
     clear_w4a16_kernel_cache()
+    clear_low_rank_caches()
 
 
 __all__ = list(META.entry_points)

--- a/b12x/gemm/trellis_linear/api.py
+++ b/b12x/gemm/trellis_linear/api.py
@@ -32,6 +32,11 @@ from ._low_rank import (
 PreparedWeight = PreparedTrellis256DenseWeight
 
 
+def _has_16_byte_alignment(tensor: torch.Tensor) -> bool:
+    """Check real storage while allowing fake-tensor graph tracing."""
+    return torch.compiler.is_compiling() or int(tensor.data_ptr()) % 16 == 0
+
+
 @dataclass(frozen=True)
 class PreparedAdditiveWeight:
     """Packed Trellis weight plus an additive BF16 rank-16 correction.
@@ -101,9 +106,11 @@ def view_buffers(buffers: Buffers, *, size_m: int) -> Buffers:
 
     if not isinstance(buffers, Buffers):
         raise TypeError("dense Trellis buffer views require Buffers")
+    compiling = torch.compiler.is_compiling()
     capacity = int(buffers.output.shape[0])
-    size_m = int(size_m)
-    if size_m <= 0 or size_m > capacity:
+    if not compiling:
+        size_m = int(size_m)
+    if not compiling and (size_m <= 0 or size_m > capacity):
         raise ValueError(
             f"dense Trellis row count must be in [1, {capacity}], got {size_m}"
         )
@@ -111,7 +118,9 @@ def view_buffers(buffers: Buffers, *, size_m: int) -> Buffers:
     def rows(name: str, tensor: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
         if tensor is None:
             return None
-        if tensor.ndim != 2 or int(tensor.shape[0]) != capacity:
+        if not compiling and (
+            tensor.ndim != 2 or int(tensor.shape[0]) != capacity
+        ):
             raise ValueError(
                 f"dense Trellis {name} does not share the {capacity}-row capacity"
             )
@@ -122,7 +131,7 @@ def view_buffers(buffers: Buffers, *, size_m: int) -> Buffers:
         assert result is not None
         return result
 
-    if size_m == capacity:
+    if not compiling and size_m == capacity:
         return buffers
     return Buffers(
         output=required_rows("output", buffers.output),
@@ -142,11 +151,15 @@ def view_pair_buffers(buffers: PairBuffers, *, size_m: int) -> PairBuffers:
 
     if not isinstance(buffers, PairBuffers):
         raise TypeError("paired Trellis buffer views require PairBuffers")
-    if buffers.output.ndim != 2 or buffers.low_rank_hidden.ndim != 3:
+    compiling = torch.compiler.is_compiling()
+    if not compiling and (
+        buffers.output.ndim != 2 or buffers.low_rank_hidden.ndim != 3
+    ):
         raise ValueError("paired Trellis capacity storage has incompatible ranks")
     capacity = int(buffers.output.shape[0])
-    size_m = int(size_m)
-    if (
+    if not compiling:
+        size_m = int(size_m)
+    if not compiling and (
         size_m <= 0
         or size_m > capacity
         or tuple(buffers.low_rank_hidden.shape[:2]) != (2, capacity)
@@ -155,7 +168,7 @@ def view_pair_buffers(buffers: PairBuffers, *, size_m: int) -> PairBuffers:
         raise ValueError(
             f"paired Trellis row count must be in [1, {capacity}], got {size_m}"
         )
-    if size_m == capacity:
+    if not compiling and size_m == capacity:
         return buffers
     rank = int(buffers.low_rank_hidden.shape[2])
     hidden = buffers.low_rank_hidden.view(-1, rank)[: 2 * size_m]
@@ -479,7 +492,9 @@ def run_additive(
         raise TypeError("run_additive requires a prepared additive weight")
     if x.dtype != weight.a_t.dtype:
         raise TypeError("additive Trellis input and factor dtypes must match")
-    expected_hidden = (int(x.shape[0]), weight.rank) if x.ndim == 2 else ()
+    compiling = torch.compiler.is_compiling()
+    rows = x.shape[0] if compiling else int(x.shape[0])
+    expected_hidden = (rows, weight.rank) if x.ndim == 2 else ()
     if low_rank_hidden is None:
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
@@ -492,11 +507,11 @@ def run_additive(
             device=x.device,
         )
     elif (
-        tuple(low_rank_hidden.shape) != expected_hidden
+        (not compiling and tuple(low_rank_hidden.shape) != expected_hidden)
         or low_rank_hidden.dtype != x.dtype
         or low_rank_hidden.device != x.device
         or not low_rank_hidden.is_contiguous()
-        or int(low_rank_hidden.data_ptr()) % 16 != 0
+        or not _has_16_byte_alignment(low_rank_hidden)
     ):
         raise ValueError(
             "low_rank_hidden must be contiguous, 16-byte-aligned storage with "
@@ -543,14 +558,16 @@ def run_additive_pair(
         raise TypeError("run_additive_pair requires caller-owned pair buffers")
     if x.ndim != 2:
         raise ValueError("paired additive input must be a matrix")
-    expected_output = (int(x.shape[0]), 2 * int(weight.left.out_features))
-    expected_hidden = (2, int(x.shape[0]), weight.rank)
+    compiling = torch.compiler.is_compiling()
+    rows = x.shape[0] if compiling else int(x.shape[0])
+    expected_output = (rows, 2 * int(weight.left.out_features))
+    expected_hidden = (2, rows, weight.rank)
     if (
         x.dtype != torch.bfloat16
         or x.device != weight.left.trellis.device
         or not x.is_contiguous()
-        or tuple(buffers.output.shape) != expected_output
-        or tuple(buffers.low_rank_hidden.shape) != expected_hidden
+        or (not compiling and tuple(buffers.output.shape) != expected_output)
+        or (not compiling and tuple(buffers.low_rank_hidden.shape) != expected_hidden)
     ):
         raise ValueError(
             "paired additive input or caller-owned storage is incompatible"

--- a/b12x/gemm/trellis_linear/api.py
+++ b/b12x/gemm/trellis_linear/api.py
@@ -96,6 +96,76 @@ class PairBuffers:
     low_rank_hidden: torch.Tensor
 
 
+def view_buffers(buffers: Buffers, *, size_m: int) -> Buffers:
+    """Return exact-row views backed by one preallocated buffer capacity."""
+
+    if not isinstance(buffers, Buffers):
+        raise TypeError("dense Trellis buffer views require Buffers")
+    capacity = int(buffers.output.shape[0])
+    size_m = int(size_m)
+    if size_m <= 0 or size_m > capacity:
+        raise ValueError(
+            f"dense Trellis row count must be in [1, {capacity}], got {size_m}"
+        )
+
+    def rows(name: str, tensor: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+        if tensor is None:
+            return None
+        if tensor.ndim != 2 or int(tensor.shape[0]) != capacity:
+            raise ValueError(
+                f"dense Trellis {name} does not share the {capacity}-row capacity"
+            )
+        return tensor[:size_m]
+
+    def required_rows(name: str, tensor: torch.Tensor) -> torch.Tensor:
+        result = rows(name, tensor)
+        assert result is not None
+        return result
+
+    if size_m == capacity:
+        return buffers
+    return Buffers(
+        output=required_rows("output", buffers.output),
+        gemm_output=required_rows("gemm_output", buffers.gemm_output),
+        c_tmp=buffers.c_tmp,
+        input_f16=rows("input_f16", buffers.input_f16),
+        rotated_f16=required_rows("rotated_f16", buffers.rotated_f16),
+        rotated_compute=rows("rotated_compute", buffers.rotated_compute),
+        gemm_output_f16=rows("gemm_output_f16", buffers.gemm_output_f16),
+        output_f16=rows("output_f16", buffers.output_f16),
+        low_rank_hidden=rows("low_rank_hidden", buffers.low_rank_hidden),
+    )
+
+
+def view_pair_buffers(buffers: PairBuffers, *, size_m: int) -> PairBuffers:
+    """Return exact-row paired views backed by one preallocated capacity."""
+
+    if not isinstance(buffers, PairBuffers):
+        raise TypeError("paired Trellis buffer views require PairBuffers")
+    if buffers.output.ndim != 2 or buffers.low_rank_hidden.ndim != 3:
+        raise ValueError("paired Trellis capacity storage has incompatible ranks")
+    capacity = int(buffers.output.shape[0])
+    size_m = int(size_m)
+    if (
+        size_m <= 0
+        or size_m > capacity
+        or tuple(buffers.low_rank_hidden.shape[:2]) != (2, capacity)
+        or int(buffers.base.output.shape[0]) != capacity
+    ):
+        raise ValueError(
+            f"paired Trellis row count must be in [1, {capacity}], got {size_m}"
+        )
+    if size_m == capacity:
+        return buffers
+    rank = int(buffers.low_rank_hidden.shape[2])
+    hidden = buffers.low_rank_hidden.view(-1, rank)[: 2 * size_m]
+    return PairBuffers(
+        base=view_buffers(buffers.base, size_m=size_m),
+        output=buffers.output[:size_m],
+        low_rank_hidden=hidden.view(2, size_m, rank),
+    )
+
+
 def prepare_additive_weight(
     base: PreparedWeight,
     a: torch.Tensor,

--- a/b12x/integration/vllm/README.md
+++ b/b12x/integration/vllm/README.md
@@ -55,6 +55,7 @@ vllm serve "$B12X_FP6_MODEL_DIR" \
 |---|---|---|
 | `B12X_ENABLE_FP6` | off | Master gate |
 | `B12X_FP6_MODEL_DIR` | — | Checkpoint path for spawned workers |
+| `B12X_QSRT_MODEL_DIR` | — | QSRT checkpoint path used to locate `b12x-qsrt-manifest.json` |
 | `B12X_MOE_WARM_MS` | auto | Override MoE decode warm-run token counts |
 | `B12X_DYNAMIC_DETERMINISTIC_OUTPUT` | off | Deterministic MoE combine (KLD scoring) |
 | `B12X_DISABLE_BF16_GEMV` | off | Disable small-N bf16 GEMV routing |

--- a/b12x/integration/vllm/README.md
+++ b/b12x/integration/vllm/README.md
@@ -1,6 +1,7 @@
-# b12x FP6 vLLM integration
+# B12X vLLM quantization plugins
 
-Thin vLLM adapter for b12x MX-FP6 (W6A6/W6A8) checkpoints.  This mirrors
+Thin vLLM adapters for B12X MX-FP6 (W6A6/W6A8) and Qwen3.8 dense-MLP QSRT K5
+checkpoints. The MX-FP6 adapter mirrors
 how the maintainer's private fork wires NVFP4: the glue lives in
 ``b12x/integration/`` and calls the public ``plan`` / ``bind`` / ``run``
 APIs — b12x itself does not auto-load into vLLM.
@@ -11,6 +12,7 @@ APIs — b12x itself does not auto-load into vLLM.
 |---|---|
 | `fp6_serving.py` | Framework-agnostic quant methods (`B12XFP6MoEMethod`, `B12XFP6LinearMethod`) |
 | `plugin.py` | vLLM ``QuantizationConfig`` + weight loaders + entry point |
+| `qsrt_plugin.py` | TP1 Qwen3.8 K5/rank-16 config, exact weight loaders, graph storage, and entry point |
 
 ## Install into a vLLM fork
 
@@ -28,6 +30,7 @@ point if you install b12x with vLLM present):
 ```toml
 [project.entry-points."vllm.general_plugins"]
 b12x_fp6 = "b12x.integration.vllm.plugin:register_b12x_fp6"
+b12x_qsrt = "b12x.integration.vllm.qsrt_plugin:register_b12x_qsrt"
 ```
 
 ### 3. Launch
@@ -57,5 +60,8 @@ vllm serve "$B12X_FP6_MODEL_DIR" \
 | `B12X_DISABLE_BF16_GEMV` | off | Disable small-N bf16 GEMV routing |
 | `TORCH_COMPILE_DISABLE=1` | — | Required for bit-identical KLD (vLLM Inductor) |
 
-See [docs/mxfp6-vllm-integration.md](../../docs/mxfp6-vllm-integration.md) for
+The Qwen3.8 QSRT checkpoint contract and launch are specified in
+[qwen38-qsrt-vllm-integration.md](../../../docs/qwen38-qsrt-vllm-integration.md).
+
+See [docs/mxfp6-vllm-integration.md](../../../docs/mxfp6-vllm-integration.md) for
 the full lifecycle and maintainer drop-in instructions.

--- a/b12x/integration/vllm/README.md
+++ b/b12x/integration/vllm/README.md
@@ -12,7 +12,7 @@ APIs — b12x itself does not auto-load into vLLM.
 |---|---|
 | `fp6_serving.py` | Framework-agnostic quant methods (`B12XFP6MoEMethod`, `B12XFP6LinearMethod`) |
 | `plugin.py` | vLLM ``QuantizationConfig`` + weight loaders + entry point |
-| `qsrt_plugin.py` | TP1 Qwen3.8 K5/rank-16 config, exact weight loaders, graph storage, and entry point |
+| `qsrt_plugin.py` | TP1 Qwen3.8 K5/rank-16 config, exact weight loaders, bounded workspace, and entry point |
 
 ## Install into a vLLM fork
 

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -136,6 +136,9 @@ def _workspace_capacity_rows(config: dict[str, Any]) -> int:
 def _capture_sizes(capacity_rows: int) -> tuple[int, ...]:
     if capacity_rows <= 0:
         raise ValueError("B12X QSRT workspace capacity must be positive")
+    # Warm common eager-decode rows even when vLLM declares a different graph
+    # capture set. Every row view shares one capacity-sized allocation, so this
+    # bounded warmup does not create row-indexed persistent storage.
     sizes = set(_DEFAULT_CAPTURE_MS)
     configured_sizes: set[int] = set()
     try:
@@ -163,9 +166,7 @@ def _capture_sizes(capacity_rows: int) -> tuple[int, ...]:
 def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
-    if not torch.compiler.is_compiling() and (
-        rows <= 0 or rows > capacity_rows
-    ):
+    if not torch.compiler.is_compiling() and (rows <= 0 or rows > capacity_rows):
         raise ValueError(
             f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
         )
@@ -195,9 +196,7 @@ def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
 def _shared_pair_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
-    if not torch.compiler.is_compiling() and (
-        rows <= 0 or rows > capacity_rows
-    ):
+    if not torch.compiler.is_compiling() and (rows <= 0 or rows > capacity_rows):
         raise ValueError(
             f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
         )
@@ -503,11 +502,7 @@ def register_b12x_qsrt() -> None:
             if x.dtype != torch.bfloat16 or not x.is_contiguous():
                 raise ValueError("B12X QSRT requires contiguous BF16 activations")
             x2d = x.reshape(-1, x.shape[-1])
-            rows = (
-                x2d.shape[0]
-                if torch.compiler.is_compiling()
-                else int(x2d.shape[0])
-            )
+            rows = x2d.shape[0] if torch.compiler.is_compiling() else int(x2d.shape[0])
             capacity_rows = self.workspace_capacity_rows
             weight = layer.b12x_qsrt_weight
             if layer.b12x_qsrt_group == "gate_up":

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -25,7 +25,6 @@ CHECKPOINT_KIND = "qwen38_dense_mlp_qsrt_k5_rank16_checkpoint_v1"
 DESCRIPTOR_SHA256 = "17cf4ca9ef1e3a07c3354c12f7ac887b4e081b1668bea61eb37d8f2b410bb968"
 RANK = 16
 BITS = 5
-_MAX_CAPTURE_M = 512
 _DEFAULT_CAPTURE_MS = (1, 2, 4, 8, 16)
 _COMPONENT_DTYPES = {
     "trellis": torch.int16,
@@ -37,7 +36,7 @@ _COMPONENT_DTYPES = {
 
 _registered = False
 _CONFIG_CLS: Optional[type] = None
-_WARMED_GEOMETRIES: set[tuple[int, int, int, int, int]] = set()
+_WARMED_GEOMETRIES: set[tuple[int, int, int, int, int, int]] = set()
 _SHARED_BUFFERS: dict[tuple[int, int, int, int], Any] = {}
 _SHARED_PAIR_BUFFERS: dict[tuple[int, int, int, int], Any] = {}
 logger = logging.getLogger("b12x.vllm_qsrt")
@@ -68,6 +67,7 @@ def _projection_group(prefix: str, modules: set[str]) -> str | None:
 
 
 def _validate_quantization_config(config: dict[str, Any]) -> tuple[str, ...]:
+    _workspace_capacity_rows(config)
     modules = config.get("modules")
     if (
         config.get("quant_method") != QUANT_NAME
@@ -107,7 +107,21 @@ def _device_index(device: torch.device) -> int:
     return torch.cuda.current_device() if device.index is None else int(device.index)
 
 
-def _capture_sizes() -> tuple[int, ...]:
+def _workspace_capacity_rows(config: dict[str, Any]) -> int:
+    """Return the checkpoint-declared upper bound for shared row storage."""
+
+    value = config.get("workspace_capacity_rows")
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(
+            "B12X QSRT quantization configuration requires a positive "
+            "workspace_capacity_rows"
+        )
+    return value
+
+
+def _capture_sizes(capacity_rows: int) -> tuple[int, ...]:
+    if capacity_rows <= 0:
+        raise ValueError("B12X QSRT workspace capacity must be positive")
     sizes = set(_DEFAULT_CAPTURE_MS)
     configured_sizes: set[int] = set()
     try:
@@ -122,23 +136,27 @@ def _capture_sizes() -> tuple[int, ...]:
             configured_sizes = {int(value) for value in configured}
     except Exception:
         logger.debug("vLLM CUDA-graph sizes are unavailable", exc_info=True)
-    unsupported = sorted(value for value in configured_sizes if value > _MAX_CAPTURE_M)
+    unsupported = sorted(value for value in configured_sizes if value > capacity_rows)
     if unsupported:
         raise NotImplementedError(
-            "B12X QSRT CUDA graphs support at most "
-            f"{_MAX_CAPTURE_M} rows; configured sizes include {unsupported}"
+            "B12X QSRT CUDA-graph rows exceed the declared workspace capacity "
+            f"{capacity_rows}: {unsupported}"
         )
     sizes.update(configured_sizes)
-    return tuple(sorted(value for value in sizes if 1 <= value <= _MAX_CAPTURE_M))
+    return tuple(sorted(value for value in sizes if 1 <= value <= capacity_rows))
 
 
-def _shared_buffers(weight: Any, rows: int) -> Any:
+def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
+    if rows <= 0 or rows > capacity_rows:
+        raise ValueError(
+            f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
+        )
     base = weight.base
     key = (
         _device_index(base.trellis.device),
-        int(rows),
+        int(capacity_rows),
         int(base.in_features),
         int(base.out_features),
     )
@@ -151,21 +169,24 @@ def _shared_buffers(weight: Any, rows: int) -> Any:
             )
         buffers = trellis_linear.make_buffers(
             weight,
-            size_m=rows,
+            size_m=capacity_rows,
             input_dtype=torch.bfloat16,
         )
-        if rows <= _MAX_CAPTURE_M:
-            _SHARED_BUFFERS[key] = buffers
-    return buffers
+        _SHARED_BUFFERS[key] = buffers
+    return trellis_linear.view_buffers(buffers, size_m=rows)
 
 
-def _shared_pair_buffers(weight: Any, rows: int) -> Any:
+def _shared_pair_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
+    if rows <= 0 or rows > capacity_rows:
+        raise ValueError(
+            f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
+        )
     base = weight.left
     key = (
         _device_index(base.trellis.device),
-        int(rows),
+        int(capacity_rows),
         int(base.in_features),
         int(base.out_features),
     )
@@ -177,12 +198,11 @@ def _shared_pair_buffers(weight: Any, rows: int) -> Any:
             )
         buffers = trellis_linear.make_pair_buffers(
             weight,
-            size_m=rows,
+            size_m=capacity_rows,
             input_dtype=torch.bfloat16,
         )
-        if rows <= _MAX_CAPTURE_M:
-            _SHARED_PAIR_BUFFERS[key] = buffers
-    return buffers
+        _SHARED_PAIR_BUFFERS[key] = buffers
+    return trellis_linear.view_pair_buffers(buffers, size_m=rows)
 
 
 def _run_weight(
@@ -261,10 +281,10 @@ def register_b12x_qsrt() -> None:
         return
     try:
         from vllm.logger import init_logger
-
+    except ImportError:
+        logger.debug("vLLM logger is unavailable; using stdlib logging", exc_info=True)
+    else:
         logger = init_logger("vllm.b12x_qsrt")
-    except Exception:
-        pass
 
     from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
     from vllm.model_executor.layers.quantization import register_quantization_config
@@ -272,6 +292,9 @@ def register_b12x_qsrt() -> None:
     from vllm.model_executor.utils import set_weight_attrs
 
     class _VllmQSRTLinearMethod(LinearMethodBase):  # type: ignore[misc]
+        def __init__(self, workspace_capacity_rows: int) -> None:
+            self.workspace_capacity_rows = int(workspace_capacity_rows)
+
         def create_weights(
             self,
             layer: Any,
@@ -387,12 +410,17 @@ def register_b12x_qsrt() -> None:
                 dtype=a_parameter.dtype,
                 device=a_parameter.device,
             )
-            sizes = _capture_sizes()
+            capacity_rows = self.workspace_capacity_rows
+            sizes = _capture_sizes(capacity_rows)
+            if stacked:
+                _shared_pair_buffers(weight, capacity_rows, capacity_rows)
+            else:
+                _shared_buffers(weight, capacity_rows, capacity_rows)
             for rows in sizes:
                 if stacked:
-                    _shared_pair_buffers(weight, rows)
+                    _shared_pair_buffers(weight, rows, capacity_rows)
                 else:
-                    _shared_buffers(weight, rows)
+                    _shared_buffers(weight, rows, capacity_rows)
             for rows in sizes:
                 if stacked:
                     geometry = (
@@ -401,6 +429,7 @@ def register_b12x_qsrt() -> None:
                         rows,
                         int(weight.left.in_features),
                         int(weight.left.out_features),
+                        capacity_rows,
                     )
                     device = weight.left.trellis.device
                     input_features = int(weight.left.in_features)
@@ -411,6 +440,7 @@ def register_b12x_qsrt() -> None:
                         rows,
                         int(weight.base.in_features),
                         int(weight.base.out_features),
+                        capacity_rows,
                     )
                     device = weight.base.trellis.device
                     input_features = int(weight.base.in_features)
@@ -425,10 +455,14 @@ def register_b12x_qsrt() -> None:
                     trellis_linear.run_additive_pair(
                         x,
                         weight,
-                        buffers=_shared_pair_buffers(weight, rows),
+                        buffers=_shared_pair_buffers(weight, rows, capacity_rows),
                     )
                 else:
-                    _run_weight(x, weight, _shared_buffers(weight, rows))
+                    _run_weight(
+                        x,
+                        weight,
+                        _shared_buffers(weight, rows, capacity_rows),
+                    )
                 _WARMED_GEOMETRIES.add(geometry)
             device = (
                 weight.left.trellis.device if stacked else weight.base.trellis.device
@@ -448,6 +482,7 @@ def register_b12x_qsrt() -> None:
                 raise ValueError("B12X QSRT requires contiguous BF16 activations")
             x2d = x.reshape(-1, x.shape[-1])
             rows = int(x2d.shape[0])
+            capacity_rows = self.workspace_capacity_rows
             weight = layer.b12x_qsrt_weight
             if layer.b12x_qsrt_group == "gate_up":
                 from b12x.gemm import trellis_linear
@@ -455,10 +490,10 @@ def register_b12x_qsrt() -> None:
                 result = trellis_linear.run_additive_pair(
                     x2d,
                     weight,
-                    buffers=_shared_pair_buffers(weight, rows),
+                    buffers=_shared_pair_buffers(weight, rows, capacity_rows),
                 )
             else:
-                buffers = _shared_buffers(weight, rows)
+                buffers = _shared_buffers(weight, rows, capacity_rows)
                 result = _run_weight(x2d, weight, buffers)
             if x.dim() > 2:
                 result = result.reshape(*x.shape[:-1], result.shape[-1])
@@ -486,9 +521,10 @@ def register_b12x_qsrt() -> None:
             super().__init__()
             self._config = dict(config)
             self._modules = set(_validate_quantization_config(self._config))
+            self._workspace_capacity_rows = _workspace_capacity_rows(self._config)
             self._model_dir = model_dir or os.environ.get(MODEL_DIR_ENV) or None
             self._manifest_validated = False
-            self._method = _VllmQSRTLinearMethod()
+            self._method = _VllmQSRTLinearMethod(self._workspace_capacity_rows)
 
         def __reduce__(self):
             return (_rebuild_config, (self._config, self._model_dir))

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -1,0 +1,593 @@
+"""vLLM quantization plugin for TP1 Qwen3.8 dense-MLP QSRT K5.
+
+The plugin claims only checkpoint modules enumerated by the
+``b12x_qsrt`` quantization configuration. It binds each removed BF16 dense-MLP
+matrix to a native K5 trellis payload and BF16 rank-16 correction. No decoded
+weight or unquantized fallback exists in the claimed linear method.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+
+QUANT_NAME = "b12x_qsrt"
+MODEL_DIR_ENV = "B12X_QSRT_MODEL_DIR"
+MANIFEST_FILENAME = "b12x-qsrt-manifest.json"
+CHECKPOINT_KIND = "qwen38_dense_mlp_qsrt_k5_rank16_checkpoint_v1"
+DESCRIPTOR_SHA256 = "17cf4ca9ef1e3a07c3354c12f7ac887b4e081b1668bea61eb37d8f2b410bb968"
+RANK = 16
+BITS = 5
+_MAX_CAPTURE_M = 512
+_DEFAULT_CAPTURE_MS = (1, 2, 4, 8, 16)
+_COMPONENT_DTYPES = {
+    "trellis": torch.int16,
+    "suh": torch.float16,
+    "svh": torch.float16,
+    "a": torch.bfloat16,
+    "b": torch.bfloat16,
+}
+
+_registered = False
+_CONFIG_CLS: Optional[type] = None
+_WARMED_GEOMETRIES: set[tuple[int, int, int, int, int]] = set()
+_SHARED_BUFFERS: dict[tuple[int, int, int, int], Any] = {}
+_SHARED_PAIR_BUFFERS: dict[tuple[int, int, int, int], Any] = {}
+logger = logging.getLogger("b12x.vllm_qsrt")
+
+
+def _norm_key(name: str) -> str:
+    value = str(name).removeprefix("model.")
+    return value.replace("language_model.model.", "language_model.")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _projection_group(prefix: str, modules: set[str]) -> str | None:
+    normalized = _norm_key(prefix)
+    if normalized.endswith(".gate_up_proj"):
+        parent = normalized.removesuffix(".gate_up_proj")
+        if {f"{parent}.gate_proj", f"{parent}.up_proj"} <= modules:
+            return "gate_up"
+    if normalized.endswith(".down_proj") and normalized in modules:
+        return "down"
+    return None
+
+
+def _validate_quantization_config(config: dict[str, Any]) -> tuple[str, ...]:
+    modules = config.get("modules")
+    if (
+        config.get("quant_method") != QUANT_NAME
+        or config.get("format") != "qwen38_dense_mlp_qsrt_k5_rank16"
+        or config.get("bits") != BITS
+        or config.get("codebook") != "sqg_fp16"
+        or config.get("descriptor_sha256") != DESCRIPTOR_SHA256
+        or config.get("rank") != RANK
+        or config.get("tensor_parallel_size") != 1
+        or not isinstance(modules, list)
+        or len(modules) != 192
+        or any(not isinstance(value, str) for value in modules)
+    ):
+        raise ValueError("B12X QSRT quantization configuration is incompatible")
+    normalized = tuple(_norm_key(value) for value in modules)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("B12X QSRT module inventory contains duplicates")
+    expected_suffixes = {"gate_proj", "up_proj", "down_proj"}
+    counts: dict[int, set[str]] = {}
+    prefix = "language_model.layers."
+    for name in normalized:
+        if not name.startswith(prefix) or ".mlp." not in name:
+            raise ValueError(f"B12X QSRT module is outside the decoder MLP: {name}")
+        layer_text, projection = name[len(prefix) :].split(".mlp.", 1)
+        if not layer_text.isdigit() or projection not in expected_suffixes:
+            raise ValueError(f"B12X QSRT module identity is invalid: {name}")
+        layer = int(layer_text)
+        if not 0 <= layer < 64:
+            raise ValueError(f"B12X QSRT decoder layer is out of range: {name}")
+        counts.setdefault(layer, set()).add(projection)
+    if counts != {layer: expected_suffixes for layer in range(64)}:
+        raise ValueError("B12X QSRT module inventory is not the complete 64-layer MLP")
+    return normalized
+
+
+def _device_index(device: torch.device) -> int:
+    return torch.cuda.current_device() if device.index is None else int(device.index)
+
+
+def _capture_sizes() -> tuple[int, ...]:
+    sizes = set(_DEFAULT_CAPTURE_MS)
+    configured_sizes: set[int] = set()
+    try:
+        from vllm.config import get_current_vllm_config
+
+        configured = getattr(
+            get_current_vllm_config().compilation_config,
+            "cudagraph_capture_sizes",
+            None,
+        )
+        if configured:
+            configured_sizes = {int(value) for value in configured}
+    except Exception:
+        logger.debug("vLLM CUDA-graph sizes are unavailable", exc_info=True)
+    unsupported = sorted(value for value in configured_sizes if value > _MAX_CAPTURE_M)
+    if unsupported:
+        raise NotImplementedError(
+            "B12X QSRT CUDA graphs support at most "
+            f"{_MAX_CAPTURE_M} rows; configured sizes include {unsupported}"
+        )
+    sizes.update(configured_sizes)
+    return tuple(sorted(value for value in sizes if 1 <= value <= _MAX_CAPTURE_M))
+
+
+def _shared_buffers(weight: Any, rows: int) -> Any:
+    from b12x.gemm import trellis_linear
+
+    base = weight.base
+    key = (
+        _device_index(base.trellis.device),
+        int(rows),
+        int(base.in_features),
+        int(base.out_features),
+    )
+    buffers = _SHARED_BUFFERS.get(key)
+    if buffers is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "B12X QSRT scratch is absent during CUDA-graph capture; "
+                "include the row count in vLLM cudagraph_capture_sizes"
+            )
+        buffers = trellis_linear.make_buffers(
+            weight,
+            size_m=rows,
+            input_dtype=torch.bfloat16,
+        )
+        if rows <= _MAX_CAPTURE_M:
+            _SHARED_BUFFERS[key] = buffers
+    return buffers
+
+
+def _shared_pair_buffers(weight: Any, rows: int) -> Any:
+    from b12x.gemm import trellis_linear
+
+    base = weight.left
+    key = (
+        _device_index(base.trellis.device),
+        int(rows),
+        int(base.in_features),
+        int(base.out_features),
+    )
+    buffers = _SHARED_PAIR_BUFFERS.get(key)
+    if buffers is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "B12X QSRT gate/up pair storage is absent during CUDA-graph capture"
+            )
+        buffers = trellis_linear.make_pair_buffers(
+            weight,
+            size_m=rows,
+            input_dtype=torch.bfloat16,
+        )
+        if rows <= _MAX_CAPTURE_M:
+            _SHARED_PAIR_BUFFERS[key] = buffers
+    return buffers
+
+
+def _run_weight(
+    x: torch.Tensor,
+    weight: Any,
+    buffers: Any,
+    *,
+    output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from b12x.gemm import trellis_linear
+
+    kwargs = buffers.run_kwargs()
+    if output is not None:
+        kwargs["output"] = output
+    return trellis_linear.run_additive(
+        x,
+        weight,
+        low_rank_hidden=buffers.low_rank_hidden,
+        **kwargs,
+    )
+
+
+def _parameter_loader(
+    *,
+    component: str,
+    stacked: bool,
+    loaded_slots: set[tuple[str, int]],
+):
+    expected_dtype = _COMPONENT_DTYPES[component]
+
+    def load(
+        parameter: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        shard_id: int | None = None,
+    ) -> None:
+        if loaded_weight.dtype != expected_dtype:
+            raise TypeError(
+                f"B12X QSRT {component} must use {expected_dtype}, "
+                f"got {loaded_weight.dtype}"
+            )
+        if stacked:
+            if not isinstance(shard_id, int) or shard_id not in (0, 1):
+                raise ValueError(f"B12X QSRT {component} requires gate/up shard 0 or 1")
+            target = parameter.data[shard_id]
+            slot = shard_id
+        else:
+            if shard_id is not None:
+                raise ValueError(f"B12X QSRT down {component} is not a fused shard")
+            target = parameter.data
+            slot = 0
+        identity = (component, slot)
+        if identity in loaded_slots:
+            raise ValueError(f"B12X QSRT payload was loaded twice: {identity}")
+        if tuple(target.shape) != tuple(loaded_weight.shape):
+            raise ValueError(
+                f"B12X QSRT {component} shape differs: expected "
+                f"{tuple(target.shape)}, got {tuple(loaded_weight.shape)}"
+            )
+        target.copy_(loaded_weight)
+        loaded_slots.add(identity)
+
+    return load
+
+
+def _rebuild_config(config: dict[str, Any], model_dir: Optional[str]) -> Any:
+    register_b12x_qsrt()
+    assert _CONFIG_CLS is not None
+    return _CONFIG_CLS(config, model_dir)
+
+
+def register_b12x_qsrt() -> None:
+    """Register the ``b12x_qsrt`` quantization method in every vLLM process."""
+
+    global _registered, _CONFIG_CLS, logger
+    if _registered:
+        return
+    try:
+        from vllm.logger import init_logger
+
+        logger = init_logger("vllm.b12x_qsrt")
+    except Exception:
+        pass
+
+    from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
+    from vllm.model_executor.layers.quantization import register_quantization_config
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+    from vllm.model_executor.utils import set_weight_attrs
+
+    class _VllmQSRTLinearMethod(LinearMethodBase):  # type: ignore[misc]
+        def create_weights(
+            self,
+            layer: Any,
+            input_size_per_partition: int,
+            output_partition_sizes: list[int],
+            input_size: int,
+            output_size: int,
+            params_dtype: torch.dtype,
+            **extra_weight_attrs: Any,
+        ) -> None:
+            del extra_weight_attrs
+            if (
+                params_dtype != torch.bfloat16
+                or input_size_per_partition != input_size
+                or sum(output_partition_sizes) != output_size
+            ):
+                raise ValueError("B12X QSRT supports BF16 TP1 execution only")
+            stacked = len(output_partition_sizes) == 2
+            if stacked:
+                if (
+                    output_partition_sizes[0] != output_partition_sizes[1]
+                    or input_size != 5120
+                    or output_partition_sizes[0] != 17408
+                ):
+                    raise ValueError("B12X QSRT gate/up geometry is incompatible")
+                size_k, size_n, stack = input_size, output_partition_sizes[0], 2
+                layer.b12x_qsrt_group = "gate_up"
+            else:
+                if (
+                    len(output_partition_sizes) != 1
+                    or input_size != 17408
+                    or output_size != 5120
+                ):
+                    raise ValueError("B12X QSRT down geometry is incompatible")
+                size_k, size_n, stack = input_size, output_size, 1
+                layer.b12x_qsrt_group = "down"
+            shapes = {
+                "trellis": (size_k // 16, size_n // 16, 16 * BITS),
+                "suh": (size_k,),
+                "svh": (size_n,),
+                "a": (size_k, RANK),
+                "b": (size_n, RANK),
+            }
+            loaded_slots: set[tuple[str, int]] = set()
+            layer.b12x_qsrt_loaded_slots = loaded_slots
+            for component, shape in shapes.items():
+                storage_shape = (stack, *shape) if stacked else shape
+                parameter = torch.nn.Parameter(
+                    torch.empty(storage_shape, dtype=_COMPONENT_DTYPES[component]),
+                    requires_grad=False,
+                )
+                set_weight_attrs(
+                    parameter,
+                    {
+                        "weight_loader": _parameter_loader(
+                            component=component,
+                            stacked=stacked,
+                            loaded_slots=loaded_slots,
+                        )
+                    },
+                )
+                layer.register_parameter(f"qsrt_{component}", parameter)
+
+        def process_weights_after_loading(self, layer: Any) -> None:
+            from b12x.gemm import trellis_linear
+
+            if not trellis_linear.is_supported(layer.qsrt_trellis.device):
+                raise NotImplementedError(
+                    "B12X QSRT requires an SM120 or SM121 CUDA device with "
+                    "the declared B12X kernel dependencies"
+                )
+            stacked = layer.b12x_qsrt_group == "gate_up"
+            expected_slots = {
+                (component, slot)
+                for component in _COMPONENT_DTYPES
+                for slot in range(2 if stacked else 1)
+            }
+            if layer.b12x_qsrt_loaded_slots != expected_slots:
+                raise ValueError(
+                    "B12X QSRT checkpoint did not load every payload tensor"
+                )
+
+            def tensor(component: str, slot: int | None) -> torch.Tensor:
+                value = getattr(layer, f"qsrt_{component}").data
+                return value if slot is None else value[slot]
+
+            def prepare_base(slot: int | None) -> Any:
+                return trellis_linear.prepare_weight(
+                    tensor("trellis", slot),
+                    tensor("suh", slot),
+                    tensor("svh", slot),
+                    codebook="sqg_fp16",
+                    params_dtype=torch.bfloat16,
+                )
+
+            if stacked:
+                weight = trellis_linear.prepare_additive_pair(
+                    prepare_base(0),
+                    prepare_base(1),
+                    tensor("a", None),
+                    tensor("b", None),
+                )
+            else:
+                weight = trellis_linear.prepare_additive_weight(
+                    prepare_base(None),
+                    tensor("a", None),
+                    tensor("b", None),
+                )
+            layer.b12x_qsrt_weight = weight
+            a_parameter = layer.qsrt_a
+            a_parameter.data = torch.empty(
+                0,
+                dtype=a_parameter.dtype,
+                device=a_parameter.device,
+            )
+            sizes = _capture_sizes()
+            for rows in sizes:
+                if stacked:
+                    _shared_pair_buffers(weight, rows)
+                else:
+                    _shared_buffers(weight, rows)
+            for rows in sizes:
+                if stacked:
+                    geometry = (
+                        2,
+                        _device_index(weight.left.trellis.device),
+                        rows,
+                        int(weight.left.in_features),
+                        int(weight.left.out_features),
+                    )
+                    device = weight.left.trellis.device
+                    input_features = int(weight.left.in_features)
+                else:
+                    geometry = (
+                        1,
+                        _device_index(weight.base.trellis.device),
+                        rows,
+                        int(weight.base.in_features),
+                        int(weight.base.out_features),
+                    )
+                    device = weight.base.trellis.device
+                    input_features = int(weight.base.in_features)
+                if geometry in _WARMED_GEOMETRIES:
+                    continue
+                x = torch.zeros(
+                    (rows, input_features),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                if stacked:
+                    trellis_linear.run_additive_pair(
+                        x,
+                        weight,
+                        buffers=_shared_pair_buffers(weight, rows),
+                    )
+                else:
+                    _run_weight(x, weight, _shared_buffers(weight, rows))
+                _WARMED_GEOMETRIES.add(geometry)
+            device = (
+                weight.left.trellis.device if stacked else weight.base.trellis.device
+            )
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+
+        def apply(
+            self,
+            layer: Any,
+            x: torch.Tensor,
+            bias: Optional[torch.Tensor] = None,
+        ) -> torch.Tensor:
+            if bias is not None:
+                raise ValueError("B12X QSRT Qwen dense MLPs do not have bias")
+            if x.dtype != torch.bfloat16 or not x.is_contiguous():
+                raise ValueError("B12X QSRT requires contiguous BF16 activations")
+            x2d = x.reshape(-1, x.shape[-1])
+            rows = int(x2d.shape[0])
+            weight = layer.b12x_qsrt_weight
+            if layer.b12x_qsrt_group == "gate_up":
+                from b12x.gemm import trellis_linear
+
+                result = trellis_linear.run_additive_pair(
+                    x2d,
+                    weight,
+                    buffers=_shared_pair_buffers(weight, rows),
+                )
+            else:
+                buffers = _shared_buffers(weight, rows)
+                result = _run_weight(x2d, weight, buffers)
+            if x.dim() > 2:
+                result = result.reshape(*x.shape[:-1], result.shape[-1])
+            return result
+
+    import vllm.model_executor.layers.linear as _vllm_linear
+
+    register_v2 = getattr(
+        _vllm_linear,
+        "register_weight_loader_v2_supported_method",
+        None,
+    )
+    if register_v2 is not None:
+        register_v2(_VllmQSRTLinearMethod)
+    elif _VllmQSRTLinearMethod.__name__ not in _vllm_linear.WEIGHT_LOADER_V2_SUPPORTED:
+        _vllm_linear.WEIGHT_LOADER_V2_SUPPORTED.append(_VllmQSRTLinearMethod.__name__)
+
+    @register_quantization_config(QUANT_NAME)
+    class B12XQSRTConfig(QuantizationConfig):  # type: ignore[misc]
+        def __init__(
+            self,
+            config: dict[str, Any],
+            model_dir: Optional[str] = None,
+        ) -> None:
+            super().__init__()
+            self._config = dict(config)
+            self._modules = set(_validate_quantization_config(self._config))
+            self._model_dir = model_dir or os.environ.get(MODEL_DIR_ENV) or None
+            self._manifest_validated = False
+            self._method = _VllmQSRTLinearMethod()
+
+        def __reduce__(self):
+            return (_rebuild_config, (self._config, self._model_dir))
+
+        @classmethod
+        def get_name(cls) -> str:
+            return QUANT_NAME
+
+        @classmethod
+        def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+            return [torch.bfloat16]
+
+        @classmethod
+        def get_min_capability(cls) -> int:
+            return 120
+
+        @staticmethod
+        def get_config_filenames() -> list[str]:
+            return []
+
+        @classmethod
+        def from_config(cls, config: dict[str, Any]) -> "B12XQSRTConfig":
+            return cls(config)
+
+        @classmethod
+        def override_quantization_method(
+            cls,
+            hf_quant_cfg: dict[str, Any],
+            user_quant: Optional[str],
+            hf_config: Any = None,
+        ) -> Optional[str]:
+            del user_quant, hf_config
+            if hf_quant_cfg.get("quant_method") == QUANT_NAME:
+                return QUANT_NAME
+            return None
+
+        def maybe_update_config(
+            self,
+            model_name: str,
+            hf_config: Any = None,
+            revision: Any = None,
+        ) -> None:
+            del hf_config, revision
+            if self._model_dir is None and model_name:
+                self._model_dir = model_name
+
+        def _validate_manifest(self) -> None:
+            if self._manifest_validated:
+                return
+            model_dir = self._model_dir or os.environ.get(MODEL_DIR_ENV)
+            if not model_dir:
+                raise RuntimeError(
+                    f"B12X QSRT model directory is unknown; set {MODEL_DIR_ENV}"
+                )
+            path = Path(model_dir).expanduser().resolve() / MANIFEST_FILENAME
+            document = json.loads(path.read_text())
+            if not isinstance(document, dict):
+                raise TypeError(f"{path} must contain a JSON object")
+            build = document.get("build", {})
+            root = path.parent
+            if (
+                document.get("kind") != CHECKPOINT_KIND
+                or document.get("status") != "implemented"
+                or document.get("indexed_tensor_count") != 1967
+                or _sha256(root / "config.json") != document.get("config_sha256")
+                or _sha256(root / "model.safetensors.index.json")
+                != document.get("index_sha256")
+                or build.get("artifact_manifest_sha256")
+                != self._config.get("artifact_manifest_sha256")
+                or build.get("adapter_manifest_sha256")
+                != self._config.get("adapter_manifest_sha256")
+                or build.get("recovery_report_sha256")
+                != self._config.get("recovery_report_sha256")
+                or build.get("recovery_overlay_sha256")
+                != self._config.get("recovery_overlay_sha256")
+            ):
+                raise ValueError("B12X QSRT checkpoint manifest is incompatible")
+            self._manifest_validated = True
+
+        def get_quant_method(self, layer: Any, prefix: str):
+            if not isinstance(layer, LinearBase):
+                return None
+            group = _projection_group(prefix, self._modules)
+            if group is None:
+                return None
+            self._validate_manifest()
+            return self._method
+
+    _CONFIG_CLS = B12XQSRTConfig
+    _registered = True
+
+
+__all__ = [
+    "BITS",
+    "CHECKPOINT_KIND",
+    "DESCRIPTOR_SHA256",
+    "MANIFEST_FILENAME",
+    "MODEL_DIR_ENV",
+    "QUANT_NAME",
+    "RANK",
+    "register_b12x_qsrt",
+]

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -66,6 +66,20 @@ def _projection_group(prefix: str, modules: set[str]) -> str | None:
     return None
 
 
+def _select_linear_method(
+    prefix: str,
+    modules: set[str],
+    *,
+    packed_method: Any,
+    unquantized_method: Any,
+) -> Any:
+    """Select packed execution only for the declared decoder MLP inventory."""
+
+    if _projection_group(prefix, modules) is None:
+        return unquantized_method
+    return packed_method
+
+
 def _validate_quantization_config(config: dict[str, Any]) -> tuple[str, ...]:
     _workspace_capacity_rows(config)
     modules = config.get("modules")
@@ -286,7 +300,11 @@ def register_b12x_qsrt() -> None:
     else:
         logger = init_logger("vllm.b12x_qsrt")
 
-    from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
+    from vllm.model_executor.layers.linear import (
+        LinearBase,
+        LinearMethodBase,
+        UnquantizedLinearMethod,
+    )
     from vllm.model_executor.layers.quantization import register_quantization_config
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
     from vllm.model_executor.utils import set_weight_attrs
@@ -525,6 +543,7 @@ def register_b12x_qsrt() -> None:
             self._model_dir = model_dir or os.environ.get(MODEL_DIR_ENV) or None
             self._manifest_validated = False
             self._method = _VllmQSRTLinearMethod(self._workspace_capacity_rows)
+            self._unquantized_method = UnquantizedLinearMethod()
 
         def __reduce__(self):
             return (_rebuild_config, (self._config, self._model_dir))
@@ -607,11 +626,15 @@ def register_b12x_qsrt() -> None:
         def get_quant_method(self, layer: Any, prefix: str):
             if not isinstance(layer, LinearBase):
                 return None
-            group = _projection_group(prefix, self._modules)
-            if group is None:
-                return None
-            self._validate_manifest()
-            return self._method
+            method = _select_linear_method(
+                prefix,
+                self._modules,
+                packed_method=self._method,
+                unquantized_method=self._unquantized_method,
+            )
+            if method is self._method:
+                self._validate_manifest()
+            return method
 
     _CONFIG_CLS = B12XQSRTConfig
     _registered = True

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -163,7 +163,9 @@ def _capture_sizes(capacity_rows: int) -> tuple[int, ...]:
 def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
-    if rows <= 0 or rows > capacity_rows:
+    if not torch.compiler.is_compiling() and (
+        rows <= 0 or rows > capacity_rows
+    ):
         raise ValueError(
             f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
         )
@@ -193,7 +195,9 @@ def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
 def _shared_pair_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
-    if rows <= 0 or rows > capacity_rows:
+    if not torch.compiler.is_compiling() and (
+        rows <= 0 or rows > capacity_rows
+    ):
         raise ValueError(
             f"B12X QSRT row count must be in [1, {capacity_rows}], got {rows}"
         )
@@ -499,7 +503,11 @@ def register_b12x_qsrt() -> None:
             if x.dtype != torch.bfloat16 or not x.is_contiguous():
                 raise ValueError("B12X QSRT requires contiguous BF16 activations")
             x2d = x.reshape(-1, x.shape[-1])
-            rows = int(x2d.shape[0])
+            rows = (
+                x2d.shape[0]
+                if torch.compiler.is_compiling()
+                else int(x2d.shape[0])
+            )
             capacity_rows = self.workspace_capacity_rows
             weight = layer.b12x_qsrt_weight
             if layer.b12x_qsrt_group == "gate_up":

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -22,6 +22,8 @@ QUANT_NAME = "b12x_qsrt"
 MODEL_DIR_ENV = "B12X_QSRT_MODEL_DIR"
 MANIFEST_FILENAME = "b12x-qsrt-manifest.json"
 CHECKPOINT_KIND = "qwen38_dense_mlp_qsrt_k5_rank16_checkpoint_v1"
+QUALITY_SELECTION_FILENAME = "b12x-qsrt-receipts/quality-selection.json"
+QUALITY_SELECTION_KIND = "qwen38_full_depth_mlp_adapter_quality_selection_v1"
 DESCRIPTOR_SHA256 = "17cf4ca9ef1e3a07c3354c12f7ac887b4e081b1668bea61eb37d8f2b410bb968"
 RANK = 16
 BITS = 5
@@ -53,6 +55,67 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(8 << 20), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _validate_quality_selection_receipt(
+    root: Path,
+    manifest: dict[str, Any],
+    config: dict[str, Any],
+) -> None:
+    """Validate an optional post-training checkpoint-selection receipt."""
+
+    filename = config.get("quality_selection_report")
+    expected_sha256 = config.get("quality_selection_report_sha256")
+    receipt = manifest.get("quality_selection")
+    if filename is None and expected_sha256 is None and receipt is None:
+        return
+    build = manifest.get("build")
+    if (
+        filename != QUALITY_SELECTION_FILENAME
+        or not isinstance(expected_sha256, str)
+        or len(expected_sha256) != 64
+        or not isinstance(build, dict)
+        or build.get("quality_selection_report_sha256") != expected_sha256
+        or not isinstance(receipt, dict)
+        or receipt.get("status") != "implemented"
+        or receipt.get("classification") != "research-only"
+        or receipt.get("file") != filename
+        or receipt.get("sha256") != expected_sha256
+        or receipt.get("selected_overlay_sha256")
+        != build.get("recovery_overlay_sha256")
+    ):
+        raise ValueError("B12X QSRT quality selection receipt is incompatible")
+    path = root / filename
+    if not path.is_file() or _sha256(path) != expected_sha256:
+        raise ValueError("B12X QSRT quality selection content differs")
+    document = json.loads(path.read_text())
+    if not isinstance(document, dict):
+        raise TypeError(f"{path} must contain a JSON object")
+    source_recovery = document.get("source_recovery")
+    selected = document.get("selected_overlay")
+    contract = document.get("selection_contract")
+    if (
+        document.get("kind") != QUALITY_SELECTION_KIND
+        or document.get("schema_version") != 1
+        or document.get("status") != "implemented"
+        or document.get("classification") != "research-only"
+        or not isinstance(source_recovery, dict)
+        or source_recovery.get("complete_report_sha256")
+        != build.get("recovery_report_sha256")
+        or source_recovery.get("adapter_manifest_sha256")
+        != build.get("adapter_manifest_sha256")
+        or not isinstance(selected, dict)
+        or selected.get("sha256") != build.get("recovery_overlay_sha256")
+        or selected.get("step") != receipt.get("selected_step")
+        or selected.get("rank") != RANK
+        or selected.get("variant") != "weighted"
+        or selected.get("tensor_count") != 384
+        or not isinstance(contract, dict)
+        or contract.get("metric") != "strict-overlap-filtered token mean KLD"
+        or contract.get("partition") != "analysis"
+        or contract.get("direction") != "lower"
+    ):
+        raise ValueError("B12X QSRT quality selection report is incompatible")
 
 
 def _projection_group(prefix: str, modules: set[str]) -> str | None:
@@ -624,6 +687,7 @@ def register_b12x_qsrt() -> None:
                 != self._config.get("recovery_overlay_sha256")
             ):
                 raise ValueError("B12X QSRT checkpoint manifest is incompatible")
+            _validate_quality_selection_receipt(root, document, self._config)
             self._manifest_validated = True
 
         def get_quant_method(self, layer: Any, prefix: str):
@@ -649,6 +713,8 @@ __all__ = [
     "DESCRIPTOR_SHA256",
     "MANIFEST_FILENAME",
     "MODEL_DIR_ENV",
+    "QUALITY_SELECTION_FILENAME",
+    "QUALITY_SELECTION_KIND",
     "QUANT_NAME",
     "RANK",
     "register_b12x_qsrt",

--- a/b12x/integration/vllm/qsrt_plugin.py
+++ b/b12x/integration/vllm/qsrt_plugin.py
@@ -226,6 +226,41 @@ def _capture_sizes(capacity_rows: int) -> tuple[int, ...]:
     return tuple(sorted(value for value in sizes if 1 <= value <= capacity_rows))
 
 
+def _require_cudagraphs_disabled(vllm_config: Any | None = None) -> None:
+    """Reject whole-model CUDA-graph replay for the QSRT linear method.
+
+    The packed kernels support direct CUDA-graph capture in isolation, but
+    whole-model vLLM graph replay lacks end-to-end correctness qualification
+    and is outside the implemented contract. ``torch.compile`` remains
+    supported when its CUDA-graph mode is disabled.
+    """
+
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except Exception:
+            logger.debug("vLLM CUDA-graph mode is unavailable", exc_info=True)
+            return
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    mode = getattr(compilation_config, "cudagraph_mode", None)
+    mode_name = getattr(mode, "name", None)
+    disabled = (
+        mode == 0
+        or mode_name == "NONE"
+        or (isinstance(mode, str) and mode.upper() == "NONE")
+    )
+    if not disabled:
+        raise ValueError(
+            "B12X QSRT requires CUDA graphs to be disabled for whole-model "
+            "execution. Set --compilation-config "
+            "'{\"cudagraph_mode\":\"NONE\","
+            "\"custom_ops\":[\"-apply_rotary_emb\"]}'. torch.compile "
+            "may remain enabled."
+        )
+
+
 def _shared_buffers(weight: Any, rows: int, capacity_rows: int) -> Any:
     from b12x.gemm import trellis_linear
 
@@ -608,6 +643,7 @@ def register_b12x_qsrt() -> None:
             self._workspace_capacity_rows = _workspace_capacity_rows(self._config)
             self._model_dir = model_dir or os.environ.get(MODEL_DIR_ENV) or None
             self._manifest_validated = False
+            self._cudagraph_mode_validated = False
             self._method = _VllmQSRTLinearMethod(self._workspace_capacity_rows)
             self._unquantized_method = UnquantizedLinearMethod()
 
@@ -700,6 +736,9 @@ def register_b12x_qsrt() -> None:
                 unquantized_method=self._unquantized_method,
             )
             if method is self._method:
+                if not self._cudagraph_mode_validated:
+                    _require_cudagraphs_disabled()
+                    self._cudagraph_mode_validated = True
                 self._validate_manifest()
             return method
 

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -11439,6 +11439,13 @@ def _trellis256_dense_gemm_op(
     force_tile_k: int,
     force_tile_n: int,
 ) -> None:
+    for name, tensor in (
+        ("rotated_compute", rotated_compute),
+        ("c_tmp", c_tmp),
+        ("gemm_output", gemm_output),
+    ):
+        if int(tensor.data_ptr()) % 16 != 0:
+            raise ValueError(f"{name} must be at least 16-byte aligned")
     _trellis256_dense_gemm_flat(
         rotated_compute,
         trellis,
@@ -11542,12 +11549,11 @@ def _trellis_dense_buffer(
     device: torch.device,
 ) -> torch.Tensor:
     """Validate caller-owned dense scratch or allocate it before capture."""
-    if torch.compiler.is_compiling():
-        if buffer is None:
-            raise RuntimeError(
-                f"compiled Trellis execution requires caller-owned {name} storage"
-            )
-        return buffer
+    compiling = torch.compiler.is_compiling()
+    if compiling and buffer is None:
+        raise RuntimeError(
+            f"compiled Trellis execution requires caller-owned {name} storage"
+        )
     if buffer is None:
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
@@ -11555,13 +11561,21 @@ def _trellis_dense_buffer(
                 "provide caller-owned storage"
             )
         return torch.empty(shape, dtype=dtype, device=device)
+    # FakeTensor tracing preserves static metadata, but the row extent is
+    # symbolic and the storage pointer is unavailable. Kernel-facing pointers
+    # are checked inside the opaque GEMM operator before it launches.
     if (
-        tuple(buffer.shape) != shape
+        buffer.ndim != 2
+        or int(buffer.shape[1]) != int(shape[1])
         or buffer.dtype != dtype
         or buffer.device != device
         or not buffer.is_contiguous()
-        or not (
-            torch.compiler.is_compiling() or int(buffer.data_ptr()) % 16 == 0
+        or (
+            not compiling
+            and (
+                int(buffer.shape[0]) != int(shape[0])
+                or int(buffer.data_ptr()) % 16 != 0
+            )
         )
     ):
         raise ValueError(
@@ -11650,9 +11664,9 @@ def _run_trellis256_dense_current_device(
         dtype=x.dtype,
         device=x.device,
     )
-    if c_tmp is not None and not (
-        torch.compiler.is_compiling() or int(c_tmp.data_ptr()) % 16 == 0
-    ):
+    # FakeTensor tracing cannot expose a storage pointer. The opaque GEMM
+    # operator checks the real c_tmp pointer immediately before kernel launch.
+    if c_tmp is not None and not compiling and int(c_tmp.data_ptr()) % 16 != 0:
         raise ValueError("c_tmp must be at least 16-byte aligned")
 
     gemm_output = _trellis_dense_buffer(

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -11231,6 +11231,308 @@ def _resolve_exl3_hadamard_128(hadamard_128):
     return hadamard_128
 
 
+@torch.library.custom_op(
+    "b12x::trellis_hadamard_128",
+    mutates_args=("destination",),
+)
+def _trellis_hadamard_128_op(
+    source: torch.Tensor,
+    destination: torch.Tensor,
+    left_scale: torch.Tensor,
+    right_scale: torch.Tensor,
+    has_left_scale: bool,
+    has_right_scale: bool,
+    scale: float,
+) -> None:
+    """Expose the EXL3 rotation extension as a TorchDynamo-visible operator."""
+    hadamard_128 = _resolve_exl3_hadamard_128(None)
+    hadamard_128(
+        source,
+        destination,
+        left_scale if has_left_scale else None,
+        right_scale if has_right_scale else None,
+        scale,
+    )
+
+
+@_trellis_hadamard_128_op.register_fake
+def _trellis_hadamard_128_fake(
+    source: torch.Tensor,
+    destination: torch.Tensor,
+    left_scale: torch.Tensor,
+    right_scale: torch.Tensor,
+    has_left_scale: bool,
+    has_right_scale: bool,
+    scale: float,
+) -> None:
+    del (
+        source,
+        destination,
+        left_scale,
+        right_scale,
+        has_left_scale,
+        has_right_scale,
+        scale,
+    )
+
+
+def _run_exl3_hadamard_128(
+    source: torch.Tensor,
+    destination: torch.Tensor,
+    left_scale: torch.Tensor | None,
+    right_scale: torch.Tensor | None,
+    scale: float,
+    hadamard_128,
+) -> None:
+    """Run EXL3 H128 eagerly or through its registered compiled operator."""
+    if torch.compiler.is_compiling():
+        if hadamard_128 is not None:
+            raise RuntimeError(
+                "compiled Trellis execution requires the registered EXL3 H128 "
+                "operator"
+            )
+        _trellis_hadamard_128_op(
+            source,
+            destination,
+            source if left_scale is None else left_scale,
+            source if right_scale is None else right_scale,
+            left_scale is not None,
+            right_scale is not None,
+            scale,
+        )
+        return
+    resolved = _resolve_exl3_hadamard_128(hadamard_128)
+    resolved(source, destination, left_scale, right_scale, scale)
+
+
+def _trellis256_dense_gemm_flat(
+    rotated_compute: torch.Tensor,
+    trellis: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    c_tmp: torch.Tensor | None,
+    gemm_output: torch.Tensor,
+    trellis_bits: int,
+    trellis_codebook: str,
+    trellis_pair_kind: str,
+    trellis_rate_axis: str,
+    moe_block_size: int,
+    force_tile_k: int,
+    force_tile_n: int,
+) -> None:
+    """Launch one dense Trellis GEMM from flattened tensor arguments."""
+    m, size_k = (int(value) for value in rotated_compute.shape)
+    size_n = int(gemm_output.shape[1])
+    compute_dtype = rotated_compute.dtype
+    element_dtype = "fp16" if compute_dtype == torch.float16 else "bf16"
+    cutlass_dtype = (
+        cutlass.Float16 if compute_dtype == torch.float16 else cutlass.BFloat16
+    )
+    props = torch.cuda.get_device_properties(rotated_compute.device)
+    sms = int(props.multi_processor_count)
+    max_shared_mem = int(
+        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+    )
+    if force_tile_k <= 0:
+        if moe_block_size == 64:
+            moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
+                size_m=m,
+                size_k=size_k,
+                size_n=size_n,
+                sms=sms,
+            )
+        else:
+            tile_k, tile_n = _trellis256_dense_tile_config(size_k, size_n)
+    else:
+        tile_k, tile_n = force_tile_k, force_tile_n
+    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
+        raise ValueError(f"unsupported Trellis dense moe_block_size={moe_block_size}")
+    route_blocks = (m + moe_block_size - 1) // moe_block_size
+    route_slots = route_blocks * moe_block_size
+    launch = _compile_w4a16_gemm_launch(
+        size_m=m,
+        size_n=size_n,
+        size_k=size_k,
+        num_experts=1,
+        top_k=1,
+        mul_topk_weights=False,
+        moe_block_size=moe_block_size,
+        max_m_blocks=route_blocks,
+        element_dtype=element_dtype,
+        packed_route_indices=None,
+        sms=sms,
+        max_shared_mem=max_shared_mem,
+        device=rotated_compute.device,
+        c_tmp=c_tmp,
+        weight_layout="trellis_t256",
+        scale_format="e4m3_k32",
+        w13_layout="packed",
+        trellis_bits=trellis_bits,
+        trellis_codebook=trellis_codebook,
+        trellis_pair_kind=trellis_pair_kind or None,
+        trellis_rate_axis=trellis_rate_axis or None,
+        dense_route_fast_path=True,
+        route_slots=route_slots,
+        force_tile_config=(tile_k, tile_n),
+    )
+    dummy_i32 = workspace[:1]
+    n_tiles = size_n // tile_n
+    grid_x = min(
+        sms * int(launch.kernel.blocks_per_sm),
+        max(route_blocks * n_tiles, 1),
+    )
+    launch.kernel.compiled(
+        make_ptr(
+            cutlass_dtype,
+            rotated_compute.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        make_ptr(
+            cutlass_dtype,
+            rotated_compute.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        trellis,
+        make_ptr(
+            cutlass_dtype,
+            gemm_output.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ),
+        scale.view(torch.uint8).view(torch.int32).view(-1),
+        global_scale,
+        dummy_i32,
+        dummy_i32,
+        dummy_i32,
+        global_scale,
+        launch.c_tmp,
+        workspace,
+        dummy_i32
+        if trellis_codebook == MCG
+        else _trellis256_execution_lut(rotated_compute.device, trellis_codebook),
+        m,
+        grid_x,
+        current_cuda_stream(),
+    )
+
+
+@torch.library.custom_op(
+    "b12x::trellis256_dense_gemm",
+    mutates_args=("workspace", "c_tmp", "gemm_output"),
+)
+def _trellis256_dense_gemm_op(
+    rotated_compute: torch.Tensor,
+    trellis: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    c_tmp: torch.Tensor,
+    gemm_output: torch.Tensor,
+    trellis_bits: int,
+    trellis_codebook: str,
+    trellis_pair_kind: str,
+    trellis_rate_axis: str,
+    moe_block_size: int,
+    force_tile_k: int,
+    force_tile_n: int,
+) -> None:
+    _trellis256_dense_gemm_flat(
+        rotated_compute,
+        trellis,
+        scale,
+        global_scale,
+        workspace,
+        c_tmp,
+        gemm_output,
+        trellis_bits,
+        trellis_codebook,
+        trellis_pair_kind,
+        trellis_rate_axis,
+        moe_block_size,
+        force_tile_k,
+        force_tile_n,
+    )
+
+
+@_trellis256_dense_gemm_op.register_fake
+def _trellis256_dense_gemm_fake(
+    rotated_compute: torch.Tensor,
+    trellis: torch.Tensor,
+    scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    c_tmp: torch.Tensor,
+    gemm_output: torch.Tensor,
+    trellis_bits: int,
+    trellis_codebook: str,
+    trellis_pair_kind: str,
+    trellis_rate_axis: str,
+    moe_block_size: int,
+    force_tile_k: int,
+    force_tile_n: int,
+) -> None:
+    del (
+        rotated_compute,
+        trellis,
+        scale,
+        global_scale,
+        workspace,
+        c_tmp,
+        gemm_output,
+        trellis_bits,
+        trellis_codebook,
+        trellis_pair_kind,
+        trellis_rate_axis,
+        moe_block_size,
+        force_tile_k,
+        force_tile_n,
+    )
+
+
+def _run_trellis256_dense_gemm(
+    rotated_compute: torch.Tensor,
+    prepared_dense,
+    c_tmp: torch.Tensor | None,
+    gemm_output: torch.Tensor,
+    *,
+    moe_block_size: int,
+    force_tile_config: tuple[int, int] | None,
+) -> None:
+    """Dispatch the dense GEMM through an opaque operator while compiling."""
+    force_tile_k, force_tile_n = (
+        (0, 0)
+        if force_tile_config is None
+        else (int(force_tile_config[0]), int(force_tile_config[1]))
+    )
+    arguments = (
+        rotated_compute,
+        prepared_dense.trellis,
+        prepared_dense.scale,
+        prepared_dense.global_scale,
+        prepared_dense.workspace,
+        c_tmp,
+        gemm_output,
+        int(prepared_dense.trellis_bits),
+        str(prepared_dense.trellis_codebook),
+        str(prepared_dense.trellis_pair_kind or ""),
+        str(prepared_dense.trellis_rate_axis or ""),
+        int(moe_block_size),
+        force_tile_k,
+        force_tile_n,
+    )
+    if torch.compiler.is_compiling():
+        if c_tmp is None:
+            raise RuntimeError(
+                "compiled Trellis execution requires caller-owned GEMM scratch"
+            )
+        _trellis256_dense_gemm_op(*arguments)
+        return
+    _trellis256_dense_gemm_flat(*arguments)
+
+
 def _trellis_dense_buffer(
     name: str,
     buffer: torch.Tensor | None,
@@ -11240,6 +11542,12 @@ def _trellis_dense_buffer(
     device: torch.device,
 ) -> torch.Tensor:
     """Validate caller-owned dense scratch or allocate it before capture."""
+    if torch.compiler.is_compiling():
+        if buffer is None:
+            raise RuntimeError(
+                f"compiled Trellis execution requires caller-owned {name} storage"
+            )
+        return buffer
     if buffer is None:
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
@@ -11252,7 +11560,9 @@ def _trellis_dense_buffer(
         or buffer.dtype != dtype
         or buffer.device != device
         or not buffer.is_contiguous()
-        or int(buffer.data_ptr()) % 16 != 0
+        or not (
+            torch.compiler.is_compiling() or int(buffer.data_ptr()) % 16 == 0
+        )
     ):
         raise ValueError(
             f"{name} must be contiguous, 16-byte-aligned {dtype} with shape "
@@ -11285,6 +11595,11 @@ def _run_trellis256_dense_current_device(
     Outer rotations follow EXL3 order exactly: fp16 ``suh`` multiply before the
     input H128, and fp16 ``svh`` multiply after the output H128.
     """
+    if stream is not None:
+        raise ValueError(
+            "dense Trellis execution follows the current Torch stream and does "
+            "not accept a raw driver stream"
+        )
     if getattr(prepared_dense, "weight_layout", None) != "trellis_t256":
         raise ValueError("run_trellis256_dense requires prepared trellis_t256 weights")
     if int(getattr(prepared_dense, "num_experts", 0)) != 1:
@@ -11312,17 +11627,15 @@ def _run_trellis256_dense_current_device(
             "prepared dense weight must select fp16 or bf16 compute, got "
             f"{compute_dtype}"
         )
-    element_dtype = "fp16" if compute_dtype == torch.float16 else "bf16"
-    cutlass_dtype = (
-        cutlass.Float16 if compute_dtype == torch.float16 else cutlass.BFloat16
-    )
-    if x.ndim != 2 or int(x.shape[0]) <= 0:
+    compiling = torch.compiler.is_compiling()
+    if x.ndim != 2 or (not compiling and int(x.shape[0]) <= 0):
         raise ValueError(f"x must be a non-empty rank-2 tensor, got {tuple(x.shape)}")
     if x.dtype not in (torch.float16, torch.bfloat16):
         raise TypeError(f"x must be fp16 or bf16, got {x.dtype}")
     if not x.is_cuda or not x.is_contiguous():
         raise ValueError("x must be a contiguous CUDA tensor")
-    m, size_k = (int(v) for v in x.shape)
+    m = x.shape[0] if compiling else int(x.shape[0])
+    size_k = int(x.shape[1])
     size_n = int(prepared_dense.out_features)
     if size_k != int(prepared_dense.in_features):
         raise ValueError(
@@ -11337,10 +11650,10 @@ def _run_trellis256_dense_current_device(
         dtype=x.dtype,
         device=x.device,
     )
-    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
+    if c_tmp is not None and not (
+        torch.compiler.is_compiling() or int(c_tmp.data_ptr()) % 16 == 0
+    ):
         raise ValueError("c_tmp must be at least 16-byte aligned")
-
-    hadamard_128 = _resolve_exl3_hadamard_128(hadamard_128)
 
     gemm_output = _trellis_dense_buffer(
         "gemm_output",
@@ -11368,7 +11681,14 @@ def _run_trellis256_dense_current_device(
         dtype=torch.float16,
         device=x.device,
     )
-    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
+    _run_exl3_hadamard_128(
+        x_f16,
+        rotated_f16,
+        prepared_dense.suh,
+        None,
+        1.0,
+        hadamard_128,
+    )
     if compute_dtype == torch.float16:
         rotated_compute = rotated_f16
     else:
@@ -11381,97 +11701,13 @@ def _run_trellis256_dense_current_device(
         )
         rotated_compute.copy_(rotated_f16)
 
-    props = torch.cuda.get_device_properties(x.device)
-    sms = int(props.multi_processor_count)
-    max_shared_mem = int(
-        getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
-    )
-    moe_block_size = int(_moe_block_size)
-    if _force_tile_config is None and moe_block_size == 64:
-        moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
-            size_m=m,
-            size_k=size_k,
-            size_n=size_n,
-            sms=sms,
-        )
-    else:
-        tile_k, tile_n = (
-            _trellis256_dense_tile_config(size_k, size_n)
-            if _force_tile_config is None
-            else (int(_force_tile_config[0]), int(_force_tile_config[1]))
-        )
-    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
-        raise ValueError(f"unsupported Trellis dense moe_block_size={moe_block_size}")
-    route_blocks = (m + moe_block_size - 1) // moe_block_size
-    route_slots = route_blocks * moe_block_size
-    launch = _compile_w4a16_gemm_launch(
-        size_m=m,
-        size_n=size_n,
-        size_k=size_k,
-        num_experts=1,
-        top_k=1,
-        mul_topk_weights=False,
-        moe_block_size=moe_block_size,
-        max_m_blocks=route_blocks,
-        element_dtype=element_dtype,
-        packed_route_indices=None,
-        sms=sms,
-        max_shared_mem=max_shared_mem,
-        device=x.device,
-        c_tmp=c_tmp,
-        weight_layout="trellis_t256",
-        scale_format="e4m3_k32",
-        w13_layout="packed",
-        trellis_bits=trellis_bits,
-        trellis_codebook=trellis_codebook,
-        trellis_pair_kind=trellis_pair_kind,
-        trellis_rate_axis=trellis_rate_axis,
-        dense_route_fast_path=True,
-        route_slots=route_slots,
-        force_tile_config=(tile_k, tile_n),
-    )
-    dummy_i32 = prepared_dense.workspace[:1]
-    stream = current_cuda_stream() if stream is None else stream
-    n_tiles = size_n // tile_n
-    grid_x = min(
-        sms * int(launch.kernel.blocks_per_sm),
-        max(route_blocks * n_tiles, 1),
-    )
-    launch.kernel.compiled(
-        make_ptr(
-            cutlass_dtype,
-            rotated_compute.data_ptr(),
-            cute.AddressSpace.gmem,
-            assumed_align=16,
-        ),
-        make_ptr(
-            cutlass_dtype,
-            rotated_compute.data_ptr(),
-            cute.AddressSpace.gmem,
-            assumed_align=16,
-        ),
-        prepared_dense.trellis,
-        make_ptr(
-            cutlass_dtype,
-            gemm_output.data_ptr(),
-            cute.AddressSpace.gmem,
-            assumed_align=16,
-        ),
-        prepared_dense.scale.view(torch.uint8).view(torch.int32).view(-1),
-        prepared_dense.global_scale,
-        dummy_i32,
-        dummy_i32,
-        dummy_i32,
-        prepared_dense.global_scale,
-        launch.c_tmp,
-        prepared_dense.workspace,
-        # MCG kernels never dereference the LUT ABI slot.
-        dummy_i32
-        if trellis_codebook == "mcg"
-        else _trellis256_execution_lut(x.device, trellis_codebook),
-        m,
-        grid_x,
-        stream,
+    _run_trellis256_dense_gemm(
+        rotated_compute,
+        prepared_dense,
+        c_tmp,
+        gemm_output,
+        moe_block_size=int(_moe_block_size),
+        force_tile_config=_force_tile_config,
     )
 
     if compute_dtype == torch.float16:
@@ -11487,7 +11723,14 @@ def _run_trellis256_dense_current_device(
         gemm_output_f16.copy_(gemm_output)
         gemm_f16 = gemm_output_f16
     if output.dtype == torch.float16:
-        hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
+        _run_exl3_hadamard_128(
+            gemm_f16,
+            output,
+            None,
+            prepared_dense.svh,
+            1.0,
+            hadamard_128,
+        )
     else:
         output_f16 = _trellis_dense_buffer(
             "output_f16",
@@ -11496,7 +11739,14 @@ def _run_trellis256_dense_current_device(
             dtype=torch.float16,
             device=x.device,
         )
-        hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
+        _run_exl3_hadamard_128(
+            gemm_f16,
+            output_f16,
+            None,
+            prepared_dense.svh,
+            1.0,
+            hadamard_128,
+        )
         output.copy_(output_f16)
     return output
 

--- a/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
+++ b/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
@@ -788,8 +788,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         "--quality-selection-report",
         type=Path,
         help=(
-            "content-bound analysis report that selects one saved optimizer "
-            "boundary instead of the trainer's screening choice"
+            "content-bound KLD ranking report that names the saved optimizer "
+            "boundary supplying the rank-16 factor overlay; without it, the "
+            "completion report under --recovery-root selects the overlay"
         ),
     )
     parser.add_argument("--qsrt-root", type=Path, required=True)

--- a/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
+++ b/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
@@ -287,7 +287,10 @@ def _validate_archives(
                 raise ValueError("selected Qwen recovery overlay metadata differs")
         identity.update(
             {
-                "factor_source": "selected 50M-token full-model QAT overlay",
+                "factor_source": (
+                    "rank-16 dense-MLP factors selected by the completed "
+                    "full-depth quantization-aware recovery report"
+                ),
                 "recovery_report": str(complete_path),
                 "recovery_report_sha256": _sha256(complete_path),
                 "selected_overlay": str(overlay_path),
@@ -419,12 +422,12 @@ def _run_case(
     b_before = weight.b.clone()
     eager = packed_run().clone()
     pointers_before = _tensor_pointers(packed_buffers)
+    packed_buffers.output.fill_(float("nan"))
     packed_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(packed_graph):
         captured = packed_run()
     torch.cuda.synchronize(device)
-    capture_matches_eager = bool(torch.equal(captured, eager))
-    packed_buffers.output.fill_(float("nan"))
+    capture_preserves_poison = bool(torch.isnan(packed_buffers.output).all())
     allocated_before_replay = torch.cuda.memory_allocated(device)
     packed_graph.replay()
     packed_graph.replay()
@@ -493,7 +496,7 @@ def _run_case(
     correctness = {
         "output": output_metrics,
         "linear_jacobian_vector_product": jvp_metrics,
-        "capture_matches_eager_bit_exact": capture_matches_eager,
+        "capture_preserves_output_poison": capture_preserves_poison,
         "replay_matches_eager_bit_exact": replay_matches_eager,
         "buffer_pointers_stable": pointers_before == pointers_after,
         "replay_allocation_stable": allocated_before_replay == allocated_after_replay,
@@ -502,7 +505,7 @@ def _run_case(
     correctness["passed"] = bool(
         output_metrics["passed"]
         and jvp_metrics["passed"]
-        and capture_matches_eager
+        and capture_preserves_poison
         and replay_matches_eager
         and pointers_before == pointers_after
         and allocated_before_replay == allocated_after_replay
@@ -510,6 +513,7 @@ def _run_case(
     )
     timing: dict[str, Any] = {
         "hot": {name: _summary(values) for name, values in hot.items()},
+        "hot_samples_us": hot,
         "hot_packed_over_decoded": (
             statistics.median(hot["packed_k5_rank16"])
             / statistics.median(hot["decoded_bf16_rank16"])
@@ -517,6 +521,7 @@ def _run_case(
     }
     if cold is not None:
         timing["cold"] = {name: _summary(values) for name, values in cold.items()}
+        timing["cold_samples_us"] = cold
         timing["cold_packed_over_decoded"] = statistics.median(
             cold["packed_k5_rank16"]
         ) / statistics.median(cold["decoded_bf16_rank16"])
@@ -603,12 +608,12 @@ def _run_pair_case(
     b_before = weight.b.clone()
     eager = packed_run().clone()
     pointers_before = _pair_tensor_pointers(packed_buffers)
+    packed_buffers.output.fill_(float("nan"))
     packed_graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(packed_graph):
         captured = packed_run()
     torch.cuda.synchronize(device)
-    capture_matches_eager = bool(torch.equal(captured, eager))
-    packed_buffers.output.fill_(float("nan"))
+    capture_preserves_poison = bool(torch.isnan(packed_buffers.output).all())
     allocated_before_replay = torch.cuda.memory_allocated(device)
     packed_graph.replay()
     packed_graph.replay()
@@ -689,7 +694,7 @@ def _run_pair_case(
     correctness = {
         "output": output_metrics,
         "linear_jacobian_vector_product": jvp_metrics,
-        "capture_matches_eager_bit_exact": capture_matches_eager,
+        "capture_preserves_output_poison": capture_preserves_poison,
         "replay_matches_eager_bit_exact": replay_matches_eager,
         "buffer_pointers_stable": pointers_before == pointers_after,
         "replay_allocation_stable": allocated_before_replay == allocated_after_replay,
@@ -698,7 +703,7 @@ def _run_pair_case(
     correctness["passed"] = bool(
         output_metrics["passed"]
         and jvp_metrics["passed"]
-        and capture_matches_eager
+        and capture_preserves_poison
         and replay_matches_eager
         and pointers_before == pointers_after
         and allocated_before_replay == allocated_after_replay
@@ -706,6 +711,7 @@ def _run_pair_case(
     )
     timing: dict[str, Any] = {
         "hot": {name: _summary(values) for name, values in hot.items()},
+        "hot_samples_us": hot,
         "hot_packed_over_decoded": (
             statistics.median(hot["packed_pair_k5_rank16"])
             / statistics.median(hot["decoded_fused_bf16_rank16"])
@@ -713,6 +719,7 @@ def _run_pair_case(
     }
     if cold is not None:
         timing["cold"] = {name: _summary(values) for name, values in cold.items()}
+        timing["cold_samples_us"] = cold
         timing["cold_packed_over_decoded"] = statistics.median(
             cold["packed_pair_k5_rank16"]
         ) / statistics.median(cold["decoded_fused_bf16_rank16"])
@@ -741,7 +748,6 @@ def _run_pair_case(
             + packed_buffers.output.numel() * packed_buffers.output.element_size()
             + packed_buffers.low_rank_hidden.numel()
             * packed_buffers.low_rank_hidden.element_size(),
-            "factor_kernel_launches": 2,
         },
     }
 
@@ -753,7 +759,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument(
         "--recovery-root",
         type=Path,
-        help="completed QAT run whose selected overlay replaces the initial factors",
+        help=(
+            "completed full-depth quantization-aware recovery directory whose "
+            "report selects the factor overlay"
+        ),
     )
     parser.add_argument("--qsrt-root", type=Path, required=True)
     parser.add_argument("--layer", type=int, default=0)
@@ -849,6 +858,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             "gate_up_factor_execution": (
                 "one shared rank-16 projection launch and one shared output launch"
             ),
+            "gate_up_factor_kernel_launches_expected": 2,
         },
         "archives": archive_identity,
         "device": {
@@ -929,7 +939,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     result["completed_unix_ns"] = time.time_ns()
     args.output.parent.mkdir(parents=True, exist_ok=True)
     temporary = args.output.with_name(f".{args.output.name}.{os.getpid()}.tmp")
-    temporary.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    temporary.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     temporary.replace(args.output)
     print(json.dumps(result, indent=2, sort_keys=True))
     if result["status"] != "passed":

--- a/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
+++ b/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
@@ -28,6 +28,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import numpy as np
 from safetensors import safe_open
 import torch
 
@@ -150,12 +151,20 @@ def _metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, Any]:
             dim=0,
         ).item()
     )
+    # CUDA's quantile implementation rejects tensors above its element-count
+    # limit. Error metrics are outside the timed region, so preserve an exact
+    # percentile by moving only oversized reductions to CPU.
+    p99_absolute_error: float
+    if flat_error.is_cuda and flat_error.numel() > (1 << 24):
+        p99_absolute_error = float(np.quantile(flat_error.cpu().numpy(), 0.99))
+    else:
+        p99_absolute_error = float(torch.quantile(flat_error, 0.99).item())
     return {
         "finite": bool(torch.isfinite(actual).all()),
         "relative_l2": relative_l2,
         "cosine": cosine,
         "mean_absolute_error": float(flat_error.mean().item()),
-        "p99_absolute_error": float(torch.quantile(flat_error, 0.99).item()),
+        "p99_absolute_error": p99_absolute_error,
         "maximum_absolute_error": float(flat_error.max().item()),
         "passed": (
             bool(torch.isfinite(actual).all())

--- a/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
+++ b/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
@@ -226,6 +226,9 @@ def _load_qsrt_contract(qsrt_root: Path) -> dict[str, Any]:
         validate_completed_layer,
         validate_final_report as validate_artifact_report,
     )
+    from qsrt.qwen38_serving_checkpoint import (  # noqa: PLC0415
+        validate_recovery_selection,
+    )
 
     return {
         "load_layer_factors": load_layer_factors,
@@ -235,6 +238,7 @@ def _load_qsrt_contract(qsrt_root: Path) -> dict[str, Any]:
         "layer_filename": layer_filename,
         "validate_completed_layer": validate_completed_layer,
         "validate_artifact_report": validate_artifact_report,
+        "validate_recovery_selection": validate_recovery_selection,
     }
 
 
@@ -244,6 +248,7 @@ def _validate_archives(
     artifact_root: Path,
     adapter_root: Path,
     recovery_root: Path | None,
+    quality_selection_report: Path | None,
     expected_adapter_manifest_sha256: str,
 ) -> dict[str, Any]:
     artifact_manifest, _, artifact_manifest_sha256 = contract[
@@ -271,21 +276,12 @@ def _validate_archives(
         "factor_source": "sealed activation-weighted rank-16 initialization",
     }
     if recovery_root is not None:
-        complete_path = recovery_root / "complete.json"
-        complete = json.loads(complete_path.read_text())
-        overlay_record = complete.get("selected_overlay", {})
-        overlay_path = Path(str(overlay_record.get("path", ""))).resolve()
-        if (
-            complete.get("kind") != "qwen38_full_depth_mlp_adapter_recovery_report_v1"
-            or complete.get("status") != "complete"
-            or complete.get("adapter_installation", {}).get("adapter_manifest_sha256")
-            != adapter_manifest_sha256
-            or not overlay_path.is_file()
-            or overlay_path.parent != recovery_root
-            or overlay_path.stat().st_size != overlay_record.get("bytes")
-            or _sha256(overlay_path) != overlay_record.get("sha256")
-        ):
-            raise ValueError("Qwen recovery report does not bind one selected overlay")
+        selection = contract["validate_recovery_selection"](
+            recovery_root,
+            adapter_manifest_sha256=adapter_manifest_sha256,
+            quality_selection_report=quality_selection_report,
+        )
+        overlay_path = selection.overlay
         with safe_open(str(overlay_path), framework="pt", device="cpu") as handle:
             metadata = handle.metadata() or {}
             if (
@@ -298,14 +294,29 @@ def _validate_archives(
             {
                 "factor_source": (
                     "rank-16 dense-MLP factors selected by the completed "
-                    "full-depth quantization-aware recovery report"
+                    "quality-analysis report"
+                    if quality_selection_report is not None
+                    else (
+                        "rank-16 dense-MLP factors selected by the completed "
+                        "full-depth quantization-aware recovery report"
+                    )
                 ),
-                "recovery_report": str(complete_path),
-                "recovery_report_sha256": _sha256(complete_path),
+                "recovery_report": str(recovery_root / "complete.json"),
+                "recovery_report_sha256": selection.report_sha256,
                 "selected_overlay": str(overlay_path),
-                "selected_overlay_sha256": overlay_record["sha256"],
+                "selected_overlay_sha256": selection.overlay_sha256,
             }
         )
+        if selection.quality_selection_path is not None:
+            identity["quality_selection_report"] = str(
+                selection.quality_selection_path
+            )
+            identity["quality_selection_report_sha256"] = (
+                selection.quality_selection_sha256
+            )
+            identity["selected_optimizer_step"] = selection.quality_selection[
+                "selected_overlay"
+            ]["step"]
     return identity
 
 
@@ -773,6 +784,14 @@ def main(argv: Sequence[str] | None = None) -> None:
             "report selects the factor overlay"
         ),
     )
+    parser.add_argument(
+        "--quality-selection-report",
+        type=Path,
+        help=(
+            "content-bound analysis report that selects one saved optimizer "
+            "boundary instead of the trainer's screening choice"
+        ),
+    )
     parser.add_argument("--qsrt-root", type=Path, required=True)
     parser.add_argument("--layer", type=int, default=0)
     parser.add_argument(
@@ -803,6 +822,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         raise SystemExit(
             "layer, replay counts, or adapter manifest identity is invalid"
         )
+    if args.quality_selection_report is not None and args.recovery_root is None:
+        raise SystemExit("--quality-selection-report requires --recovery-root")
     if not torch.cuda.is_available():
         raise SystemExit("CUDA is required")
     major, minor = torch.cuda.get_device_capability()
@@ -818,11 +839,17 @@ def main(argv: Sequence[str] | None = None) -> None:
         if args.recovery_root is None
         else args.recovery_root.expanduser().resolve()
     )
+    quality_selection_report = (
+        None
+        if args.quality_selection_report is None
+        else args.quality_selection_report.expanduser().resolve()
+    )
     archive_identity = _validate_archives(
         contract,
         artifact_root=artifact_root,
         adapter_root=adapter_root,
         recovery_root=recovery_root,
+        quality_selection_report=quality_selection_report,
         expected_adapter_manifest_sha256=args.expected_adapter_manifest_sha256,
     )
     selected_overlay = (

--- a/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
+++ b/benchmarks/benchmark_qwen38_qsrt_k5_dense.py
@@ -1,0 +1,940 @@
+#!/usr/bin/env python3
+"""Qualify packed Qwen3.8-27B K5 dense linears with rank-16 corrections.
+
+The benchmark loads one sealed Qwen3.8 dense-MLP QSRT K5 layer and its sealed
+activation-weighted low-rank factors.  It compares B12X execution against an
+independently decoded BF16 matrix for output and linear-Jacobian parity, proves
+bit-exact eager/CUDA-graph replay, and measures packed versus decoded latency.
+
+The decoded matrix is a correctness and timing control only.  The packed case
+passes the native trellis payload directly to :mod:`b12x.gemm.trellis_linear`
+and never materializes or dispatches through the decoded control.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import statistics
+import subprocess
+import sys
+import time
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from safetensors import safe_open
+import torch
+
+from benchmarks.common import make_l2_flush_fn, nvidia_smi_gpu_mode_snapshot
+from b12x.gemm import trellis_linear
+
+
+_RESULT_KIND = "b12x_qwen38_qsrt_k5_dense_qualification"
+_SCHEMA_VERSION = 1
+_DESCRIPTOR_SHA256 = "17cf4ca9ef1e3a07c3354c12f7ac887b4e081b1668bea61eb37d8f2b410bb968"
+_ARTIFACT_MANIFEST_SHA256 = (
+    "039845f8176afd254d0f028d3cd72791a5df9580d14ad524d7b3dbb828ddd052"
+)
+_INITIAL_ADAPTER_MANIFEST_SHA256 = (
+    "1c6207cc41b2b3511bdd49970408fddf714419742a60d1ac053762c03f3a74c5"
+)
+_PROJECTIONS = ("gate_proj", "up_proj", "down_proj")
+_RELATIVE_L2_LIMIT = 2.0e-2
+_COSINE_LIMIT = 0.999
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_sha256() -> str:
+    root = Path(__file__).resolve().parents[1]
+    paths = (
+        Path(__file__).resolve(),
+        root / "b12x/gemm/trellis_linear/__init__.py",
+        root / "b12x/gemm/trellis_linear/_low_rank.py",
+        root / "b12x/gemm/trellis_linear/api.py",
+        root / "b12x/moe/_shared/kernels/w4a16/kernel.py",
+        root / "b12x/moe/_shared/kernels/w4a16/prepare.py",
+        root / "b12x/_lib/quant/sqg_fp16_d3l.py",
+    )
+    digest = hashlib.sha256()
+    for path in paths:
+        relative = path.relative_to(root).as_posix().encode()
+        payload = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "little"))
+        digest.update(relative)
+        digest.update(len(payload).to_bytes(8, "little"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _git_value(*args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ("git", *args),
+            cwd=Path(__file__).resolve().parents[1],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _positive_ints(value: str) -> tuple[int, ...]:
+    try:
+        result = tuple(int(item) for item in value.split(","))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected comma-separated integers") from error
+    if (
+        not result
+        or len(set(result)) != len(result)
+        or any(item <= 0 for item in result)
+    ):
+        raise argparse.ArgumentTypeError("values must be unique positive integers")
+    return result
+
+
+def _projection_names(value: str) -> tuple[str, ...]:
+    result = tuple(item.strip() for item in value.split(",") if item.strip())
+    if (
+        not result
+        or len(set(result)) != len(result)
+        or any(item not in _PROJECTIONS for item in result)
+    ):
+        raise argparse.ArgumentTypeError(
+            f"projections must be a unique subset of {','.join(_PROJECTIONS)}"
+        )
+    return result
+
+
+def _tensor_pointers(buffers: trellis_linear.Buffers) -> dict[str, int | None]:
+    return {
+        name: None if value is None else int(value.data_ptr())
+        for name, value in vars(buffers).items()
+    }
+
+
+def _pair_tensor_pointers(
+    buffers: trellis_linear.PairBuffers,
+) -> dict[str, int | None]:
+    result = {
+        f"base.{name}": None if value is None else int(value.data_ptr())
+        for name, value in vars(buffers.base).items()
+    }
+    result["output"] = int(buffers.output.data_ptr())
+    result["low_rank_hidden"] = int(buffers.low_rank_hidden.data_ptr())
+    return result
+
+
+def _metrics(actual: torch.Tensor, expected: torch.Tensor) -> dict[str, Any]:
+    difference = (actual - expected).float()
+    reference = expected.float()
+    flat_error = difference.abs().flatten()
+    reference_norm = float(reference.norm().item())
+    relative_l2 = float(difference.norm().item()) / max(reference_norm, 1.0e-30)
+    cosine = float(
+        torch.nn.functional.cosine_similarity(
+            actual.float().flatten(),
+            reference.flatten(),
+            dim=0,
+        ).item()
+    )
+    return {
+        "finite": bool(torch.isfinite(actual).all()),
+        "relative_l2": relative_l2,
+        "cosine": cosine,
+        "mean_absolute_error": float(flat_error.mean().item()),
+        "p99_absolute_error": float(torch.quantile(flat_error, 0.99).item()),
+        "maximum_absolute_error": float(flat_error.max().item()),
+        "passed": (
+            bool(torch.isfinite(actual).all())
+            and relative_l2 <= _RELATIVE_L2_LIMIT
+            and cosine >= _COSINE_LIMIT
+        ),
+    }
+
+
+def _summary(samples: list[float]) -> dict[str, float]:
+    ordered = sorted(samples)
+    return {
+        "median_us": statistics.median(ordered),
+        "p10_us": ordered[max(0, int(0.10 * (len(ordered) - 1)))],
+        "p90_us": ordered[min(len(ordered) - 1, int(0.90 * (len(ordered) - 1)))],
+        "minimum_us": ordered[0],
+        "maximum_us": ordered[-1],
+    }
+
+
+def _interleaved_times_us(
+    graphs: dict[str, torch.cuda.CUDAGraph],
+    *,
+    replays: int,
+    flush_l2: Callable[[], None] | None,
+) -> dict[str, list[float]]:
+    samples = {name: [] for name in graphs}
+    events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] = []
+    names = list(graphs)
+    for replay in range(replays):
+        order = names if replay % 2 == 0 else list(reversed(names))
+        for name in order:
+            if flush_l2 is not None:
+                flush_l2()
+            begin = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            begin.record()
+            graphs[name].replay()
+            end.record()
+            events.append((name, begin, end))
+    torch.cuda.synchronize()
+    for name, begin, end in events:
+        samples[name].append(begin.elapsed_time(end) * 1000.0)
+    return samples
+
+
+def _load_qsrt_contract(qsrt_root: Path) -> dict[str, Any]:
+    sys.path.insert(0, str(qsrt_root))
+    from qsrt.qwen38_adapter_archive import (  # noqa: PLC0415
+        load_layer_factors,
+        validate_final_report as validate_adapter_report,
+    )
+    from qsrt.qwen38_mlp import (  # noqa: PLC0415
+        PROJECTION_BY_NAME,
+        decode_qsrt_projection,
+    )
+    from qsrt.qwen38_mlp_artifact import (  # noqa: PLC0415
+        layer_filename,
+        validate_completed_layer,
+        validate_final_report as validate_artifact_report,
+    )
+
+    return {
+        "load_layer_factors": load_layer_factors,
+        "validate_adapter_report": validate_adapter_report,
+        "projection_by_name": PROJECTION_BY_NAME,
+        "decode_qsrt_projection": decode_qsrt_projection,
+        "layer_filename": layer_filename,
+        "validate_completed_layer": validate_completed_layer,
+        "validate_artifact_report": validate_artifact_report,
+    }
+
+
+def _validate_archives(
+    contract: dict[str, Any],
+    *,
+    artifact_root: Path,
+    adapter_root: Path,
+    recovery_root: Path | None,
+    expected_adapter_manifest_sha256: str,
+) -> dict[str, Any]:
+    artifact_manifest, _, artifact_manifest_sha256 = contract[
+        "validate_artifact_report"
+    ](artifact_root, verify_layer_hashes=False)
+    adapter_manifest, adapter_report, adapter_manifest_sha256 = contract[
+        "validate_adapter_report"
+    ](adapter_root, verify_layer_hashes=False)
+    if (
+        artifact_manifest_sha256 != _ARTIFACT_MANIFEST_SHA256
+        or artifact_manifest.get("codec", {}).get("descriptor_sha256")
+        != _DESCRIPTOR_SHA256
+        or adapter_manifest_sha256 != expected_adapter_manifest_sha256
+        or adapter_manifest.get("k5_artifact", {}).get("manifest_sha256")
+        != artifact_manifest_sha256
+        or "weighted" not in adapter_report.get("variants", [])
+        or 16 not in adapter_report.get("ranks", [])
+    ):
+        raise ValueError("Qwen K5 artifact and rank-16 adapter identities do not close")
+    identity: dict[str, Any] = {
+        "artifact_manifest_sha256": artifact_manifest_sha256,
+        "artifact_report_sha256": _sha256(artifact_root / "report.json"),
+        "adapter_manifest_sha256": adapter_manifest_sha256,
+        "adapter_report_sha256": _sha256(adapter_root / "report.json"),
+        "factor_source": "sealed activation-weighted rank-16 initialization",
+    }
+    if recovery_root is not None:
+        complete_path = recovery_root / "complete.json"
+        complete = json.loads(complete_path.read_text())
+        overlay_record = complete.get("selected_overlay", {})
+        overlay_path = Path(str(overlay_record.get("path", ""))).resolve()
+        if (
+            complete.get("kind") != "qwen38_full_depth_mlp_adapter_recovery_report_v1"
+            or complete.get("status") != "complete"
+            or complete.get("adapter_installation", {}).get("adapter_manifest_sha256")
+            != adapter_manifest_sha256
+            or not overlay_path.is_file()
+            or overlay_path.parent != recovery_root
+            or overlay_path.stat().st_size != overlay_record.get("bytes")
+            or _sha256(overlay_path) != overlay_record.get("sha256")
+        ):
+            raise ValueError("Qwen recovery report does not bind one selected overlay")
+        with safe_open(str(overlay_path), framework="pt", device="cpu") as handle:
+            metadata = handle.metadata() or {}
+            if (
+                metadata.get("kind") != "qwen38_full_depth_mlp_adapter_overlay_v1"
+                or metadata.get("rank") != "16"
+                or metadata.get("variant") != "weighted"
+            ):
+                raise ValueError("selected Qwen recovery overlay metadata differs")
+        identity.update(
+            {
+                "factor_source": "selected 50M-token full-model QAT overlay",
+                "recovery_report": str(complete_path),
+                "recovery_report_sha256": _sha256(complete_path),
+                "selected_overlay": str(overlay_path),
+                "selected_overlay_sha256": overlay_record["sha256"],
+            }
+        )
+    return identity
+
+
+def _load_projection(
+    contract: dict[str, Any],
+    *,
+    artifact_root: Path,
+    adapter_root: Path,
+    selected_overlay: Path | None,
+    layer: int,
+    projection: str,
+    device: torch.device,
+    artifact_manifest_sha256: str,
+) -> tuple[dict[str, torch.Tensor], dict[str, Any]]:
+    receipt = contract["validate_completed_layer"](
+        artifact_root,
+        layer=layer,
+        manifest_sha256=artifact_manifest_sha256,
+        verify_file_hash=True,
+    )
+    layer_path = artifact_root / "layers" / contract["layer_filename"](layer)
+    prefix = f"{projection}.qsrt_k5"
+    with safe_open(str(layer_path), framework="pt", device="cpu") as handle:
+        tensors = {
+            name: handle.get_tensor(f"{prefix}.{name}").contiguous()
+            for name in ("trellis", "suh", "svh")
+        }
+    if selected_overlay is None:
+        factors = contract["load_layer_factors"](
+            adapter_root,
+            layer=layer,
+            variant="weighted",
+            rank=16,
+        )[projection]
+    else:
+        factor_prefix = f"model.language_model.layers.{layer}.mlp.{projection}"
+        with safe_open(str(selected_overlay), framework="pt", device="cpu") as handle:
+            factors = (
+                handle.get_tensor(f"{factor_prefix}.a"),
+                handle.get_tensor(f"{factor_prefix}.b"),
+            )
+    replay = {
+        "bits": 5,
+        **{name: tensor.to(device) for name, tensor in tensors.items()},
+    }
+    decoded_source = contract["decode_qsrt_projection"](
+        replay,
+        contract["projection_by_name"][projection],
+        bits=5,
+    )
+    gpu = {
+        **replay,
+        "a": factors[0].to(device).contiguous(),
+        "b": factors[1].to(device).contiguous(),
+        "decoded_kn": decoded_source.T.to(
+            device=device, dtype=torch.bfloat16
+        ).contiguous(),
+    }
+    provenance = {
+        "layer_file": str(layer_path),
+        "layer_file_bytes": layer_path.stat().st_size,
+        "layer_file_sha256": receipt["payload_sha256"],
+        "projection": projection,
+        "trellis_shape": list(gpu["trellis"].shape),
+        "suh_shape": list(gpu["suh"].shape),
+        "svh_shape": list(gpu["svh"].shape),
+        "a_shape": list(gpu["a"].shape),
+        "b_shape": list(gpu["b"].shape),
+        "decoded_control_shape": list(gpu["decoded_kn"].shape),
+    }
+    return gpu, provenance
+
+
+@torch.inference_mode()
+def _run_case(
+    tensors: dict[str, torch.Tensor],
+    *,
+    rows: int,
+    warmup: int,
+    hot_replays: int,
+    cold_replays: int,
+    seed: int,
+) -> dict[str, Any]:
+    device = tensors["trellis"].device
+    base = trellis_linear.prepare_weight(
+        tensors["trellis"],
+        tensors["suh"],
+        tensors["svh"],
+        codebook="sqg_fp16",
+        params_dtype=torch.bfloat16,
+    )
+    weight = trellis_linear.prepare_additive_weight(base, tensors["a"], tensors["b"])
+    packed_buffers = trellis_linear.make_buffers(
+        weight,
+        size_m=rows,
+        input_dtype=torch.bfloat16,
+    )
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    x = torch.randn(
+        (rows, int(base.in_features)),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device=device, dtype=torch.bfloat16)
+    direction = torch.randn(
+        (rows, int(base.in_features)),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device=device, dtype=torch.bfloat16)
+
+    def packed_run() -> torch.Tensor:
+        return trellis_linear.run_additive(
+            x,
+            weight,
+            low_rank_hidden=packed_buffers.low_rank_hidden,
+            **packed_buffers.run_kwargs(),
+        )
+
+    for _ in range(warmup):
+        packed_run()
+    torch.cuda.synchronize(device)
+    trellis_before = tensors["trellis"].clone()
+    a_t_before = weight.a_t.clone()
+    b_before = weight.b.clone()
+    eager = packed_run().clone()
+    pointers_before = _tensor_pointers(packed_buffers)
+    packed_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(packed_graph):
+        captured = packed_run()
+    torch.cuda.synchronize(device)
+    capture_matches_eager = bool(torch.equal(captured, eager))
+    packed_buffers.output.fill_(float("nan"))
+    allocated_before_replay = torch.cuda.memory_allocated(device)
+    packed_graph.replay()
+    packed_graph.replay()
+    torch.cuda.synchronize(device)
+    allocated_after_replay = torch.cuda.memory_allocated(device)
+    replay_matches_eager = bool(torch.equal(captured, eager))
+    pointers_after = _tensor_pointers(packed_buffers)
+    immutable_weights = bool(
+        torch.equal(tensors["trellis"], trellis_before)
+        and torch.equal(weight.a_t, a_t_before)
+        and torch.equal(weight.b, b_before)
+    )
+
+    reference_output = torch.empty_like(packed_buffers.output)
+    reference_hidden = torch.empty(
+        (rows, weight.rank),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    reference_correction = torch.empty_like(reference_output)
+
+    def reference_run() -> torch.Tensor:
+        torch.mm(x, tensors["decoded_kn"], out=reference_output)
+        torch.mm(x, tensors["a"], out=reference_hidden)
+        torch.mm(reference_hidden, tensors["b"].T, out=reference_correction)
+        reference_output.add_(reference_correction)
+        return reference_output
+
+    for _ in range(warmup):
+        reference_run()
+    expected = reference_run().clone()
+    reference_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(reference_graph):
+        reference_run()
+    torch.cuda.synchronize(device)
+
+    jvp_buffers = trellis_linear.make_buffers(
+        weight,
+        size_m=rows,
+        input_dtype=torch.bfloat16,
+    )
+    actual_jvp = trellis_linear.run_additive(
+        direction,
+        weight,
+        low_rank_hidden=jvp_buffers.low_rank_hidden,
+        **jvp_buffers.run_kwargs(),
+    ).clone()
+    expected_jvp = direction @ tensors["decoded_kn"]
+    expected_jvp.add_((direction @ tensors["a"]) @ tensors["b"].T)
+    torch.cuda.synchronize(device)
+
+    hot = _interleaved_times_us(
+        {"packed_k5_rank16": packed_graph, "decoded_bf16_rank16": reference_graph},
+        replays=hot_replays,
+        flush_l2=None,
+    )
+    cold = None
+    if cold_replays:
+        cold = _interleaved_times_us(
+            {"packed_k5_rank16": packed_graph, "decoded_bf16_rank16": reference_graph},
+            replays=cold_replays,
+            flush_l2=make_l2_flush_fn(True),
+        )
+    output_metrics = _metrics(eager, expected)
+    jvp_metrics = _metrics(actual_jvp, expected_jvp)
+    correctness = {
+        "output": output_metrics,
+        "linear_jacobian_vector_product": jvp_metrics,
+        "capture_matches_eager_bit_exact": capture_matches_eager,
+        "replay_matches_eager_bit_exact": replay_matches_eager,
+        "buffer_pointers_stable": pointers_before == pointers_after,
+        "replay_allocation_stable": allocated_before_replay == allocated_after_replay,
+        "packed_weight_and_factors_immutable": immutable_weights,
+    }
+    correctness["passed"] = bool(
+        output_metrics["passed"]
+        and jvp_metrics["passed"]
+        and capture_matches_eager
+        and replay_matches_eager
+        and pointers_before == pointers_after
+        and allocated_before_replay == allocated_after_replay
+        and immutable_weights
+    )
+    timing: dict[str, Any] = {
+        "hot": {name: _summary(values) for name, values in hot.items()},
+        "hot_packed_over_decoded": (
+            statistics.median(hot["packed_k5_rank16"])
+            / statistics.median(hot["decoded_bf16_rank16"])
+        ),
+    }
+    if cold is not None:
+        timing["cold"] = {name: _summary(values) for name, values in cold.items()}
+        timing["cold_packed_over_decoded"] = statistics.median(
+            cold["packed_k5_rank16"]
+        ) / statistics.median(cold["decoded_bf16_rank16"])
+    return {
+        "rows": rows,
+        "correctness": correctness,
+        "timing": timing,
+        "storage": {
+            "packed_trellis_bytes": tensors["trellis"].numel()
+            * tensors["trellis"].element_size(),
+            "rotation_bytes": sum(
+                tensors[name].numel() * tensors[name].element_size()
+                for name in ("suh", "svh")
+            ),
+            "adapter_bytes": sum(
+                tensors[name].numel() * tensors[name].element_size()
+                for name in ("a", "b")
+            ),
+            "decoded_control_bytes": tensors["decoded_kn"].numel()
+            * tensors["decoded_kn"].element_size(),
+            "scratch_bytes": sum(
+                value.numel() * value.element_size()
+                for value in vars(packed_buffers).values()
+                if isinstance(value, torch.Tensor)
+            ),
+        },
+    }
+
+
+@torch.inference_mode()
+def _run_pair_case(
+    gate: dict[str, torch.Tensor],
+    up: dict[str, torch.Tensor],
+    *,
+    rows: int,
+    warmup: int,
+    hot_replays: int,
+    cold_replays: int,
+    seed: int,
+) -> dict[str, Any]:
+    device = gate["trellis"].device
+    bases = [
+        trellis_linear.prepare_weight(
+            tensors["trellis"],
+            tensors["suh"],
+            tensors["svh"],
+            codebook="sqg_fp16",
+            params_dtype=torch.bfloat16,
+        )
+        for tensors in (gate, up)
+    ]
+    a = torch.stack((gate["a"], up["a"]), dim=0).contiguous()
+    b = torch.stack((gate["b"], up["b"]), dim=0).contiguous()
+    weight = trellis_linear.prepare_additive_pair(*bases, a, b)
+    packed_buffers = trellis_linear.make_pair_buffers(
+        weight,
+        size_m=rows,
+        input_dtype=torch.bfloat16,
+    )
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    x = torch.randn(
+        (rows, int(weight.left.in_features)),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device=device, dtype=torch.bfloat16)
+    direction = torch.randn(
+        (rows, int(weight.left.in_features)),
+        generator=generator,
+        dtype=torch.float32,
+    ).to(device=device, dtype=torch.bfloat16)
+
+    def packed_run() -> torch.Tensor:
+        return trellis_linear.run_additive_pair(
+            x,
+            weight,
+            buffers=packed_buffers,
+        )
+
+    for _ in range(warmup):
+        packed_run()
+    torch.cuda.synchronize(device)
+    trellis_before = [value["trellis"].clone() for value in (gate, up)]
+    a_t_before = weight.a_t.clone()
+    b_before = weight.b.clone()
+    eager = packed_run().clone()
+    pointers_before = _pair_tensor_pointers(packed_buffers)
+    packed_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(packed_graph):
+        captured = packed_run()
+    torch.cuda.synchronize(device)
+    capture_matches_eager = bool(torch.equal(captured, eager))
+    packed_buffers.output.fill_(float("nan"))
+    allocated_before_replay = torch.cuda.memory_allocated(device)
+    packed_graph.replay()
+    packed_graph.replay()
+    torch.cuda.synchronize(device)
+    allocated_after_replay = torch.cuda.memory_allocated(device)
+    replay_matches_eager = bool(torch.equal(captured, eager))
+    pointers_after = _pair_tensor_pointers(packed_buffers)
+    immutable_weights = bool(
+        all(
+            torch.equal(tensors["trellis"], before)
+            for tensors, before in zip((gate, up), trellis_before, strict=True)
+        )
+        and torch.equal(weight.a_t, a_t_before)
+        and torch.equal(weight.b, b_before)
+    )
+
+    width = int(weight.left.out_features)
+    decoded_pair = torch.cat((gate["decoded_kn"], up["decoded_kn"]), dim=1)
+    a_pair = torch.cat((gate["a"], up["a"]), dim=1)
+    b_block = torch.zeros(
+        (2 * width, 2 * weight.rank),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    b_block[:width, : weight.rank].copy_(gate["b"])
+    b_block[width:, weight.rank :].copy_(up["b"])
+    reference_output = torch.empty_like(packed_buffers.output)
+    reference_hidden = torch.empty(
+        (rows, 2 * weight.rank),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    reference_correction = torch.empty_like(reference_output)
+
+    def reference_run() -> torch.Tensor:
+        torch.mm(x, decoded_pair, out=reference_output)
+        torch.mm(x, a_pair, out=reference_hidden)
+        torch.mm(reference_hidden, b_block.T, out=reference_correction)
+        reference_output.add_(reference_correction)
+        return reference_output
+
+    for _ in range(warmup):
+        reference_run()
+    expected = reference_run().clone()
+    reference_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(reference_graph):
+        reference_run()
+    torch.cuda.synchronize(device)
+
+    jvp_buffers = trellis_linear.make_pair_buffers(
+        weight,
+        size_m=rows,
+        input_dtype=torch.bfloat16,
+    )
+    actual_jvp = trellis_linear.run_additive_pair(
+        direction,
+        weight,
+        buffers=jvp_buffers,
+    ).clone()
+    expected_jvp = direction @ decoded_pair
+    expected_jvp.add_((direction @ a_pair) @ b_block.T)
+    torch.cuda.synchronize(device)
+
+    names = {
+        "packed_pair_k5_rank16": packed_graph,
+        "decoded_fused_bf16_rank16": reference_graph,
+    }
+    hot = _interleaved_times_us(names, replays=hot_replays, flush_l2=None)
+    cold = None
+    if cold_replays:
+        cold = _interleaved_times_us(
+            names,
+            replays=cold_replays,
+            flush_l2=make_l2_flush_fn(True),
+        )
+    output_metrics = _metrics(eager, expected)
+    jvp_metrics = _metrics(actual_jvp, expected_jvp)
+    correctness = {
+        "output": output_metrics,
+        "linear_jacobian_vector_product": jvp_metrics,
+        "capture_matches_eager_bit_exact": capture_matches_eager,
+        "replay_matches_eager_bit_exact": replay_matches_eager,
+        "buffer_pointers_stable": pointers_before == pointers_after,
+        "replay_allocation_stable": allocated_before_replay == allocated_after_replay,
+        "packed_weights_and_factors_immutable": immutable_weights,
+    }
+    correctness["passed"] = bool(
+        output_metrics["passed"]
+        and jvp_metrics["passed"]
+        and capture_matches_eager
+        and replay_matches_eager
+        and pointers_before == pointers_after
+        and allocated_before_replay == allocated_after_replay
+        and immutable_weights
+    )
+    timing: dict[str, Any] = {
+        "hot": {name: _summary(values) for name, values in hot.items()},
+        "hot_packed_over_decoded": (
+            statistics.median(hot["packed_pair_k5_rank16"])
+            / statistics.median(hot["decoded_fused_bf16_rank16"])
+        ),
+    }
+    if cold is not None:
+        timing["cold"] = {name: _summary(values) for name, values in cold.items()}
+        timing["cold_packed_over_decoded"] = statistics.median(
+            cold["packed_pair_k5_rank16"]
+        ) / statistics.median(cold["decoded_fused_bf16_rank16"])
+    return {
+        "rows": rows,
+        "correctness": correctness,
+        "timing": timing,
+        "storage": {
+            "packed_trellis_bytes": sum(
+                tensors["trellis"].numel() * tensors["trellis"].element_size()
+                for tensors in (gate, up)
+            ),
+            "rotation_bytes": sum(
+                tensors[name].numel() * tensors[name].element_size()
+                for tensors in (gate, up)
+                for name in ("suh", "svh")
+            ),
+            "adapter_bytes": a.numel() * a.element_size()
+            + b.numel() * b.element_size(),
+            "decoded_control_bytes": decoded_pair.numel() * decoded_pair.element_size(),
+            "scratch_bytes": sum(
+                value.numel() * value.element_size()
+                for value in vars(packed_buffers.base).values()
+                if isinstance(value, torch.Tensor)
+            )
+            + packed_buffers.output.numel() * packed_buffers.output.element_size()
+            + packed_buffers.low_rank_hidden.numel()
+            * packed_buffers.low_rank_hidden.element_size(),
+            "factor_kernel_launches": 2,
+        },
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--adapter-root", type=Path, required=True)
+    parser.add_argument(
+        "--recovery-root",
+        type=Path,
+        help="completed QAT run whose selected overlay replaces the initial factors",
+    )
+    parser.add_argument("--qsrt-root", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=0)
+    parser.add_argument(
+        "--projections",
+        type=_projection_names,
+        default=_projection_names(",".join(_PROJECTIONS)),
+    )
+    parser.add_argument(
+        "--rows", type=_positive_ints, default=_positive_ints("1,8,32,128")
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--hot-replays", type=int, default=100)
+    parser.add_argument("--cold-replays", type=int, default=30)
+    parser.add_argument("--seed", type=int, default=20260819)
+    parser.add_argument(
+        "--expected-adapter-manifest-sha256",
+        default=_INITIAL_ADAPTER_MANIFEST_SHA256,
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if (
+        not 0 <= args.layer < 64
+        or args.warmup <= 0
+        or args.hot_replays <= 0
+        or args.cold_replays < 0
+        or len(args.expected_adapter_manifest_sha256) != 64
+    ):
+        raise SystemExit(
+            "layer, replay counts, or adapter manifest identity is invalid"
+        )
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if major != 12 or minor not in (0, 1):
+        raise SystemExit(f"SM120/SM121 is required, got SM{major}{minor}")
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    contract = _load_qsrt_contract(args.qsrt_root.expanduser().resolve())
+    artifact_root = args.artifact_root.expanduser().resolve()
+    adapter_root = args.adapter_root.expanduser().resolve()
+    recovery_root = (
+        None
+        if args.recovery_root is None
+        else args.recovery_root.expanduser().resolve()
+    )
+    archive_identity = _validate_archives(
+        contract,
+        artifact_root=artifact_root,
+        adapter_root=adapter_root,
+        recovery_root=recovery_root,
+        expected_adapter_manifest_sha256=args.expected_adapter_manifest_sha256,
+    )
+    selected_overlay = (
+        None
+        if recovery_root is None
+        else Path(str(archive_identity["selected_overlay"]))
+    )
+    properties = torch.cuda.get_device_properties(device)
+    result: dict[str, Any] = {
+        "kind": _RESULT_KIND,
+        "schema_version": _SCHEMA_VERSION,
+        "status": "running",
+        "classification": "qualification",
+        "created_unix_ns": time.time_ns(),
+        "provenance": {
+            "command": shlex.join(
+                [sys.executable, *(sys.argv if argv is None else argv)]
+            ),
+            "commit": _git_value("rev-parse", "HEAD"),
+            "branch": _git_value("branch", "--show-current"),
+            "git_dirty": bool(_git_value("status", "--porcelain")),
+            "source_sha256": _source_sha256(),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "qsrt_root": str(args.qsrt_root.expanduser().resolve()),
+        },
+        "contract": {
+            "model": "Qwen/Qwen3.8-27B",
+            "scope": "all selected dense decoder MLP projections at TP1",
+            "layer": args.layer,
+            "projections": list(args.projections),
+            "rows": list(args.rows),
+            "codebook": "sqg_fp16_d3l",
+            "rate": 5,
+            "adapter_variant": "weighted",
+            "adapter_rank": 16,
+            "output_relative_l2_limit": _RELATIVE_L2_LIMIT,
+            "output_cosine_limit": _COSINE_LIMIT,
+            "jvp_relative_l2_limit": _RELATIVE_L2_LIMIT,
+            "jvp_cosine_limit": _COSINE_LIMIT,
+            "eager_graph_requirement": "bit exact",
+            "decoded_weight_use": "independent control only; absent from packed closure",
+            "gate_up_factor_execution": (
+                "one shared rank-16 projection launch and one shared output launch"
+            ),
+        },
+        "archives": archive_identity,
+        "device": {
+            "name": properties.name,
+            "uuid": str(getattr(properties, "uuid", "")),
+            "capability": [major, minor],
+            "torch": torch.__version__,
+            "mode": nvidia_smi_gpu_mode_snapshot(),
+        },
+        "cases": [],
+    }
+    loaded: dict[
+        str,
+        tuple[dict[str, torch.Tensor], dict[str, Any]],
+    ] = {}
+    for projection_index, projection in enumerate(args.projections):
+        tensors, projection_identity = _load_projection(
+            contract,
+            artifact_root=artifact_root,
+            adapter_root=adapter_root,
+            selected_overlay=selected_overlay,
+            layer=args.layer,
+            projection=projection,
+            device=device,
+            artifact_manifest_sha256=archive_identity["artifact_manifest_sha256"],
+        )
+        loaded[projection] = (tensors, projection_identity)
+        projection_cases = []
+        for rows in args.rows:
+            case = _run_case(
+                tensors,
+                rows=rows,
+                warmup=args.warmup,
+                hot_replays=args.hot_replays,
+                cold_replays=args.cold_replays,
+                seed=args.seed + 1000 * projection_index + rows,
+            )
+            projection_cases.append(case)
+        result["cases"].append(
+            {
+                "identity": projection_identity,
+                "rows": projection_cases,
+                "passed": all(
+                    case["correctness"]["passed"] for case in projection_cases
+                ),
+            }
+        )
+    paired_gate_up = None
+    if {"gate_proj", "up_proj"} <= loaded.keys():
+        pair_cases = [
+            _run_pair_case(
+                loaded["gate_proj"][0],
+                loaded["up_proj"][0],
+                rows=rows,
+                warmup=args.warmup,
+                hot_replays=args.hot_replays,
+                cold_replays=args.cold_replays,
+                seed=args.seed + 900000 + rows,
+            )
+            for rows in args.rows
+        ]
+        paired_gate_up = {
+            "semantic_role": "vLLM gate_up_proj packed execution",
+            "projections": [
+                loaded["gate_proj"][1],
+                loaded["up_proj"][1],
+            ],
+            "rows": pair_cases,
+            "passed": all(case["correctness"]["passed"] for case in pair_cases),
+        }
+        result["paired_gate_up"] = paired_gate_up
+    passed = all(case["passed"] for case in result["cases"])
+    if paired_gate_up is not None:
+        passed = passed and paired_gate_up["passed"]
+    result["status"] = "passed" if passed else "failed"
+    del loaded
+    torch.cuda.empty_cache()
+    result["completed_unix_ns"] = time.time_ns()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = args.output.with_name(f".{args.output.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    temporary.replace(args.output)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if result["status"] != "passed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/qwen38-qsrt-vllm-integration.md
+++ b/docs/qwen38-qsrt-vllm-integration.md
@@ -81,4 +81,8 @@ It checks packed output and input-vector Jacobian parity against independently
 decoded controls, immutable payloads and factors, bit-exact eager/graph replay,
 pointer and allocation stability, and interleaved hot/cold latency. The paired
 gate/up case compares against one fused BF16 base GEMM plus a rank-32
-block-diagonal control correction.
+block-diagonal control correction. Pass `--recovery-root` with
+`--quality-selection-report` when packaging selected an optimizer boundary from
+an external KLD panel. The benchmark validates the recovery report, the complete
+candidate population, the KLD ranking, and the selected overlay content before
+loading any factor.

--- a/docs/qwen38-qsrt-vllm-integration.md
+++ b/docs/qwen38-qsrt-vllm-integration.md
@@ -1,0 +1,81 @@
+# Qwen3.8 dense-MLP QSRT K5 serving
+
+Status: **research-only**. The loader and packed operators are implemented.
+SM120 numerical, CUDA-graph, full-model quality, and latency qualification are
+required before deployment.
+
+## Checkpoint contract
+
+The `b12x_qsrt` quantization method accepts a TP1 Qwen3.8-27B checkpoint whose
+`config.json` declares all 192 decoder dense-MLP source modules. Every official
+BF16 `gate_proj.weight`, `up_proj.weight`, and `down_proj.weight` is absent from
+the tensor index and is replaced by these tensors under the same source-module
+prefix:
+
+| Suffix | Dtype | Semantic role |
+| --- | --- | --- |
+| `qsrt_trellis` | I16 | Native `[K/16,N/16,80]` uniform-K5 trellis payload |
+| `qsrt_suh` | FP16 | Input outer-rotation vector |
+| `qsrt_svh` | FP16 | Output outer-rotation vector |
+| `qsrt_a` | BF16 | `[K,16]` additive factor |
+| `qsrt_b` | BF16 | `[N,16]` additive factor |
+
+The reconstruction profile is `sqg_fp16_d3l`, exposed to B12X as the
+`sqg_fp16` codebook. The plugin rejects another bitrate, profile descriptor,
+rank, tensor-parallel size, module inventory, tensor shape, or dtype. The
+checkpoint manifest must bind the K5 artifact, rank panel, completed recovery
+report, and selected factor overlay. Manifest, `config.json`, and tensor-index
+hashes are checked before a claimed linear is constructed.
+
+All attention, gated-DeltaNet, normalization, embedding, vision, MTP, and
+`lm_head` tensors remain BF16 and use vLLM's unquantized methods. A tensor is
+never decoded to a dense matrix inside the packed method, and an unsupported
+packed input raises instead of selecting a Torch or decoded-weight fallback.
+
+## Execution contract
+
+`gate_proj` and `up_proj` retain independent K5 payloads and outer rotations.
+Their two rank-16 A projections share one native BF16 tensor-core launch, and
+their two B projections share one native output launch. The packed base
+operators execute in source order and copy their results into one stable
+`gate_up_proj` output before the paired correction is added. `down_proj` uses
+one A launch and one B launch. A complete 64-layer decoder therefore dispatches
+256 factor kernels instead of the 384 kernels produced by independent
+per-projection adapters.
+
+Every CUDA-graph-visible output and scratch tensor has a stable owner. The
+plugin allocates configured capture row counts during weight processing and
+reuses gate/up and down-projection storage by geometry. Qwen3.8 decoder layers
+execute in source order: the following activation consumes a gate/up output,
+and the following decoder layer's input normalization consumes a down output,
+before the same storage address is written again. CUDA stream ordering retains
+that lifetime rule during graph capture and replay. Capture with an unprepared
+row count or factor geometry fails closed. A device outside SM120/SM121, TP
+greater than one, activation dtype other than BF16, bias, non-contiguous input,
+and capture sizes above 512 rows are unsupported.
+
+## vLLM registration and launch
+
+Installing B12X registers the entry point:
+
+```toml
+[project.entry-points."vllm.general_plugins"]
+b12x_qsrt = "b12x.integration.vllm.qsrt_plugin:register_b12x_qsrt"
+```
+
+Launch the materialized checkpoint by local path so every spawned worker can
+validate its manifest:
+
+```bash
+export B12X_QSRT_MODEL_DIR=/models/Qwen3.8-27B-QSRT-K5-R16
+vllm serve "$B12X_QSRT_MODEL_DIR" \
+  --tensor-parallel-size 1 \
+  --dtype bfloat16
+```
+
+`benchmarks/benchmark_qwen38_qsrt_k5_dense.py` validates a real sealed layer.
+It checks packed output and input-vector Jacobian parity against independently
+decoded controls, immutable payloads and factors, bit-exact eager/graph replay,
+pointer and allocation stability, and interleaved hot/cold latency. The paired
+gate/up case compares against one fused BF16 base GEMM plus a rank-32
+block-diagonal control correction.

--- a/docs/qwen38-qsrt-vllm-integration.md
+++ b/docs/qwen38-qsrt-vllm-integration.md
@@ -1,8 +1,10 @@
 # Qwen3.8 dense-MLP QSRT K5 serving
 
 Status: **research-only**. The loader and packed operators are implemented.
-SM120 numerical, CUDA-graph, full-model quality, and latency qualification are
-required before deployment.
+SM120 packed-operator numerical and direct CUDA-graph execution are qualified
+by the sealed-layer benchmark. Whole-model CUDA-graph execution is unsupported
+and rejected because it has not passed end-to-end correctness qualification.
+Full-model quality and latency qualification are required before deployment.
 
 ## Checkpoint contract
 
@@ -44,18 +46,16 @@ one A launch and one B launch. A complete 64-layer decoder therefore dispatches
 256 factor kernels instead of the 384 kernels produced by independent
 per-projection adapters.
 
-Every CUDA-graph-visible output and scratch tensor has a stable owner. The
+Every packed-operator output and scratch tensor has a stable owner. The
 checkpoint's `workspace_capacity_rows` value bounds one buffer pool allocated
 during weight processing. Exact-row views of that fixed pool serve eager and
-CUDA-graph execution without device allocation or cache growth. Qwen3.8 decoder layers
-execute in source order: the following activation consumes a gate/up output,
-and the following decoder layer's input normalization consumes a down output,
-before the same storage address is written again. CUDA stream ordering retains
-that lifetime rule during graph capture and replay. Capture with an unprepared
-factor geometry fails closed, and a request above the declared row capacity is
-rejected. A device outside SM120/SM121, TP
-greater than one, activation dtype other than BF16, bias, non-contiguous input,
-and capture sizes above the declared workspace capacity are unsupported.
+compiled execution without device allocation or cache growth. Direct graph
+capture of one packed projection is qualified by the sealed-layer benchmark,
+but whole-model vLLM graph replay is outside the implemented contract. The
+plugin rejects that runtime before loading weights. A request above the
+declared row capacity is rejected. A device outside SM120/SM121, TP greater
+than one, activation dtype other than BF16, bias, non-contiguous input, and
+whole-model CUDA graphs are unsupported.
 
 ## vLLM registration and launch
 
@@ -73,8 +73,14 @@ validate its manifest:
 export B12X_QSRT_MODEL_DIR=/models/Qwen3.8-27B-QSRT-K5-R16
 vllm serve "$B12X_QSRT_MODEL_DIR" \
   --tensor-parallel-size 1 \
-  --dtype bfloat16
+  --dtype bfloat16 \
+  --compilation-config \
+    '{"cudagraph_mode":"NONE","custom_ops":["-apply_rotary_emb"]}'
 ```
+
+This configuration retains `torch.compile` and disables only CUDA graphs.
+Omitting it, or selecting a non-`NONE` CUDA-graph mode, fails before checkpoint
+weights are loaded.
 
 `benchmarks/benchmark_qwen38_qsrt_k5_dense.py` validates a real sealed layer.
 It checks packed output and input-vector Jacobian parity against independently

--- a/docs/qwen38-qsrt-vllm-integration.md
+++ b/docs/qwen38-qsrt-vllm-integration.md
@@ -22,7 +22,8 @@ prefix:
 
 The reconstruction profile is `sqg_fp16_d3l`, exposed to B12X as the
 `sqg_fp16` codebook. The plugin rejects another bitrate, profile descriptor,
-rank, tensor-parallel size, module inventory, tensor shape, or dtype. The
+rank, tensor-parallel size, module inventory, shared-workspace row capacity,
+tensor shape, or dtype. The
 checkpoint manifest must bind the K5 artifact, rank panel, completed recovery
 report, and selected factor overlay. Manifest, `config.json`, and tensor-index
 hashes are checked before a claimed linear is constructed.
@@ -44,15 +45,17 @@ one A launch and one B launch. A complete 64-layer decoder therefore dispatches
 per-projection adapters.
 
 Every CUDA-graph-visible output and scratch tensor has a stable owner. The
-plugin allocates configured capture row counts during weight processing and
-reuses gate/up and down-projection storage by geometry. Qwen3.8 decoder layers
+checkpoint's `workspace_capacity_rows` value bounds one buffer pool allocated
+during weight processing. Exact-row views of that fixed pool serve eager and
+CUDA-graph execution without device allocation or cache growth. Qwen3.8 decoder layers
 execute in source order: the following activation consumes a gate/up output,
 and the following decoder layer's input normalization consumes a down output,
 before the same storage address is written again. CUDA stream ordering retains
 that lifetime rule during graph capture and replay. Capture with an unprepared
-row count or factor geometry fails closed. A device outside SM120/SM121, TP
+factor geometry fails closed, and a request above the declared row capacity is
+rejected. A device outside SM120/SM121, TP
 greater than one, activation dtype other than BF16, bias, non-contiguous input,
-and capture sizes above 512 rows are unsupported.
+and capture sizes above the declared workspace capacity are unsupported.
 
 ## vLLM registration and launch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "setuptools.build_meta"
 
 [project.entry-points."vllm.general_plugins"]
 b12x_fp6 = "b12x.integration.vllm.plugin:register_b12x_fp6"
+b12x_qsrt = "b12x.integration.vllm.qsrt_plugin:register_b12x_qsrt"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import torch
+from torch._dynamo.exc import Unsupported
 
 from b12x.gemm import trellis_linear
 from b12x.gemm.trellis_linear import api
@@ -131,18 +132,24 @@ def test_trellis_mutating_custom_ops_support_fake_tensor_tracing() -> None:
 
 
 def test_dense_compilation_preserves_static_buffer_validation(
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
 
-    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
     expected = {
         "shape": (2, 4),
         "dtype": torch.float32,
         "device": torch.device("cpu"),
     }
+
+    def validate(buffer: torch.Tensor) -> torch.Tensor:
+        checked = w4a16_kernel._trellis_dense_buffer(
+            "output", buffer, **expected
+        )
+        return checked + 1
+
+    compiled = torch.compile(validate, backend="eager", fullgraph=True)
     valid = torch.empty((2, 4), dtype=torch.float32)
-    assert w4a16_kernel._trellis_dense_buffer("output", valid, **expected) is valid
+    assert torch.equal(compiled(valid), valid + 1)
 
     invalid = (
         torch.empty((2, 5), dtype=torch.float32),
@@ -150,8 +157,10 @@ def test_dense_compilation_preserves_static_buffer_validation(
         torch.empty((4, 2), dtype=torch.float32).T,
     )
     for buffer in invalid:
-        with pytest.raises(ValueError, match="output must be contiguous"):
-            w4a16_kernel._trellis_dense_buffer("output", buffer, **expected)
+        # Full-graph Dynamo wraps the user validation error observed during
+        # tracing as Unsupported instead of allowing an invalid graph.
+        with pytest.raises(Unsupported, match="Observed exception"):
+            compiled(buffer)
 
 
 @pytest.mark.parametrize(

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -130,6 +130,82 @@ def test_trellis_mutating_custom_ops_support_fake_tensor_tracing() -> None:
         )
 
 
+def test_dense_compilation_preserves_static_buffer_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    expected = {
+        "shape": (2, 4),
+        "dtype": torch.float32,
+        "device": torch.device("cpu"),
+    }
+    valid = torch.empty((2, 4), dtype=torch.float32)
+    assert w4a16_kernel._trellis_dense_buffer("output", valid, **expected) is valid
+
+    invalid = (
+        torch.empty((2, 5), dtype=torch.float32),
+        torch.empty((2, 4), dtype=torch.float16),
+        torch.empty((4, 2), dtype=torch.float32).T,
+    )
+    for buffer in invalid:
+        with pytest.raises(ValueError, match="output must be contiguous"):
+            w4a16_kernel._trellis_dense_buffer("output", buffer, **expected)
+
+
+@pytest.mark.parametrize(
+    ("misaligned_name", "misaligned_index", "dtype", "shape"),
+    [
+        ("rotated_compute", 0, torch.bfloat16, (2, 4)),
+        ("c_tmp", 5, torch.float32, (32,)),
+        ("gemm_output", 6, torch.bfloat16, (2, 4)),
+    ],
+)
+def test_compiled_dense_operator_checks_real_kernel_pointer_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+    misaligned_name: str,
+    misaligned_index: int,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+) -> None:
+    import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    elements = 1
+    for extent in shape:
+        elements *= extent
+    storage = torch.empty(elements + 1, dtype=dtype)
+    misaligned = storage[1:].view(shape)
+    assert misaligned.is_contiguous()
+    assert int(misaligned.data_ptr()) % 16 != 0
+
+    arguments = [
+        torch.empty((2, 4), dtype=torch.bfloat16),
+        torch.empty((1, 1, 5), dtype=torch.int16),
+        torch.empty((1,), dtype=torch.float16),
+        torch.ones((1,), dtype=torch.float32),
+        torch.empty((32,), dtype=torch.int32),
+        torch.empty((32,), dtype=torch.float32),
+        torch.empty((2, 4), dtype=torch.bfloat16),
+        5,
+        "sqg_fp16",
+        "",
+        "",
+        64,
+        64,
+        128,
+    ]
+    arguments[misaligned_index] = misaligned
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_trellis256_dense_gemm_flat",
+        lambda *_args: pytest.fail("misaligned storage reached the kernel launcher"),
+    )
+
+    with pytest.raises(ValueError, match=misaligned_name):
+        w4a16_kernel._trellis256_dense_gemm_op(*arguments)
+
+
 def _decode_3inst_fp16(window: np.ndarray) -> np.ndarray:
     value = window.astype(np.uint64)
     value = ((value * _MCG) & np.uint64(0xFFFFFFFF)).astype(np.uint32)

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -9,17 +9,13 @@ import torch
 
 from b12x.gemm import trellis_linear
 from b12x.gemm.trellis_linear import api
-from b12x._lib.quant.mxfp8_rows import quantize_mxfp8_rows_cute
 from b12x._lib.quant.sqg_e4m3 import (
     sqg_cheb_normal_e4m3_direct_lut_cpu,
     sqg_xor_cheb_t12_direct_lut_cpu,
 )
-from b12x.gemm._shared.wo_mxfp8 import empty_mxfp8_rows_for_dense_gemm
-from b12x.moe._shared.kernels.activations import (
-    SITU_DEFAULT_BETA,
-    SITU_DEFAULT_LINEAR_BETA,
-)
+from b12x._lib.quant.sqg_fp16_d3l import sqg_fp16_d3l_direct_lut_cpu
 from b12x.moe._shared.kernels.w4a16.kernel import _trellis256_dense_launch_geometry
+
 _MCG = np.uint64(0xCBAC1FED)
 _MUL1 = np.uint64(0x83DCD12D)
 _MASK = np.uint32(0x8FFF8FFF)
@@ -70,10 +66,6 @@ def _decode_mul1_e4m3_fp16(window: np.ndarray) -> np.ndarray:
     )
 
 
-
-
-
-
 @lru_cache(maxsize=None)
 def _sqg_cheb_normal_e4m3_table(bits: int) -> np.ndarray:
     if bits not in (2, 3, 4):
@@ -85,9 +77,7 @@ def _sqg_cheb_normal_e4m3_table(bits: int) -> np.ndarray:
     return labels.view(torch.float8_e4m3fn).to(torch.float16).numpy()
 
 
-def _decode_sqg_cheb_normal_e4m3_fp16(
-    window: np.ndarray, bits: int
-) -> np.ndarray:
+def _decode_sqg_cheb_normal_e4m3_fp16(window: np.ndarray, bits: int) -> np.ndarray:
     indices = np.asarray(window, dtype=np.uint32) & np.uint32(0xFFFF)
     return _sqg_cheb_normal_e4m3_table(bits)[indices]
 
@@ -103,11 +93,16 @@ def _sqg_xor_cheb_t12_table(bits: int) -> np.ndarray:
     return labels.view(torch.float8_e4m3fn).to(torch.float16).numpy()
 
 
-def _decode_sqg_xor_cheb_t12_fp16(
-    window: np.ndarray, bits: int
-) -> np.ndarray:
+def _decode_sqg_xor_cheb_t12_fp16(window: np.ndarray, bits: int) -> np.ndarray:
     indices = np.asarray(window, dtype=np.uint32) & np.uint32(0xFFFF)
     return _sqg_xor_cheb_t12_table(bits)[indices]
+
+
+@lru_cache(maxsize=None)
+def _sqg_fp16_d3l_table(bits: int) -> np.ndarray:
+    if bits not in (5, 6):
+        raise ValueError(f"unsupported SQG-FP16-D3L test rate K{bits}")
+    return sqg_fp16_d3l_direct_lut_cpu(bits).numpy()
 
 
 def _decode_lane(
@@ -128,9 +123,7 @@ def _decode_lane(
         first = tile_words[..., first_word % width].astype(np.uint64)
         last = tile_words[..., last_word % width].astype(np.uint64)
         merged = (first << np.uint64(32)) | last
-        window = ((merged >> np.uint64(shift)) & np.uint64(0xFFFF)).astype(
-            np.uint32
-        )
+        window = ((merged >> np.uint64(shift)) & np.uint64(0xFFFF)).astype(np.uint32)
         if codebook == "mcg":
             values.append(_decode_3inst_fp16(window))
         elif codebook == "mul1-e4m3":
@@ -139,6 +132,8 @@ def _decode_lane(
             values.append(_decode_sqg_cheb_normal_e4m3_fp16(window, bits))
         elif codebook == "sqg_e4m3":
             values.append(_decode_sqg_xor_cheb_t12_fp16(window, bits))
+        elif codebook == "sqg_fp16":
+            values.append(_sqg_fp16_d3l_table(bits)[window])
         else:
             raise ValueError(f"unsupported test codebook {codebook!r}")
     return np.stack(values, axis=-1).astype(np.float16)
@@ -159,9 +154,7 @@ def _reconstruct_native(
         for n_tile in range(n_tiles):
             lanes = np.stack(
                 [
-                    _decode_lane(
-                        words[k_tile, n_tile], lane, bits, codebook=codebook
-                    )
+                    _decode_lane(words[k_tile, n_tile], lane, bits, codebook=codebook)
                     for lane in range(32)
                 ]
             )
@@ -193,13 +186,8 @@ def _reference_mxfp8_rows(source: torch.Tensor) -> torch.Tensor:
     exponent = torch.ceil(torch.log2(safe)).clamp(-127, 127)
     scale = torch.pow(torch.tensor(2.0, device=source.device), exponent)
     scale = torch.where(max_abs > 0, scale, torch.ones_like(scale))
-    return (
-        (blocks / scale)
-        .to(torch.float8_e4m3fn)
-        .float()
-        .mul(scale)
-        .reshape(m, k)
-    )
+    return (blocks / scale).to(torch.float8_e4m3fn).float().mul(scale).reshape(m, k)
+
 
 def test_prepare_weight_delegates_without_copy(monkeypatch) -> None:
     tensors = tuple(torch.empty(0) for _ in range(3))
@@ -278,6 +266,21 @@ def test_prepare_pair_weight_rejects_malformed_descriptor_before_cuda(
         )
 
 
+def test_prepare_additive_weight_requires_rank_16(monkeypatch) -> None:
+    monkeypatch.setattr(api, "PreparedTrellis256DenseWeight", SimpleNamespace)
+    base = SimpleNamespace(
+        in_features=3,
+        out_features=4,
+        params_dtype=torch.bfloat16,
+        trellis=torch.empty(0, dtype=torch.bfloat16),
+    )
+    a = torch.empty((3, 8), dtype=torch.bfloat16)
+    b = torch.empty((4, 8), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match=r"\[in_features, 16\]"):
+        trellis_linear.prepare_additive_weight(base, a, b)
+
+
 def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
     x = torch.empty(0)
     weight = SimpleNamespace()
@@ -325,6 +328,113 @@ def test_run_delegates_caller_owned_capture_storage(monkeypatch) -> None:
     assert seen["kwargs"]["output_f16"] is output_f16
 
 
+def test_run_additive_uses_caller_owned_rank_storage(monkeypatch) -> None:
+    x = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    a = torch.arange(48, dtype=torch.float32).reshape(3, 16)
+    b = torch.arange(64, dtype=torch.float32).reshape(4, 16)
+    output = torch.ones((2, 4), dtype=torch.float32)
+    hidden = torch.empty((2, 16), dtype=torch.float32)
+    base = SimpleNamespace()
+    weight = api.PreparedAdditiveWeight(base=base, a_t=a.T.contiguous(), b=b, rank=16)
+    seen = {}
+
+    def fake_run(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return output
+
+    def fake_additive(x_value, a_t_value, b_value, hidden_value, output_value):
+        seen["additive"] = (x_value, a_t_value, b_value, hidden_value, output_value)
+        hidden_value.copy_(x_value @ a_t_value.T)
+        output_value.addmm_(hidden_value, b_value.T)
+
+    monkeypatch.setattr(api, "run", fake_run)
+    monkeypatch.setattr(api, "run_low_rank_additive", fake_additive)
+    expected = output.clone() + (x @ a) @ b.T
+    actual = trellis_linear.run_additive(
+        x,
+        weight,
+        low_rank_hidden=hidden,
+        output=output,
+    )
+
+    assert actual is output
+    assert torch.equal(actual, expected)
+    assert torch.equal(hidden, x @ a)
+    assert seen["args"] == (x, base)
+    assert seen["kwargs"]["output"] is output
+    assert all(
+        observed is expected
+        for observed, expected in zip(
+            seen["additive"],
+            (x, weight.a_t, b, hidden, output),
+            strict=True,
+        )
+    )
+
+
+def test_run_additive_pair_preserves_bases_before_shared_buffer_reuse(
+    monkeypatch,
+) -> None:
+    x = torch.ones((2, 4), dtype=torch.bfloat16)
+    left = SimpleNamespace(
+        in_features=4,
+        out_features=3,
+        trellis=torch.empty(0, dtype=torch.int16),
+        trellis_bits=5,
+        trellis_codebook="sqg_fp16",
+    )
+    right = SimpleNamespace(
+        in_features=4,
+        out_features=3,
+        trellis=torch.empty(0, dtype=torch.int16),
+        trellis_bits=5,
+        trellis_codebook="sqg_fp16",
+    )
+    weight = api.PreparedAdditivePair(
+        left=left,
+        right=right,
+        a_t=torch.empty((2, 16, 4), dtype=torch.bfloat16),
+        b=torch.empty((2, 3, 16), dtype=torch.bfloat16),
+        rank=16,
+    )
+    base_output = torch.empty((2, 3), dtype=torch.bfloat16)
+    base_buffers = api.Buffers(
+        output=base_output,
+        gemm_output=torch.empty_like(base_output),
+        c_tmp=torch.empty(1),
+        rotated_f16=torch.empty((2, 4), dtype=torch.float16),
+    )
+    buffers = api.PairBuffers(
+        base=base_buffers,
+        output=torch.empty((2, 6), dtype=torch.bfloat16),
+        low_rank_hidden=torch.empty((2, 2, 16), dtype=torch.bfloat16),
+    )
+    events = []
+
+    def fake_project(*_args):
+        events.append("project")
+
+    def fake_run(_x, base, **kwargs):
+        events.append("left" if base is left else "right")
+        kwargs["output"].fill_(1 if base is left else 2)
+        return kwargs["output"]
+
+    def fake_add(*_args):
+        events.append("add")
+        buffers.output.add_(3)
+
+    monkeypatch.setattr(api, "run_low_rank_pair_project", fake_project)
+    monkeypatch.setattr(api, "run", fake_run)
+    monkeypatch.setattr(api, "run_low_rank_pair_add", fake_add)
+    actual = trellis_linear.run_additive_pair(x, weight, buffers=buffers)
+
+    assert actual is buffers.output
+    assert events == ["project", "left", "right", "add"]
+    assert torch.equal(actual[:, :3], torch.full((2, 3), 4, dtype=torch.bfloat16))
+    assert torch.equal(actual[:, 3:], torch.full((2, 3), 5, dtype=torch.bfloat16))
+
+
 def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
     seen = {}
 
@@ -369,6 +479,7 @@ def test_dense_launch_geometry_avoids_short_spill_waves(
         )
         == expected
     )
+
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
 def test_trellis_dense_cuda_graph_replay_is_stable() -> None:
@@ -502,9 +613,7 @@ def test_dense_sqg_xor_cheb_t12_matches_reference(bits: int) -> None:
         params_dtype=torch.float16,
     )
     assert weight.trellis_codebook == "sqg_e4m3"
-    reference_weight = _reconstruct_native(
-        trellis, codebook="sqg_e4m3"
-    ).to(device)
+    reference_weight = _reconstruct_native(trellis, codebook="sqg_e4m3").to(device)
     x = (torch.randn((m, features), device=device) * 1.0e-3).to(torch.float16)
 
     def identity_hadamard(
@@ -538,6 +647,189 @@ def test_dense_sqg_xor_cheb_t12_matches_reference(bits: int) -> None:
     )
     assert float(relative_error) <= 2.0e-2
     assert float(cosine) >= 0.999
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("bits", [5, 6])
+def test_dense_sqg_fp16_additive_matches_reference_and_captures(bits: int) -> None:
+    """Close packed K5/K6 plus a rank-16 branch through eager and graph paths."""
+
+    torch.manual_seed(0xD3F16 + bits)
+    device = torch.device("cuda", torch.cuda.current_device())
+    m = 3
+    features = 128
+    rank = 16
+    trellis = torch.randint(
+        -32768,
+        32767,
+        (features // 16, features // 16, 16 * bits),
+        dtype=torch.int16,
+        device=device,
+    )
+    scale = torch.ones(features, dtype=torch.float16, device=device)
+    base = trellis_linear.prepare_weight(
+        trellis,
+        scale,
+        scale.clone(),
+        codebook="sqg_fp16",
+        params_dtype=torch.bfloat16,
+    )
+    a = (torch.randn((features, rank), device=device) * 1.0e-2).to(torch.bfloat16)
+    b = (torch.randn((features, rank), device=device) * 1.0e-2).to(torch.bfloat16)
+    weight = trellis_linear.prepare_additive_weight(base, a, b)
+    a_t_before = weight.a_t.clone()
+    b_before = weight.b.clone()
+    buffers = trellis_linear.make_buffers(
+        weight,
+        size_m=m,
+        input_dtype=torch.bfloat16,
+    )
+    x = (torch.randn((m, features), device=device) * 1.0e-3).to(torch.bfloat16)
+
+    def identity_hadamard(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        _left_scale,
+        _right_scale,
+        _scale: float,
+    ) -> None:
+        destination.copy_(source)
+
+    actual = trellis_linear.run_additive(
+        x,
+        weight,
+        low_rank_hidden=buffers.low_rank_hidden,
+        hadamard_128=identity_hadamard,
+        **buffers.run_kwargs(),
+    ).clone()
+    torch.cuda.synchronize(device)
+
+    reference_weight = _reconstruct_native(
+        trellis,
+        codebook="sqg_fp16",
+    ).to(device=device, dtype=torch.bfloat16)
+    rotated_x = x.to(torch.float16).to(torch.bfloat16)
+    reference_base = (rotated_x @ reference_weight).to(torch.float16).to(torch.bfloat16)
+    expected = reference_base + (x @ a) @ b.T
+    relative_error = (actual - expected).float().norm() / expected.float().norm()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().flatten(), expected.float().flatten(), dim=0
+    )
+    assert float(relative_error) <= 2.0e-2
+    assert float(cosine) >= 0.999
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = trellis_linear.run_additive(
+            x,
+            weight,
+            low_rank_hidden=buffers.low_rank_hidden,
+            hadamard_128=identity_hadamard,
+            **buffers.run_kwargs(),
+        )
+    buffers.output.fill_(float("nan"))
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    allocated_after = torch.cuda.memory_allocated(device)
+    assert torch.equal(captured, actual)
+    assert allocated_after == allocated_before
+    assert torch.equal(weight.a_t, a_t_before)
+    assert torch.equal(weight.b, b_before)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_dense_sqg_fp16_additive_pair_matches_reference_and_captures() -> None:
+    """Close paired gate/up factors through eager and CUDA-graph execution."""
+
+    torch.manual_seed(0xD3F162)
+    device = torch.device("cuda", torch.cuda.current_device())
+    rows = 3
+    features = 128
+    trellises = [
+        torch.randint(
+            -32768,
+            32767,
+            (features // 16, features // 16, 16 * 5),
+            dtype=torch.int16,
+            device=device,
+        )
+        for _ in range(2)
+    ]
+    scale = torch.ones(features, dtype=torch.float16, device=device)
+    bases = [
+        trellis_linear.prepare_weight(
+            trellis,
+            scale.clone(),
+            scale.clone(),
+            codebook="sqg_fp16",
+            params_dtype=torch.bfloat16,
+        )
+        for trellis in trellises
+    ]
+    a = (torch.randn((2, features, 16), device=device) * 1.0e-2).to(torch.bfloat16)
+    b = (torch.randn((2, features, 16), device=device) * 1.0e-2).to(torch.bfloat16)
+    weight = trellis_linear.prepare_additive_pair(*bases, a, b)
+    buffers = trellis_linear.make_pair_buffers(
+        weight,
+        size_m=rows,
+        input_dtype=torch.bfloat16,
+    )
+    x = (torch.randn((rows, features), device=device) * 1.0e-3).to(torch.bfloat16)
+
+    def identity_hadamard(
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        _left_scale,
+        _right_scale,
+        _scale: float,
+    ) -> None:
+        destination.copy_(source)
+
+    actual = trellis_linear.run_additive_pair(
+        x,
+        weight,
+        buffers=buffers,
+        hadamard_128=identity_hadamard,
+    ).clone()
+    torch.cuda.synchronize(device)
+
+    expected_parts = []
+    rotated_x = x.to(torch.float16).to(torch.bfloat16)
+    for index, trellis in enumerate(trellises):
+        decoded = _reconstruct_native(trellis, codebook="sqg_fp16").to(
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        base = (rotated_x @ decoded).to(torch.float16).to(torch.bfloat16)
+        hidden = (x @ a[index]).to(torch.bfloat16)
+        correction = (hidden @ b[index].T).to(torch.bfloat16)
+        expected_parts.append((base + correction).to(torch.bfloat16))
+    expected = torch.cat(expected_parts, dim=1)
+    relative_error = (actual - expected).float().norm() / expected.float().norm()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().flatten(), expected.float().flatten(), dim=0
+    )
+    assert float(relative_error) <= 2.0e-2
+    assert float(cosine) >= 0.999
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = trellis_linear.run_additive_pair(
+            x,
+            weight,
+            buffers=buffers,
+            hadamard_128=identity_hadamard,
+        )
+    buffers.output.fill_(float("nan"))
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    graph.replay()
+    torch.cuda.synchronize(device)
+    allocated_after = torch.cuda.memory_allocated(device)
+    assert torch.equal(captured, actual)
+    assert allocated_after == allocated_before
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
@@ -607,11 +899,7 @@ def test_dense_pair_matches_independent_reference_and_captures(
     suh = torch.ones(reference_weight.shape[0], dtype=torch.float16, device=device)
     svh = torch.ones(reference_weight.shape[1], dtype=torch.float16, device=device)
     codebook_kwargs = (
-        {
-            "mcg": torch.tensor(
-                0xCBAC1FED, dtype=torch.uint32, device=device
-            )
-        }
+        {"mcg": torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device)}
         if codebook == "mcg"
         else {"codebook": codebook}
     )
@@ -686,12 +974,6 @@ def test_dense_pair_matches_independent_reference_and_captures(
     graph.replay()
     torch.cuda.synchronize(device)
     assert torch.equal(captured, actual)
-
-
-
-
-
-
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -75,6 +75,61 @@ def test_capacity_buffer_views_reuse_storage_without_cache_growth() -> None:
         api.view_pair_buffers(pair, size_m=0)
 
 
+def test_trellis_mutating_custom_ops_support_fake_tensor_tracing() -> None:
+    """Every opaque serving operator must expose its mutation schema to Dynamo."""
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    with FakeTensorMode():
+        source = torch.empty((3, 128), dtype=torch.float16)
+        destination = torch.empty_like(source)
+        optional_scale = torch.empty(0, dtype=torch.float16)
+        torch.ops.b12x.trellis_hadamard_128(
+            source,
+            destination,
+            optional_scale,
+            optional_scale,
+            False,
+            False,
+            1.0,
+        )
+
+        rotated = torch.empty((3, 256), dtype=torch.bfloat16)
+        trellis = torch.empty((16, 16, 80), dtype=torch.int16)
+        scales = torch.empty((16, 16), dtype=torch.float16)
+        global_scale = torch.ones(1, dtype=torch.float32)
+        workspace = torch.empty(4096, dtype=torch.int32)
+        c_tmp = torch.empty(256, dtype=torch.float32)
+        output = torch.empty((3, 256), dtype=torch.bfloat16)
+        torch.ops.b12x.trellis256_dense_gemm(
+            rotated,
+            trellis,
+            scales,
+            global_scale,
+            workspace,
+            c_tmp,
+            output,
+            5,
+            "sqg_fp16",
+            "",
+            "",
+            64,
+            64,
+            128,
+        )
+
+        rank = 16
+        a_t = torch.empty((rank, 256), dtype=torch.bfloat16)
+        b = torch.empty((256, rank), dtype=torch.bfloat16)
+        hidden = torch.empty((3, rank), dtype=torch.bfloat16)
+        torch.ops.b12x.trellis_low_rank_additive(
+            rotated,
+            a_t,
+            b,
+            hidden,
+            output,
+        )
+
+
 def _decode_3inst_fp16(window: np.ndarray) -> np.ndarray:
     value = window.astype(np.uint64)
     value = ((value * _MCG) & np.uint64(0xFFFFFFFF)).astype(np.uint32)

--- a/tests/gemm/test_trellis_linear.py
+++ b/tests/gemm/test_trellis_linear.py
@@ -29,6 +29,52 @@ def _sm12x_available() -> bool:
     return major == 12 and minor in (0, 1)
 
 
+def _capacity_buffers(capacity: int) -> api.Buffers:
+    def matrix(width: int, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        return torch.empty((capacity, width), dtype=dtype)
+
+    return api.Buffers(
+        output=matrix(7),
+        gemm_output=matrix(7),
+        c_tmp=torch.empty(31, dtype=torch.float32),
+        input_f16=matrix(5, torch.float16),
+        rotated_f16=matrix(5, torch.float16),
+        rotated_compute=matrix(5),
+        gemm_output_f16=matrix(7, torch.float16),
+        output_f16=matrix(7, torch.float16),
+        low_rank_hidden=matrix(16),
+    )
+
+
+def test_capacity_buffer_views_reuse_storage_without_cache_growth() -> None:
+    capacity = 8
+    buffers = _capacity_buffers(capacity)
+    view = api.view_buffers(buffers, size_m=3)
+    assert view.output.shape == (3, 7)
+    assert view.low_rank_hidden is not None
+    assert view.low_rank_hidden.shape == (3, 16)
+    assert view.output.data_ptr() == buffers.output.data_ptr()
+    assert view.c_tmp is buffers.c_tmp
+    assert view.output.is_contiguous()
+
+    pair = api.PairBuffers(
+        base=buffers,
+        output=torch.empty((capacity, 14), dtype=torch.bfloat16),
+        low_rank_hidden=torch.empty((2, capacity, 16), dtype=torch.bfloat16),
+    )
+    pair_view = api.view_pair_buffers(pair, size_m=3)
+    assert pair_view.output.shape == (3, 14)
+    assert pair_view.low_rank_hidden.shape == (2, 3, 16)
+    assert pair_view.output.data_ptr() == pair.output.data_ptr()
+    assert pair_view.low_rank_hidden.data_ptr() == pair.low_rank_hidden.data_ptr()
+    assert pair_view.low_rank_hidden.is_contiguous()
+
+    with pytest.raises(ValueError, match=r"\[1, 8\]"):
+        api.view_buffers(buffers, size_m=9)
+    with pytest.raises(ValueError, match=r"\[1, 8\]"):
+        api.view_pair_buffers(pair, size_m=0)
+
+
 def _decode_3inst_fp16(window: np.ndarray) -> np.ndarray:
     value = window.astype(np.uint64)
     value = ((value * _MCG) & np.uint64(0xFFFFFFFF)).astype(np.uint32)

--- a/tests/test_vllm_qsrt_plugin.py
+++ b/tests/test_vllm_qsrt_plugin.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from b12x.integration.vllm.qsrt_plugin import (
+    BITS,
+    DESCRIPTOR_SHA256,
+    QUANT_NAME,
+    RANK,
+    _capture_sizes,
+    _norm_key,
+    _parameter_loader,
+    _projection_group,
+    _validate_quantization_config,
+)
+
+
+def _config() -> dict[str, object]:
+    return {
+        "quant_method": QUANT_NAME,
+        "format": "qwen38_dense_mlp_qsrt_k5_rank16",
+        "bits": BITS,
+        "codebook": "sqg_fp16",
+        "descriptor_sha256": DESCRIPTOR_SHA256,
+        "rank": RANK,
+        "tensor_parallel_size": 1,
+        "modules": [
+            f"model.language_model.layers.{layer}.mlp.{projection}"
+            for layer in range(64)
+            for projection in ("gate_proj", "up_proj", "down_proj")
+        ],
+    }
+
+
+def test_quantization_config_claims_only_complete_decoder_mlps() -> None:
+    modules = set(_validate_quantization_config(_config()))
+    assert len(modules) == 192
+    assert _norm_key("language_model.model.layers.7.mlp.down_proj") in modules
+    assert (
+        _projection_group(
+            "language_model.model.layers.7.mlp.gate_up_proj",
+            modules,
+        )
+        == "gate_up"
+    )
+    assert (
+        _projection_group(
+            "language_model.model.layers.7.self_attn.qkv_proj",
+            modules,
+        )
+        is None
+    )
+
+
+def test_quantization_config_rejects_an_incomplete_layer() -> None:
+    config = _config()
+    config["modules"] = config["modules"][:-1]
+    with pytest.raises(ValueError, match="incompatible"):
+        _validate_quantization_config(config)
+
+
+def test_stacked_payload_loader_is_exactly_once_and_dtype_strict() -> None:
+    loaded: set[tuple[str, int]] = set()
+    loader = _parameter_loader(
+        component="trellis",
+        stacked=True,
+        loaded_slots=loaded,
+    )
+    parameter = torch.nn.Parameter(
+        torch.zeros((2, 2, 3), dtype=torch.int16),
+        requires_grad=False,
+    )
+    value = torch.arange(6, dtype=torch.int16).reshape(2, 3)
+    loader(parameter, value, 1)
+    assert torch.equal(parameter[1], value)
+    assert loaded == {("trellis", 1)}
+    with pytest.raises(ValueError, match="loaded twice"):
+        loader(parameter, value, 1)
+    with pytest.raises(TypeError, match="must use"):
+        loader(parameter, value.float(), 0)
+
+
+def _install_fake_vllm_config(
+    monkeypatch: pytest.MonkeyPatch,
+    sizes: list[int],
+) -> None:
+    package = ModuleType("vllm")
+    config = ModuleType("vllm.config")
+    config.get_current_vllm_config = lambda: SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_capture_sizes=sizes)
+    )
+    package.config = config
+    monkeypatch.setitem(sys.modules, "vllm", package)
+    monkeypatch.setitem(sys.modules, "vllm.config", config)
+
+
+def test_capture_sizes_include_vllm_graph_geometries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_vllm_config(monkeypatch, [32, 64, 128])
+    assert _capture_sizes() == (1, 2, 4, 8, 16, 32, 64, 128)
+
+
+def test_capture_sizes_reject_rows_outside_packed_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_vllm_config(monkeypatch, [512, 1024])
+    with pytest.raises(NotImplementedError, match="at most 512 rows"):
+        _capture_sizes()

--- a/tests/test_vllm_qsrt_plugin.py
+++ b/tests/test_vllm_qsrt_plugin.py
@@ -16,6 +16,7 @@ from b12x.integration.vllm.qsrt_plugin import (
     _parameter_loader,
     _projection_group,
     _validate_quantization_config,
+    _workspace_capacity_rows,
 )
 
 
@@ -28,6 +29,7 @@ def _config() -> dict[str, object]:
         "descriptor_sha256": DESCRIPTOR_SHA256,
         "rank": RANK,
         "tensor_parallel_size": 1,
+        "workspace_capacity_rows": 8192,
         "modules": [
             f"model.language_model.layers.{layer}.mlp.{projection}"
             for layer in range(64)
@@ -56,11 +58,19 @@ def test_quantization_config_claims_only_complete_decoder_mlps() -> None:
     )
 
 
-def test_quantization_config_rejects_an_incomplete_layer() -> None:
+def test_quantization_config_rejects_a_short_module_inventory() -> None:
     config = _config()
     config["modules"] = config["modules"][:-1]
     with pytest.raises(ValueError, match="incompatible"):
         _validate_quantization_config(config)
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, True, 1.5])
+def test_workspace_capacity_requires_a_positive_integer(value: object) -> None:
+    config = _config()
+    config["workspace_capacity_rows"] = value
+    with pytest.raises(ValueError, match="workspace_capacity_rows"):
+        _workspace_capacity_rows(config)
 
 
 def test_stacked_payload_loader_is_exactly_once_and_dtype_strict() -> None:
@@ -102,12 +112,12 @@ def test_capture_sizes_include_vllm_graph_geometries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_vllm_config(monkeypatch, [32, 64, 128])
-    assert _capture_sizes() == (1, 2, 4, 8, 16, 32, 64, 128)
+    assert _capture_sizes(256) == (1, 2, 4, 8, 16, 32, 64, 128)
 
 
 def test_capture_sizes_reject_rows_outside_packed_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_vllm_config(monkeypatch, [512, 1024])
-    with pytest.raises(NotImplementedError, match="at most 512 rows"):
-        _capture_sizes()
+    with pytest.raises(NotImplementedError, match="capacity 512"):
+        _capture_sizes(512)

--- a/tests/test_vllm_qsrt_plugin.py
+++ b/tests/test_vllm_qsrt_plugin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -9,6 +11,8 @@ import torch
 from b12x.integration.vllm.qsrt_plugin import (
     BITS,
     DESCRIPTOR_SHA256,
+    QUALITY_SELECTION_FILENAME,
+    QUALITY_SELECTION_KIND,
     QUANT_NAME,
     RANK,
     _capture_sizes,
@@ -16,6 +20,8 @@ from b12x.integration.vllm.qsrt_plugin import (
     _parameter_loader,
     _projection_group,
     _select_linear_method,
+    _sha256,
+    _validate_quality_selection_receipt,
     _validate_quantization_config,
     _workspace_capacity_rows,
 )
@@ -88,6 +94,60 @@ def test_quantization_config_rejects_a_short_module_inventory() -> None:
     config["modules"] = config["modules"][:-1]
     with pytest.raises(ValueError, match="incompatible"):
         _validate_quantization_config(config)
+
+
+def test_quality_selection_receipt_binds_the_selected_overlay(tmp_path: Path) -> None:
+    report = {
+        "kind": QUALITY_SELECTION_KIND,
+        "schema_version": 1,
+        "status": "implemented",
+        "classification": "research-only",
+        "source_recovery": {
+            "complete_report_sha256": "a" * 64,
+            "adapter_manifest_sha256": "b" * 64,
+        },
+        "selected_overlay": {
+            "sha256": "c" * 64,
+            "step": 100,
+            "rank": RANK,
+            "variant": "weighted",
+            "tensor_count": 384,
+        },
+        "selection_contract": {
+            "metric": "strict-overlap-filtered token mean KLD",
+            "partition": "analysis",
+            "direction": "lower",
+        },
+    }
+    path = tmp_path / QUALITY_SELECTION_FILENAME
+    path.parent.mkdir()
+    path.write_text(json.dumps(report))
+    digest = _sha256(path)
+    config = {
+        "quality_selection_report": QUALITY_SELECTION_FILENAME,
+        "quality_selection_report_sha256": digest,
+    }
+    manifest = {
+        "build": {
+            "quality_selection_report_sha256": digest,
+            "recovery_report_sha256": "a" * 64,
+            "adapter_manifest_sha256": "b" * 64,
+            "recovery_overlay_sha256": "c" * 64,
+        },
+        "quality_selection": {
+            "status": "implemented",
+            "classification": "research-only",
+            "file": QUALITY_SELECTION_FILENAME,
+            "sha256": digest,
+            "selected_step": 100,
+            "selected_overlay_sha256": "c" * 64,
+        },
+    }
+
+    _validate_quality_selection_receipt(tmp_path, manifest, config)
+    path.write_text('{"status": "tampered"}\n')
+    with pytest.raises(ValueError, match="content differs"):
+        _validate_quality_selection_receipt(tmp_path, manifest, config)
 
 
 @pytest.mark.parametrize("value", [None, 0, -1, True, 1.5])

--- a/tests/test_vllm_qsrt_plugin.py
+++ b/tests/test_vllm_qsrt_plugin.py
@@ -19,6 +19,7 @@ from b12x.integration.vllm.qsrt_plugin import (
     _norm_key,
     _parameter_loader,
     _projection_group,
+    _require_cudagraphs_disabled,
     _select_linear_method,
     _sha256,
     _validate_quality_selection_receipt,
@@ -206,3 +207,23 @@ def test_capture_sizes_reject_rows_outside_packed_contract(
     _install_fake_vllm_config(monkeypatch, [512, 1024])
     with pytest.raises(NotImplementedError, match="capacity 512"):
         _capture_sizes(512)
+
+
+@pytest.mark.parametrize("mode", [0, SimpleNamespace(name="NONE"), "NONE"])
+def test_cuda_graph_contract_allows_disabled_modes(mode: object) -> None:
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=mode)
+    )
+    _require_cudagraphs_disabled(config)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [None, SimpleNamespace(name="FULL_AND_PIECEWISE"), "PIECEWISE"],
+)
+def test_cuda_graph_contract_rejects_graph_replay(mode: object) -> None:
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=mode)
+    )
+    with pytest.raises(ValueError, match="requires CUDA graphs to be disabled"):
+        _require_cudagraphs_disabled(config)

--- a/tests/test_vllm_qsrt_plugin.py
+++ b/tests/test_vllm_qsrt_plugin.py
@@ -15,6 +15,7 @@ from b12x.integration.vllm.qsrt_plugin import (
     _norm_key,
     _parameter_loader,
     _projection_group,
+    _select_linear_method,
     _validate_quantization_config,
     _workspace_capacity_rows,
 )
@@ -55,6 +56,30 @@ def test_quantization_config_claims_only_complete_decoder_mlps() -> None:
             modules,
         )
         is None
+    )
+
+
+def test_linear_method_selection_preserves_unclaimed_bf16_modules() -> None:
+    modules = set(_validate_quantization_config(_config()))
+    packed = object()
+    unquantized = object()
+    assert (
+        _select_linear_method(
+            "language_model.model.layers.7.mlp.gate_up_proj",
+            modules,
+            packed_method=packed,
+            unquantized_method=unquantized,
+        )
+        is packed
+    )
+    assert (
+        _select_linear_method(
+            "visual.merger.linear_fc1",
+            modules,
+            packed_method=packed,
+            unquantized_method=unquantized,
+        )
+        is unquantized
     )
 
 


### PR DESCRIPTION
## Resulting behavior

This change implements a research-only TP1 packed dense-MLP path for
Qwen3.8-27B checkpoints produced by `local-inference-lab/qsrt`. The
`b12x_qsrt` vLLM plugin claims exactly the `gate_proj`, `up_proj`, and
`down_proj` modules in all 64 decoder layers. Each claimed projection executes
its native five-bit `sqg_fp16_d3l` trellis payload plus an additive rank-16
BF16 correction. The claimed path has no decoded-matrix or Torch fallback.

Gate and up retain independent payloads and rotations and use the paired
projection and output-add operators. Down uses the corresponding
single-projection operators. Attention, gated-DeltaNet, normalization,
embeddings, vision, MTP, and output-head modules remain unquantized and are
not claimed by this plugin.

## Operation contract

- TP1, BF16 activations, rank 16, uniform K5, and SM120/SM121 are supported.
- The checkpoint manifest, tensor index, configuration hashes, exact
  192-module allowlist, payload shapes, dtypes, quality-selection receipt, and
  exactly-once loading are validated before execution.
- `workspace_capacity_rows` declares the maximum flattened activation rows
  accepted by one serving step.
- Gate/up and down each allocate one geometry-specific buffer pool at the
  declared capacity during weight processing. Smaller requests use exact-row
  views backed by that fixed storage; request row count does not create another
  CUDA allocation or cache entry.
- Requests above the declared capacity fail before execution.
- Packed offsets use 64-bit arithmetic.
- Compiled execution retains static rank, width, dtype, device, and contiguity
  checks. Real kernel-facing buffer addresses are checked for 16-byte alignment
  inside the opaque GEMM operator immediately before launch.
- Direct packed-projection CUDA-graph capture is supported and qualified.
  Whole-model vLLM CUDA-graph replay is unsupported and rejected before
  checkpoint weights load. `torch.compile` remains supported when
  `cudagraph_mode` is `NONE`.

## Compatibility

The additive API is opt-in through prepared additive weights, fixed-capacity
buffer constructors, exact-row buffer views, and the single or paired
execution functions. vLLM discovers the integration through the `b12x_qsrt`
general-plugin entry point. Unsupported checkpoints, ranks, devices, and
linear modules are not claimed.

The plugin is qualified only for the research-only
`Qwen3.8-27B-QSRT-K5-MLP-r16-quality-step0000-v1` artifact. It is not a
production MXFP8-tier replacement: attention-path tensors remain BF16 and
paired serving performance is outside the qualified scope.

## Validation

- CPU plugin, manifest, additive API, and report-contract tests pass; Ruff,
  formatting, bytecode compilation, and diff checks pass.
- All 47 focused Trellis-linear tests pass on SM120 after the compiled-buffer
  validation change. A full-graph K5-plus-rank-16 reproducer remains bit-exact
  with eager execution and rejects a contiguous 2-byte-offset GEMM output
  before launch.
- The guarded CUDA 13.3 / PyTorch 2.13 runtime image passes 93 GPU tests.
- All 192 selected payloads across 64 layers pass packed output and
  input-vector Jacobian parity against decoded BF16, immutable-weight and
  stable-buffer checks, replay-allocation checks, and bit-exact direct
  eager/CUDA-graph checks.
- Every layer covers one and 128 rows. Layers 0, 31, and 63 additionally cover
  8, 32, 512, 2,048, and 8,192 rows.
- A controlled whole-model reproducer retrieves 4/8 deterministic needles
  under CUDA-graph replay and 8/8 in eager and compiled no-graph modes. The
  guarded plugin rejects the unsupported graph-enabled configuration before
  weight loading.
- The guarded image's default launcher retains `torch.compile`, disables CUDA
  graphs, and retrieves all 8/8 short-context needles at
  `max_model_len=261632`.
- Same-runtime 32,768-token fidelity over 32,767 positions measures mean KLD
  `0.00274572946`, p99 KLD `0.0229173`, and top-1 agreement `97.7020%`; the
  paired MXFP8-T3 checkpoint measures `0.00633584211`, `0.0492137`, and
  `96.9451%`.
- Full-population fidelity covers 5,120 contexts and 10,480,640 positions.
  Packed QSRT versus runtime-native vLLM BF16 measures mean KLD
  `0.00312287968`, p99 KLD `0.0313921`, and 97.5076% top-1 agreement. On the
  832-context contamination-excluded qualification population, packed versus
  decoded mean-KLD ratio is `1.0073154`, and packed QSRT beats MXFP8-T3 by
  `-0.00312210337` with 95% interval
  `[-0.00380504174, -0.00264499683]`.
- Deterministic task retention is 40/40 with no BF16 regression, and all eight
  needles are retrieved at approximately 2k, 100k, and 195k context levels.
  Public capability is qualified: 56/70 questions pass, 55/57 BF16-pass
  questions remain passing, and the paired run has two regressions, one
  improvement, and 67/70 pass/fail agreement.
- Target-only, MTP3, DSpark7, 2K/8K/32K prefill, and the fixed vision fixture
  pass their functional gates. Serving performance remains unsupported:
  packed target-only decode is `2.1763` tok/s versus MXFP8-T3 at `20.4046`
  tok/s.
- Research-artifact publication is qualified by release-decision SHA-256
  `52d4fea4cad5ef112c5d4b616b0d1138cbc2d1b8ea95c96aff064803778999bd`;
  the published image is
  `voipmonitor/vllm@sha256:47109f9fa6d84ad15e3b92615c186d9a9a413dec8ef07f6a6410f96f75a48b6a`.

The immutable runtime image uses B12X pull-request commit
`1dfe87039951735b39e937e4a1d1bffe25b79e79` and reconciled B12X tree
`28f10076d5df9898d0d68ac41edec0f787c93b57`. The image and complete source
inventory are published by
[blackwell-llm-docker#27](https://github.com/local-inference-lab/blackwell-llm-docker/pull/27).
Pull-request head `fe96602864fe8b1dbcc1322af9a8fd6a1c7b3c22` adds
fail-closed compiled-buffer validation, an actual full-graph validation
regression, and standalone selection-report help.
The immutable image path allocates these buffers with `make_buffers` and
validates them during eager warmup, so the head change does not alter the
qualified valid-buffer execution path.
