### PR TITLE
fix(moe): sanitize inactive QSRT W4A16 routes

### DIFF
--- a/b12x/moe/_shared/kernels/micro.py
+++ b/b12x/moe/_shared/kernels/micro.py
@@ -406,6 +406,7 @@ class MoEMicroKernelBackend:
         weight_layout: str = "modelopt",
         trellis_bits: int | None = None,
         trellis_coupled: bool = False,
+        stage_inactive_routes: bool = False,
     ):
         activation = normalize_moe_activation(activation)
         if int(compile_time_phase) not in {0, 1, 2}:
@@ -473,8 +474,10 @@ class MoEMicroKernelBackend:
         self.weight_layout_trellis256 = weight_layout == "trellis3_t256"
         self.trellis_bits = 0 if trellis_bits is None else int(trellis_bits)
         self.trellis_coupled = bool(trellis_coupled)
+        self.stage_inactive_routes = bool(stage_inactive_routes)
         self.trellis_ksplit = 1
         self.trellis_scratch_u32 = 0
+        self.route_slots = 0
         self._cfg = None
         self.m_const = 0
         self.m1_fc2_onepass = False
@@ -497,6 +500,7 @@ class MoEMicroKernelBackend:
             self.weight_layout,
             self.trellis_bits,
             self.trellis_coupled,
+            self.stage_inactive_routes,
             self.trellis_ksplit,
             self.scale_format,
             self.e8m0_scale_layout,
@@ -511,6 +515,7 @@ class MoEMicroKernelBackend:
             self.m1_fc2_onepass,
             self.m1_fc2_rows_per_cta,
             self.launch_block_dim,
+            self.route_slots,
         )
 
     @cute.jit
@@ -547,6 +552,32 @@ class MoEMicroKernelBackend:
                 + w31 * x31
             )
         return fp4_dot4_sum_f32acc(u_packed, x0, x1, x2, x3)
+
+    @cute.jit
+    def _fc2_route(
+        self,
+        topk_ids: cute.Tensor,
+        topk_weights: cute.Tensor,
+        eid_addr: Int32,
+        route_expert_limit: Int32,
+    ) -> Tuple[Int32, Float32]:
+        """Return an addressable expert and its effective router weight.
+
+        Fixed-M fused launches receive a route table sanitized in shared
+        memory before FC1 and FC2 execute. The FC2-only endpoint instead uses
+        runtime M with a compile-time expert-capacity bucket, so it must check
+        each route against the resident expert count supplied by the caller.
+        Invalid routes address expert zero with an exact-zero effective weight.
+        """
+        if cutlass.const_expr(self.compile_time_phase == 2):
+            raw_expert = Int64(topk_ids[eid_addr])
+            expert = Int32(0)
+            weight = Float32(0.0)
+            if raw_expert >= Int64(0) and raw_expert < Int64(route_expert_limit):
+                expert = Int32(raw_expert)
+                weight = Float32(topk_weights[eid_addr])
+            return expert, weight
+        return Int32(topk_ids[eid_addr]), Float32(topk_weights[eid_addr])
 
     @cute.jit
     def _scale_byte_to_f32(self, byte: Uint32) -> Float32:
@@ -894,6 +925,7 @@ class MoEMicroKernelBackend:
         self.m1_fc2_rows_per_cta = m1_fc2_rows
         self.launch_block_dim = _K_PER_CTA * 16 if m1_half_cta_fc2 else _BLOCK_DIM
         self.grid_x = grid_x
+        self.route_slots = m * cfg.num_topk
         # Required inter_fp32 element count: the per-token intermediate plus
         # the trellis K-split scratch tail. Callers must zero-initialize; the
         # kernel restores the tail to zero after each use.
@@ -933,6 +965,7 @@ class MoEMicroKernelBackend:
         w2_alphas: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
     ):
         cfg = self._cfg
@@ -965,8 +998,9 @@ class MoEMicroKernelBackend:
 
         for kk in cutlass.range_constexpr(cfg.num_topk):
             eid_addr = Int32(kk)
