### PR TITLE
perf(moe): specialize valid single-token routes

### DIFF
--- a/b12x/moe/_shared/kernels/micro.py
+++ b/b12x/moe/_shared/kernels/micro.py
@@ -924,6 +924,9 @@ class MoEMicroKernelBackend:
     def _resolve_route_expert(self, route_eid: Int32) -> Tuple[Int32, Int32]:
         """Return an in-range expert id and an integer active-route predicate."""
 
+        if cutlass.const_expr(self.single_token):
+            return route_eid, Int32(1)
+
         cfg = self._cfg
         eid = Int32(0)
         route_active = Int32(0)


### PR DESCRIPTION
## Purpose

Compile out route bounds predicates for the unpadded M=1 micro-MoE specialization. The single-token launch receives exactly `top_k` router-selected expert IDs; multi-row and padded launches retain the existing invalid-route guards.

This does not change weights, quantization, activation math, routing, or output dtype. No existing open B12X PR covers this M=1 specialization.

## Test plan and result

- `pytest -q tests/moe/test_cute_migration_moe_standard_corpus.py -k qwen38_nvfp4_padding_live_graph_oracle`
- Result: `6 passed, 7 deselected` on RTX PRO 6000 Blackwell. This covers M=1 through M=6, CUDA-graph replay, the valid M=1 path, and invalid padded rows for M>1.
- Matched GLM-5.3 NVFP4 TP4 MTP0 normal-sampling C1: `123.2 -> 128.3 tok/s` at context 0 and `122.7 -> 127.8 tok/s` at 8k.

Assisted by OpenAI Codex; the submitter reviewed the measured behavior and final change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Specializes the unpadded `M=1` micro-MoE path.
- Returns `route_eid` directly with `route_active=1` for valid single-token routes.
- Preserves route-bounds guards for multi-row and padded launches.
- Does not change weights, quantization, activation math, routing, or output dtype.
- Maintains compatibility with existing `M>1` invalid-route handling.
- Validation passed: `6 passed, 7 deselected`, covering `M=1`–`M=6`, CUDA-graph replay, and invalid padded rows.
- GLM-5.3 NVFP4 TP4 MTP0 normal-sampling C1 throughput increased from `123.2` to `128.3 tok/s` at context 0 and from `122.7` to `127.8 tok/s` at 8k.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->