### PR TITLE
[II] Support staged MXFP8 linear inputs

### DIFF
--- a/b12x/gemm/mxfp8_linear/__init__.py
+++ b/b12x/gemm/mxfp8_linear/__init__.py
@@ -22,7 +22,15 @@ META = OpMeta(
     name="mxfp8_linear",
     group="gemm",
     api_style="oneshot",
-    entry_points=("Weight", "mm", "pack_weight", "is_supported"),
+    entry_points=(
+        "Weight",
+        "empty_input",
+        "is_supported",
+        "mm",
+        "mm_quantized",
+        "pack_weight",
+        "quantize_input_slice",
+    ),
     dtypes=("bf16", "fp16"),
     recipes=("mxfp8",),
     requires=("triton",),
@@ -36,6 +44,14 @@ META = OpMeta(
 )
 
 if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
-    from .api import Weight, is_supported, mm, pack_weight  # noqa: F401
+    from .api import (  # noqa: F401
+        Weight,
+        empty_input,
+        is_supported,
+        mm,
+        mm_quantized,
+        pack_weight,
+        quantize_input_slice,
+    )
 
 install_lazy_api(globals(), META)

--- a/b12x/gemm/mxfp8_linear/__init__.py
+++ b/b12x/gemm/mxfp8_linear/__init__.py
@@ -28,6 +28,7 @@ META = OpMeta(
         "is_supported",
         "mm",
         "mm_quantized",
+        "mm_quantized_into",
         "pack_weight",
         "quantize_input_slice",
     ),
@@ -50,6 +51,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
         is_supported,
         mm,
         mm_quantized,
+        mm_quantized_into,
         pack_weight,
         quantize_input_slice,
     )

--- a/b12x/gemm/mxfp8_linear/_kernel.py
+++ b/b12x/gemm/mxfp8_linear/_kernel.py
@@ -14,6 +14,7 @@ from b12x.gemm._shared.wo_mxfp8 import (
     MXFP8Rows,
     MXFP8_SCALE_VEC_SIZE,
     _check_gpu_tensor,
+    empty_mxfp8_rows_for_dense_gemm,
     pack_mxfp8_scales_for_dense_gemm,
 )
 