-            eid = Int32(topk_ids[eid_addr])
-            router_w = topk_weights[eid_addr]
+            eid, router_w = self._fc2_route(
+                topk_ids, topk_weights, eid_addr, route_expert_limit
+            )
             if cutlass.const_expr(
                 self.w4a16_mode
                 and (not self.is_gated)
@@ -1165,6 +1199,7 @@ class MoEMicroKernelBackend:
         w2_alphas: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
     ):
         cfg = self._cfg
@@ -1190,8 +1225,9 @@ class MoEMicroKernelBackend:
 
         for kk in cutlass.range_constexpr(cfg.num_topk):
             eid_addr = Int32(kk)
-            eid = Int32(topk_ids[eid_addr])
-            router_w = topk_weights[eid_addr]
+            eid, router_w = self._fc2_route(
+                topk_ids, topk_weights, eid_addr, route_expert_limit
+            )
             if cutlass.const_expr(
                 self.w4a16_mode
                 and (not self.is_gated)
@@ -1405,6 +1441,7 @@ class MoEMicroKernelBackend:
         w2_alphas: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
     ):
         cfg = self._cfg
@@ -1445,8 +1482,9 @@ class MoEMicroKernelBackend:
 
         for kk in cutlass.range_constexpr(cfg.num_topk):
             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
-            eid = Int32(topk_ids[eid_addr])
-            router_w = topk_weights[eid_addr]
+            eid, router_w = self._fc2_route(
+                topk_ids, topk_weights, eid_addr, route_expert_limit
+            )
             if cutlass.const_expr(
                 self.w4a16_mode
                 and (not self.is_gated)
@@ -1636,6 +1674,7 @@ class MoEMicroKernelBackend:
         w2_alphas: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
     ):
         cfg = self._cfg
@@ -1673,8 +1712,9 @@ class MoEMicroKernelBackend:
 
         for kk in cutlass.range_constexpr(cfg.num_topk):
             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
-            eid = Int32(topk_ids[eid_addr])
-            router_w = topk_weights[eid_addr]
+            eid, router_w = self._fc2_route(
+                topk_ids, topk_weights, eid_addr, route_expert_limit
+            )
             if cutlass.const_expr(
                 self.w4a16_mode
                 and (not self.is_gated)
@@ -1870,6 +1910,7 @@ class MoEMicroKernelBackend:
         w2_alphas: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
     ):
         cfg = self._cfg
@@ -1919,8 +1960,9 @@ class MoEMicroKernelBackend:
 
         for kk in cutlass.range_constexpr(cfg.num_topk):
             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
-            eid = Int32(topk_ids[eid_addr])
-            router_w = topk_weights[eid_addr]
+            eid, router_w = self._fc2_route(
+                topk_ids, topk_weights, eid_addr, route_expert_limit
+            )
             if cutlass.const_expr(
                 self.w4a16_mode
                 and (not self.is_gated)
@@ -2393,12 +2435,44 @@ class MoEMicroKernelBackend:
         barrier_epoch: cute.Tensor,
         trellis_lut: cute.Tensor,
         trellis_rotations: cute.Tensor,
+        route_expert_limit: Int32,
         m_val: Int32,
     ):
         cfg = self._cfg
         bidx_x, _, _ = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
         gdim_x, _, _ = cute.arch.grid_dim()
