### PR TITLE
fix(moe): keep route workspace bounds runtime-dynamic

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
+++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
@@ -19,7 +19,7 @@ _SMALL_PREFIX_MAX_ROUTE_BLOCKS = 512
 _FAST_COUNT_BLOCK_T = 1024
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["live_numel"])
 def _w4a16_route_count_kernel(
     topk_ids,
     expert_map,
@@ -122,7 +122,9 @@ def _workspace_slice(
     return tensor[:elements]
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["live_numel", "max_packed_routes", "max_route_blocks"]
+)
 def _pack_topk_routes_post_prefix_kernel(
     packed_route_indices,
     block_expert_ids,
@@ -130,8 +132,8 @@ def _pack_topk_routes_post_prefix_kernel(
     live_numel,
     BLOCK_SIZE: tl.constexpr,
     NUM_EXPERTS: tl.constexpr,
-    MAX_PACKED_ROUTES: tl.constexpr,
-    MAX_ROUTE_BLOCKS: tl.constexpr,
+    max_packed_routes,
+    max_route_blocks,
     BLOCK_T: tl.constexpr,
     SEARCH_STEPS: tl.constexpr,
 ):
@@ -146,12 +148,12 @@ def _pack_topk_routes_post_prefix_kernel(
     tl.store(
         packed_route_indices + offsets,
         live_numel,
-        mask=offsets < MAX_PACKED_ROUTES,
+        mask=offsets < max_packed_routes,
     )
 
     total = tl.load(expert_offsets + NUM_EXPERTS)
     block_rows = offsets * BLOCK_SIZE
-    valid_blocks = (offsets < MAX_ROUTE_BLOCKS) & (block_rows < total)
+    valid_blocks = (offsets < max_route_blocks) & (block_rows < total)
     low = tl.zeros((BLOCK_T,), dtype=tl.int32)
     high = tl.full((BLOCK_T,), NUM_EXPERTS, dtype=tl.int32)
     for _ in tl.static_range(0, SEARCH_STEPS):
@@ -164,7 +166,7 @@ def _pack_topk_routes_post_prefix_kernel(
     tl.store(
         block_expert_ids + offsets,
         block_experts,
-        mask=offsets < MAX_ROUTE_BLOCKS,
+        mask=offsets < max_route_blocks,
     )
 
 
@@ -264,7 +266,7 @@ def _pack_topk_routes_small_prefix_kernel(
     )
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["live_numel"])
 def _pack_topk_routes_sort_kernel(
     topk_ids,
     expert_map,
@@ -517,8 +519,8 @@ def pack_topk_routes_by_expert(
             numel,
             BLOCK_SIZE=int(block_size),
             NUM_EXPERTS=int(num_experts),
-            MAX_PACKED_ROUTES=max_packed_routes,
-            MAX_ROUTE_BLOCKS=max_route_blocks,
+            max_packed_routes=max_packed_routes,
+            max_route_blocks=max_route_blocks,
             BLOCK_T=_POST_PREFIX_BLOCK_T,
             SEARCH_STEPS=block_e.bit_length(),
             num_warps=4,

--- a/tests/moe/test_w4a16_route_pack.py
+++ b/tests/moe/test_w4a16_route_pack.py
@@ -14,6 +14,33 @@ from b12x.moe._shared.kernels.w4a16.host import (
 )
 
 
+def test_post_prefix_capacity_bounds_are_runtime_scalars() -> None:
+    kernel = route_pack_module._pack_topk_routes_post_prefix_kernel
+    constexpr_names = {kernel.arg_names[index] for index in kernel.constexprs}
+
+    assert "max_packed_routes" not in constexpr_names
+    assert "max_route_blocks" not in constexpr_names
+
+
+@pytest.mark.parametrize(
+    ("kernel", "runtime_names"),
+    [
+        (route_pack_module._w4a16_route_count_kernel, {"live_numel"}),
+        (
+            route_pack_module._pack_topk_routes_post_prefix_kernel,
+            {"live_numel", "max_packed_routes", "max_route_blocks"},
+        ),
+        (route_pack_module._pack_topk_routes_sort_kernel, {"live_numel"}),
+    ],
+)
+def test_route_pack_runtime_bounds_do_not_specialize(kernel, runtime_names) -> None:
+    do_not_specialize = {
+        value if isinstance(value, str) else kernel.arg_names[value]
+        for value in kernel.do_not_specialize
+    }
+    assert do_not_specialize >= runtime_names
+
+
 @pytest.mark.parametrize(
     ("max_tokens", "topk", "num_experts"),
     [


### PR DESCRIPTION
## Problem

Triton specializes unannotated integer arguments. Route-packing requests can therefore compile new `_w4a16_route_count_kernel`, `_pack_topk_routes_post_prefix_kernel`, and `_pack_topk_routes_sort_kernel` variants when the live route count or preallocated workspace capacity changes. In a server that treats inference-time compilation as a warning, this produces a warning on the first unmatched request shape.

## Change

- Keep post-prefix workspace bounds as runtime arguments.
- Mark live route counts and workspace bounds with `do_not_specialize`.
- Add regression checks for both constexpr membership and Triton's `do_not_specialize` metadata.

The expert count, route block size, and binary-search geometry remain compile-time constants. Route ordering, output layout, and workspace sizing are unchanged.

## Validation

- Four focused regression cases passed in the CUDA image: one verifies that workspace capacities are not constexpr arguments; three verify the non-specialized runtime arguments on the count, post-prefix, and sort kernels.
- Manual GPU smoke test used four RTX PRO 6000 Blackwell GPUs with tensor parallelism and decode-context parallelism both set to four. A fresh Triton cache warmed both supported `topk_ids` pointer-alignment layouts on every worker.
- The serving correctness gate passed deterministic short answers, strict structured output, and three-key retrieval from a 32,933-token prompt.
- vLLM's verbose JIT monitor emitted no inference-time compilation warning for the three changed route-pack kernels.