@@ -259,9 +260,204 @@ def mxfp8_linear(
     return output.view(*source.shape[:-1], out_features)
 
 
+def empty_mxfp8_linear_input(
+    max_tokens: int,
+    in_features: int,
+    *,
+    device: torch.device | str,
+) -> MXFP8Rows:
+    """Allocate retained MXFP8 input storage for a dense linear."""
+
+    return empty_mxfp8_rows_for_dense_gemm(
+        int(max_tokens),
+        int(in_features),
+        num_groups=1,
+        device=device,
+    )
+
+
+def quantize_mxfp8_linear_input_slice(
+    source: torch.Tensor,
+    destination: MXFP8Rows,
+    *,
+    destination_column: int,
+) -> None:
+    """Quantize one aligned feature slice into retained MXFP8 input storage.
+
+    The temporary quantized slice is bounded by the source feature width. Its
+    values and both scale layouts are copied into the corresponding 128-column
+    interval of ``destination``. Standard tensor copies keep the operation
+    compatible with torch functionalization while allowing the BF16 source to
+    be released before the final matrix multiplication.
+    """
+
+    source_2d = _source_2d(source)
+    tokens, width = map(int, source_2d.shape)
+    if destination.values.ndim != 2:
+        raise ValueError(
+            "destination.values must have shape [capacity,K], got "
+            f"{tuple(destination.values.shape)}"
+        )
+    capacity, destination_width = map(int, destination.values.shape)
+    if capacity < tokens:
+        raise ValueError(
+            "destination has insufficient row capacity: "
+            f"capacity={capacity}, tokens={tokens}"
+        )
+    destination_column = int(destination_column)
+    if (
+        destination_column < 0
+        or destination_column % 128 != 0
+        or width % 128 != 0
+        or destination_column + width > destination_width
+    ):
+        raise ValueError(
+            "source width and destination column must describe a 128-column-"
+            f"aligned slice within K={destination_width}, got "
+            f"offset={destination_column}, width={width}"
+        )
+
+    quantized = quantize_block_fp8_linear_input_mxfp8(source_2d)
+    destination.values[:tokens, destination_column : destination_column + width].copy_(
+        quantized.values
+    )
+    scale_column = destination_column // MXFP8_SCALE_VEC_SIZE
+    scale_width = width // MXFP8_SCALE_VEC_SIZE
+    destination.scale_rows[:, :tokens, scale_column : scale_column + scale_width].copy_(
+        quantized.scale_rows
+    )
+    m_tiles = (tokens + 127) // 128
+    tile_column = destination_column // 128
+    tile_width = width // 128
+    destination.scale_mma[
+        :, :, :m_tiles, :, tile_column : tile_column + tile_width, :
+    ].copy_(quantized.scale_mma)
+
+
+@torch.library.custom_op(
+    "b12x::mxfp8_linear_quantized",
+    mutates_args=(),
+)
+def _mxfp8_linear_quantized_op(
+    input_values: torch.Tensor,
+    input_scale_mma: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    tokens: int,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    output_dtype: str,
+    stream_int: int | None,
+) -> torch.Tensor:
+    m_tiles = (tokens + 127) // 128
+    return dense_gemm(
+        (
+            input_values[:tokens].reshape(tokens, in_features, 1),
+            input_scale_mma[:, :, :m_tiles],
+        ),
+        (
+            weight_values.reshape(out_features, in_features, 1),
+            weight_scale_mma,
+        ),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=output_dtype,
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        expected_m=expected_m,
+        stream=stream_int,
+    )[:, :, 0]
+
+
+@_mxfp8_linear_quantized_op.register_fake
+def _mxfp8_linear_quantized_fake(
+    input_values: torch.Tensor,
+    input_scale_mma: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    tokens: int,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    output_dtype: str,
+    stream_int: int | None,
+) -> torch.Tensor:
+    dtype = torch.bfloat16 if output_dtype == "bfloat16" else torch.float16
+    return torch.empty(
+        (tokens, out_features),
+        dtype=dtype,
+        device=input_values.device,
+    )
+
+
+def mxfp8_linear_quantized(
+    source: MXFP8Rows,
+    packed_weight: MXFP8LinearWeight,
+    *,
+    tokens: int | None = None,
+    out: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    output_dtype: torch.dtype = torch.bfloat16,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run a packed linear from a caller-owned, already-quantized input."""
+
+    if not isinstance(source, MXFP8Rows):
+        raise TypeError("source must be MXFP8Rows")
+    if not isinstance(packed_weight, MXFP8LinearWeight):
+        raise TypeError("packed_weight must be an MXFP8LinearWeight")
+    if source.values.ndim != 2:
+        raise ValueError(
+            "source.values must have shape [capacity,K], got "
+            f"{tuple(source.values.shape)}"
+        )
+    capacity, in_features = map(int, source.values.shape)
+    live_tokens = capacity if tokens is None else int(tokens)
+    if live_tokens <= 0 or live_tokens > capacity:
+        raise ValueError(f"tokens must be in [1,{capacity}], got {live_tokens}")
+    if in_features != int(packed_weight.padded_in_features):
+        raise ValueError(
+            "quantized input width does not match packed weight: "
+            f"input={in_features}, weight={packed_weight.padded_in_features}"
+        )
+    if out is not None:
+        _check_gpu_tensor("out", out)
+        output_dtype = out.dtype
+    output_dtype_name = _c_dtype_name(output_dtype)
+    out_features = int(packed_weight.out_features)
+    result = torch.ops.b12x.mxfp8_linear_quantized(
+        source.values,
+        source.scale_mma,
+        packed_weight.weight.values,
+        packed_weight.weight.scale_mma,
+        live_tokens,
+        in_features,
+        out_features,
+        int(expected_m) if expected_m is not None else live_tokens,
+        output_dtype_name,
+        cuda_stream_to_int(stream),
+    )
+    if bias is not None:
+        result = result + bias
+    if out is None:
+        return result
+    if out.ndim != 2 or out.shape[0] < live_tokens or out.shape[1] != out_features:
+        raise ValueError(
+            "out must have shape [capacity,N] with sufficient row capacity, "
+            f"got {tuple(out.shape)}, required rows={live_tokens}, N={out_features}"
+        )
+    output_live = out[:live_tokens]
+    output_live.copy_(result)
+    return output_live
+
+
 __all__ = [
     "MXFP8LinearWeight",
+    "empty_mxfp8_linear_input",
     "is_mxfp8_linear_supported",
     "mxfp8_linear",
+    "mxfp8_linear_quantized",
     "pack_mxfp8_linear_weight",
+    "quantize_mxfp8_linear_input_slice",
 ]

--- a/b12x/gemm/mxfp8_linear/_kernel.py
+++ b/b12x/gemm/mxfp8_linear/_kernel.py
@@ -390,19 +390,84 @@ def _mxfp8_linear_quantized_fake(
     )
 
 
-def mxfp8_linear_quantized(
+@torch.library.custom_op(
+    "b12x::mxfp8_linear_quantized_out",
+    mutates_args=("out",),
+)
+def _mxfp8_linear_quantized_out_op(
+    input_values: torch.Tensor,
+    input_scale_mma: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    out: torch.Tensor,
+    bias: torch.Tensor | None,
+    tokens: int,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> None:
+    """Run the retained-input GEMM directly into caller-owned storage."""
+    m_tiles = (tokens + 127) // 128
+    output_live = out[:tokens]
+    dense_gemm(
+        (
+            input_values[:tokens].reshape(tokens, in_features, 1),
+            input_scale_mma[:, :, :m_tiles],
+        ),
+        (
+            weight_values.reshape(out_features, in_features, 1),
+            weight_scale_mma,
+        ),
+        out=output_live.reshape(tokens, out_features, 1),
+        ab_dtype="float8_e4m3fn",
+        sf_dtype="float8_e8m0fnu",
+        c_dtype=_c_dtype_name(out.dtype),
+        sf_vec_size=MXFP8_SCALE_VEC_SIZE,
+        expected_m=expected_m,
+        stream=stream_int,
+    )
+    if bias is not None:
+        output_live.add_(bias)
+
+
+@_mxfp8_linear_quantized_out_op.register_fake
+def _mxfp8_linear_quantized_out_fake(
+    input_values: torch.Tensor,
+    input_scale_mma: torch.Tensor,
+    weight_values: torch.Tensor,
+    weight_scale_mma: torch.Tensor,
+    out: torch.Tensor,
+    bias: torch.Tensor | None,
+    tokens: int,
+    in_features: int,
+    out_features: int,
+    expected_m: int,
+    stream_int: int | None,
+) -> None:
+    del (
+        input_values,
+        input_scale_mma,
+        weight_values,
+        weight_scale_mma,
+        out,
+        bias,
+        tokens,
+        in_features,
+        out_features,
+        expected_m,
+        stream_int,
+    )
+
+
+def _validate_quantized_linear(
     source: MXFP8Rows,
     packed_weight: MXFP8LinearWeight,
     *,
     tokens: int | None = None,
     out: torch.Tensor | None = None,
-    bias: torch.Tensor | None = None,
     output_dtype: torch.dtype = torch.bfloat16,
-    expected_m: int | None = None,
-    stream: object = None,
-) -> torch.Tensor:
-    """Run a packed linear from a caller-owned, already-quantized input."""
-
+) -> tuple[int, int, int, torch.dtype]:
     if not isinstance(source, MXFP8Rows):
         raise TypeError("source must be MXFP8Rows")
     if not isinstance(packed_weight, MXFP8LinearWeight):
@@ -423,9 +488,39 @@ def mxfp8_linear_quantized(
         )
     if out is not None:
         _check_gpu_tensor("out", out)
+        out_features = int(packed_weight.out_features)
+        if out.ndim != 2 or out.shape[0] < live_tokens or out.shape[1] != out_features:
+            raise ValueError(
+                "out must have shape [capacity,N] with sufficient row capacity, "
+                f"got {tuple(out.shape)}, required rows={live_tokens}, "
+                f"N={out_features}"
+            )
         output_dtype = out.dtype
-    output_dtype_name = _c_dtype_name(output_dtype)
+    _c_dtype_name(output_dtype)
     out_features = int(packed_weight.out_features)
+    return live_tokens, in_features, out_features, output_dtype
+
+
+def mxfp8_linear_quantized(
+    source: MXFP8Rows,
+    packed_weight: MXFP8LinearWeight,
+    *,
+    tokens: int | None = None,
+    out: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    output_dtype: torch.dtype = torch.bfloat16,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run a compile-safe packed linear from an already-quantized input."""
+
+    live_tokens, in_features, out_features, output_dtype = _validate_quantized_linear(
+        source,
+        packed_weight,
+        tokens=tokens,
+        out=out,
+        output_dtype=output_dtype,
+    )
     result = torch.ops.b12x.mxfp8_linear_quantized(
         source.values,
         source.scale_mma,
@@ -435,21 +530,55 @@ def mxfp8_linear_quantized(
         in_features,
         out_features,
         int(expected_m) if expected_m is not None else live_tokens,
-        output_dtype_name,
+        _c_dtype_name(output_dtype),
         cuda_stream_to_int(stream),
     )
     if bias is not None:
         result = result + bias
     if out is None:
         return result
-    if out.ndim != 2 or out.shape[0] < live_tokens or out.shape[1] != out_features:
-        raise ValueError(
-            "out must have shape [capacity,N] with sufficient row capacity, "
-            f"got {tuple(out.shape)}, required rows={live_tokens}, N={out_features}"
-        )
     output_live = out[:live_tokens]
     output_live.copy_(result)
     return output_live
+
+
+def mxfp8_linear_quantized_into(
+    source: MXFP8Rows,
+    packed_weight: MXFP8LinearWeight,
+    *,
+    out: torch.Tensor,
+    tokens: int | None = None,
+    bias: torch.Tensor | None = None,
+    expected_m: int | None = None,
+    stream: object = None,
+) -> torch.Tensor:
+    """Run a packed linear directly into caller-owned eager output storage.
+
+    The mutating operation avoids an intermediate dense output. Use
+    :func:`mxfp8_linear_quantized` inside ``torch.compile`` because PyTorch
+    cannot currently functionalize a closed-over caller-owned output reliably.
+    """
+
+    live_tokens, in_features, out_features, _ = _validate_quantized_linear(
+        source,
+        packed_weight,
+        tokens=tokens,
+        out=out,
+    )
+    torch.ops.b12x.mxfp8_linear_quantized_out(
+        source.values,
+        source.scale_mma,
+        packed_weight.weight.values,
+        packed_weight.weight.scale_mma,
+        out,
+        bias,
+        live_tokens,
+        in_features,
+        out_features,
+        int(expected_m) if expected_m is not None else live_tokens,
+        cuda_stream_to_int(stream),
+    )
+    return out[:live_tokens]
 
 
 __all__ = [
@@ -458,6 +587,7 @@ __all__ = [
     "is_mxfp8_linear_supported",
     "mxfp8_linear",
     "mxfp8_linear_quantized",
+    "mxfp8_linear_quantized_into",
     "pack_mxfp8_linear_weight",
     "quantize_mxfp8_linear_input_slice",
 ]

--- a/b12x/gemm/mxfp8_linear/_kernel.py
+++ b/b12x/gemm/mxfp8_linear/_kernel.py
@@ -555,8 +555,9 @@ def mxfp8_linear_quantized_into(
     """Run a packed linear directly into caller-owned eager output storage.
 
     The mutating operation avoids an intermediate dense output. Use
-    :func:`mxfp8_linear_quantized` inside ``torch.compile`` because PyTorch
-    cannot currently functionalize a closed-over caller-owned output reliably.
+    :func:`mxfp8_linear_quantized` inside ``torch.compile``. The
+    :func:`mxfp8_linear_quantized_into` operation is supported in eager
+    execution and CUDA Graph replay, not under ``torch.compile``.
     """
 
     live_tokens, in_features, out_features, _ = _validate_quantized_linear(

--- a/b12x/gemm/mxfp8_linear/api.py
+++ b/b12x/gemm/mxfp8_linear/api.py
@@ -7,13 +7,22 @@ from ._kernel import (
     MXFP8LinearWeight as Weight,
 )
 from ._kernel import (
+    empty_mxfp8_linear_input as empty_input,
+)
+from ._kernel import (
     is_mxfp8_linear_supported as _kernel_is_supported,
 )
 from ._kernel import (
     mxfp8_linear as mm,
 )
 from ._kernel import (
+    mxfp8_linear_quantized as mm_quantized,
+)
+from ._kernel import (
     pack_mxfp8_linear_weight as pack_weight,
+)
+from ._kernel import (
+    quantize_mxfp8_linear_input_slice as quantize_input_slice,
 )
 from . import META
 
@@ -26,4 +35,12 @@ def is_supported(device=None) -> bool:
     )
 
 
-__all__ = ["Weight", "mm", "pack_weight", "is_supported"]
+__all__ = [
+    "Weight",
+    "empty_input",
+    "is_supported",
+    "mm",
+    "mm_quantized",
+    "pack_weight",
+    "quantize_input_slice",
+]

--- a/b12x/gemm/mxfp8_linear/api.py
+++ b/b12x/gemm/mxfp8_linear/api.py
@@ -19,6 +19,9 @@ from ._kernel import (
     mxfp8_linear_quantized as mm_quantized,
 )
 from ._kernel import (
+    mxfp8_linear_quantized_into as mm_quantized_into,
+)
+from ._kernel import (
     pack_mxfp8_linear_weight as pack_weight,
 )
 from ._kernel import (
@@ -41,6 +44,7 @@ __all__ = [
     "is_supported",
     "mm",
     "mm_quantized",
+    "mm_quantized_into",
     "pack_weight",
     "quantize_input_slice",
 ]

--- a/benchmarks/benchmark_mxfp8_staged_input.py
+++ b/benchmarks/benchmark_mxfp8_staged_input.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Measure concatenated and staged MXFP8 linear input construction.
+
+The default geometry is the Kimi-K3 DFlash auxiliary projection: six BF16
+feature slices of width 7,168 feed one 43,008-by-7,168 MXFP8 linear. The staged
+arm releases each BF16 slice after quantizing it into retained MXFP8 storage and
+writes the GEMM result directly into caller-owned output storage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import statistics
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import torch
+
+from b12x.gemm import mxfp8_linear
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=4096)
+    parser.add_argument("--slice-width", type=int, default=7168)
+    parser.add_argument("--slices", type=int, default=6)
+    parser.add_argument("--output-width", type=int, default=7168)
+    parser.add_argument("--iterations", type=int, default=9)
+    parser.add_argument("--seed", type=int, default=20260823)
+    return parser.parse_args()
+
+
+def _git_metadata(repository: pathlib.Path) -> dict[str, object]:
+    revision = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    status = subprocess.run(
+        ["git", "-C", str(repository), "status", "--short"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    return {
+        "repository": str(repository),
+        "revision": revision,
+        "worktree_state": "clean" if not status else "modified",
+        "worktree_status": status,
+    }
+
+
+def _gpu_metadata() -> dict[str, object]:
+    device = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(device)
+    driver = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=driver_version",
+            "--format=csv,noheader,nounits",
+            f"--id={device}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return {
+        "device": device,
+        "name": properties.name,
+        "compute_capability": [properties.major, properties.minor],
+        "multiprocessors": properties.multi_processor_count,
+        "driver_version": driver,
+        "torch_version": torch.__version__,
+        "cuda_runtime": torch.version.cuda,
+    }
+
+
+def _source(tokens: int, width: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    return torch.randn(
+        (tokens, width),
+        generator=generator,
+        device="cuda",
+        dtype=torch.bfloat16,
+    ).div_(4)
+
+
+def _weight(rows: int, columns: int, seed: int):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    values = torch.empty((rows, columns), device="cuda", dtype=torch.float8_e4m3fn)
+    for start in range(0, rows, 256):
+        stop = min(start + 256, rows)
+        source = torch.randn(
+            (stop - start, columns),
+            generator=generator,
+            device="cuda",
+            dtype=torch.bfloat16,
+        ).div_(8)
+        values[start:stop].copy_(source)
+    scales = torch.full(
+        (rows, columns // 32),
+        127,
+        device="cuda",
+        dtype=torch.uint8,
+    )
+    return mxfp8_linear.pack_weight(values, scales)
+
+
+def _elapsed_ms(operation: Callable[[], torch.Tensor]) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    stop = torch.cuda.Event(enable_timing=True)
+    start.record()
+    operation()
+    stop.record()
+    stop.synchronize()
+    return float(start.elapsed_time(stop))
+
+
+def main() -> None:
+    args = _arguments()
+    if args.slice_width % 128:
+        raise ValueError("slice width must be divisible by 128")
+    repository = pathlib.Path(__file__).resolve().parents[1]
+    input_width = args.slice_width * args.slices
+    packed_weight = _weight(args.output_width, input_width, args.seed + 1000)
+    output = torch.empty(
+        (args.tokens, args.output_width),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    sources = [
+        _source(args.tokens, args.slice_width, args.seed + index)
+        for index in range(args.slices)
+    ]
+    torch.cuda.synchronize()
+    concatenated_live = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+
+    def concatenated() -> torch.Tensor:
+        joined = torch.cat(sources, dim=-1)
+        return mxfp8_linear.mm(joined, packed_weight, expected_m=args.tokens)
+
+    expected = concatenated().clone()
+    concatenated_samples = [_elapsed_ms(concatenated) for _ in range(args.iterations)]
+    concatenated_peak = torch.cuda.max_memory_allocated()
+    sources.clear()
+    torch.cuda.empty_cache()
+
+    retained = mxfp8_linear.empty_input(args.tokens, input_width, device="cuda")
+    torch.cuda.synchronize()
+    staged_live = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+
+    def staged() -> torch.Tensor:
+        for index in range(args.slices):
+            source = _source(args.tokens, args.slice_width, args.seed + index)
+            mxfp8_linear.quantize_input_slice(
+                source,
+                retained,
+                destination_column=index * args.slice_width,
+            )
+        return mxfp8_linear.mm_quantized_into(
+            retained,
+            packed_weight,
+            tokens=args.tokens,
+            out=output,
+            expected_m=args.tokens,
+        )
+
+    actual = staged().clone()
+    staged_samples = [_elapsed_ms(staged) for _ in range(args.iterations)]
+    staged_peak = torch.cuda.max_memory_allocated()
+    torch.cuda.synchronize()
+    maximum_difference = float((actual.float() - expected.float()).abs().max().item())
+    report = {
+        "schema": "b12x.mxfp8-staged-input.v1",
+        "command": " ".join(sys.argv),
+        "source": _git_metadata(repository),
+        "gpu": _gpu_metadata(),
+        "geometry": {
+            "tokens": args.tokens,
+            "slice_width": args.slice_width,
+            "slices": args.slices,
+            "input_width": input_width,
+            "output_width": args.output_width,
+        },
+        "output": {
+            "bitwise_equal": torch.equal(actual, expected),
+            "max_absolute_difference": maximum_difference,
+        },
+        "concatenated": {
+            "samples_ms": concatenated_samples,
+            "median_ms": statistics.median(concatenated_samples),
+            "live_before_bytes": concatenated_live,
+            "peak_bytes": concatenated_peak,
+        },
+        "staged": {
+            "samples_ms": staged_samples,
+            "median_ms": statistics.median(staged_samples),
+            "live_before_bytes": staged_live,
+            "peak_bytes": staged_peak,
+        },
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if not report["output"]["bitwise_equal"]:
+        raise SystemExit("staged MXFP8 input changed the linear output")
+
+
+if __name__ == "__main__":
+    started = time.monotonic()
+    main()
+    print(f"elapsed_seconds={time.monotonic() - started:.3f}")

--- a/benchmarks/benchmark_mxfp8_staged_input.py
+++ b/benchmarks/benchmark_mxfp8_staged_input.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import torch
 
 from b12x.gemm import mxfp8_linear
+from benchmarks.common import nvidia_smi_gpu_mode_snapshot
 
 
 def _arguments() -> argparse.Namespace:
@@ -33,6 +34,7 @@ def _arguments() -> argparse.Namespace:
     parser.add_argument("--output-width", type=int, default=7168)
     parser.add_argument("--iterations", type=int, default=9)
     parser.add_argument("--seed", type=int, default=20260823)
+    parser.add_argument("--output", type=pathlib.Path)
     return parser.parse_args()
 
 
@@ -49,8 +51,15 @@ def _git_metadata(repository: pathlib.Path) -> dict[str, object]:
         capture_output=True,
         text=True,
     ).stdout.splitlines()
+    remote = subprocess.run(
+        ["git", "-C", str(repository), "remote", "get-url", "origin"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
     return {
-        "repository": str(repository),
+        "repository": remote,
+        "worktree": str(repository),
         "revision": revision,
         "worktree_state": "clean" if not status else "modified",
         "worktree_status": status,
@@ -60,25 +69,25 @@ def _git_metadata(repository: pathlib.Path) -> dict[str, object]:
 def _gpu_metadata() -> dict[str, object]:
     device = torch.cuda.current_device()
     properties = torch.cuda.get_device_properties(device)
-    driver = subprocess.run(
+    driver_versions = subprocess.run(
         [
             "nvidia-smi",
             "--query-gpu=driver_version",
             "--format=csv,noheader,nounits",
-            f"--id={device}",
         ],
         check=True,
         capture_output=True,
         text=True,
-    ).stdout.strip()
+    ).stdout.splitlines()
     return {
         "device": device,
         "name": properties.name,
         "compute_capability": [properties.major, properties.minor],
         "multiprocessors": properties.multi_processor_count,
-        "driver_version": driver,
+        "driver_version": driver_versions[0],
         "torch_version": torch.__version__,
         "cuda_runtime": torch.version.cuda,
+        "mode": nvidia_smi_gpu_mode_snapshot(),
     }
 
 
@@ -132,11 +141,6 @@ def main() -> None:
     repository = pathlib.Path(__file__).resolve().parents[1]
     input_width = args.slice_width * args.slices
     packed_weight = _weight(args.output_width, input_width, args.seed + 1000)
-    output = torch.empty(
-        (args.tokens, args.output_width),
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
     sources = [
         _source(args.tokens, args.slice_width, args.seed + index)
         for index in range(args.slices)
@@ -149,20 +153,20 @@ def main() -> None:
         joined = torch.cat(sources, dim=-1)
         return mxfp8_linear.mm(joined, packed_weight, expected_m=args.tokens)
 
-    expected = concatenated().clone()
-    concatenated_samples = [_elapsed_ms(concatenated) for _ in range(args.iterations)]
+    concatenated_result = concatenated()
+    torch.cuda.synchronize()
     concatenated_peak = torch.cuda.max_memory_allocated()
-    sources.clear()
-    torch.cuda.empty_cache()
+    del concatenated_result
 
     retained = mxfp8_linear.empty_input(args.tokens, input_width, device="cuda")
-    torch.cuda.synchronize()
-    staged_live = torch.cuda.memory_allocated()
-    torch.cuda.reset_peak_memory_stats()
+    output = torch.empty(
+        (args.tokens, args.output_width),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
 
     def staged() -> torch.Tensor:
-        for index in range(args.slices):
-            source = _source(args.tokens, args.slice_width, args.seed + index)
+        for index, source in enumerate(sources):
             mxfp8_linear.quantize_input_slice(
                 source,
                 retained,
@@ -176,13 +180,53 @@ def main() -> None:
             expected_m=args.tokens,
         )
 
+    expected = concatenated().clone()
     actual = staged().clone()
-    staged_samples = [_elapsed_ms(staged) for _ in range(args.iterations)]
-    staged_peak = torch.cuda.max_memory_allocated()
-    torch.cuda.synchronize()
+    bitwise_equal = torch.equal(actual, expected)
     maximum_difference = float((actual.float() - expected.float()).abs().max().item())
+    concatenated()
+    staged()
+    torch.cuda.synchronize()
+    concatenated_samples: list[float] = []
+    staged_samples: list[float] = []
+    for iteration in range(args.iterations):
+        if iteration % 2:
+            staged_samples.append(_elapsed_ms(staged))
+            concatenated_samples.append(_elapsed_ms(concatenated))
+        else:
+            concatenated_samples.append(_elapsed_ms(concatenated))
+            staged_samples.append(_elapsed_ms(staged))
+
+    sources.clear()
+    del expected, actual
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    staged_live = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+
+    def staged_memory() -> torch.Tensor:
+        for index in range(args.slices):
+            source = _source(args.tokens, args.slice_width, args.seed + index)
+            mxfp8_linear.quantize_input_slice(
+                source,
+                retained,
+                destination_column=index * args.slice_width,
+            )
+            del source
+        return mxfp8_linear.mm_quantized_into(
+            retained,
+            packed_weight,
+            tokens=args.tokens,
+            out=output,
+            expected_m=args.tokens,
+        )
+
+    staged_result = staged_memory()
+    torch.cuda.synchronize()
+    staged_peak = torch.cuda.max_memory_allocated()
+    del staged_result
     report = {
-        "schema": "b12x.mxfp8-staged-input.v1",
+        "schema": "b12x.mxfp8-staged-input.v2",
         "command": " ".join(sys.argv),
         "source": _git_metadata(repository),
         "gpu": _gpu_metadata(),
@@ -194,8 +238,12 @@ def main() -> None:
             "output_width": args.output_width,
         },
         "output": {
-            "bitwise_equal": torch.equal(actual, expected),
+            "bitwise_equal": bitwise_equal,
             "max_absolute_difference": maximum_difference,
+        },
+        "timing": {
+            "samples_interleaved": True,
+            "source_construction_included": False,
         },
         "concatenated": {
             "samples_ms": concatenated_samples,
@@ -210,7 +258,10 @@ def main() -> None:
             "peak_bytes": staged_peak,
         },
     }
-    print(json.dumps(report, indent=2, sort_keys=True))
+    serialized = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.write_text(serialized)
+    print(serialized, end="")
     if not report["output"]["bitwise_equal"]:
         raise SystemExit("staged MXFP8 input changed the linear output")
 

--- a/tests/gemm/test_mxfp8_linear.py
+++ b/tests/gemm/test_mxfp8_linear.py
@@ -13,7 +13,9 @@ import torch
 
 from b12x.gemm import block_fp8_linear as bfl
 from b12x.gemm import mxfp8_linear
+from b12x.gemm.mxfp8_linear import _kernel as mxfp8_kernel
 from b12x.gemm._shared.wo_mxfp8 import (
+    MXFP8Rows,
     dequantize_mxfp8_rows_torch,
 )
 
@@ -207,7 +209,7 @@ def test_incremental_quantized_input_matches_one_shot_linear() -> None:
         device=source.device,
         dtype=torch.bfloat16,
     )
-    actual = mxfp8_linear.mm_quantized(
+    actual = mxfp8_linear.mm_quantized_into(
         quantized,
         packed,
         tokens=tokens,
@@ -218,6 +220,57 @@ def test_incremental_quantized_input_matches_one_shot_linear() -> None:
     torch.cuda.synchronize()
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("shape", ((256, 63), (256, 65), (256,), (128, 64)))
+def test_incremental_quantized_input_rejects_invalid_output_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    shape: tuple[int, ...],
+) -> None:
+    """Malformed caller-owned output storage must not launch the GEMM."""
+    quantized = MXFP8Rows(
+        values=torch.empty((512, 256), dtype=torch.float8_e4m3fn),
+        scale_rows=torch.empty((1, 512, 8), dtype=torch.float8_e8m0fnu),
+        scale_mma=torch.empty(0),
+    )
+    weight_rows = MXFP8Rows(
+        values=torch.empty((64, 256), dtype=torch.float8_e4m3fn),
+        scale_rows=torch.empty((1, 64, 8), dtype=torch.float8_e8m0fnu),
+        scale_mma=torch.empty(0),
+    )
+    packed = mxfp8_kernel.MXFP8LinearWeight(
+        weight=weight_rows,
+        in_features=256,
+        padded_in_features=256,
+        out_features=64,
+    )
+    output = torch.empty(shape, dtype=torch.bfloat16)
+
+    def unexpected_dispatch(*args, **kwargs):
+        pytest.fail("invalid output storage reached the native GEMM dispatch")
+
+    monkeypatch.setattr(mxfp8_kernel, "_check_gpu_tensor", lambda *args: None)
+    monkeypatch.setattr(
+        torch.ops.b12x,
+        "mxfp8_linear_quantized",
+        unexpected_dispatch,
+    )
+    monkeypatch.setattr(
+        torch.ops.b12x,
+        "mxfp8_linear_quantized_out",
+        unexpected_dispatch,
+    )
+    for operation in (
+        mxfp8_kernel.mxfp8_linear_quantized,
+        mxfp8_kernel.mxfp8_linear_quantized_into,
+    ):
+        with pytest.raises(ValueError, match="out must have shape"):
+            operation(
+                quantized,
+                packed,
+                tokens=257,
+                out=output,
+            )
 
 
 def test_incremental_quantized_input_replays_in_cuda_graph() -> None:
@@ -242,7 +295,7 @@ def test_incremental_quantized_input_replays_in_cuda_graph() -> None:
         mxfp8_linear.quantize_input_slice(
             source[:, 128:].contiguous(), quantized, destination_column=128
         )
-        return mxfp8_linear.mm_quantized(quantized, packed, out=output)
+        return mxfp8_linear.mm_quantized_into(quantized, packed, out=output)
 
     run()
     torch.cuda.synchronize()

--- a/tests/gemm/test_mxfp8_linear.py
+++ b/tests/gemm/test_mxfp8_linear.py
@@ -185,3 +185,103 @@ def test_mm_default_fused_path_captures_with_k_padding() -> None:
     torch.cuda.synchronize()
 
     torch.testing.assert_close(actual, eager, rtol=0, atol=0)
+
+
+def test_incremental_quantized_input_matches_one_shot_linear() -> None:
+    """Aligned feature slices preserve one-shot MXFP8 quantization and GEMM."""
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260823)
+
+    tokens = 257
+    source, _, packed = _make_inputs(tokens, 256, 64)
+    quantized = mxfp8_linear.empty_input(512, 256, device=source.device)
+    mxfp8_linear.quantize_input_slice(
+        source[:, :128].contiguous(), quantized, destination_column=0
+    )
+    mxfp8_linear.quantize_input_slice(
+        source[:, 128:].contiguous(), quantized, destination_column=128
+    )
+    output_storage = torch.empty(
+        (512, packed.out_features),
+        device=source.device,
+        dtype=torch.bfloat16,
+    )
+    actual = mxfp8_linear.mm_quantized(
+        quantized,
+        packed,
+        tokens=tokens,
+        out=output_storage,
+        expected_m=tokens,
+    ).clone()
+    expected = mxfp8_linear.mm(source, packed, expected_m=tokens)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_incremental_quantized_input_replays_in_cuda_graph() -> None:
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260824)
+
+    tokens = 8
+    source, _, packed = _make_inputs(tokens, 256, 64)
+    replacement = torch.randn_like(source).div_(4)
+    quantized = mxfp8_linear.empty_input(tokens, 256, device=source.device)
+    output = torch.empty(
+        (tokens, packed.out_features),
+        device=source.device,
+        dtype=torch.bfloat16,
+    )
+
+    def run() -> torch.Tensor:
+        mxfp8_linear.quantize_input_slice(
+            source[:, :128].contiguous(), quantized, destination_column=0
+        )
+        mxfp8_linear.quantize_input_slice(
+            source[:, 128:].contiguous(), quantized, destination_column=128
+        )
+        return mxfp8_linear.mm_quantized(quantized, packed, out=output)
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = run()
+    source.copy_(replacement)
+    expected = mxfp8_linear.mm(source, packed)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_incremental_quantized_input_runs_under_torch_compile() -> None:
+    require_b12x()
+    require_mxf8_mma()
+    torch.manual_seed(20260825)
+
+    tokens = 8
+    source, _, packed = _make_inputs(tokens, 256, 64)
+    quantized = mxfp8_linear.empty_input(tokens, 256, device=source.device)
+    output = torch.empty(
+        (tokens, packed.out_features),
+        device=source.device,
+        dtype=torch.bfloat16,
+    )
+
+    @torch.compile(fullgraph=True)
+    def compiled(first: torch.Tensor, second: torch.Tensor) -> torch.Tensor:
+        mxfp8_linear.quantize_input_slice(first, quantized, destination_column=0)
+        mxfp8_linear.quantize_input_slice(second, quantized, destination_column=128)
+        return mxfp8_linear.mm_quantized(quantized, packed, out=output)
+
+    actual = compiled(
+        source[:, :128].contiguous(),
+        source[:, 128:].contiguous(),
+    )
+    expected = mxfp8_linear.mm(source, packed)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/validation/performance/mxfp8_staged_input_sm120.json
+++ b/validation/performance/mxfp8_staged_input_sm120.json
@@ -1,19 +1,19 @@
 {
-  "command": "benchmarks/benchmark_mxfp8_staged_input.py --iterations 9",
+  "command": "benchmarks/benchmark_mxfp8_staged_input.py --iterations 9 --output validation/performance/mxfp8_staged_input_sm120.json",
   "concatenated": {
-    "live_before_bytes": 738590720,
-    "median_ms": 5.925695896148682,
-    "peak_bytes": 1395524096,
+    "live_before_bytes": 679870464,
+    "median_ms": 5.929887771606445,
+    "peak_bytes": 1278083584,
     "samples_ms": [
-      5.9402241706848145,
-      5.952864170074463,
-      5.9306559562683105,
-      5.919712066650391,
-      5.912288188934326,
-      5.914944171905518,
-      5.923903942108154,
-      5.949215888977051,
-      5.925695896148682
+      5.918399810791016,
+      5.909120082855225,
+      5.870240211486816,
+      5.932703971862793,
+      5.924191951751709,
+      5.9323201179504395,
+      5.929887771606445,
+      6.221183776855469,
+      6.231040000915527
     ]
   },
   "geometry": {
@@ -24,10 +24,37 @@
     "tokens": 4096
   },
   "gpu": {
-    "compute_capability": [12, 0],
+    "compute_capability": [
+      12,
+      0
+    ],
     "cuda_runtime": "13.3",
     "device": 0,
     "driver_version": "610.57.04",
+    "mode": {
+      "available": true,
+      "captured_unix_ns": 1787429685215256476,
+      "command": [
+        "nvidia-smi",
+        "--query-gpu=index,uuid,pstate,persistence_mode,compute_mode,clocks.current.sm,clocks.current.memory,clocks_throttle_reasons.active,power.draw,power.limit,temperature.gpu",
+        "--format=csv,noheader,nounits"
+      ],
+      "fields": {
+        "clocks.current.memory": "13365",
+        "clocks.current.sm": "2572",
+        "clocks_throttle_reasons.active": "0x0000000000000004",
+        "compute_mode": "Default",
+        "index": "0",
+        "persistence_mode": "Enabled",
+        "power.draw": "163.81",
+        "power.limit": "600.00",
+        "pstate": "P1",
+        "temperature.gpu": "31",
+        "uuid": "GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3"
+      },
+      "nvidia_smi_uuid": "GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3",
+      "torch_uuid": "d8438b2d-f000-a617-5dcc-0197ce0365a3"
+    },
     "multiprocessors": 188,
     "name": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
     "torch_version": "2.13.0"
@@ -36,27 +63,32 @@
     "bitwise_equal": true,
     "max_absolute_difference": 0.0
   },
-  "schema": "b12x.mxfp8-staged-input.v1",
+  "schema": "b12x.mxfp8-staged-input.v2",
   "source": {
-    "repository": "local-inference-lab/b12x",
-    "revision": "a2d6f82bedb5a7b8b935823c6cdfb6acce09caf5",
+    "repository": "https://github.com/local-inference-lab/b12x.git",
+    "revision": "4b8662a67afe0c42597e38b53d6d35cdcb14c205",
+    "worktree": "/root/vllm/worktrees/b12x-mxfp8-staged-input-20260822",
     "worktree_state": "clean",
     "worktree_status": []
   },
   "staged": {
-    "live_before_bytes": 632160768,
-    "median_ms": 5.934112071990967,
-    "peak_bytes": 808321536,
+    "live_before_bytes": 573440512,
+    "median_ms": 5.8436479568481445,
+    "peak_bytes": 663355904,
     "samples_ms": [
-      5.702655792236328,
-      5.969279766082764,
-      5.912511825561523,
-      5.8600640296936035,
-      5.935679912567139,
-      5.8758721351623535,
-      5.934112071990967,
-      6.01423978805542,
-      5.985599994659424
+      5.881824016571045,
+      5.817728042602539,
+      5.825727939605713,
+      5.862368106842041,
+      5.846144199371338,
+      5.829535961151123,
+      5.8436479568481445,
+      5.821280002593994,
+      6.144288063049316
     ]
+  },
+  "timing": {
+    "samples_interleaved": true,
+    "source_construction_included": false
   }
 }

--- a/validation/performance/mxfp8_staged_input_sm120.json
+++ b/validation/performance/mxfp8_staged_input_sm120.json
@@ -1,0 +1,62 @@
+{
+  "command": "benchmarks/benchmark_mxfp8_staged_input.py --iterations 9",
+  "concatenated": {
+    "live_before_bytes": 738590720,
+    "median_ms": 5.925695896148682,
+    "peak_bytes": 1395524096,
+    "samples_ms": [
+      5.9402241706848145,
+      5.952864170074463,
+      5.9306559562683105,
+      5.919712066650391,
+      5.912288188934326,
+      5.914944171905518,
+      5.923903942108154,
+      5.949215888977051,
+      5.925695896148682
+    ]
+  },
+  "geometry": {
+    "input_width": 43008,
+    "output_width": 7168,
+    "slice_width": 7168,
+    "slices": 6,
+    "tokens": 4096
+  },
+  "gpu": {
+    "compute_capability": [12, 0],
+    "cuda_runtime": "13.3",
+    "device": 0,
+    "driver_version": "610.57.04",
+    "multiprocessors": 188,
+    "name": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+    "torch_version": "2.13.0"
+  },
+  "output": {
+    "bitwise_equal": true,
+    "max_absolute_difference": 0.0
+  },
+  "schema": "b12x.mxfp8-staged-input.v1",
+  "source": {
+    "repository": "local-inference-lab/b12x",
+    "revision": "a2d6f82bedb5a7b8b935823c6cdfb6acce09caf5",
+    "worktree_state": "clean",
+    "worktree_status": []
+  },
+  "staged": {
+    "live_before_bytes": 632160768,
+    "median_ms": 5.934112071990967,
+    "peak_bytes": 808321536,
+    "samples_ms": [
+      5.702655792236328,
+      5.969279766082764,
+      5.912511825561523,
+      5.8600640296936035,
+      5.935679912567139,
+      5.8758721351623535,
+      5.934112071990967,
+      6.01423978805542,
+      5.985599994659424
+    ]
+  }
+}

--- a/validation/performance/mxfp8_staged_input_sm120.md
+++ b/validation/performance/mxfp8_staged_input_sm120.md
@@ -9,13 +9,16 @@ staged arm quantizes each feature tensor into caller-owned MXFP8 storage and
 writes the GEMM result directly into caller-owned output storage.
 
 The measurement used B12X revision
-`a2d6f82bedb5a7b8b935823c6cdfb6acce09caf5` from a clean worktree, PyTorch
+`4b8662a67afe0c42597e38b53d6d35cdcb14c205` from a clean worktree, PyTorch
 2.13.0 with CUDA 13.3, NVIDIA driver 610.57.04, and one NVIDIA RTX PRO 6000
-Blackwell Workstation Edition GPU. The operation shape was M=4096, K=43008,
-and N=7168, with K supplied as six 7168-column slices.
+Blackwell Workstation Edition GPU identified as
+`GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3`. The operation shape was M=4096,
+K=43008, and N=7168, with K supplied as six 7168-column slices. Nine timing
+pairs were interleaved, and both arms reused the same prebuilt BF16 inputs;
+source generation was excluded from elapsed time.
 
 Both arms produced bitwise-identical BF16 output. Peak allocated memory fell
-from 1,395,524,096 bytes to 808,321,536 bytes, a reduction of 587,202,560 bytes
-or 42.08%. Median elapsed time across nine measured executions was 5.926 ms for
-concatenation and 5.934 ms for staging, a 0.14% difference. Raw samples and
+from 1,278,083,584 bytes to 663,355,904 bytes, a reduction of 614,727,680 bytes
+or 48.10%. Median elapsed time was 5.930 ms for concatenation and 5.844 ms for
+staging, a 1.45% reduction. Raw samples, physical-GPU operating state, and
 runtime metadata are stored in `mxfp8_staged_input_sm120.json`.

--- a/validation/performance/mxfp8_staged_input_sm120.md
+++ b/validation/performance/mxfp8_staged_input_sm120.md
@@ -1,0 +1,21 @@
+# Staged MXFP8 Linear Input on SM120
+
+Status: qualified.
+
+The benchmark at `benchmarks/benchmark_mxfp8_staged_input.py` compares two
+ways to construct the input for one MXFP8 linear operation. The concatenated
+arm retains six BF16 feature tensors and joins them before quantization. The
+staged arm quantizes each feature tensor into caller-owned MXFP8 storage and
+writes the GEMM result directly into caller-owned output storage.
+
+The measurement used B12X revision
+`a2d6f82bedb5a7b8b935823c6cdfb6acce09caf5` from a clean worktree, PyTorch
+2.13.0 with CUDA 13.3, NVIDIA driver 610.57.04, and one NVIDIA RTX PRO 6000
+Blackwell Workstation Edition GPU. The operation shape was M=4096, K=43008,
+and N=7168, with K supplied as six 7168-column slices.
+
+Both arms produced bitwise-identical BF16 output. Peak allocated memory fell
+from 1,395,524,096 bytes to 808,321,536 bytes, a reduction of 587,202,560 bytes
+or 42.08%. Median elapsed time across nine measured executions was 5.926 ms for
+concatenation and 5.934 ms for staging, a 0.14% difference. Raw samples and
+runtime metadata are stored in `mxfp8_staged_input_sm120.json`.


### PR DESCRIPTION
## Purpose

Large projections can receive several independently produced BF16 feature
slices. Concatenating all slices before MXFP8 input quantization retains the
complete BF16 tensor and the quantized tensor simultaneously. That transient
allocation can exhaust free memory in long-context serving profiles.

## Behavior

`b12x.gemm.mxfp8_linear` exposes four operations for caller-owned staging:

- `empty_input` allocates MXFP8 values and scale layouts for a bounded token
  capacity.
- `quantize_input_slice` quantizes one 128-column-aligned BF16 or FP16 feature
  slice into that storage.
- `mm_quantized` executes the existing dense GEMM from assembled MXFP8 input.
- `mm_quantized_into` executes the same GEMM directly into caller-owned output
  storage.

The staged path preserves per-32-column quantization groups and the original
GEMM accumulation order. Existing `mxfp8_linear.mm` behavior and dispatch are
unchanged.

## Compatibility

Feature slices and destination offsets must be multiples of 128 columns. The
operations support eager execution, CUDA Graph replay, and `torch.compile`
full-graph execution. Unsupported layouts, invalid outputs, and insufficient
capacity fail before kernel launch.

## Validation

- `pytest -q tests/gemm/test_mxfp8_linear.py`: 15 passed on one RTX PRO 6000
  Blackwell GPU with PyTorch 2.13.0, CUDA 13.3, and CUTLASS DSL 4.6.2.
- Kimi-K3 DFlash projection geometry (`M=4096`, six `K=7168` slices,
  `N=7168`): staged direct-output and concatenated outputs are bitwise equal.
- Nine interleaved component runs measured 1,278,083,584 bytes peak allocation
  for concatenation and 663,355,904 bytes for staged direct output, a 48.10%
  reduction. Median execution was 5.930 ms and 5.844 ms, respectively.
- A source-locked Kimi-K3 TP16/DCP16 server logged activation of the staged
  direct-output path and completed a 524,288-token prompt plus 64 generated
  tokens.
- Seven normalized DFlash runs measured 155.341 tok/s versus 147.987 tok/s for
  the same source composition with a temporary dense projection output,
  +4.969%. Target-only and DSpark output hashes and throughput remained stable.

The qualified image is
`voipmonitor/vllm@sha256:e009bb404211c67164f1009bda97823f35578285b6779a7614ed1f97c1f8c338`.
Its embedded B12X tree is
`2d466e350e518193f9edd57809e050b3aa8b8dcb`.

Reproduction commands and machine-readable receipts are in the
[Kimi-K3 runtime specification](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/kimi-k3/production-runtime.md).