+        if cutlass.const_expr(self.stage_inactive_routes):
+            # The native direct path bypasses dynamic route packing, so stage
+            # its bounded route table once per CTA. Invalid IDs receive an
+            # addressable placeholder and an exact-zero effective weight.
+            # Inner FC1/FC2 loops then retain their unchecked hot path while
+            # caller-owned route tensors remain unchanged across graph replay.
+            staged_ids_ptr = cute.arch.alloc_smem(Int32, self.route_slots)
+            staged_weights_ptr = cute.arch.alloc_smem(Float32, self.route_slots)
+            staged_ids = cute.make_tensor(
+                staged_ids_ptr, cute.make_layout(self.route_slots)
+            )
+            staged_weights = cute.make_tensor(
+                staged_weights_ptr, cute.make_layout(self.route_slots)
+            )
+            route_slot = Int32(tidx)
+            while route_slot < Int32(self.route_slots):
+                raw_expert = Int64(topk_ids[route_slot])
+                expert = Int32(0)
+                weight = Float32(0.0)
+                if (
+                    raw_expert >= Int64(0)
+                    and raw_expert < Int64(route_expert_limit)
+                ):
+                    expert = Int32(raw_expert)
+                    weight = Float32(topk_weights[route_slot])
+                staged_ids[route_slot] = expert
+                staged_weights[route_slot] = weight
+                route_slot += Int32(self.launch_block_dim)
+            cute.arch.sync_threads()
+            topk_ids = staged_ids
+            topk_weights = staged_weights
         if cutlass.const_expr(self.compile_time_phase == 2):
             self._run_fc2(
                 Int32(bidx_x),
@@ -2412,6 +2486,7 @@ class MoEMicroKernelBackend:
                 intermediate,
                 topk_ids,
                 topk_weights,
+                route_expert_limit,
                 scatter_output,
                 trellis_lut,
             )
@@ -5500,6 +5575,7 @@ class MoEMicroKernelBackend:
             intermediate,
             topk_ids,
             topk_weights,
+            route_expert_limit,
             scatter_output,
             trellis_lut,
         )
@@ -5631,6 +5707,7 @@ class MoEMicroKernelBackend:
         intermediate: cute.Tensor,
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
+        route_expert_limit: Int32,
         scatter_output: cute.Tensor,
         trellis_lut: cute.Tensor,
     ):
@@ -5674,6 +5751,7 @@ class MoEMicroKernelBackend:
                             w2_alphas,
                             topk_ids,
                             topk_weights,
+                            route_expert_limit,
                             scatter_output,
                         )
                     else:
@@ -5687,6 +5765,7 @@ class MoEMicroKernelBackend:
                             w2_alphas,
                             topk_ids,
                             topk_weights,
+                            route_expert_limit,
                             scatter_output,
                         )
             else:
@@ -5703,6 +5782,7 @@ class MoEMicroKernelBackend:
                             w2_alphas,
                             topk_ids,
                             topk_weights,
+                            route_expert_limit,
                             scatter_output,
                         )
                     else:
@@ -5716,6 +5796,7 @@ class MoEMicroKernelBackend:
                             w2_alphas,
                             topk_ids,
                             topk_weights,
+                            route_expert_limit,
                             scatter_output,
                         )
                     fc2_task += Int32(gdim_x)
@@ -5740,6 +5821,7 @@ class MoEMicroKernelBackend:
                         w2_alphas,
                         topk_ids,
                         topk_weights,
+                        route_expert_limit,
                         scatter_output,
                     )
                 elif cutlass.const_expr(cfg.fc2_n_chunks > 1):
@@ -5753,6 +5835,7 @@ class MoEMicroKernelBackend:
                         w2_alphas,
                         topk_ids,
                         topk_weights,
+                        route_expert_limit,
                         scatter_output,
                     )
                 else:
@@ -5766,6 +5849,7 @@ class MoEMicroKernelBackend:
                         w2_alphas,
                         topk_ids,
                         topk_weights,
+                        route_expert_limit,
                         scatter_output,
                     )
                 fc2_task += Int32(gdim_x)
@@ -5788,6 +5872,7 @@ class MoEMicroKernelBackend:
         out_ptr: cute.Pointer,
         barrier_count: cute.Tensor,
         barrier_epoch: cute.Tensor,
+        route_expert_limit: Int32,
         m_val: Int32,
         grid_x: Int32,
         stream,
@@ -5888,6 +5973,7 @@ class MoEMicroKernelBackend:
                 if cutlass.const_expr(trellis_rot_ptr is not None)
                 else barrier_count
             ),
