### PR TITLE
perf(moe): use dynamic tactic for GLM-5.3 M4

### DIFF
--- a/b12x/moe/fused_moe/_impl.py
+++ b/b12x/moe/fused_moe/_impl.py
@@ -2168,6 +2168,38 @@ def select_tp_moe_backend(
     return "dynamic"
 
 
+def _nvfp4_glm53_m4_dynamic_candidate(
+    *,
+    num_tokens: int,
+    num_topk: int,
+    weight_E: int,
+    k: int,
+    n: int,
+    activation: str,
+    quant_mode: str,
+) -> bool:
+    """Select the measured GLM-5.3 TP4 M4 dynamic tactic.
+
+    This is deliberately keyed on the complete static kernel geometry rather
+    than lowering the process-wide micro/dynamic cutover. The latter also
+    changes unrelated CUDA-graph buckets and model shapes. Actual-weight graph
+    replay on SM120 places this one crossover at M4: dynamic is about 20
+    percent faster than direct micro while preserving the same NVFP4 numeric
+    contract.
+    """
+
+    return bool(
+        _current_compute_capability() == (12, 0)
+        and _normalize_quant_mode(quant_mode) == "nvfp4"
+        and normalize_moe_activation(activation) == "silu"
+        and int(num_tokens) == 4
+        and int(num_topk) == 8
+        and int(weight_E) == 288
+        and int(k) == 4096
+        and int(n) == 512
+    )
+
+
 def _dynamic_task_geometry(
     E: int,
     n: int,
@@ -5844,6 +5876,16 @@ def _resolve_workspace_layout(
         num_topk=num_topk,
         quant_mode=quant_mode,
     )
+    if implementation == "micro" and _nvfp4_glm53_m4_dynamic_candidate(
+        num_tokens=num_tokens,
+        num_topk=num_topk,
+        weight_E=weight_E,
+        k=k,
+        n=n,
+        activation=activation,
+        quant_mode=quant_mode,
+    ):
+        implementation = "dynamic"
     if implementation == "micro" and not _band_runs_direct_micro(
         num_tokens=num_tokens,
         k=k,

--- a/tests/moe/test_tp_moe_relu2_reference.py
+++ b/tests/moe/test_tp_moe_relu2_reference.py
@@ -324,6 +324,58 @@ def test_single_token_multi_expert_situ_avoids_micro_and_matches_reference() -> 
     assert metrics.cos > 0.9999, f"situ: {metrics}"
 
 
+def test_glm53_m4_nvfp4_uses_measured_dynamic_crossover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tp_moe, "_current_compute_capability", lambda: (12, 0))
+
+    implementation, _, _ = tp_moe._resolve_workspace_layout(
+        num_tokens=4,
+        weight_E=288,
+        num_topk=8,
+        k=4096,
+        n=512,
+        activation="silu",
+        quant_mode="nvfp4",
+    )
+
+    assert implementation == "dynamic"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("num_tokens", 3),
+        ("weight_E", 256),
+        ("num_topk", 6),
+        ("k", 3072),
+        ("n", 640),
+        ("activation", "relu2"),
+        ("quant_mode", "w4a8_nvfp4"),
+    ],
+)
+def test_glm53_m4_nvfp4_crossover_rejects_nearby_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: int | str,
+) -> None:
+    monkeypatch.setattr(tp_moe, "_current_compute_capability", lambda: (12, 0))
+    kwargs: dict[str, int | str] = {
+        "num_tokens": 4,
+        "weight_E": 288,
+        "num_topk": 8,
+        "k": 4096,
+        "n": 512,
+        "activation": "silu",
+        "quant_mode": "nvfp4",
+    }
+    kwargs[field] = value
+
+    implementation, _, _ = tp_moe._resolve_workspace_layout(**kwargs)
+
+    assert implementation == "micro"
+
+
 @pytest.mark.parametrize("m", [1, 2, 4])
 def test_silu_tiny_dynamic_direct_matches_reference(m: int) -> None:
     output, reference = _run_activation_case(


### PR DESCRIPTION
## Summary

- Select B12X's existing dynamic NVFP4 MoE tactic for the exact SM120 GLM-5.3 TP4 verification shape: `M=4`, `topk=8`, `E=288`, `K=4096`, local `N=512`, SiLU.
- Keep the global micro/dynamic threshold and every other architecture, width, expert geometry, activation, and quantization mode unchanged.
- Cover the exact match and seven nearby-shape rejection cases.

## Why

MTP3 verifies four target tokens per step, and the default planner sends this exact geometry through the micro tactic. An actual-weight SM120 comparison measured the existing dynamic tactic about 20% faster for the routed-expert call, with the same NVFP4 contract and slightly better agreement with the dequantized oracle.

## Serving evidence

Matched normal-sampling runs used GLM-5.3-Flash-NVFP4 W4A4, TP4, Marlin probabilistic MTP3 with standard rejection, C32 capacity, full CUDA graphs, and no temperature override. vLLM stayed fixed at `883d104a3`; the B12X control was `2fcf23a`.

| C1 arm | Delivered tok/s | Verifier rounds/s |
|---|---:|---:|
| stock selector | 174.5 | 70.6 |
| exact-M4 dynamic, run 1 | 182.7 | 76.1 |
| exact-M4 dynamic, run 2 | 179.9 | 76.0 |

- Mean C1 delivered throughput: **+3.9%**.
- Acceptance-normalized C1 verifier throughput: **+7.7%**.
- Mean C30 aggregate throughput: 1,510.2 → 1,535.6 tok/s (**+1.7%**).
- MTP0 control remained flat: 139.6 tok/s stock versus 139.5/139.7 tok/s with the selector.
- Both candidate boots completed graph capture and replay without eager fallback or replay allocation.

Benchmark shape:

```bash
python llm_decode_bench.py \
  --host <server> --port 5001 --model GLM-5.3-Flash \
  --contexts 0 --concurrency 1,30 --duration 30
```

Hardware: four SM120 RTX PRO 6000 Blackwell Max-Q GPUs, 300 W each, +6000 MHz memory offset.

Raw JSON SHA-256:

- control: `fde1050b574af48e31dece2ed3908730e78de33342e2df2ec1f6301d9ed780a4`
- candidate run 1: `ea567a465f1141c3f3543fc6ac9ef705be3268b8fdac52e8084a182e9b626369`
- candidate run 2: `a92e06b05e1743284a5a36f9412b75bf810dd7ec2fa25e05743c736f55244636`

## Combined-stack `llm_decode_bench` context

This table demonstrates that the focused patches compose; it is not attributed to this selector alone.

| Concurrency | Published control tok/s | Full patch stack tok/s | Control verifier rounds/s | Full stack verifier rounds/s |
|---:|---:|---:|---:|---:|
| 1 | 174.2 | 207.9 | 70.9 | 81.7 |
| 2 | 300.3 | 316.2 | 125.3 | 131.4 |
| 4 | 498.0 | 506.7 | 201.2 | 206.0 |
| 8 | 733.4 | 755.2 | 298.0 | 304.6 |
| 16 | 1,094.0 | 1,104.1 | 442.6 | 441.5 |
| 32 | 1,648.3 | 1,579.8 | 641.9 | 636.5 |

Full-sweep JSON SHA-256:

- published control: `430f7149e3d733019993d4dce7cd14da512799475ec2371f63a66685d553329c`
- full stack: `d75bbd26ff419da9709eb3da36044d7c86b893f808c6f5872d3e9aa9af9c0110`

## Source and image provenance

The isolated A/B used one clean local qualification image built at `2026-08-28T18:57:21Z`, image ID `sha256:aef068522bbcfd6f0e4b865d39f8aca80d090af813c65960d743a0486d87f48c`.

- vLLM integration commit: `883d104a358b35fea8bff1d31ac6f827e19cbf5b`
- Runtime-equivalent JJ PR head: `b77333ca8824897ff6ddf96a62208ea406c555a9`
- vLLM upstream base: `e7097feb6fcdf57911cd68884420af2d80600dd7`
- B12X base: `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`
- Base-image source overlay: absent; image label patch SHA-256 is the empty-patch hash.
- Control and candidate used the same image; only the two files in this PR were mounted for the candidate.

The published C1-C32 control used `voipmonitor/vllm:glm53-flash-dflash2-mxfp8-vllm82bbab8-b12xfdbb504-fi1ac6942-cu133-torch213-20260828-r1-gitd3920aaa7c05` at manifest digest `sha256:1a210a6dcd4eeef4b9515aa03b8117dbd1bad70ed101cdf72ec4692015e2ac4b`.

## Correctness

- Exact selector plus seven nearby-shape rejection tests pass.
- CUDA SiLU dynamic/direct/reference parity passes for `M=1,2,4` with actual quantized tensors.
- Estonia `max`, normal sampling, C30/R30 produced semantic 29/30 and 30/30 on matched repeats; the single first-run miss did not recur.
- `ruff check` passes for both changed files.

OpenAI Codex assisted with implementation, tests, profiling, benchmarking, and PR preparation. Human review of every changed line and the serving contract is required before merge.
