### PR TITLE
[II] Stabilize large W4A16 prefill route packing

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
+++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 import torch
 
+from b12x._lib.env import env_flag
 from b12x.moe._shared.kernels.w4a16.host import route_pack_capacity
 
 
@@ -17,6 +18,9 @@ _SMALL_PREFIX_MAX_ROUTE_BLOCKS = 512
 
 
 _FAST_COUNT_BLOCK_T = 1024
+_STABLE_SORT_MIN_ROUTES = 4096
+_STABLE_SORT_BLOCK_T = 4096
+_STABLE_SORT_EXPERTS_PER_PROGRAM = 1
 
 
 @triton.jit
@@ -285,6 +289,73 @@ def _pack_topk_routes_sort_kernel(
     tl.store(packed_route_indices + ranks, offsets, mask=valid)
 
 
+@triton.jit
+def _pack_topk_routes_stable_kernel(
+    topk_ids,
+    expert_map,
+    packed_route_indices,
+    expert_offsets,
+    live_numel,
+    NUMEL_CAPACITY: tl.constexpr,
+    NUM_EXPERTS: tl.constexpr,
+    HAS_EXPERT_MAP: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    EXPERTS_PER_PROGRAM: tl.constexpr,
+):
+    """Pack each expert's routes in ascending token-major route order."""
+    expert_ids = (
+        tl.program_id(0) * EXPERTS_PER_PROGRAM
+        + tl.arange(0, EXPERTS_PER_PROGRAM)
+    )
+    expert_mask = expert_ids < NUM_EXPERTS
+    output_starts = tl.load(
+        expert_offsets + expert_ids,
+        mask=expert_mask,
+        other=0,
+    )
+    output_counts = tl.zeros((EXPERTS_PER_PROGRAM,), dtype=tl.int32)
+    lanes = tl.arange(0, BLOCK_T)
+
+    for start in tl.range(0, NUMEL_CAPACITY, BLOCK_T):
+        offsets = start + lanes
+        raw_ids = tl.load(
+            topk_ids + offsets,
+            mask=offsets < live_numel,
+            other=-1,
+        ).to(tl.int32)
+        valid = (
+            (offsets < live_numel)
+            & (raw_ids >= 0)
+            & (raw_ids < NUM_EXPERTS)
+        )
+        ids = raw_ids
+        if HAS_EXPERT_MAP:
+            safe_ids = tl.minimum(tl.maximum(raw_ids, 0), NUM_EXPERTS - 1)
+            ids = tl.load(expert_map + safe_ids, mask=valid, other=-1).to(
+                tl.int32
+            )
+            valid = valid & (ids >= 0) & (ids < NUM_EXPERTS)
+
+        matches = (
+            expert_mask[:, None]
+            & valid[None, :]
+            & (expert_ids[:, None] == ids[None, :])
+        )
+        match_i32 = matches.to(tl.int32)
+        local_ranks = tl.cumsum(match_i32, axis=1) - 1
+        output_indices = (
+            output_starts[:, None]
+            + output_counts[:, None]
+            + local_ranks
+        )
+        tl.store(
+            packed_route_indices + output_indices,
+            offsets[None, :],
+            mask=matches,
+        )
+        output_counts += tl.sum(match_i32, axis=1)
+
+
 def pack_topk_routes_by_expert(
     topk_ids: torch.Tensor,
     block_size: int,
@@ -509,17 +580,38 @@ def pack_topk_routes_by_expert(
             SEARCH_STEPS=block_e.bit_length(),
             num_warps=4,
         )
-    _pack_topk_routes_sort_kernel[sort_grid](
-        topk_ids,
-        expert_map_tensor,
-        packed_route_indices,
-        expert_offsets,
-        numel,
-        NUM_EXPERTS=int(num_experts),
-        HAS_EXPERT_MAP=expert_map is not None,
-        BLOCK_T=_SORT_BLOCK_T,
-        num_warps=4,
-    )
+    if (
+        env_flag("W4A16_STABLE_ROUTE_PACK")
+        and numel >= _STABLE_SORT_MIN_ROUTES
+    ):
+        stable_grid = (
+            triton.cdiv(num_experts, _STABLE_SORT_EXPERTS_PER_PROGRAM),
+        )
+        _pack_topk_routes_stable_kernel[stable_grid](
+            topk_ids,
+            expert_map_tensor,
+            packed_route_indices,
+            expert_offsets,
+            numel,
+            NUMEL_CAPACITY=numel_capacity,
+            NUM_EXPERTS=int(num_experts),
+            HAS_EXPERT_MAP=expert_map is not None,
+            BLOCK_T=_STABLE_SORT_BLOCK_T,
+            EXPERTS_PER_PROGRAM=_STABLE_SORT_EXPERTS_PER_PROGRAM,
+            num_warps=8,
+        )
+    else:
+        _pack_topk_routes_sort_kernel[sort_grid](
+            topk_ids,
+            expert_map_tensor,
+            packed_route_indices,
+            expert_offsets,
+            numel,
+            NUM_EXPERTS=int(num_experts),
+            HAS_EXPERT_MAP=expert_map is not None,
+            BLOCK_T=_SORT_BLOCK_T,
+            num_warps=4,
+        )
     return packed_route_indices, block_expert_ids, packed_route_count
 
 

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -338,6 +338,106 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("use_expert_map", [False, True])
+def test_large_prefill_stable_route_pack_is_repeatable(
+    monkeypatch,
+    use_expert_map: bool,
+) -> None:
+    monkeypatch.setenv("B12X_W4A16_STABLE_ROUTE_PACK", "1")
+    tokens = 4096
+    topk = 16
+    num_experts = 896
+    block_size = 16
+    generator = torch.Generator(device="cuda").manual_seed(20260822)
+    topk_ids = torch.randint(
+        0,
+        num_experts,
+        (tokens, topk),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    topk_ids[0, 0] = -1
+    topk_ids[-1, -1] = num_experts
+    expert_map = None
+    if use_expert_map:
+        expert_map = torch.arange(
+            num_experts, dtype=torch.int32, device="cuda"
+        )
+        expert_map[1::2] = -1
+
+    _, capacity_routes, capacity_blocks = route_pack_capacity(
+        topk_ids.numel(),
+        block_size,
+        num_experts,
+        topk=topk,
+    )
+    workspaces = {
+        "packed_route_indices": torch.empty(
+            capacity_routes, dtype=torch.int32, device="cuda"
+        ),
+        "block_expert_ids": torch.empty(
+            capacity_blocks, dtype=torch.int32, device="cuda"
+        ),
+        "packed_route_count": torch.empty(1, dtype=torch.int32, device="cuda"),
+        "expert_offsets": torch.empty(
+            num_experts + 1, dtype=torch.int32, device="cuda"
+        ),
+        "expert_counts": torch.empty(
+            num_experts, dtype=torch.int32, device="cuda"
+        ),
+    }
+
+    def run() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return pack_topk_routes_by_expert(
+            topk_ids,
+            block_size,
+            num_experts,
+            expert_map=expert_map,
+            **workspaces,
+        )
+
+    first_routes, first_blocks, first_count = run()
+    first_routes = first_routes.clone()
+    first_blocks = first_blocks.clone()
+    first_count = first_count.clone()
+
+    for _ in range(3):
+        routes, blocks, count = run()
+        assert torch.equal(routes, first_routes)
+        assert torch.equal(blocks, first_blocks)
+        assert torch.equal(count, first_count)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_routes, graph_blocks, graph_count = run()
+    for _ in range(3):
+        graph.replay()
+        torch.cuda.synchronize()
+        assert torch.equal(graph_routes, first_routes)
+        assert torch.equal(graph_blocks, first_blocks)
+        assert torch.equal(graph_count, first_count)
+
+    raw_ids = topk_ids.cpu().reshape(-1).to(torch.int64)
+    mapped_ids = raw_ids
+    valid = (raw_ids >= 0) & (raw_ids < num_experts)
+    if expert_map is not None:
+        host_map = expert_map.cpu().to(torch.int64)
+        mapped_ids = host_map[raw_ids.clamp(0, num_experts - 1)]
+        valid &= (mapped_ids >= 0) & (mapped_ids < num_experts)
+
+    sentinel = int(topk_ids.numel())
+    packed_routes = first_routes[first_routes < sentinel].cpu().to(torch.int64)
+    assert torch.equal(
+        packed_routes.sort().values,
+        torch.nonzero(valid, as_tuple=False).flatten(),
+    )
+    for expert in range(num_experts):
+        expert_routes = packed_routes[mapped_ids[packed_routes] == expert]
+        assert torch.equal(expert_routes, expert_routes.sort().values)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
 @pytest.mark.parametrize("block_size", [8, 16, 32, 48, 64])
 def test_pack_topk_routes_by_expert_applies_expert_map(


### PR DESCRIPTION
## Behavior

Adds an opt-in stable route writer for W4A16 workloads with at least 4,096 routed rows. `B12X_W4A16_STABLE_ROUTE_PACK=1` packs every expert's rows in ascending flattened token-major order. Smaller route sets retain the existing atomic writer, so decode latency is unchanged.

## Technical reason

The existing large-shape writer assigns per-expert output positions with `tl.atomic_add`. The packed rows are semantically equivalent, but their order varies between launches. W4A16 prefill can therefore feed different row layouts into downstream tiled kernels for identical inputs.

The stable writer assigns one Triton program per expert, scans the bounded route workspace in fixed order, and computes local ranks with a prefix sum. Invalid routes and expert-map entries remain excluded under the existing route-pack contract. The implementation uses the existing caller-owned workspaces and is safe under CUDA Graph replay.

## Compatibility

- Default behavior is unchanged.
- The stable writer is enabled only through `B12X_W4A16_STABLE_ROUTE_PACK=1` and only for route sets with at least 4,096 entries.
- Route counts, block padding, expert block ownership, sentinel rows, and returned tensor identities are unchanged.
- No native CUDA source or additional workspace is introduced.

## Validation

- `tests/moe/test_w4a16_route_pack.py`: 79 passed on one SM120 GPU.
- Kimi-K3 prefill geometry (4,096 tokens, top-16, 896 experts, block size 16), 50 repeated executions:
  - atomic writer: 50 distinct eager layouts and 50 distinct CUDA Graph layouts;
  - stable writer: one eager layout and one CUDA Graph layout;
  - all live routes formed an exact input permutation, every block contained one expert, and each expert's routes were ascending.
- GPU time at that geometry over 500 iterations:
  - atomic CUDA Graph path: 16.37 microseconds;
  - stable CUDA Graph path: 114.74 microseconds;
  - incremental cost: 98.37 microseconds per MoE layer during qualifying prefill calls.
- The official Kimi-K3 MXFP4 checkpoint on TP16/DCP16 completed a captured 208,026-token prompt plus 8,192 greedy completion tokens with coherent output when stable route packing and correct final AttnRes ownership were active. The same request with atomic large-shape packing entered a repeated-token loop. The server exposed 1,058,823 physical target-KV tokens and used 4,096-token scheduler chunks.

The route-layout benchmark receipt is `r32-clean-source-locked-20260822/route-pack/kimi-k3-4096x16.json` in the Kimi-K3 qualification artifact set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds an opt-in stable route writer for W4A16 workloads with at least 4,096 routes. Enable it with `B12X_W4A16_STABLE_ROUTE_PACK=1`.

The stable writer packs each expert’s rows in ascending flattened token-major order. It uses existing workspaces and remains safe during CUDA Graph replay.

The atomic writer remains the default for smaller route sets and when the flag is disabled. Route counts, padding, expert ownership, sentinel rows, and returned tensor identities remain unchanged.

Validation includes 79 passing route-pack tests, repeated eager and CUDA Graph executions, exact live-route permutations, ascending per-expert routes, invalid expert IDs, and expert-map handling. At the tested Kimi-K3 geometry, stable packing adds 98.37 microseconds per MoE layer compared with the atomic CUDA Graph path. The qualification run completed the specified long prompt and greedy continuation with stable packing enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->