+            route_expert_limit,
             m_val,
         ).launch(
             grid=(grid_x, Int32(1), Int32(1)),
@@ -5950,6 +6036,7 @@ class MoEMicroKernelBackend:
             ptr(cutlass.BFloat16, out),
             barrier_count,
             barrier_epoch,
+            Int32(w1_alphas.numel()),
             Int32(m),
             Int32(grid_x),
             stream,

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -771,6 +771,9 @@ class MoEMicroKernelW4A16SmallMDirect(MoEMicroKernelBackend):
             swiglu_beta=swiglu_beta,
             w13_layout=w13_layout,
             compile_time_phase=compile_time_phase,
+            # Fused direct launches have a compile-time route-table extent.
+            # FC2-only uses runtime M and sanitizes each route inside FC2.
+            stage_inactive_routes=int(compile_time_phase) != 2,
         )
 
 
@@ -9191,12 +9194,13 @@ def _compile_w4a16_small_m_direct(
         dummy(cutlass.BFloat16),
         barrier_fake,
         barrier_fake,
+        Int32(num_experts),
         Int32(m),
         Int32(kernel.grid_x),
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_facts(
             "moe.w4a16.small_m_direct",
-            1,
+            2,
             ("device_index", None if device is None else int(device.index or 0)),
             ("m", int(m)),
             ("hidden_size", int(hidden_size)),
@@ -9328,12 +9332,13 @@ def _compile_w4a16_fc2_direct(
         dummy(cutlass.BFloat16),
         barrier_fake,
         barrier_fake,
+        Int32(expert_capacity),
         Int32(2),
         Int32(kernel.grid_x),
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_facts(
             "moe.w4a16.fc2_direct",
-            3,
+            4,
             ("device_index", int(device.index or 0)),
             ("hidden_size", int(hidden_size)),
             ("intermediate_size", int(intermediate_size)),
@@ -10544,6 +10549,7 @@ def _w4a16_small_m_direct_launch_flat(
         ptr(cutlass.BFloat16, output),
         barrier_count,
         barrier_epoch,
+        Int32(num_experts),
         Int32(m),
         Int32(direct_launch.grid_x),
         cuda.CUstream(stream_int),
@@ -10691,6 +10697,7 @@ def _w4a16_fc2_direct_launch_flat(
         ptr(cutlass.BFloat16, output),
         barrier_count,
         barrier_epoch,
+        Int32(num_experts),
         Int32(m),
         Int32(launch.grid_x),
         cuda.CUstream(stream_int),

--- a/b12x/moe/fused_moe/_impl.py
+++ b/b12x/moe/fused_moe/_impl.py
@@ -8361,6 +8361,7 @@ def _get_micro_kernel(
         dummy(cutlass.BFloat16),  # out_ptr
         barrier_fake,  # barrier_count
         barrier_fake,  # barrier_epoch
+        Int32(weight_E),  # route_expert_limit
         Int32(compile_m),  # m_val
         Int32(1),  # grid_x
         current_cuda_stream(),  # stream

--- a/tests/moe/test_w4a16_e2e.py
+++ b/tests/moe/test_w4a16_e2e.py
@@ -62,6 +62,19 @@ def test_w4a16_small_m_host_barrier_reset_kill_switch(
     assert not _small_m_direct_host_barrier_reset_enabled()
 
 
+def test_w4a16_fc2_runtime_m_does_not_use_fixed_route_staging() -> None:
+    kernel = MoEMicroKernelW4A16SmallMDirect(
+        activation="silu",
+        fast_math=False,
+        share_input_across_experts=False,
+        share_expert_scales=True,
+        single_token=False,
+        scale_format="e8m0_k32",
+        compile_time_phase=2,
+    )
+    assert not kernel.stage_inactive_routes
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("host_barrier_reset", [False, True])
 def test_w4a16_small_m_direct_barrier_modes_eager_and_graph(
@@ -1082,6 +1095,163 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
         assert bool(torch.isfinite(buffers.output).all().item())
         assert torch.equal(buffers.output, eager)
         _assert_matches_oracle(buffers.output, expected, activation=activation)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    ("m", "route_ids_dtype"),
+    [
+        (1, torch.int32),
+        (2, torch.int32),
+        (4, torch.int32),
+        (8, torch.int32),
+        (1, torch.int64),
+    ],
+)
+def test_w4a16_e8m0_native_micro_ignores_inactive_routes_during_graph_replay(
+    m: int,
+    route_ids_dtype: torch.dtype,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native small-M execution must not address weights for inactive routes."""
+    import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
+
+    monkeypatch.setenv("B12X_W4A16_SMALL_M_DIRECT", "1")
+    direct_launches = 0
+    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
+
+    def spy_direct_launch(*args, **kwargs) -> None:
+        nonlocal direct_launches
+        direct_launches += 1
+        real_direct_launch(*args, **kwargs)
+
+    monkeypatch.setattr(
+        w4a16_kernel,
+        "_w4a16_small_m_direct_launch_flat",
+        spy_direct_launch,
+    )
+    experts, hidden_size, intermediate_size = 4, 128, 192
+    topk, activation = 2, "situ"
+    rows = 2 * intermediate_size
+    torch.manual_seed(20260817 + m)
+    w13 = torch.randint(
+        0,
+        256,
+        (experts, rows, hidden_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (experts, hidden_size, intermediate_size // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    w13_scale = _pattern_e8m0((experts, rows, hidden_size // 32))
+    w2_scale = _pattern_e8m0((experts, hidden_size, intermediate_size // 32), offset=1)
+    global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+    prepared = prepare_w4a16_e8m0_native_weights(
+        w13,
+        w13_scale,
+        global_scale,
+        w2,
+        w2_scale,
+        global_scale,
+        activation=activation,
+        params_dtype=torch.bfloat16,
+        w13_layout="w31",
+    )
+    buffers = make_w4a16_buffers(
+        prepared,
+        m=m,
+        topk=topk,
+        dtype=torch.bfloat16,
+        device=torch.device("cuda"),
+    )
+    fc2_n_chunks = ((intermediate_size // 2) + 127) // 128
+    intermediate_cache2 = torch.zeros(
+        2 * m * fc2_n_chunks * 128 * topk,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    inputs = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.randint(
+        0, experts, (m, topk), dtype=route_ids_dtype, device="cuda"
+    )
+    topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
+
+    def launch() -> torch.Tensor:
+        return run_w4a16_moe(
+            inputs,
+            prepared,
+            topk_weights,
+            topk_ids,
+            activation=activation,
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=intermediate_cache2,
+            output=buffers.output,
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            expert_offsets=buffers.expert_offsets,
+        )
+
+    valid_eager = launch().clone()
+    torch.cuda.synchronize()
+    assert direct_launches == 1
+    assert bool(torch.isfinite(valid_eager).all().item())
+    assert bool((valid_eager.abs().sum(dim=1) > 0).all().item())
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = launch()
+    assert direct_launches == 2
+
+    inactive_ids = topk_ids.clone()
+    invalid_upper = 1 << 32 if route_ids_dtype == torch.int64 else experts
+    inactive_ids[-1] = torch.tensor(
+        [-1, invalid_upper], dtype=route_ids_dtype, device="cuda"
+    )
+    if m > 1:
+        inactive_ids[0, 0] = -1
+    topk_ids.copy_(inactive_ids)
+    original_weights = topk_weights.clone()
+    active = (inactive_ids >= 0) & (inactive_ids < experts)
+    reference_ids = torch.where(active, inactive_ids, torch.zeros_like(inactive_ids))
+    reference_weights = torch.where(
+        active, topk_weights, torch.zeros_like(topk_weights)
+    )
+    expected = moe_reference_w4a16_fp4_e8m0_k32(
+        inputs,
+        w13,
+        w13_scale,
+        global_scale,
+        w2,
+        w2_scale,
+        global_scale,
+        reference_ids,
+        reference_weights,
+        experts,
+        hidden_size,
+        intermediate_size,
+        activation=activation,
+        w13_layout="w31",
+    )
+
+    eager = launch().clone()
+    torch.cuda.synchronize()
+    _assert_matches_oracle(eager, expected, activation=activation)
+    torch.testing.assert_close(eager[-1], torch.zeros_like(eager[-1]), rtol=0, atol=0)
+
+    captured.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(captured).all().item())
+    torch.testing.assert_close(captured, eager, rtol=0, atol=0)
+    torch.testing.assert_close(topk_ids, inactive_ids, rtol=0, atol=0)
+    torch.testing.assert_close(topk_weights, original_weights, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
@@ -3268,15 +3438,11 @@ def test_w4a16_fc2_only_is_cuda_graph_safe_with_preallocated_output() -> None:
     intermediate = torch.ones(
         (routes, intermediate_size), dtype=torch.bfloat16, device="cuda"
     )
-    route_ids = torch.tensor(
-        [0, 1, 2, 3, 4, 0, 2], dtype=torch.int32, device="cuda"
-    )
+    route_ids = torch.tensor([0, 1, 2, 3, 4, 0, 2], dtype=torch.int32, device="cuda")
     route_weights = torch.linspace(
         0.125, 0.875, routes, dtype=torch.float32, device="cuda"
     )
-    output = torch.empty(
-        (routes, hidden_size), dtype=torch.bfloat16, device="cuda"
-    )
+    output = torch.empty((routes, hidden_size), dtype=torch.bfloat16, device="cuda")
 
     prepared = prepare_w4a16_fc2_e8m0(w2, scales)
     prewarm_w4a16_fc2_e8m0(prepared, route_ids_dtype=torch.int32)


### PR DESCRIPTION
## Bug description

The Kimi-K3 QSRT atoms-v2 compatibility tree predates the inactive-route handling in B12X PR #227. Fixed-M native W4A16 launches can therefore address graph-padding or otherwise inactive expert IDs instead of treating those routes as zero contribution.

In the qualified TP8/DCP8 runtime, a four-token partial-prefill tail produced NaN logits, Kimi control markers, and low-entropy repetition. The direct vLLM stream was already corrupt; the gateway only preserved those bytes.

## Base and duplicate-work check

This is a **stacked compatibility port**, not a competing implementation of #227:

- comparison base: `agent/pr197-base-glm52-sqg`
- upstream implementation: #227 at `0eba6ae99e0d1fad6ec268d8c291f498ec1dd4d9`
- product files in this PR are byte-identical to the production-qualified port

After the QSRT prerequisites and #227 land on `master`, this PR can be replaced by that merged source composition.

## Resulting behavior

- Fixed-M fused phases stage a bounded per-CTA route table.
- IDs outside `[0, resident_expert_count)` address expert zero with an exact-zero effective weight.
- FC2-only runtime-M execution validates each route inline and does not use fixed route staging.
- `int64` route IDs are range-checked before narrowing.
- Caller-owned route IDs and weights remain unchanged across eager execution and CUDA Graph replay.
- Compile/launch argument order and cache identities include the new resident-expert limit.

## Validation

- Source-matched CUDA 13.3 / PyTorch 2.13 container:
  - `test_w4a16_fc2_runtime_m_does_not_use_fixed_route_staging`: passed
- Python compilation: passed for all modified source and test files.
- Ruff check: passed for the regression test; product files preserve the exact qualified bytes from the runtime port.
- Product SHA-256 values match the deployed candidate:
  - `micro.py`: `c2f1140afb0f17b31615aa3072c8fcec5dfbf67afa9193ee07eab19b40e7894d`
  - `w4a16/kernel.py`: `14e86df31092abf179b2550302bb34271f43db5a18ef8ba7b4fcf3fac61abebf`
  - `fused_moe/_impl.py`: `b6341b7814087b735d5db0def2bea2a49d5ff41ca607c24dee597b35193036dc`
- Full Kimi-K3 QSRT TP8/DCP8 runtime:
  - exact four-token tail: 10/10 coherent unique-salt greedy runs
  - captured incident payload: 5/5 direct vLLM and 5/5 gateway runs coherent
  - LMCache L1/L2 replay: 12,288 external-hit tokens and byte-equivalent output

## Compatibility

The change is limited to native W4A16 direct micro execution on the QSRT compatibility stack. Dynamic MoE and unrelated quantization recipes retain their behavior.

## AI assistance

AI assistance was used for root-cause analysis, source-port preparation, tests, and PR drafting. The submitting human must review every changed line and be able to defend the behavior before merge.

Signed-off-by: myshytf <9619163+myshytf@users.noreply.github.com>
