### PR TITLE
perf(mhc): use chunk projection geometry at 4080 tokens

### DIFF
--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -120,8 +120,20 @@ _PREFILL_TF32_TMA_STAGES = int(
         os.getenv("B12X_MHC_PREFILL_TMA_STAGES", "1"),
     )
 )
+_RAW_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = os.getenv(
+    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS"
+)
 _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = int(
-    os.getenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", "4096")
+    _RAW_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS or "4096"
+)
+# The GLM-5.3 vLLM integration presents 4080 live-token tiles at its 4096-token
+# scheduler limit. The hidden-4096 chunk kernel retains its measured geometry
+# across that 16-token boundary. Other hidden sizes retain the generic limit.
+_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS = int(
+    os.getenv(
+        "B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS",
+        _RAW_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS or "4080",
+    )
 )
 _PREFILL_TF32_TMA_LONG_MIN_TOKENS = int(
     os.getenv("B12X_MHC_PREFILL_TF32_TMA_LONG_MIN_TOKENS", "8192")
@@ -129,7 +141,7 @@ _PREFILL_TF32_TMA_LONG_MIN_TOKENS = int(
 # At hidden=4096, one CTA owns all 24 mix columns so A is loaded once instead
 # of once per 8-column N tile. M192/K64 gives the best 4096-token balance of B
 # reuse and SM coverage; K splitting supplies enough CTAs for all SMs.
-# Keep the previous geometry for hidden=7168, where wide-N regresses.
+# Hidden size 7168 retains narrow-N geometry because wide-N regresses there.
 _PREFILL_TF32_TMA_CHUNK_4096_M_WARPS = int(
     os.getenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "12")
 )
@@ -255,6 +267,13 @@ def _source_tiles_for_hidden(hidden_size: int) -> int:
             f"{_SOURCE_TILE_H}"
         )
     return hidden_size // _SOURCE_TILE_H
+
+
+def _mhc_prefill_tf32_chunk_min_tokens(hidden_size: int) -> int:
+    """Return the live-token threshold for TF32 chunk geometry."""
+    if int(hidden_size) == _HIDDEN:
+        return _PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS
+    return _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
 
 
 def _split_k_for_hidden(hidden_size: int) -> int:
