### PR TITLE
perf(gdn): support direct KDA binding

### DIFF
--- a/b12x/sequence/gdn_decode/_impl.py
+++ b/b12x/sequence/gdn_decode/_impl.py
@@ -531,9 +531,12 @@ def bind_kda(
     """Bind lower-bounded KDA tensors to a GDN decode plan.
 
     KDA uses one Q/K/V head per recurrent state head. ``raw_g`` has shape
-    ``[max_tokens, heads, key_head_dim]`` and ``raw_beta`` has shape
-    ``[max_tokens, heads]``. The recurrent-state and packed-request contracts
-    are identical to :func:`bind`.
+    ``[tokens, heads, key_head_dim]`` and ``raw_beta`` has shape
+    ``[tokens, heads]``. Token and request tensor capacities may be smaller
+    than the plan while state columns remain fixed. When request capacity is
+    smaller than the plan, every bound request row is live and ``num_seqs``
+    must match it. ``query_start_loc[-1]`` must match the independent,
+    device-side ``num_tokens`` live-count scalar.
     """
     if not isinstance(plan, Plan):
         raise TypeError(f"plan must be Plan, got {type(plan)!r}")
@@ -547,6 +550,43 @@ def bind_kda(
         raise ValueError(
             "KDA decode requires gate_activation='sigmoid', got "
             f"{caps.gate_activation!r}"
+        )
+
+    if mixed_qkv.ndim != 2:
+        raise ValueError(
+            f"mixed_qkv must be rank 2, got shape={tuple(mixed_qkv.shape)}"
+        )
+    if num_accepted_tokens.ndim != 1:
+        raise ValueError(
+            "num_accepted_tokens must be rank 1, got "
+            f"shape={tuple(num_accepted_tokens.shape)}"
+        )
+    if state_indices.ndim != 2:
+        raise ValueError(
+            f"state_indices must be rank 2, got shape={tuple(state_indices.shape)}"
+        )
+    bound_tokens = int(mixed_qkv.shape[0])
+    bound_seqs = int(num_accepted_tokens.shape[0])
+    bound_columns = int(state_indices.shape[1])
+    if not 0 < bound_tokens <= caps.max_tokens:
+        raise ValueError(
+            "KDA token capacity must fit the plan, got "
+            f"{bound_tokens}/{caps.max_tokens}"
+        )
+    if not 0 < bound_seqs <= caps.max_seqs:
+        raise ValueError(
+            "KDA request capacity must fit the plan, got "
+            f"{bound_seqs}/{caps.max_seqs}"
+        )
+    if bound_columns != caps.state_index_columns:
+        raise ValueError(
+            "KDA bindings require the planned state-index columns, got "
+            f"{bound_columns}/{caps.state_index_columns}"
+        )
+    if bound_tokens > bound_seqs * bound_columns:
+        raise ValueError(
+            "KDA token capacity must fit request columns, got "
+            f"{bound_tokens} > {bound_seqs} * {bound_columns}"
         )
 
     scratch_storage = scratch_tensor(scratch, plan.scratch_specs(), owner="KDA decode")
@@ -567,28 +607,29 @@ def bind_kda(
     _require_tensor(
         "mixed_qkv",
         mixed_qkv,
-        shape=(caps.max_tokens, caps.packed_qkv_width),
+        shape=(bound_tokens, caps.packed_qkv_width),
         device=caps.device,
         dtypes=model,
     )
     _require_tensor(
         "raw_g",
         raw_g,
-        shape=(caps.max_tokens, caps.value_heads, caps.key_head_dim),
+        shape=(bound_tokens, caps.value_heads, caps.key_head_dim),
         device=caps.device,
         dtypes=model,
     )
     _require_tensor(
         "raw_beta",
         raw_beta,
-        shape=(caps.max_tokens, caps.value_heads),
+        shape=(bound_tokens, caps.value_heads),
         device=caps.device,
         dtypes=model,
+        contiguous=False,
     )
     _require_tensor(
         "z",
         z,
-        shape=(caps.max_tokens, caps.value_heads, caps.value_head_dim),
+        shape=(bound_tokens, caps.value_heads, caps.value_head_dim),
         device=caps.device,
         dtypes=model,
     )
@@ -627,21 +668,21 @@ def bind_kda(
     _require_tensor(
         "query_start_loc",
         query_start_loc,
-        shape=(caps.max_seqs + 1,),
+        shape=(bound_seqs + 1,),
         device=caps.device,
         dtypes=(torch.int32,),
     )
     _require_tensor(
         "num_accepted_tokens",
         num_accepted_tokens,
-        shape=(caps.max_seqs,),
+        shape=(bound_seqs,),
         device=caps.device,
         dtypes=(torch.int32,),
     )
     _require_tensor(
         "state_indices",
         state_indices,
-        shape=(caps.max_seqs, caps.state_index_columns),
+        shape=(bound_seqs, bound_columns),
         device=caps.device,
         dtypes=(torch.int32, torch.int64),
     )
@@ -656,7 +697,7 @@ def bind_kda(
     _require_tensor(
         "output",
         output,
-        shape=(caps.max_tokens, caps.value_heads, caps.value_head_dim),
+        shape=(bound_tokens, caps.value_heads, caps.value_head_dim),
         device=caps.device,
         dtypes=model,
     )

--- a/b12x/sequence/gdn_decode/_kernels.py
+++ b/b12x/sequence/gdn_decode/_kernels.py
@@ -23,35 +23,56 @@ def _reset_validation_kernel(
         tl.store(error_code, 0)
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["bound_seqs", "bound_tokens"])
 def _validate_packed_metadata_kernel(
     query_start_loc,
     num_accepted_tokens,
     num_seqs,
     num_tokens,
+    bound_seqs,
+    bound_tokens,
     error_code,
     MAX_SEQS: tl.constexpr,
     MAX_TOKENS: tl.constexpr,
     STATE_INDEX_COLUMNS: tl.constexpr,
+    EXACT_SEQS: tl.constexpr,
 ):
     request = tl.program_id(0)
-    live_seqs = tl.load(num_seqs).to(tl.int32)
+    declared_seqs = tl.load(num_seqs).to(tl.int32)
+    if EXACT_SEQS:
+        live_seqs = bound_seqs
+    else:
+        live_seqs = declared_seqs
     live_tokens = tl.load(num_tokens).to(tl.int32)
 
     if request == 0:
         counts_invalid = (
-            (live_seqs < 0)
-            | (live_seqs > MAX_SEQS)
+            (bound_seqs < 0)
+            | (bound_seqs > MAX_SEQS)
+            | (bound_tokens < 0)
+            | (bound_tokens > MAX_TOKENS)
+            | (live_seqs < 0)
+            | (live_seqs > bound_seqs)
             | (live_tokens < 0)
-            | (live_tokens > MAX_TOKENS)
+            | (live_tokens > bound_tokens)
         )
         first = tl.load(query_start_loc).to(tl.int32)
-        safe_last = tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS))
-        last = tl.load(query_start_loc + safe_last).to(tl.int32)
-        if counts_invalid | (first != 0) | (last != live_tokens):
-            tl.atomic_or(error_code, 2)
+        if EXACT_SEQS:
+            last = tl.load(query_start_loc + bound_seqs).to(tl.int32)
+            if (
+                counts_invalid
+                | (declared_seqs != bound_seqs)
+                | (first != 0)
+                | (last != live_tokens)
+            ):
+                tl.atomic_or(error_code, 2)
+        else:
+            safe_last = tl.maximum(0, tl.minimum(live_seqs, bound_seqs))
+            last = tl.load(query_start_loc + safe_last).to(tl.int32)
+            if counts_invalid | (first != 0) | (last != live_tokens):
+                tl.atomic_or(error_code, 2)
 
-    if request < tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS)):
+    if request < tl.maximum(0, tl.minimum(live_seqs, bound_seqs)):
         start = tl.load(query_start_loc + request).to(tl.int32)
         end = tl.load(query_start_loc + request + 1).to(tl.int32)
         accepted = tl.load(num_accepted_tokens + request).to(tl.int32)
@@ -68,12 +89,13 @@ def _validate_packed_metadata_kernel(
             tl.atomic_or(error_code, 2)
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["bound_seqs"])
 def _validate_active_state_slots_kernel(
     query_start_loc,
     num_accepted_tokens,
     state_indices,
     num_seqs,
+    bound_seqs,
     duplicate_slots,
     error_code,
     stride_indices_request: tl.constexpr,
@@ -84,12 +106,16 @@ def _validate_active_state_slots_kernel(
     TABLE_SIZE: tl.constexpr,
     HAS_NULL_STATE_INDEX: tl.constexpr,
     NULL_STATE_INDEX: tl.constexpr,
+    EXACT_SEQS: tl.constexpr,
 ):
     cell = tl.program_id(0)
     request = cell // STATE_INDEX_COLUMNS
     column = cell % STATE_INDEX_COLUMNS
-    live_seqs = tl.load(num_seqs).to(tl.int32)
-    if request >= tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS)):
+    if EXACT_SEQS:
+        live_seqs = bound_seqs
+    else:
+        live_seqs = tl.load(num_seqs).to(tl.int32)
+    if request >= tl.maximum(0, tl.minimum(live_seqs, bound_seqs)):
         return
 
     start = tl.load(query_start_loc + request).to(tl.int32)
