### PR TITLE
feat(gdn): add direct single-token KDA decode

### DIFF
--- a/b12x/sequence/gdn_decode/__init__.py
+++ b/b12x/sequence/gdn_decode/__init__.py
@@ -57,6 +57,7 @@ META = OpMeta(
         "bind_kda",
         "run",
         "run_kda",
+        "run_kda_single_token",
         "reference",
         "is_supported",
     ),
@@ -96,6 +97,7 @@ if TYPE_CHECKING:
         reference,
         run,
         run_kda,
+        run_kda_single_token,
     )
 
 install_lazy_api(globals(), META)

--- a/b12x/sequence/gdn_decode/_impl.py
+++ b/b12x/sequence/gdn_decode/_impl.py
@@ -851,6 +851,126 @@ def run_kda(
     return binding.output
 
 
+def run_kda_single_token(
+    binding: KdaBinding,
+    *,
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    z: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    lower_bound: float = -5.0,
+    eps: float = 1e-6,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """Run trusted ordinary KDA decode directly on caller-owned tensors.
+
+    Every input row is one live request and ``state_indices[:, 0]`` contains
+    unique, in-range scheduler-owned state slots. Callers that cannot provide
+    that contract must use :func:`run_kda`, which validates packed metadata on
+    the device before mutating recurrent state.
+    """
+    if not isinstance(binding, KdaBinding):
+        raise TypeError(f"binding must be KdaBinding, got {type(binding)!r}")
+    caps = binding.plan.caps
+    num_tokens = int(mixed_qkv.shape[0])
+    if num_tokens <= 0 or num_tokens > caps.max_tokens:
+        raise ValueError(
+            f"single-token KDA rows={num_tokens} exceed capacity {caps.max_tokens}"
+        )
+    model = (caps.model_dtype,)
+    _require_tensor(
+        "mixed_qkv",
+        mixed_qkv,
+        shape=(num_tokens, caps.packed_qkv_width),
+        device=caps.device,
+        dtypes=model,
+    )
+    _require_tensor(
+        "raw_g",
+        raw_g,
+        shape=(num_tokens, caps.value_heads, caps.key_head_dim),
+        device=caps.device,
+        dtypes=model,
+    )
+    if tuple(raw_beta.shape) != (num_tokens, caps.value_heads):
+        raise ValueError(
+            "raw_beta shape must be "
+            f"{(num_tokens, caps.value_heads)}, got {tuple(raw_beta.shape)}"
+        )
+    if raw_beta.device != caps.device or raw_beta.dtype not in model:
+        raise ValueError(
+            "raw_beta must match the planned model device/dtype, got "
+            f"{raw_beta.device}/{raw_beta.dtype}"
+        )
+    for name, tensor in (("z", z), ("output", output)):
+        _require_tensor(
+            name,
+            tensor,
+            shape=(num_tokens, caps.value_heads, caps.value_head_dim),
+            device=caps.device,
+            dtypes=model,
+        )
+    _require_tensor(
+        "state_indices",
+        state_indices,
+        shape=(num_tokens, 1),
+        device=caps.device,
+        dtypes=(torch.int32, torch.int64),
+    )
+    for name, tensor in (
+        ("mixed_qkv", mixed_qkv),
+        ("raw_g", raw_g),
+        ("raw_beta", raw_beta),
+        ("z", z),
+        ("state_indices", state_indices),
+    ):
+        if _overlaps(output, tensor):
+            raise ValueError(f"output must not overlap read-only tensor {name}")
+
+    lower_bound_value = float(lower_bound)
+    if not math.isfinite(lower_bound_value) or lower_bound_value >= 0.0:
+        raise ValueError(
+            "lower_bound must be finite and negative, got "
+            f"{lower_bound_value}"
+        )
+    eps_value = float(eps)
+    if not math.isfinite(eps_value) or eps_value <= 0.0:
+        raise ValueError(f"eps must be finite and positive, got {eps_value}")
+    scale_value = caps.key_head_dim**-0.5 if scale is None else float(scale)
+    if not math.isfinite(scale_value) or scale_value <= 0.0:
+        raise ValueError(f"scale must be finite and positive, got {scale_value}")
+
+    from ._kernels import run_kda_single_token as launch_kda_single_token
+
+    launch_kda_single_token(
+        mixed_qkv,
+        raw_g,
+        raw_beta,
+        z,
+        binding.A_log,
+        binding.dt_bias,
+        binding.norm_weight,
+        binding.recurrent_state,
+        state_indices,
+        output,
+        eps=eps_value,
+        scale=scale_value,
+        lower_bound=lower_bound_value,
+        key_heads=caps.key_heads,
+        value_heads=caps.value_heads,
+        key_head_dim=caps.key_head_dim,
+        value_head_dim=caps.value_head_dim,
+        qk_l2norm=caps.qk_l2norm,
+        null_state_index=caps.null_state_index,
+        block_v=binding.plan.recurrent_block_v,
+        recurrent_num_warps=binding.plan.recurrent_num_warps,
+        norm_num_warps=binding.plan.norm_num_warps,
+    )
+    return output
+
+
 __all__ = [
     "Caps",
     "Plan",
@@ -861,4 +981,5 @@ __all__ = [
     "bind_kda",
     "run",
     "run_kda",
+    "run_kda_single_token",
 ]

--- a/b12x/sequence/gdn_decode/_kernels.py
+++ b/b12x/sequence/gdn_decode/_kernels.py
@@ -179,6 +179,7 @@ def _packed_sequential_kda_decode_kernel(
     QK_L2NORM: tl.constexpr,
     HAS_NULL_STATE_INDEX: tl.constexpr,
     NULL_STATE_INDEX: tl.constexpr,
+    TRUSTED_SINGLE_TOKEN: tl.constexpr,
 ):
     value_tile = tl.program_id(0)
     request_value_head = tl.program_id(1)
@@ -186,17 +187,22 @@ def _packed_sequential_kda_decode_kernel(
     value_head = request_value_head % VALUE_HEADS
     key_head = value_head
 
-    live_seqs = tl.load(num_seqs).to(tl.int32)
-    if (request >= tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS))) | (
-        tl.load(error_code).to(tl.int32) != 0
-    ):
-        return
+    if TRUSTED_SINGLE_TOKEN:
+        start = request
+        end = request + 1
+        accepted_column = 0
+    else:
+        live_seqs = tl.load(num_seqs).to(tl.int32)
+        if (request >= tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS))) | (
+            tl.load(error_code).to(tl.int32) != 0
+        ):
+            return
 