@@ -5018,7 +5037,8 @@ def _run_mhc_prefill_tf32_project_launch(
     if not fn.is_contiguous():
         raise ValueError("fn must be contiguous")
     out_flat = out.view(tokens, _MHC_MULT * hidden_size)
-    chunk_geometry = tokens >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
+    chunk_min_tokens = _mhc_prefill_tf32_chunk_min_tokens(hidden_size)
+    chunk_geometry = tokens >= chunk_min_tokens
     long_geometry = (
         hidden_size == _HIDDEN and tokens >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
     )
@@ -5070,7 +5090,7 @@ def _run_mhc_prefill_tf32_project_launch(
         ("hidden_size", hidden_size),
         ("split_k", split_k),
         ("chunk_geometry", chunk_geometry),
-        ("chunk_min_tokens", _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS),
+        ("chunk_min_tokens", chunk_min_tokens),
         ("long_geometry", long_geometry),
         ("long_min_tokens", _PREFILL_TF32_TMA_LONG_MIN_TOKENS),
         ("tile_m", kernel.tile_m),
@@ -5099,7 +5119,7 @@ def _run_mhc_prefill_tf32_project_launch(
 
 def mhc_prefill_tf32_project_splits(*, tokens: int, hidden_size: int) -> int:
     """Return the projection split count selected by the TF32 prefill kernel."""
-    chunk_geometry = int(tokens) >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
+    chunk_geometry = int(tokens) >= _mhc_prefill_tf32_chunk_min_tokens(hidden_size)
     long_geometry = (
         int(hidden_size) == _HIDDEN and int(tokens) >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
     )

--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -126,9 +126,9 @@ _RAW_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = os.getenv(
 _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = int(
     _RAW_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS or "4096"
 )
-# The GLM-5.3 vLLM integration presents 4080 live-token tiles at its 4096-token
-# scheduler limit. The hidden-4096 chunk kernel retains its measured geometry
-# across that 16-token boundary. Other hidden sizes retain the generic limit.
+# A 4096-row scheduler batch can reserve 16 rows for bookkeeping and pass 4080
+# live rows to the projection. Hidden size 4096 retains the measured chunk
+# geometry across that boundary. Other hidden sizes retain the generic limit.
 _PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS = int(
     os.getenv(
         "B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS",

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -22,7 +22,15 @@ from benchmarks.common import (
     require_sm120,
 )
 from b12x.norm.mhc._impl import B12XMHCScratchCaps, plan_mhc_scratch, b12x_mhc_post_pre
-from b12x.norm.mhc._kernels import _mhc_prefill_tf32_chunk_min_tokens
+from b12x.norm.mhc import _kernels as mhc_kernels
+
+
+def _resolved_mhc_prefill_tf32_chunk_min_tokens(hidden_size: int) -> int:
+    """Resolve the runtime threshold across both compared B12X revisions."""
+    resolver = getattr(mhc_kernels, "_mhc_prefill_tf32_chunk_min_tokens", None)
+    if resolver is not None:
+        return int(resolver(hidden_size))
+    return int(os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", "4096"))
 
 
 def _mhc_pre_reference(
@@ -132,14 +140,18 @@ def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> tuple[float, f
     return float(diff.abs().max().item()), float(torch.sqrt(torch.mean(diff * diff)).item())
 
 
-def _bench_graph(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float]:
+def _bench_graph(
+    fn, *, warmup: int, iters: int, l2_flush
+) -> tuple[float, float, list[float]]:
     graph = capture_cuda_graph(fn, warmup=warmup)
     stats = bench_cuda_graph(graph, replays=iters, l2_flush=l2_flush)
     samples = stats["replay_us"]
-    return statistics.median(samples), min(samples)
+    return statistics.median(samples), min(samples), samples
 
 
-def _bench_eager(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float]:
+def _bench_eager(
+    fn, *, warmup: int, iters: int, l2_flush
+) -> tuple[float, float, list[float]]:
     samples = []
     for _ in range(warmup):
         if l2_flush is not None:
@@ -148,7 +160,7 @@ def _bench_eager(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float
     torch.cuda.synchronize()
     for _ in range(iters):
         samples.append(bench_gpu_ms(fn, warmup=0, iters=1, l2_flush=l2_flush) * 1000.0)
-    return statistics.median(samples), min(samples)
+    return statistics.median(samples), min(samples), samples
 
 
 def _register_vllm_mhc_tilelang(vllm_path: pathlib.Path) -> None:
@@ -191,6 +203,11 @@ def main() -> None:
     parser.add_argument("--hc-eps", type=float, default=1e-6)
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--print-samples",
+        action="store_true",
+        help="Append every measured timing sample to the result line.",
+    )
     parser.add_argument("--eager", action="store_true")
     parser.add_argument("--skip-check", action="store_true")
     parser.add_argument("--l2-flush", action="store_true")
@@ -314,7 +331,7 @@ def main() -> None:
             os.environ.get("B12X_MHC_PREFILL_TMA_STAGES", "1"),
         )
     )
-    prefill_tf32_tma_chunk_min_tokens = _mhc_prefill_tf32_chunk_min_tokens(
+    prefill_tf32_tma_chunk_min_tokens = _resolved_mhc_prefill_tf32_chunk_min_tokens(
         args.hidden_size
     )
     prefill_tf32_tma_chunk_geometry = (
@@ -576,15 +593,16 @@ def main() -> None:
 
     l2_flush = make_l2_flush_fn(args.l2_flush, args.l2_flush_bytes)
     bench = _bench_eager if args.eager else _bench_graph
-    fused_median, fused_min = bench(
+    fused_median, fused_min, fused_samples = bench(
         run_fused, warmup=args.warmup, iters=args.iters, l2_flush=l2_flush
     )
     if args.compare_vllm:
-        vllm_median, vllm_min = bench(
+        vllm_median, vllm_min, vllm_samples = bench(
             run_vllm_fused, warmup=args.warmup, iters=args.iters, l2_flush=l2_flush
         )
     else:
         vllm_median = vllm_min = float("nan")
+        vllm_samples = []
     mode = "eager" if args.eager else "graph"
 
     line = (
@@ -599,6 +617,7 @@ def main() -> None:
         f"k{prefill_tf32_tma_k}s{prefill_tf32_tma_stages}"
         f"wm{prefill_tf32_tma_m_warps}wn{prefill_tf32_tma_n_warps} "
         f"prefill_tf32_chunk_geometry={prefill_tf32_tma_chunk_geometry} "
+        f"prefill_tf32_chunk_min_tokens={prefill_tf32_tma_chunk_min_tokens} "
         f"prefill_tf32_long_geometry={prefill_tf32_tma_long_geometry} "
         f"prefill_tf32_k_splits={prefill_tf32_tma_k_splits} "
         f"prefill_gram_threads={prefill_gram_threads} "
@@ -619,6 +638,10 @@ def main() -> None:
             f"bf16ref_post_max={bf16ref_post_max:.3g} "
             f"bf16ref_comb_max={bf16ref_comb_max:.3g}"
         )
+    if args.print_samples:
+        line += " post_pre_samples_us=" + ",".join(
+            f"{sample:.2f}" for sample in fused_samples
+        )
     if args.compare_vllm:
         line += (
             " vllm_deep_gemm=True"
@@ -628,6 +651,10 @@ def main() -> None:
             f"vllm_post_max={vllm_post_max:.3g} vllm_comb_max={vllm_comb_max:.3g} "
             f"vllm_out_max={vllm_out_max:.3g} vllm_out_rmse={vllm_out_rmse:.3g}"
         )
+        if args.print_samples:
+            line += " vllm_post_pre_samples_us=" + ",".join(
+                f"{sample:.2f}" for sample in vllm_samples
+            )
     print(line)
 
 

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -26,7 +26,11 @@ from b12x.norm.mhc import _kernels as mhc_kernels
 
 
 def _resolved_mhc_prefill_tf32_chunk_min_tokens(hidden_size: int) -> int:
-    """Resolve the runtime threshold across both compared B12X revisions."""
+    """Return the effective runtime threshold for the requested hidden size.
+
+    B12X revisions with hidden-size-specific selection expose a resolver.
+    Revisions with only the global policy expose the threshold constant.
+    """
     resolver = getattr(mhc_kernels, "_mhc_prefill_tf32_chunk_min_tokens", None)
     if resolver is not None:
         return int(resolver(hidden_size))

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -22,6 +22,7 @@ from benchmarks.common import (
     require_sm120,
 )
 from b12x.norm.mhc._impl import B12XMHCScratchCaps, plan_mhc_scratch, b12x_mhc_post_pre
+from b12x.norm.mhc._kernels import _mhc_prefill_tf32_chunk_min_tokens
 
 
 def _mhc_pre_reference(
@@ -313,8 +314,8 @@ def main() -> None:
             os.environ.get("B12X_MHC_PREFILL_TMA_STAGES", "1"),
         )
     )
-    prefill_tf32_tma_chunk_min_tokens = int(
-        os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", "4096")
+    prefill_tf32_tma_chunk_min_tokens = _mhc_prefill_tf32_chunk_min_tokens(
+        args.hidden_size
     )
     prefill_tf32_tma_chunk_geometry = (
         args.tokens >= prefill_tf32_tma_chunk_min_tokens

--- a/docs/evidence/mhc_hidden4096_4080_row_projection.md
+++ b/docs/evidence/mhc_hidden4096_4080_row_projection.md
@@ -1,8 +1,9 @@
-# Hidden-size-4096 mHC projection at 4080 live rows
+# Hidden-size-4096 multi-head connection projection at 4080 live rows
 
 Status: **qualified** for CUDA graph replay on SM120 with the software and
-hardware conditions recorded below. The result qualifies the mHC projection
-operation; it does not by itself predict end-to-end serving throughput.
+hardware conditions recorded below. The result qualifies the multi-head
+connection (mHC) projection operation; it does not by itself predict
+end-to-end serving throughput.
 
 ## Operation and revisions
 
@@ -112,9 +113,9 @@ The qualified arm reported output RMSE `4.76e-06`, projection maximum error
 | Comparison B | `m16n8k256s1wm1wn1`, one K split | 381.60 us | 378.53 us |
 
 The pooled comparison median is 381.60 us and the pooled qualified median is
-296.61 us. The qualified geometry reduces latency by 22.27%. Expressed in the
-opposite direction, fixed-work throughput is 1.2865 times the comparison arm,
-or 28.65% higher.
+296.58 us. The qualified geometry reduces latency by 22.28%. Expressed in the
+opposite direction, fixed-work throughput is 1.2867 times the comparison arm,
+or 28.67% higher.
 
 ### Raw replay samples in microseconds
 

--- a/docs/evidence/mhc_hidden4096_4080_row_projection.md
+++ b/docs/evidence/mhc_hidden4096_4080_row_projection.md
@@ -1,0 +1,152 @@
+# Hidden-size-4096 mHC projection at 4080 live rows
+
+Status: **qualified** for CUDA graph replay on SM120 with the software and
+hardware conditions recorded below. The result qualifies the mHC projection
+operation; it does not by itself predict end-to-end serving throughput.
+
+## Operation and revisions
+
+The operation is the fused multi-head connection post/pre transform with BF16
+inputs, a 24-by-16384 FP32 projection, TF32 tensor-core math, fused RMSNorm,
+4096 hidden columns, four residual streams, and 4080 live rows. A scheduler
+batch with capacity 4096 can reserve 16 rows and present this live-row count to
+the kernel.
+
+- Comparison revision: `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`
+- Qualified revision: `86a840624a0e9fc0a8077c2d43184456c8c66cf9`
+- Qualified worktree:
+  `/root/vllm/worktrees/b12x-glm53-mhc-prefill-2fcf23a0-20260828`
+- Comparison kernel SHA-256:
+  `decba110f9e817d2f5016f7255a01d4349381a435380eba559f3a50490954859`
+- Qualified kernel SHA-256:
+  `14ecec5e95491f5c8285f50c77089d3ff1446fbff3e1cfd13edc05abfaf86aea`
+- Benchmark SHA-256:
+  `8a29604868889d5f0f5368ce1d5f49077068f1c02cab9d5c919608945c9fc102`
+- Container image:
+  `voipmonitor/vllm:glm53-flash-nvfp4-luke-clean-vllme75bcfd-b12x58a046f-fi1ac6942-cu133-torch213-20260828-r1`
+- Container image ID:
+  `sha256:ecc2b7a12cc369d1f04fc896be29170a8fbb1e027f1dd9f58f202f23a54a38ea`
+
+The comparison arm used the B12X tree embedded in the container. The qualified
+arm mounted `b12x/norm/mhc/_kernels.py` from the qualified revision. Both arms
+mounted the benchmark from the qualified revision so that threshold selection
+and raw sample reporting were identical.
+
+## Hardware and execution mode
+
+- Physical GPU index: 7
+- GPU UUID: `GPU-0027fc86-3322-ce2a-856c-f49eb61eb63e`
+- GPU: NVIDIA RTX PRO 6000 Blackwell Workstation Edition
+- Compute architecture: SM120, compiled with `CUTE_DSL_ARCH=sm_120a`
+- Persistence mode: enabled
+- Compute mode: default
+- Initial state: P8, 180 MHz SM, 405 MHz memory, throttle mask `0x0`, 29 C
+- Final state: P1, 2610 MHz SM, 13365 MHz memory, throttle mask `0x0`, 31 C
+- CUDA visibility inside the container: physical GPU 7 mapped to logical GPU 0
+- Timing mode: captured CUDA graph, 20 warmup replays, 30 measured replays per
+  arm, no requested L2 flush
+- Arm order: comparison A, qualified A, qualified B, comparison B
+- Compile state: a fresh B12X and CuTe DSL cache directory for every arm
+
+Clocks were not administratively locked. The balanced arm order and identical
+medians in both comparison arms limit drift in this qualification, but the
+recorded result is not a fixed-clock release certification.
+
+## Command
+
+Each arm ran the following command from `/opt/glm53-flash/b12x` inside the
+container. The qualified arm additionally mounted the qualified
+`b12x/norm/mhc/_kernels.py` at the corresponding container path.
+
+```bash
+/opt/venv/bin/python -B benchmarks/benchmark_residual.py \
+  --tokens 4080 \
+  --expected-m 4096 \
+  --hidden-size 4096 \
+  --split-k 64 \
+  --block-k 256 \
+  --block-h 512 \
+  --fuse-rmsnorm \
+  --prefill-tf32-mma \
+  --no-prefill-block-m \
+  --warmup 20 \
+  --iters 30 \
+  --print-samples
+```
+
+The container environment set `CUDA_VISIBLE_DEVICES=0`,
+`CUDA_DEVICE_ORDER=PCI_BUS_ID`, `CUTE_DSL_ARCH=sm_120a`,
+`PYTHONDONTWRITEBYTECODE=1`, and arm-local `B12X_COMPILE_CACHE_DIR` and
+`CUTE_DSL_CACHE_DIR` values.
+
+## Correctness and graph replay
+
+`tests/gemm/test_launch_custom_ops.py` launches the production projection on
+both sides of the dispatch boundary, captures it in a CUDA graph, mutates the
+stable input allocation, poisons the output workspace with NaNs, and replays
+the graph. The reconstructed projection must be finite, nonzero, and within
+`rtol=0.02, atol=0.0625` of `torch.nn.functional.linear`.
+
+The targeted command passed on the recorded GPU:
+
+```bash
+/opt/venv/bin/python -B -m pytest -q \
+  tests/gemm/test_launch_custom_ops.py \
+  -k "mhc_prefill_chunk_geometry or mhc_prefill_chunk_boundary"
+```
+
+Result: `3 passed, 11 deselected`.
+
+For the 4080-row benchmark, the comparison arm reported output RMSE
+`4.76e-06`, projection maximum error `0.0625`, and projection RMSE `0.000875`.
+The qualified arm reported output RMSE `4.76e-06`, projection maximum error
+`0.0625`, and projection RMSE `0.000861`.
+
+## Timing result
+
+| Arm | Selected geometry | Median latency | Minimum latency |
+|---|---|---:|---:|
+| Comparison A | `m16n8k256s1wm1wn1`, one K split | 381.60 us | 378.53 us |
+| Qualified A | `m192n24k64s2wm12wn1`, eight K splits | 296.10 us | 292.51 us |
+| Qualified B | `m192n24k64s2wm12wn1`, eight K splits | 296.59 us | 292.54 us |
+| Comparison B | `m16n8k256s1wm1wn1`, one K split | 381.60 us | 378.53 us |
+
+The pooled comparison median is 381.60 us and the pooled qualified median is
+296.61 us. The qualified geometry reduces latency by 22.27%. Expressed in the
+opposite direction, fixed-work throughput is 1.2865 times the comparison arm,
+or 28.65% higher.
+
+### Raw replay samples in microseconds
+
+Comparison A:
+
+```text
+382.66,378.72,380.58,380.58,382.62,382.62,380.58,380.58,380.58,384.67,378.53,381.60,380.54,380.58,382.62,378.53,383.65,382.62,380.58,380.58,382.62,382.62,381.60,378.53,382.62,382.62,382.62,381.60,382.62,382.59
+```
+
+Qualified A:
+
+```text
+298.59,294.82,296.61,296.61,294.53,296.64,294.56,298.62,294.59,296.61,294.56,298.66,294.53,292.51,295.62,296.61,298.66,294.56,294.56,294.53,296.64,297.60,292.51,296.61,294.59,294.53,296.64,298.66,295.58,296.58
+```
+
+Qualified B:
+
+```text
+299.55,294.91,296.61,294.53,296.64,296.61,294.56,297.63,294.56,294.56,296.61,296.61,296.61,294.56,295.58,294.56,296.58,292.54,296.61,294.59,296.61,295.58,296.61,296.61,298.66,296.61,294.56,294.56,295.58,296.61
+```
+
+Comparison B:
+
+```text
+382.50,380.83,384.67,380.58,382.62,382.62,380.58,382.62,380.58,380.58,381.63,382.56,378.53,384.67,378.53,382.62,381.60,380.58,380.58,380.54,382.62,378.53,383.65,380.58,382.62,382.62,380.58,381.60,382.59,380.58
+```
+
+## Compatibility
+
+The 4080-row threshold applies only to hidden size 4096. Hidden size 7168 and
+other hidden sizes retain the 4096-row threshold. The global environment
+override continues to set every hidden size unless
+`B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS` explicitly overrides hidden
+size 4096. Live row counts remain runtime launch inputs and are not part of the
+kernel compile key.

--- a/tests/gemm/test_launch_custom_ops.py
+++ b/tests/gemm/test_launch_custom_ops.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import pytest
 import torch
+import torch.nn.functional as F
 from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -68,6 +70,86 @@ def test_mhc_prefill_chunk_geometry_covers_hidden4096_scheduler_payload() -> Non
     assert residual_kernels.mhc_prefill_tf32_project_splits(
         tokens=4080, hidden_size=4096
     ) == 8
+
+
+@pytest.mark.parametrize("tokens", [4079, 4080])
+def test_mhc_prefill_chunk_boundary_matches_reference_under_graph_replay(
+    tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise both sides of the 4080-row dispatch boundary on SM120."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("the hidden-4096 projection geometry is qualified on SM120")
+
+    import b12x.norm.mhc._kernels as residual_kernels
+
+    monkeypatch.delenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS", raising=False)
+    monkeypatch.delenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", raising=False)
+    device = torch.device("cuda")
+    hidden_size = 4096
+    split_k = 64
+    generator = torch.Generator(device=device)
+    generator.manual_seed(40_790 + tokens)
+    residual = (
+        torch.randn(
+            (tokens, 4, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.02
+    ).contiguous()
+    projection = (
+        torch.randn(
+            (24, 4 * hidden_size),
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.02
+    ).contiguous()
+    partials = torch.empty((tokens, split_k, 25), device=device, dtype=torch.float32)
+    active_splits = residual_kernels.mhc_prefill_tf32_project_splits(
+        tokens=tokens,
+        hidden_size=hidden_size,
+    )
+
+    def launch() -> None:
+        residual_kernels.run_mhc_prefill_tf32_project(
+            out=residual,
+            fn=projection,
+            partials=partials,
+        )
+
+    launch()
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    residual.copy_(
+        torch.randn(
+            residual.shape,
+            device=device,
+            dtype=residual.dtype,
+            generator=generator,
+        )
+        * 0.02
+    )
+    partials.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    actual = partials[:, 0, 1:25].clone()
+    if active_splits > 1:
+        actual += partials[:, 2 : active_splits + 1, 1:25].sum(dim=1)
+    reference = F.linear(residual.flatten(1).float(), projection)
+    assert torch.isfinite(actual).all()
+    assert torch.count_nonzero(actual).item() > 0
+    torch.testing.assert_close(actual, reference, rtol=0.02, atol=0.0625)
 
 
 def test_mhc_sm121_decode_partial_group_policy(monkeypatch) -> None:

--- a/tests/gemm/test_launch_custom_ops.py
+++ b/tests/gemm/test_launch_custom_ops.py
@@ -57,6 +57,19 @@ def test_mhc_sm121_decode_finalize_policy(monkeypatch) -> None:
     assert select(num_tokens=16, hidden_size=7168, compute_capability=(12, 1)) == 0
 
 
+def test_mhc_prefill_chunk_geometry_covers_hidden4096_scheduler_payload() -> None:
+    import b12x.norm.mhc._kernels as residual_kernels
+
+    assert residual_kernels._mhc_prefill_tf32_chunk_min_tokens(4096) == 4080
+    assert residual_kernels._mhc_prefill_tf32_chunk_min_tokens(7168) == 4096
+    assert residual_kernels.mhc_prefill_tf32_project_splits(
+        tokens=4079, hidden_size=4096
+    ) == 1
+    assert residual_kernels.mhc_prefill_tf32_project_splits(
+        tokens=4080, hidden_size=4096
+    ) == 8
+
+
 def test_mhc_sm121_decode_partial_group_policy(monkeypatch) -> None:
     import b12x.norm.mhc._kernels as residual_kernels
 


### PR DESCRIPTION
## Result

Status: **implemented and qualified** for the hidden-size-4096 multi-head
connection projection on SM120.

The TF32 TMA projection selects chunk geometry at 4080 live rows when the
hidden size is 4096. A GLM-5.3 scheduler batch with a 4096-token capacity and
16 reserved rows produces this launch shape. Hidden size 7168 retains the
generic 4096-row threshold.

## Technical reason

The 4096-row threshold routed a 4080-by-4096 projection to scalar geometry
with one K split. The chunk kernel uses eight K splits and the measured
`m192n24k64s2wm12wn1` geometry. This geometry exposes enough CTA parallelism
and reuses each source tile across all 24 mix columns.

## Configuration and compatibility

- `B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS` remains the global threshold
  override.
- `B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS` overrides only hidden
  size 4096.
- When the global override is set and the hidden-size-4096 override is absent,
  the global value applies to every hidden size.
- Batches below 4080 rows retain scalar geometry.
- Hidden size 7168, decode kernels, finalization policy, scratch layout,
  numerical formats, and public operation signatures are unchanged.
- The live row count remains a runtime launch input and is not part of a
  compile key.

## Validation

Source base: B12X `master` at
`2fcf23a0ce269be27b2e03fece73d46e90e6aeea`.

Hardware: physical GPU 7,
`GPU-0027fc86-3322-ce2a-856c-f49eb61eb63e`, NVIDIA RTX PRO 6000 Blackwell
Workstation Edition, SM120 compiled with `CUTE_DSL_ARCH=sm_120a`.

The production launcher test covers scalar dispatch at 4079 rows, chunk
dispatch at 4080 rows, CUDA graph capture and replay, stable output
allocation, mutated input, NaN-poisoned workspace, and comparison with
`torch.nn.functional.linear`:

```bash
/opt/venv/bin/python -B -m pytest -q \
  tests/gemm/test_launch_custom_ops.py \
  -k "mhc_prefill_chunk_geometry or mhc_prefill_chunk_boundary"
```

Result: `3 passed, 11 deselected`.

The benchmark command for every balanced comparison arm was:

```bash
/opt/venv/bin/python -B benchmarks/benchmark_residual.py \
  --tokens 4080 \
  --expected-m 4096 \
  --hidden-size 4096 \
  --split-k 64 \
  --block-k 256 \
  --block-h 512 \
  --fuse-rmsnorm \
  --prefill-tf32-mma \
  --no-prefill-block-m \
  --warmup 20 \
  --iters 30 \
  --print-samples
```

Each arm used a fresh B12X and CuTe DSL compilation cache. Arm order was
comparison A, qualified A, qualified B, comparison B. Both comparison arms
had a 381.60 us median. The qualified arms had 296.10 us and 296.59 us
medians; the pooled qualified median was 296.58 us. Latency decreased by
22.28%, equivalent to 28.67% higher fixed-work throughput.

The qualified output had RMSE `4.76e-06`. The reconstructed projection had
maximum absolute error `0.0625` and RMSE `0.000861`.

The exact revisions, source hashes, image, hardware state, raw replay samples,
correctness tolerances, and ratio direction are recorded in
[`docs/evidence/mhc_hidden4096_4080_row_projection.md`](https://github.com/local-inference-lab/b12x/blob/09d783fa43e9cc1edc46a00d40aacba1b72c5825/docs/evidence/mhc_hidden4096_4080_row_projection.md).

## AI assistance disclosure

AI assistance was used to implement the dispatch policy, add qualification
coverage, run the measurements, and prepare this pull-request description.