@@ -140,7 +166,7 @@ def _validate_active_state_slots_kernel(
         tl.atomic_or(error_code, 1)
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["bound_seqs"])
 def _packed_sequential_kda_decode_kernel(
     mixed_qkv,
     a,
@@ -152,6 +178,7 @@ def _packed_sequential_kda_decode_kernel(
     num_accepted_tokens,
     state_indices,
     num_seqs,
+    bound_seqs,
     output,
     error_code,
     scale,
@@ -179,6 +206,7 @@ def _packed_sequential_kda_decode_kernel(
     QK_L2NORM: tl.constexpr,
     HAS_NULL_STATE_INDEX: tl.constexpr,
     NULL_STATE_INDEX: tl.constexpr,
+    EXACT_SEQS: tl.constexpr,
 ):
     value_tile = tl.program_id(0)
     request_value_head = tl.program_id(1)
@@ -186,8 +214,11 @@ def _packed_sequential_kda_decode_kernel(
     value_head = request_value_head % VALUE_HEADS
     key_head = value_head
 
-    live_seqs = tl.load(num_seqs).to(tl.int32)
-    if (request >= tl.maximum(0, tl.minimum(live_seqs, MAX_SEQS))) | (
+    if EXACT_SEQS:
+        live_seqs = bound_seqs
+    else:
+        live_seqs = tl.load(num_seqs).to(tl.int32)
+    if (request >= tl.maximum(0, tl.minimum(live_seqs, bound_seqs))) | (
         tl.load(error_code).to(tl.int32) != 0
     ):
         return
@@ -505,6 +536,11 @@ def _launch_gdn_decode(
             "Qwen GDN decode requires three value heads per key head, got "
             f"key_heads={key_heads}, value_heads={value_heads}"
         )
+    bound_tokens = int(mixed_qkv.shape[0]) if lower_bounded_kda else max_tokens
+    bound_seqs = (
+        int(num_accepted_tokens.shape[0]) if lower_bounded_kda else max_seqs
+    )
+    exact_request_capacity = lower_bounded_kda and bound_seqs < max_seqs
 
     _reset_validation_kernel[(triton.cdiv(duplicate_table_size, _VALIDATION_BLOCK),)](
         duplicate_slots,
@@ -514,23 +550,27 @@ def _launch_gdn_decode(
         num_warps=1,
         num_stages=1,
     )
-    _validate_packed_metadata_kernel[(max_seqs,)](
+    _validate_packed_metadata_kernel[(bound_seqs,)](
         query_start_loc,
         num_accepted_tokens,
         num_seqs,
         num_tokens,
+        bound_seqs,
+        bound_tokens,
         error_code,
         MAX_SEQS=int(max_seqs),
         MAX_TOKENS=int(max_tokens),
         STATE_INDEX_COLUMNS=int(state_index_columns),
+        EXACT_SEQS=bool(exact_request_capacity),
         num_warps=1,
         num_stages=1,
     )
-    _validate_active_state_slots_kernel[(max_seqs * state_index_columns,)](
+    _validate_active_state_slots_kernel[(bound_seqs * state_index_columns,)](
         query_start_loc,
         num_accepted_tokens,
         state_indices,
         num_seqs,
+        bound_seqs,
         duplicate_slots,
         error_code,
         stride_indices_request=int(state_indices.stride(0)),
@@ -541,6 +581,7 @@ def _launch_gdn_decode(
         TABLE_SIZE=int(duplicate_table_size),
         HAS_NULL_STATE_INDEX=bool(has_null_state_index),
         NULL_STATE_INDEX=int(null_state_index),
+        EXACT_SEQS=bool(exact_request_capacity),
         num_warps=1,
         num_stages=1,
     )
@@ -583,7 +624,7 @@ def _launch_gdn_decode(
     else:
         value_tiles = triton.cdiv(value_head_dim, block_v)
         _packed_sequential_kda_decode_kernel[
-            (value_tiles, max_seqs * value_heads)
+            (value_tiles, bound_seqs * value_heads)
         ](
             mixed_qkv,
             a,
@@ -595,6 +636,7 @@ def _launch_gdn_decode(
             num_accepted_tokens,
             state_indices,
             num_seqs,
+            bound_seqs,
             output,
             error_code,
             float(scale),
@@ -622,10 +664,11 @@ def _launch_gdn_decode(
             QK_L2NORM=bool(qk_l2norm),
             HAS_NULL_STATE_INDEX=bool(has_null_state_index),
             NULL_STATE_INDEX=int(null_state_index),
+            EXACT_SEQS=bool(exact_request_capacity),
             num_warps=int(recurrent_num_warps),
             num_stages=3,
         )
-    _gated_rmsnorm_kernel[(max_tokens * value_heads,)](
+    _gated_rmsnorm_kernel[(bound_tokens * value_heads,)](
         output,
         z,
         norm_weight,

--- a/tests/sequence/test_gdn_decode_kda.py
+++ b/tests/sequence/test_gdn_decode_kda.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import gc
+from dataclasses import replace
 
 import pytest
 import torch
 
+import b12x
 from b12x.sequence import gdn_decode as gdn
 
 from ..conftest import require_b12x as require_sm120
@@ -34,6 +36,7 @@ def _make_case(
     max_tokens: int = 5,
     state_dtype: torch.dtype = torch.float32,
     null_state_index: int | None = None,
+    raw_beta_stride: int = 1,
 ) -> gdn.KdaBinding:
     max_seqs = len(query_lengths)
     live_tokens = sum(query_lengths)
@@ -60,6 +63,10 @@ def _make_case(
     state_indices = torch.arange(
         max_seqs * columns, dtype=torch.int64, device=device
     ).view(max_seqs, columns)
+    raw_beta_storage = _randn(
+        (max_tokens, heads * raw_beta_stride), device=device
+    )
+    raw_beta = raw_beta_storage[:, ::raw_beta_stride]
     return gdn.bind_kda(
         plan,
         scratch=torch.empty(
@@ -67,7 +74,7 @@ def _make_case(
         ),
         mixed_qkv=_randn((max_tokens, caps.packed_qkv_width), device=device),
         raw_g=_randn((max_tokens, heads, 128), device=device),
-        raw_beta=_randn((max_tokens, heads), device=device),
+        raw_beta=raw_beta,
         z=_randn((max_tokens, heads, 128), device=device),
         A_log=_randn((heads,), device=device, dtype=torch.float32, scale=0.1),
         dt_bias=_randn(
@@ -85,7 +92,9 @@ def _make_case(
         ),
         query_start_loc=query_start_loc,
         num_accepted_tokens=torch.tensor(
-            [2, 1], dtype=torch.int32, device=device
+            [min(length, 2) for length in query_lengths],
+            dtype=torch.int32,
+            device=device,
         ),
         state_indices=state_indices,
         num_seqs=torch.tensor([max_seqs], dtype=torch.int32, device=device),
@@ -373,6 +382,176 @@ def test_glm53_tp8_head_geometry_matches_reference() -> None:
     )
 
 
+def test_kda_subcapacity_matches_reference_and_replays_cuda_graph() -> None:
+    device = require_sm120()
+    source = _make_case(
+        device=device,
+        query_lengths=(2, 1, 1),
+        max_tokens=6,
+        raw_beta_stride=2,
+    )
+    plan = gdn.plan(replace(source.plan.caps, max_tokens=8, max_seqs=4))
+    (scratch_spec,) = plan.scratch_specs()
+    scratch = torch.empty(
+        scratch_spec.shape, dtype=scratch_spec.dtype, device=device
+    )
+    first = gdn.bind_kda(
+        plan,
+        scratch=scratch,
+        mixed_qkv=source.mixed_qkv[:5],
+        raw_g=source.raw_g[:5],
+        raw_beta=source.raw_beta[:5],
+        z=source.z[:5],
+        A_log=source.A_log,
+        dt_bias=source.dt_bias,
+        norm_weight=source.norm_weight,
+        recurrent_state=source.recurrent_state,
+        query_start_loc=source.query_start_loc[:3],
+        num_accepted_tokens=source.num_accepted_tokens[:2],
+        state_indices=source.state_indices[:2],
+        num_seqs=torch.tensor([2], dtype=torch.int32, device=device),
+        num_tokens=torch.tensor([3], dtype=torch.int32, device=device),
+        output=source.output[:5],
+    )
+    state_reference = first.recurrent_state.clone()
+    expected = _reference(first, state_reference)
+
+    actual = gdn.run_kda(first)
+    torch.cuda.synchronize(device)
+
+    assert first.plan.caps.max_tokens == 8
+    assert first.mixed_qkv.shape[0] == 5
+    assert first.num_accepted_tokens.shape[0] == 2
+    assert not first.raw_beta.is_contiguous()
+    assert actual.data_ptr() == source.output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        first.recurrent_state, state_reference, rtol=1e-5, atol=2e-5
+    )
+
+    from b12x.sequence.gdn_decode import _kernels
+
+    triton_kernels = (
+        _kernels._reset_validation_kernel,
+        _kernels._validate_packed_metadata_kernel,
+        _kernels._validate_active_state_slots_kernel,
+        _kernels._packed_sequential_kda_decode_kernel,
+        _kernels._gated_rmsnorm_kernel,
+    )
+    device_index = torch.cuda.current_device()
+
+    def cache_sizes() -> tuple[int, ...]:
+        return tuple(
+            len(kernel.device_caches[device_index][0]) for kernel in triton_kernels
+        )
+
+    first_cache_sizes = cache_sizes()
+    second = gdn.bind_kda(
+        plan,
+        scratch=scratch,
+        mixed_qkv=source.mixed_qkv,
+        raw_g=source.raw_g,
+        raw_beta=source.raw_beta,
+        z=source.z,
+        A_log=source.A_log,
+        dt_bias=source.dt_bias,
+        norm_weight=source.norm_weight,
+        recurrent_state=source.recurrent_state,
+        query_start_loc=source.query_start_loc,
+        num_accepted_tokens=source.num_accepted_tokens,
+        state_indices=source.state_indices,
+        num_seqs=source.num_seqs,
+        num_tokens=source.num_tokens,
+        output=source.output,
+    )
+    state_reference = second.recurrent_state.clone()
+    expected = _reference(second, state_reference)
+
+    b12x.freeze_kernel_resolution("reduced-capacity KDA regression")
+    try:
+        actual = gdn.run_kda(second)
+        torch.cuda.synchronize(device)
+    finally:
+        b12x.unfreeze_kernel_resolution()
+
+    assert second.mixed_qkv.shape[0] == 6
+    assert second.num_accepted_tokens.shape[0] == 3
+    assert cache_sizes() == first_cache_sizes
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        second.recurrent_state, state_reference, rtol=1e-5, atol=2e-5
+    )
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = gdn.run_kda(second)
+
+    second.mixed_qkv.copy_(torch.randn_like(second.mixed_qkv).mul_(0.2))
+    second.raw_g.copy_(torch.randn_like(second.raw_g).mul_(0.2))
+    second.raw_beta.copy_(torch.randn_like(second.raw_beta).mul_(0.2))
+    second.z.copy_(torch.randn_like(second.z).mul_(0.2))
+    second.recurrent_state.copy_(
+        torch.randn_like(second.recurrent_state).mul_(0.1)
+    )
+    state_reference = second.recurrent_state.clone()
+    expected = _reference(second, state_reference)
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    torch.testing.assert_close(captured_output, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        second.recurrent_state, state_reference, rtol=1e-5, atol=2e-5
+    )
+
+
+def test_kda_subcapacity_metadata_errors_are_transactional() -> None:
+    device = require_sm120()
+    source = _make_case(device=device)
+    plan = gdn.plan(replace(source.plan.caps, max_tokens=6, max_seqs=4))
+    (scratch_spec,) = plan.scratch_specs()
+    binding = gdn.bind_kda(
+        plan,
+        scratch=torch.empty(
+            scratch_spec.shape, dtype=scratch_spec.dtype, device=device
+        ),
+        mixed_qkv=source.mixed_qkv,
+        raw_g=source.raw_g,
+        raw_beta=source.raw_beta,
+        z=source.z,
+        A_log=source.A_log,
+        dt_bias=source.dt_bias,
+        norm_weight=source.norm_weight,
+        recurrent_state=source.recurrent_state,
+        query_start_loc=source.query_start_loc,
+        num_accepted_tokens=source.num_accepted_tokens,
+        state_indices=source.state_indices,
+        num_seqs=source.num_seqs,
+        num_tokens=source.num_tokens,
+        output=source.output,
+    )
+    before = binding.recurrent_state.clone()
+
+    def assert_rejected() -> None:
+        actual = gdn.run_kda(binding)
+        torch.cuda.synchronize(device)
+
+        assert binding.error_code.item() & 2
+        assert torch.isnan(actual).all()
+        torch.testing.assert_close(
+            binding.recurrent_state, before, rtol=0, atol=0
+        )
+
+    binding.num_seqs.fill_(1)
+    assert_rejected()
+
+    binding.num_seqs.fill_(2)
+    binding.query_start_loc.copy_(
+        torch.tensor([0, 2, 3], dtype=torch.int32, device=device)
+    )
+    assert_rejected()
+
+
 def test_kda_rejected_draft_restarts_from_accepted_checkpoint() -> None:
     device = require_sm120()
     binding = _make_case(device=device)
@@ -468,6 +647,39 @@ def test_kda_cuda_graph_replay_preserves_addresses() -> None:
 
     assert captured_output.data_ptr() == output_ptr
     assert binding.recurrent_state.data_ptr() == state_ptr
+    torch.testing.assert_close(captured_output, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        binding.recurrent_state, state_reference, rtol=1e-5, atol=2e-5
+    )
+
+
+def test_kda_cuda_graph_replay_accepts_multiple_live_counts() -> None:
+    device = require_sm120()
+    binding = _make_case(device=device)
+    gdn.run_kda(binding)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_output = gdn.run_kda(binding)
+
+    binding.query_start_loc.copy_(
+        torch.tensor([0, 2, 2], dtype=torch.int32, device=device)
+    )
+    binding.num_accepted_tokens.fill_(1)
+    binding.num_seqs.fill_(1)
+    binding.num_tokens.fill_(2)
+    binding.mixed_qkv.copy_(torch.randn_like(binding.mixed_qkv).mul_(0.2))
+    binding.raw_g.copy_(torch.randn_like(binding.raw_g).mul_(0.2))
+    binding.raw_beta.copy_(torch.randn_like(binding.raw_beta).mul_(0.2))
+    binding.z.copy_(torch.randn_like(binding.z).mul_(0.2))
+    binding.recurrent_state.copy_(
+        torch.randn_like(binding.recurrent_state).mul_(0.1)
+    )
+    state_reference = binding.recurrent_state.clone()
+    expected = _reference(binding, state_reference)
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+
     torch.testing.assert_close(captured_output, expected, rtol=1e-2, atol=2e-2)
     torch.testing.assert_close(
         binding.recurrent_state, state_reference, rtol=1e-5, atol=2e-5


### PR DESCRIPTION
## Summary

- Support direct KDA binding through the existing `bind_kda` / `run_kda` API when caller-owned token and request buffers are smaller than the plan.
- Keep planned capacities as kernel maxima while reduced capacities drive launch grids and masks through runtime, `do_not_specialize` arguments.
- Preserve packed-layout validation, transactional failure, fixed state-column geometry, and CUDA graph replay.

This adds no public entry point or serving flag. "Reduced-capacity binding" describes the shape contract; the optimization is direct binding of caller buffers, not a single-token-only path.

## Contract

For reduced request-capacity bindings, every bound request row is live, `num_seqs` must equal that capacity, and `query_start_loc[bound_seqs]` must equal the independent device-side `num_tokens` scalar. Full-capacity bindings retain the existing behavior where both live counts may change between graph replays.

`raw_beta` may be row-strided because kernels already consume its explicit strides. Token and request capacities must fit the plan, state columns must exactly match the plan, and token capacity must fit the request-column envelope.

Only the reduced-capacity policy boolean specializes. Planned capacities and static model geometry remain compile-time; live request, token, and accepted-prefix counts do not enter compile/cache keys.

## Why

Speculative verification already owns exact-size projected tensors and accepted-prefix metadata. Binding those buffers to an existing plan lets integrations avoid plan-sized per-layer staging copies without moving planner policy into the caller. The vLLM consumer is local-inference-lab/vllm#504.

## Correctness and graph tests

Run on SM120 in the serving image:

```bash
/opt/venv/bin/python -m pytest tests/sequence/test_gdn_decode_kda.py -q
```

Result: `16/16 passed`.

Coverage includes:

- reference agreement for reduced-capacity output and recurrent state;
- two distinct reduced request/token capacities under frozen kernel resolution, with unchanged Triton cache cardinality;
- strided `raw_beta` on the reduced-capacity route;
- reduced-capacity CUDA graph capture/replay;
- transactional rejection of both a mismatched request count and `query_start_loc[bound_seqs] != num_tokens`, with all-NaN output and unchanged recurrent state;
- full-capacity replay with changing live counts; and
- the existing rejected-draft, duplicate-slot, null-state, large-offset, and `torch.compile` coverage.

The linked vLLM test passes `1 passed, 38 deselected` and verifies that its direct route supplies `num_tokens` from a dedicated live-count buffer rather than aliasing the terminal query offset.

Static checks:

```bash
uvx ruff check --ignore F841 b12x/sequence/gdn_decode/_impl.py b12x/sequence/gdn_decode/_kernels.py tests/sequence/test_gdn_decode_kda.py
git diff --check 2fcf23a0ce269be27b2e03fece73d46e90e6aeea...3c485daaa0140bf00d0172c55e3af83e445e2de5
```

Both passed. `F841` is ignored only for an unrelated baseline unused variable already present in the test file.

## Performance evidence

An earlier matched staged/direct-binding A/B isolated the staging-removal mechanism before this internal API refactor. Both arms used the same GLM-5.3-Flash-NVFP4 TP4 stack, W4A4 target MoE, probabilistic MTP3, FP8 KV, C32 capacity, 1M model length, 8,192-token batching, CUDA graphs capped at 128 rows, and normal model sampling.

| Arm | C1 delivered tok/s | C1 verifier steps/s | C30 aggregate tok/s | C30 verifier steps/s |
|---|---:|---:|---:|---:|
| staged control | 174.5 | 70.59 | 1,510.2 | 608.07 |
| direct binding, run 1 | 167.7 | 74.35 | 1,527.5 | 618.09 |
| direct binding, run 2 | 184.6 | 74.00 | 1,526.0 | 609.52 |

The isolated A/B supports the mechanism: C1 verifier work increased about 5.1%, while delivered throughput varied with stochastic acceptance; mean C30 delivered throughput increased about 1.1%.

The exact final heads were requalified after the terminal-offset fix. This is integration qualification, not isolated attribution to this PR:

| Run | Delivered tok/s | Verifier steps/s | Mean accepted length |
|---|---:|---:|---:|
| C1, final heads | 199.3 | 79.82 | 2.50 |

No temperature override was used. Ratio direction is candidate/control, higher is better.

Raw-result SHA-256:

- isolated staged control: `fde1050b574af48e31dece2ed3908730e78de33342e2df2ec1f6301d9ed780a4`
- isolated direct run 1: `42f4690dc6bbca86f194de02f748e5907d74c7b34458f7ead4e874fcc5dcd7b2`
- isolated direct run 2: `1119f71dc5a4cdbdd2d9fe198ce3b966d1dce1198ddcba86b8dc35f373b7ed72`
- final-head C1: `abc8891fcec2b1a98cbb90d0d5ea3520248fe8a31a40a1a3a26404558f3e1148`

Benchmark client: `llm_decode_bench` v0.4.29 at `29b8f0ecd16b061114adc3610a95e8f7a1979a69`.

## Provenance

- B12X base: `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`
- B12X head: `3c485daaa0140bf00d0172c55e3af83e445e2de5`
- vLLM #504 qualification head: `71ad9871ed6574cd559ffbe123843c48013ea7c9`
- base serving image ID: `sha256:aef068522bbcfd6f0e4b865d39f8aca80d090af813c65960d743a0486d87f48c`; the exact PR source files were bind-mounted over that image.

The qualification box used four NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition GPUs at 300 W. During C1 all four were P1, memory clock was 16,365 MHz, graphics clocks were 2,265-2,302 MHz, and the active throttle mask was zero.

## Duplicate-work check

- Closed #249 used additional public single-token entry points; this PR supersedes that design with internal direct binding through the existing API.
- vLLM #490 integrates the old API and does not cover speculative verified prefixes.
- No other open B12X PR found by the current title/body search implements reduced-capacity direct KDA binding.
- #252 is unrelated and is not a dependency.

OpenAI Codex assisted with implementation, tests, benchmarking, and PR preparation. The human submitter must review and be able to defend every changed line before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds graph-safe reduced-capacity KDA binding through the existing `bind_kda` / `run_kda` contract. Caller-owned token and request tensors can be smaller than planned capacity without staging. Planned capacities remain compile geometry. Runtime counts control launch grids and masks.

## Technical changes

- Preserves planned state-index dimensions while deriving runtime bounds from bound tensors.
- Adds bound-aware validation and launch sizing.
- Retains packed-metadata, duplicate-slot, range, padding, recurrent-state, and transactional validation.
- Supports non-contiguous `raw_beta`.
- Preserves CUDA graph capture and replay with changing live counts.
- Supports verified-prefix speculative transactions used by MTP/DFlash.
- Adds exact-capacity kernel handling to avoid unnecessary metadata loads.
- Adds no public API entrypoint or flag.

## Compatibility

Existing `bind_kda` / `run_kda` behavior remains available for packed, padded, speculative, and multi-token requests. Planned compile and cache geometry remains stable.

## Validation

- 16 KDA tests pass.
- Coverage includes reduced-capacity reference agreement, kernel-cache stability, CUDA graph replay, changing live counts, and transactional rollback.
- Lint and diff checks pass.
- Serving qualification covers the revised B12X and vLLM stack with C1 and C30 workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->