-    start = tl.load(query_start_loc + request).to(tl.int32)
-    end = tl.load(query_start_loc + request + 1).to(tl.int32)
-    if end <= start:
-        return
-    accepted_column = tl.load(num_accepted_tokens + request).to(tl.int32) - 1
+        start = tl.load(query_start_loc + request).to(tl.int32)
+        end = tl.load(query_start_loc + request + 1).to(tl.int32)
+        if end <= start:
+            return
+        accepted_column = tl.load(num_accepted_tokens + request).to(tl.int32) - 1
     source_idx = tl.load(
         state_indices
         + request.to(tl.int64) * stride_indices_request
@@ -335,6 +341,7 @@ def _gated_rmsnorm_kernel(
     SIGMOID_GATE: tl.constexpr,
     NORM_WEIGHT_FP32: tl.constexpr,
     KDA_NORM_FP32: tl.constexpr,
+    TRUSTED_LIVE_TOKENS: tl.constexpr,
 ):
     token_value_head = tl.program_id(0)
     token = token_value_head // VALUE_HEADS
@@ -347,14 +354,15 @@ def _gated_rmsnorm_kernel(
         + value_head.to(tl.int64) * stride_output_head
         + cols.to(tl.int64)
     )
-    error = tl.load(error_code).to(tl.int32)
-    if error != 0:
-        tl.store(output + output_offsets, float("nan"), mask=mask)
-        return
-    live_tokens = tl.load(num_tokens).to(tl.int32)
-    if token >= tl.maximum(0, tl.minimum(live_tokens, MAX_TOKENS)):
-        tl.store(output + output_offsets, 0.0, mask=mask)
-        return
+    if not TRUSTED_LIVE_TOKENS:
+        error = tl.load(error_code).to(tl.int32)
+        if error != 0:
+            tl.store(output + output_offsets, float("nan"), mask=mask)
+            return
+        live_tokens = tl.load(num_tokens).to(tl.int32)
+        if token >= tl.maximum(0, tl.minimum(live_tokens, MAX_TOKENS)):
+            tl.store(output + output_offsets, 0.0, mask=mask)
+            return
 
     z_offsets = (
         token_i64 * stride_z_token
@@ -622,6 +630,7 @@ def _launch_gdn_decode(
             QK_L2NORM=bool(qk_l2norm),
             HAS_NULL_STATE_INDEX=bool(has_null_state_index),
             NULL_STATE_INDEX=int(null_state_index),
+            TRUSTED_SINGLE_TOKEN=False,
             num_warps=int(recurrent_num_warps),
             num_stages=3,
         )
@@ -642,9 +651,196 @@ def _launch_gdn_decode(
         SIGMOID_GATE=bool(sigmoid_gate),
         NORM_WEIGHT_FP32=norm_weight.dtype == torch.float32,
         KDA_NORM_FP32=bool(lower_bounded_kda),
+        TRUSTED_LIVE_TOKENS=False,
         num_warps=int(norm_num_warps),
         num_stages=1,
     )
+
+
+def _launch_kda_single_token(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    z: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    recurrent_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+    scale: float,
+    lower_bound: float,
+    key_heads: int,
+    value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    qk_l2norm: bool,
+    has_null_state_index: bool,
+    null_state_index: int,
+    block_v: int,
+    recurrent_num_warps: int,
+    norm_num_warps: int,
+) -> None:
+    """Launch trusted ordinary KDA decode directly on caller-owned tensors."""
+
+    num_tokens = int(mixed_qkv.shape[0])
+    value_tiles = triton.cdiv(value_head_dim, block_v)
+    # The metadata pointers are compile-time dead in the trusted specialization.
+    # Reuse state_indices so the hot op has no staging tensors or scalar fills.
+    metadata_placeholder = state_indices
+    _packed_sequential_kda_decode_kernel[(value_tiles, num_tokens * value_heads)](
+        mixed_qkv,
+        raw_g,
+        raw_beta,
+        A_log,
+        dt_bias,
+        recurrent_state,
+        metadata_placeholder,
+        metadata_placeholder,
+        state_indices,
+        metadata_placeholder,
+        output,
+        metadata_placeholder,
+        float(scale),
+        float(lower_bound),
+        stride_mixed_token=int(mixed_qkv.stride(0)),
+        stride_a_token=int(raw_g.stride(0)),
+        stride_a_head=int(raw_g.stride(1)),
+        stride_b_token=int(raw_beta.stride(0)),
+        stride_b_head=int(raw_beta.stride(1)),
+        stride_dt_bias_head=int(dt_bias.stride(0)),
+        stride_state_slot=int(recurrent_state.stride(0)),
+        stride_state_head=int(recurrent_state.stride(1)),
+        stride_state_v=int(recurrent_state.stride(2)),
+        stride_indices_request=int(state_indices.stride(0)),
+        stride_indices_column=int(state_indices.stride(1)),
+        stride_output_token=int(output.stride(0)),
+        stride_output_head=int(output.stride(1)),
+        MAX_SEQS=num_tokens,
+        KEY_HEADS=int(key_heads),
+        VALUE_HEADS=int(value_heads),
+        KEY_HEAD_DIM=int(key_head_dim),
+        VALUE_HEAD_DIM=int(value_head_dim),
+        STATE_INDEX_COLUMNS=1,
+        BLOCK_V=int(block_v),
+        QK_L2NORM=bool(qk_l2norm),
+        HAS_NULL_STATE_INDEX=bool(has_null_state_index),
+        NULL_STATE_INDEX=int(null_state_index),
+        TRUSTED_SINGLE_TOKEN=True,
+        num_warps=int(recurrent_num_warps),
+        num_stages=3,
+    )
+    _gated_rmsnorm_kernel[(num_tokens * value_heads,)](
+        output,
+        z,
+        norm_weight,
+        metadata_placeholder,
+        metadata_placeholder,
+        float(eps),
+        stride_output_token=int(output.stride(0)),
+        stride_output_head=int(output.stride(1)),
+        stride_z_token=int(z.stride(0)),
+        stride_z_head=int(z.stride(1)),
+        MAX_TOKENS=num_tokens,
+        VALUE_HEADS=int(value_heads),
+        VALUE_HEAD_DIM=int(value_head_dim),
+        SIGMOID_GATE=True,
+        NORM_WEIGHT_FP32=norm_weight.dtype == torch.float32,
+        KDA_NORM_FP32=True,
+        TRUSTED_LIVE_TOKENS=True,
+        num_warps=int(norm_num_warps),
+        num_stages=1,
+    )
+
+
+@torch.library.custom_op(
+    "b12x::kda_decode_single_token",
+    mutates_args=("recurrent_state", "output"),
+)
+def _kda_decode_single_token_op(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    z: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    recurrent_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+    scale: float,
+    lower_bound: float,
+    key_heads: int,
+    value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    qk_l2norm: bool,
+    has_null_state_index: bool,
+    null_state_index: int,
+    block_v: int,
+    recurrent_num_warps: int,
+    norm_num_warps: int,
+) -> None:
+    _launch_kda_single_token(
+        mixed_qkv,
+        raw_g,
+        raw_beta,
+        z,
+        A_log,
+        dt_bias,
+        norm_weight,
+        recurrent_state,
+        state_indices,
+        output,
+        eps,
+        scale,
+        lower_bound,
+        key_heads,
+        value_heads,
+        key_head_dim,
+        value_head_dim,
+        qk_l2norm,
+        has_null_state_index,
+        null_state_index,
+        block_v,
+        recurrent_num_warps,
+        norm_num_warps,
+    )
+
+
+@_kda_decode_single_token_op.register_fake
+def _kda_decode_single_token_fake(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    z: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    recurrent_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    eps: float,
+    scale: float,
+    lower_bound: float,
+    key_heads: int,
+    value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    qk_l2norm: bool,
+    has_null_state_index: bool,
+    null_state_index: int,
+    block_v: int,
+    recurrent_num_warps: int,
+    norm_num_warps: int,
+) -> None:
+    del mixed_qkv, raw_g, raw_beta, z, A_log, dt_bias, norm_weight
+    del recurrent_state, state_indices, output, eps, scale, lower_bound
+    del key_heads, value_heads, key_head_dim, value_head_dim
+    del qk_l2norm, has_null_state_index, null_state_index, block_v
+    del recurrent_num_warps, norm_num_warps
 
 
 @torch.library.custom_op(
@@ -862,4 +1058,56 @@ def run_gdn_decode(
     )
 
 
-__all__ = ["run_gdn_decode"]
+def run_kda_single_token(
+    mixed_qkv: torch.Tensor,
+    raw_g: torch.Tensor,
+    raw_beta: torch.Tensor,
+    z: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    norm_weight: torch.Tensor,
+    recurrent_state: torch.Tensor,
+    state_indices: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    eps: float,
+    scale: float,
+    lower_bound: float,
+    key_heads: int,
+    value_heads: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    qk_l2norm: bool,
+    null_state_index: int | None,
+    block_v: int,
+    recurrent_num_warps: int,
+    norm_num_warps: int,
+) -> None:
+    torch.ops.b12x.kda_decode_single_token(
+        mixed_qkv,
+        raw_g,
+        raw_beta,
+        z,
+        A_log,
+        dt_bias,
+        norm_weight,
+        recurrent_state,
+        state_indices,
+        output,
+        float(eps),
+        float(scale),
+        float(lower_bound),
+        int(key_heads),
+        int(value_heads),
+        int(key_head_dim),
+        int(value_head_dim),
+        bool(qk_l2norm),
+        null_state_index is not None,
+        0 if null_state_index is None else int(null_state_index),
+        int(block_v),
+        int(recurrent_num_warps),
+        int(norm_num_warps),
+    )
+
+
+__all__ = ["run_gdn_decode", "run_kda_single_token"]

--- a/b12x/sequence/gdn_decode/api.py
+++ b/b12x/sequence/gdn_decode/api.py
@@ -15,6 +15,7 @@ from ._impl import (
     plan,
     run,
     run_kda,
+    run_kda_single_token,
 )
 
 
@@ -34,6 +35,7 @@ __all__ = [
     "bind_kda",
     "run",
     "run_kda",
+    "run_kda_single_token",
     "reference",
     "is_supported",
 ]

--- a/tests/sequence/test_gdn_decode_kda.py
+++ b/tests/sequence/test_gdn_decode_kda.py
@@ -172,7 +172,6 @@ def test_reference_applies_per_key_lower_bounded_decay() -> None:
 
 
 def test_reference_keeps_kda_rmsnorm_in_fp32_until_final_store() -> None:
-    device = torch.device("cpu")
     core = torch.linspace(-1.3, 1.7, 128, dtype=torch.float32).to(torch.bfloat16)
     q = torch.zeros(128, dtype=torch.bfloat16)
     q[0] = 1
@@ -315,6 +314,7 @@ def test_kda_rmsnorm_kernel_avoids_intermediate_bf16_rounding() -> None:
         SIGMOID_GATE=True,
         NORM_WEIGHT_FP32=False,
         KDA_NORM_FP32=True,
+        TRUSTED_LIVE_TOKENS=False,
         num_warps=4,
         num_stages=1,
     )
@@ -354,6 +354,109 @@ def test_packed_kda_matches_reference(state_dtype: torch.dtype) -> None:
         atol=8e-3 if state_dtype == torch.bfloat16 else 2e-5,
     )
     assert torch.count_nonzero(actual[4:]) == 0
+
+
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
+def test_single_token_kda_matches_reference_with_strided_beta(
+    state_dtype: torch.dtype,
+) -> None:
+    device = require_sm120()
+    binding = _make_case(
+        device=device,
+        query_lengths=(1, 1),
+        columns=1,
+        max_tokens=2,
+        state_dtype=state_dtype,
+    )
+    binding.num_accepted_tokens.fill_(1)
+    raw_beta_storage = _randn((2, 4), device=device)
+    raw_beta = raw_beta_storage[:, ::2]
+    assert raw_beta.shape == binding.raw_beta.shape
+    assert not raw_beta.is_contiguous()
+    state_reference = binding.recurrent_state.clone()
+    expected = gdn.reference.decode_kda(
+        binding.mixed_qkv,
+        binding.raw_g,
+        raw_beta,
+        binding.z,
+        binding.A_log,
+        binding.dt_bias,
+        binding.norm_weight,
+        state_reference,
+        binding.query_start_loc,
+        binding.num_accepted_tokens,
+        binding.state_indices,
+        binding.num_seqs,
+        binding.num_tokens,
+        heads=binding.plan.caps.value_heads,
+        qk_l2norm=binding.plan.caps.qk_l2norm,
+    )
+
+    actual = gdn.run_kda_single_token(
+        binding,
+        mixed_qkv=binding.mixed_qkv,
+        raw_g=binding.raw_g,
+        raw_beta=raw_beta,
+        z=binding.z,
+        state_indices=binding.state_indices,
+        output=binding.output,
+    )
+    torch.cuda.synchronize(device)
+
+    assert actual.data_ptr() == binding.output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        binding.recurrent_state,
+        state_reference,
+        rtol=1e-2 if state_dtype == torch.bfloat16 else 1e-5,
+        atol=8e-3 if state_dtype == torch.bfloat16 else 2e-5,
+    )
+
+
+def test_single_token_kda_cuda_graph_replay_preserves_addresses() -> None:
+    device = require_sm120()
+    binding = _make_case(
+        device=device,
+        query_lengths=(1, 1),
+        columns=1,
+        max_tokens=2,
+    )
+    binding.num_accepted_tokens.fill_(1)
+
+    def launch() -> torch.Tensor:
+        return gdn.run_kda_single_token(
+            binding,
+            mixed_qkv=binding.mixed_qkv,
+            raw_g=binding.raw_g,
+            raw_beta=binding.raw_beta,
+            z=binding.z,
+            state_indices=binding.state_indices,
+            output=binding.output,
+        )
+
+    launch()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = launch()
+
+    binding.mixed_qkv.copy_(torch.randn_like(binding.mixed_qkv).mul_(0.2))
+    binding.raw_g.copy_(torch.randn_like(binding.raw_g).mul_(0.2))
+    binding.raw_beta.copy_(torch.randn_like(binding.raw_beta).mul_(0.2))
+    binding.z.copy_(torch.randn_like(binding.z).mul_(0.2))
+    state_reference = binding.recurrent_state.clone()
+    expected = _reference(binding, state_reference)
+    output_ptr = captured_output.data_ptr()
+    state_ptr = binding.recurrent_state.data_ptr()
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert captured_output.data_ptr() == output_ptr
+    assert binding.recurrent_state.data_ptr() == state_ptr
+    torch.testing.assert_close(captured_output, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        binding.recurrent_state, state_reference, rtol=1e-5, atol=2e-5
+    )
 
 
 def test_glm53_tp8_head_geometry_matches_reference() -> None:


### PR DESCRIPTION
## Purpose

Add a native, graph-safe B12X KDA specialization for ordinary decode where every live request contributes exactly one token. It consumes caller-owned tensors directly and compiles out packed-metadata validation and staging work.

The API is explicit about its trusted scheduler contract. Generic packed, speculative, padded, and multi-token requests continue through `run_kda` with the existing device-side validation. No FLA or Torch fallback is added. No existing open B12X PR covers this KDA path.

## Test plan and result

- `pytest -q tests/sequence/test_gdn_decode_kda.py`
- Result: `16 passed` on RTX PRO 6000 Blackwell. Coverage includes BF16/FP32 recurrent states, exact reference comparison, strided beta, null state, duplicate-slot transactionality, CUDA-graph replay, `torch.compile`, and state offsets beyond the signed-32-bit element boundary.
- Matched GLM-5.3 NVFP4 TP4 MTP0 normal-sampling C1, when added to the separately measured M=1 MoE specialization: `128.3 -> 140.58 tok/s` at context 0 and `127.8 -> 139.97 tok/s` at 8k. Stock JJ was `123.2/122.7 tok/s`; qualified r19 was `141.0-141.1/~140.6 tok/s`.

This PR changes neither KDA math nor precision. The final serving stack remained native B12X sparse MLA, KDA, A4 MoE, and PCIe all-reduce.

Assisted by OpenAI Codex; the submitter reviewed the measured behavior and final change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `run_kda_single_token` as a native, graph-safe B12X KDA fast path for ordinary single-token decode.

- Uses caller-owned tensors directly.
- Skips packed-metadata validation and staging for the trusted single-token path.
- Preserves existing `run_kda` behavior for packed, speculative, padded, and multi-token requests.
- Keeps KDA math and precision unchanged.
- Adds validation for shapes, devices, dtypes, capacity, output aliasing, and numeric parameters.
- Adds CUDA graph replay and strided-beta coverage.

All 16 tests in `tests/sequence/test_gdn_decode_kda.py` pass, including reference accuracy, recurrent-state variants, duplicate-slot transactionality, `torch.compile`, CUDA graph replay, and large state offsets.

Measured GLM-5.3 NVFP4 TP4 MTP0 normal-sampling C1 throughput increased from 128.3/127.8 to 140.58/139.97 tok/s at context 0/8k when combined with a separately measured M=1 MoE specialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->