### PR TITLE
perf(mhc): tune SM120 medium prefill projection

### DIFF
--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -71,19 +71,11 @@ _PREFILL_MMA_THREADS = 32
 _PREFILL_MMA_TILE_M = 16
 _PREFILL_MMA_TILE_N = 8
 _PREFILL_MMA_TILE_K = 16
-_PREFILL_TMA_COMPUTE_WARPS = int(
-    os.getenv("B12X_MHC_PREFILL_TMA_WARPS", "8")
-)
+_PREFILL_TMA_COMPUTE_WARPS = int(os.getenv("B12X_MHC_PREFILL_TMA_WARPS", "8"))
 _PREFILL_TMA_THREADS = (_PREFILL_TMA_COMPUTE_WARPS + 1) * 32
-_PREFILL_TMA_TILE_M = int(
-    os.getenv("B12X_MHC_PREFILL_TMA_TILE_M", "128")
-)
-_PREFILL_TMA_TILE_N = int(
-    os.getenv("B12X_MHC_PREFILL_TMA_TILE_N", "16")
-)
-_PREFILL_TMA_TILE_K = int(
-    os.getenv("B12X_MHC_PREFILL_TMA_TILE_K", "64")
-)
+_PREFILL_TMA_TILE_M = int(os.getenv("B12X_MHC_PREFILL_TMA_TILE_M", "128"))
+_PREFILL_TMA_TILE_N = int(os.getenv("B12X_MHC_PREFILL_TMA_TILE_N", "16"))
+_PREFILL_TMA_TILE_K = int(os.getenv("B12X_MHC_PREFILL_TMA_TILE_K", "64"))
 _PREFILL_TMA_STAGES = int(os.getenv("B12X_MHC_PREFILL_TMA_STAGES", "3"))
 _PREFILL_TF32_TMA_M_WARPS = int(
     os.getenv(
@@ -94,9 +86,7 @@ _PREFILL_TF32_TMA_M_WARPS = int(
         ),
     )
 )
-_PREFILL_TF32_TMA_N_WARPS = int(
-    os.getenv("B12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1")
-)
+_PREFILL_TF32_TMA_N_WARPS = int(os.getenv("B12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1"))
 _PREFILL_TF32_TMA_COMPUTE_WARPS = _PREFILL_TF32_TMA_M_WARPS * _PREFILL_TF32_TMA_N_WARPS
 _PREFILL_TF32_TMA_THREADS = (_PREFILL_TF32_TMA_COMPUTE_WARPS + 1) * 32
 _PREFILL_TF32_TMA_TILE_M = int(
@@ -105,9 +95,7 @@ _PREFILL_TF32_TMA_TILE_M = int(
         os.getenv("B12X_MHC_PREFILL_TMA_TILE_M", "16"),
     )
 )
-_PREFILL_TF32_TMA_TILE_N = int(
-    os.getenv("B12X_MHC_PREFILL_TF32_TMA_TILE_N", "8")
-)
+_PREFILL_TF32_TMA_TILE_N = int(os.getenv("B12X_MHC_PREFILL_TF32_TMA_TILE_N", "8"))
 _PREFILL_TF32_TMA_TILE_K = int(
     os.getenv(
         "B12X_MHC_PREFILL_TF32_TMA_TILE_K",
@@ -241,9 +229,7 @@ _PREFILL_TF32_TMA_LONG_4096_STAGES = int(
 _PREFILL_TF32_TMA_LONG_4096_K_SPLITS = int(
     os.getenv("B12X_MHC_PREFILL_TF32_TMA_LONG_K_SPLITS", "4")
 )
-_PREFILL_FINALIZE_THREADS = int(
-    os.getenv("B12X_MHC_PREFILL_FINALIZE_THREADS", "256")
-)
+_PREFILL_FINALIZE_THREADS = int(os.getenv("B12X_MHC_PREFILL_FINALIZE_THREADS", "256"))
 _POST_PRE_CHUNK = 12
 
 # --- Gram-trick split finalize (multi-CTA fuse_norm, no per-h norm reduction) -
@@ -501,9 +487,7 @@ def _selected_post_pre_decode_split_n(
             f"no larger than {_SOURCE_TILES}, got {splits}"
         )
     if tile_n <= 0 or _MIXES % tile_n != 0:
-        raise ValueError(
-            f"B12X_MHC_DECODE_TILE_N must divide {_MIXES}, got {tile_n}"
-        )
+        raise ValueError(f"B12X_MHC_DECODE_TILE_N must divide {_MIXES}, got {tile_n}")
     return splits, tile_n
 
 
@@ -563,9 +547,7 @@ def _selected_post_pre_partials_per_cta(
         try:
             return _validate_post_pre_partials_per_cta(int(raw))
         except ValueError as exc:
-            raise ValueError(
-                f"invalid B12X_MHC_PARTIALS_PER_CTA={raw!r}"
-            ) from exc
+            raise ValueError(f"invalid B12X_MHC_PARTIALS_PER_CTA={raw!r}") from exc
 
     if compute_capability is None and torch.cuda.is_available():
         compute_capability = tuple(torch.cuda.get_device_capability())
@@ -5694,9 +5676,7 @@ def _run_mhc_finalize_gram_launch(
         )
     )
     single_cta = single_cta_threads > 0
-    raw_single_cta_groups = os.environ.get(
-        "B12X_MHC_DECODE_FINALIZE_CTAS"
-    )
+    raw_single_cta_groups = os.environ.get("B12X_MHC_DECODE_FINALIZE_CTAS")
     single_cta_groups = 1
     if single_cta:
         single_cta_groups = (

--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -126,10 +126,47 @@ _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS = int(
 _PREFILL_TF32_TMA_LONG_MIN_TOKENS = int(
     os.getenv("B12X_MHC_PREFILL_TF32_TMA_LONG_MIN_TOKENS", "8192")
 )
-# At hidden=4096, one CTA owns all 24 mix columns so A is loaded once instead
-# of once per 8-column N tile. M192/K64 gives the best 4096-token balance of B
-# reuse and SM coverage; K splitting supplies enough CTAs for all SMs.
-# Keep the previous geometry for hidden=7168, where wide-N regresses.
+# Hidden-size-4096 projection batches from 2304 through 3583 rows use M64 CTAs
+# and eight K splits to occupy SM120. One CTA owns all 24 mix columns, so the
+# input tile is read once instead of once per 8-column N tile. Three pipeline
+# stages hide TMA latency below 3072 rows; two stages reduce pipeline resources
+# from 3072 rows through the end of the M64 range.
+_PREFILL_TF32_TMA_MEDIUM_MIN_TOKENS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_MIN_TOKENS", "2304")
+)
+_PREFILL_TF32_TMA_MEDIUM_HIGH_MIN_TOKENS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_HIGH_MIN_TOKENS", "3072")
+)
+_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS", "3584")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_M_WARPS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_M_WARPS", "4")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_N_WARPS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_N_WARPS", "1")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_TILE_M = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_TILE_M", "64")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_TILE_N = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_TILE_N", "24")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_TILE_K = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_TILE_K", "64")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_STAGES = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_STAGES", "3")
+)
+_PREFILL_TF32_TMA_MEDIUM_HIGH_4096_STAGES = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_HIGH_STAGES", "2")
+)
+_PREFILL_TF32_TMA_MEDIUM_4096_K_SPLITS = int(
+    os.getenv("B12X_MHC_PREFILL_TF32_TMA_MEDIUM_K_SPLITS", "8")
+)
+# From 3584 rows at hidden size 4096, M192/K64 balances B reuse and SM coverage;
+# K splitting supplies enough CTAs for all SMs. Hidden size 7168 keeps narrow N
+# tiles because wide-N geometry regresses that shape.
 _PREFILL_TF32_TMA_CHUNK_4096_M_WARPS = int(
     os.getenv("B12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "12")
 )
@@ -2507,10 +2544,13 @@ class MHCPrefillTf32ProjectTmaKernel:
         *,
         hidden_size: int = _HIDDEN,
         split_k: int | None = None,
+        medium_geometry: bool = False,
+        medium_high_geometry: bool = False,
         chunk_geometry: bool = False,
         long_geometry: bool = False,
     ):
         self.hidden_size = int(hidden_size)
+        use_4096_medium_geometry = medium_geometry and self.hidden_size == _HIDDEN
         use_4096_chunk_geometry = chunk_geometry and self.hidden_size == _HIDDEN
         use_4096_long_geometry = long_geometry and self.hidden_size == _HIDDEN
         if use_4096_long_geometry:
@@ -2529,6 +2569,18 @@ class MHCPrefillTf32ProjectTmaKernel:
             self.tile_k = _PREFILL_TF32_TMA_CHUNK_4096_TILE_K
             self.num_stages = _PREFILL_TF32_TMA_CHUNK_4096_STAGES
             self.k_splits = _PREFILL_TF32_TMA_CHUNK_4096_K_SPLITS
+        elif use_4096_medium_geometry:
+            self.num_m_warps = _PREFILL_TF32_TMA_MEDIUM_4096_M_WARPS
+            self.num_n_warps = _PREFILL_TF32_TMA_MEDIUM_4096_N_WARPS
+            self.tile_m = _PREFILL_TF32_TMA_MEDIUM_4096_TILE_M
+            self.tile_n = _PREFILL_TF32_TMA_MEDIUM_4096_TILE_N
+            self.tile_k = _PREFILL_TF32_TMA_MEDIUM_4096_TILE_K
+            self.num_stages = (
+                _PREFILL_TF32_TMA_MEDIUM_HIGH_4096_STAGES
+                if medium_high_geometry
+                else _PREFILL_TF32_TMA_MEDIUM_4096_STAGES
+            )
+            self.k_splits = _PREFILL_TF32_TMA_MEDIUM_4096_K_SPLITS
         elif chunk_geometry:
             self.num_m_warps = _PREFILL_TF32_TMA_CHUNK_OTHER_M_WARPS
             self.num_n_warps = _PREFILL_TF32_TMA_CHUNK_OTHER_N_WARPS
@@ -3949,12 +4001,16 @@ def _prefill_bf16_project_tma_kernel(
 def _prefill_tf32_project_kernel(
     hidden_size: int,
     split_k: int,
+    medium_geometry: bool = False,
+    medium_high_geometry: bool = False,
     chunk_geometry: bool = False,
     long_geometry: bool = False,
 ) -> MHCPrefillTf32ProjectTmaKernel:
     return MHCPrefillTf32ProjectTmaKernel(
         hidden_size=hidden_size,
         split_k=split_k,
+        medium_geometry=medium_geometry,
+        medium_high_geometry=medium_high_geometry,
         chunk_geometry=chunk_geometry,
         long_geometry=long_geometry,
     )
@@ -4994,6 +5050,35 @@ def run_mhc_prefill_bf16_project(
     )
 
 
+def _mhc_prefill_tf32_chunk_min_tokens(hidden_size: int) -> int:
+    """Return the wide-CTA projection threshold for a hidden size."""
+    if int(hidden_size) == _HIDDEN:
+        return _PREFILL_TF32_TMA_CHUNK_4096_MIN_TOKENS
+    return _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
+
+
+def _mhc_prefill_tf32_geometry(
+    *, tokens: int, hidden_size: int
+) -> tuple[bool, bool, bool, bool]:
+    """Select medium, high-medium, chunk, and long TF32 geometries."""
+    tokens = int(tokens)
+    hidden_size = int(hidden_size)
+    chunk_min_tokens = _mhc_prefill_tf32_chunk_min_tokens(hidden_size)
+    medium_geometry = (
+        hidden_size == _HIDDEN
+        and tokens >= _PREFILL_TF32_TMA_MEDIUM_MIN_TOKENS
+        and tokens < chunk_min_tokens
+    )
+    medium_high_geometry = (
+        medium_geometry and tokens >= _PREFILL_TF32_TMA_MEDIUM_HIGH_MIN_TOKENS
+    )
+    chunk_geometry = tokens >= chunk_min_tokens
+    long_geometry = (
+        hidden_size == _HIDDEN and tokens >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
+    )
+    return medium_geometry, medium_high_geometry, chunk_geometry, long_geometry
+
+
 def _run_mhc_prefill_tf32_project_launch(
     *,
     out: torch.Tensor,
@@ -5018,13 +5103,20 @@ def _run_mhc_prefill_tf32_project_launch(
     if not fn.is_contiguous():
         raise ValueError("fn must be contiguous")
     out_flat = out.view(tokens, _MHC_MULT * hidden_size)
-    chunk_geometry = tokens >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
-    long_geometry = (
-        hidden_size == _HIDDEN and tokens >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
+    (
+        medium_geometry,
+        medium_high_geometry,
+        chunk_geometry,
+        long_geometry,
+    ) = _mhc_prefill_tf32_geometry(
+        tokens=tokens,
+        hidden_size=hidden_size,
     )
     kernel = _prefill_tf32_project_kernel(
         hidden_size,
         split_k,
+        medium_geometry,
+        medium_high_geometry,
         chunk_geometry,
         long_geometry,
     )
@@ -5069,8 +5161,12 @@ def _run_mhc_prefill_tf32_project_launch(
     compile_key = (
         ("hidden_size", hidden_size),
         ("split_k", split_k),
+        ("medium_geometry", medium_geometry),
+        ("medium_min_tokens", _PREFILL_TF32_TMA_MEDIUM_MIN_TOKENS),
+        ("medium_high_geometry", medium_high_geometry),
+        ("medium_high_min_tokens", _PREFILL_TF32_TMA_MEDIUM_HIGH_MIN_TOKENS),
         ("chunk_geometry", chunk_geometry),
-        ("chunk_min_tokens", _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS),
+        ("chunk_min_tokens", _mhc_prefill_tf32_chunk_min_tokens(hidden_size)),
         ("long_geometry", long_geometry),
         ("long_min_tokens", _PREFILL_TF32_TMA_LONG_MIN_TOKENS),
         ("tile_m", kernel.tile_m),
@@ -5099,13 +5195,20 @@ def _run_mhc_prefill_tf32_project_launch(
 
 def mhc_prefill_tf32_project_splits(*, tokens: int, hidden_size: int) -> int:
     """Return the projection split count selected by the TF32 prefill kernel."""
-    chunk_geometry = int(tokens) >= _PREFILL_TF32_TMA_CHUNK_MIN_TOKENS
-    long_geometry = (
-        int(hidden_size) == _HIDDEN and int(tokens) >= _PREFILL_TF32_TMA_LONG_MIN_TOKENS
+    (
+        medium_geometry,
+        medium_high_geometry,
+        chunk_geometry,
+        long_geometry,
+    ) = _mhc_prefill_tf32_geometry(
+        tokens=int(tokens),
+        hidden_size=int(hidden_size),
     )
     return _prefill_tf32_project_kernel(
         int(hidden_size),
         _split_k_for_hidden(int(hidden_size)),
+        medium_geometry,
+        medium_high_geometry,
         chunk_geometry,
         long_geometry,
     ).k_splits

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -21,6 +21,7 @@ from benchmarks.common import (
     make_l2_flush_fn,
     require_sm120,
 )
+from b12x.norm.mhc import _kernels as mhc_kernels
 from b12x.norm.mhc._impl import B12XMHCScratchCaps, plan_mhc_scratch, b12x_mhc_post_pre
 
 
@@ -280,131 +281,23 @@ def main() -> None:
     prefill_finalize_threads = int(
         os.environ.get("B12X_MHC_PREFILL_FINALIZE_THREADS", "256")
     )
-    prefill_tf32_tma_m_warps = int(
-        os.environ.get(
-            "B12X_MHC_PREFILL_TF32_TMA_M_WARPS",
-            os.environ.get(
-                "B12X_MHC_PREFILL_TF32_TMA_WARPS",
-                os.environ.get("B12X_MHC_PREFILL_TMA_WARPS", "1"),
-            ),
-        )
+    (
+        prefill_tf32_tma_medium_geometry,
+        prefill_tf32_tma_medium_high_geometry,
+        prefill_tf32_tma_chunk_geometry,
+        prefill_tf32_tma_long_geometry,
+    ) = mhc_kernels._mhc_prefill_tf32_geometry(
+        tokens=args.tokens,
+        hidden_size=args.hidden_size,
     )
-    prefill_tf32_tma_n_warps = int(
-        os.environ.get("B12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1")
+    prefill_tf32_kernel = mhc_kernels._prefill_tf32_project_kernel(
+        args.hidden_size,
+        args.split_k,
+        prefill_tf32_tma_medium_geometry,
+        prefill_tf32_tma_medium_high_geometry,
+        prefill_tf32_tma_chunk_geometry,
+        prefill_tf32_tma_long_geometry,
     )
-    prefill_tf32_tma_m = int(
-        os.environ.get(
-            "B12X_MHC_PREFILL_TF32_TMA_TILE_M",
-            os.environ.get("B12X_MHC_PREFILL_TMA_TILE_M", "16"),
-        )
-    )
-    prefill_tf32_tma_n = int(
-        os.environ.get("B12X_MHC_PREFILL_TF32_TMA_TILE_N", "8")
-    )
-    prefill_tf32_tma_k = int(
-        os.environ.get(
-            "B12X_MHC_PREFILL_TF32_TMA_TILE_K",
-            os.environ.get("B12X_MHC_PREFILL_TMA_TILE_K", "256"),
-        )
-    )
-    prefill_tf32_tma_stages = int(
-        os.environ.get(
-            "B12X_MHC_PREFILL_TF32_TMA_STAGES",
-            os.environ.get("B12X_MHC_PREFILL_TMA_STAGES", "1"),
-        )
-    )
-    prefill_tf32_tma_chunk_min_tokens = int(
-        os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_MIN_TOKENS", "4096")
-    )
-    prefill_tf32_tma_chunk_geometry = (
-        args.tokens >= prefill_tf32_tma_chunk_min_tokens
-    )
-    prefill_tf32_tma_long_min_tokens = int(
-        os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_MIN_TOKENS", "8192")
-    )
-    prefill_tf32_tma_long_geometry = (
-        args.hidden_size == 4096
-        and args.tokens >= prefill_tf32_tma_long_min_tokens
-    )
-    prefill_tf32_tma_k_splits = 1
-    if prefill_tf32_tma_chunk_geometry:
-        if args.hidden_size == 4096:
-            prefill_tf32_tma_m_warps = int(
-                os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "12")
-            )
-            prefill_tf32_tma_n_warps = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_N_WARPS",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1"),
-                )
-            )
-            prefill_tf32_tma_m = int(
-                os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_M", "192")
-            )
-            prefill_tf32_tma_n = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_N",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_TILE_N", "24"),
-                )
-            )
-            prefill_tf32_tma_k_splits = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_K_SPLITS", "8"
-                )
-            )
-            prefill_tf32_tma_k = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_K",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_TILE_K", "64"),
-                )
-            )
-            prefill_tf32_tma_stages = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_STAGES",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_STAGES", "2"),
-                )
-            )
-        else:
-            prefill_tf32_tma_m_warps = int(
-                os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_M_WARPS", "2")
-            )
-            prefill_tf32_tma_n_warps = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_N_WARPS",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_N_WARPS", "1"),
-                )
-            )
-            prefill_tf32_tma_m = int(
-                os.environ.get("B12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_M", "32")
-            )
-            prefill_tf32_tma_n = int(
-                os.environ.get(
-                    "B12X_MHC_PREFILL_TF32_TMA_CHUNK_TILE_N",
-                    os.environ.get("B12X_MHC_PREFILL_TF32_TMA_TILE_N", "8"),
-                )
-            )
-    if prefill_tf32_tma_long_geometry:
-        prefill_tf32_tma_m_warps = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_M_WARPS", "8")
-        )
-        prefill_tf32_tma_n_warps = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_N_WARPS", "1")
-        )
-        prefill_tf32_tma_m = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_TILE_M", "128")
-        )
-        prefill_tf32_tma_n = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_TILE_N", "24")
-        )
-        prefill_tf32_tma_k = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_TILE_K", "64")
-        )
-        prefill_tf32_tma_stages = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_STAGES", "2")
-        )
-        prefill_tf32_tma_k_splits = int(
-            os.environ.get("B12X_MHC_PREFILL_TF32_TMA_LONG_K_SPLITS", "4")
-        )
 
     device = require_sm120()
     if args.compare_vllm:
@@ -594,12 +487,18 @@ def main() -> None:
         f"fused_rmsnorm={args.fuse_rmsnorm} "
         f"prefill_tf32_mma={prefill_tf32_enabled} "
         f"prefill_tf32_selected={prefill_tf32_selected} "
-        f"prefill_tf32_tma=m{prefill_tf32_tma_m}n{prefill_tf32_tma_n}"
-        f"k{prefill_tf32_tma_k}s{prefill_tf32_tma_stages}"
-        f"wm{prefill_tf32_tma_m_warps}wn{prefill_tf32_tma_n_warps} "
+        f"prefill_tf32_tma=m{prefill_tf32_kernel.tile_m}"
+        f"n{prefill_tf32_kernel.tile_n}"
+        f"k{prefill_tf32_kernel.tile_k}"
+        f"s{prefill_tf32_kernel.num_stages}"
+        f"wm{prefill_tf32_kernel.num_m_warps}"
+        f"wn{prefill_tf32_kernel.num_n_warps} "
+        f"prefill_tf32_medium_geometry={prefill_tf32_tma_medium_geometry} "
+        f"prefill_tf32_medium_high_geometry="
+        f"{prefill_tf32_tma_medium_high_geometry} "
         f"prefill_tf32_chunk_geometry={prefill_tf32_tma_chunk_geometry} "
         f"prefill_tf32_long_geometry={prefill_tf32_tma_long_geometry} "
-        f"prefill_tf32_k_splits={prefill_tf32_tma_k_splits} "
+        f"prefill_tf32_k_splits={prefill_tf32_kernel.k_splits} "
         f"prefill_gram_threads={prefill_gram_threads} "
         f"prefill_finalize_threads={prefill_finalize_threads} "
         f"prefill_bf16_mma={prefill_bf16_enabled} "

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -149,14 +149,18 @@ def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> tuple[float, f
     )
 
 
-def _bench_graph(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float]:
+def _bench_graph(
+    fn, *, warmup: int, iters: int, l2_flush
+) -> tuple[float, float, list[float]]:
     graph = capture_cuda_graph(fn, warmup=warmup)
     stats = bench_cuda_graph(graph, replays=iters, l2_flush=l2_flush)
     samples = stats["replay_us"]
-    return statistics.median(samples), min(samples)
+    return statistics.median(samples), min(samples), samples
 
 
-def _bench_eager(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float]:
+def _bench_eager(
+    fn, *, warmup: int, iters: int, l2_flush
+) -> tuple[float, float, list[float]]:
     samples = []
     for _ in range(warmup):
         if l2_flush is not None:
@@ -165,7 +169,7 @@ def _bench_eager(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float
     torch.cuda.synchronize()
     for _ in range(iters):
         samples.append(bench_gpu_ms(fn, warmup=0, iters=1, l2_flush=l2_flush) * 1000.0)
-    return statistics.median(samples), min(samples)
+    return statistics.median(samples), min(samples), samples
 
 
 def _register_vllm_mhc_tilelang(vllm_path: pathlib.Path) -> None:
@@ -210,6 +214,11 @@ def main() -> None:
     parser.add_argument("--hc-eps", type=float, default=1e-6)
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--raw-samples",
+        action="store_true",
+        help="Print every timed GPU replay in microseconds.",
+    )
     parser.add_argument("--eager", action="store_true")
     parser.add_argument("--skip-check", action="store_true")
     parser.add_argument("--l2-flush", action="store_true")
@@ -493,15 +502,16 @@ def main() -> None:
 
     l2_flush = make_l2_flush_fn(args.l2_flush, args.l2_flush_bytes)
     bench = _bench_eager if args.eager else _bench_graph
-    fused_median, fused_min = bench(
+    fused_median, fused_min, fused_samples = bench(
         run_fused, warmup=args.warmup, iters=args.iters, l2_flush=l2_flush
     )
     if args.compare_vllm:
-        vllm_median, vllm_min = bench(
+        vllm_median, vllm_min, vllm_samples = bench(
             run_vllm_fused, warmup=args.warmup, iters=args.iters, l2_flush=l2_flush
         )
     else:
         vllm_median = vllm_min = float("nan")
+        vllm_samples = []
     mode = "eager" if args.eager else "graph"
 
     line = (
@@ -542,6 +552,12 @@ def main() -> None:
             f"bf16ref_post_max={bf16ref_post_max:.3g} "
             f"bf16ref_comb_max={bf16ref_comb_max:.3g}"
         )
+    if args.raw_samples:
+        line += (
+            " raw_post_pre_us=["
+            + ",".join(f"{sample:.2f}" for sample in fused_samples)
+            + "]"
+        )
     if args.compare_vllm:
         line += (
             " vllm_deep_gemm=True"
@@ -551,6 +567,12 @@ def main() -> None:
             f"vllm_post_max={vllm_post_max:.3g} vllm_comb_max={vllm_comb_max:.3g} "
             f"vllm_out_max={vllm_out_max:.3g} vllm_out_rmse={vllm_out_rmse:.3g}"
         )
+        if args.raw_samples:
+            line += (
+                " raw_vllm_post_pre_us=["
+                + ",".join(f"{sample:.2f}" for sample in vllm_samples)
+                + "]"
+            )
     print(line)
 
 

--- a/benchmarks/benchmark_residual.py
+++ b/benchmarks/benchmark_residual.py
@@ -96,9 +96,9 @@ def _post_pre_reference(
     )
     if norm_weight is not None:
         rms = torch.rsqrt(y_raw_fp32.square().mean(dim=-1, keepdim=True) + norm_eps)
-        y = (
-            y_raw_fp32.to(torch.bfloat16).float() * rms * norm_weight.float()
-        ).to(torch.bfloat16)
+        y = (y_raw_fp32.to(torch.bfloat16).float() * rms * norm_weight.float()).to(
+            torch.bfloat16
+        )
     else:
         y = y_raw_fp32.to(torch.bfloat16)
     return residual_out, y, post, comb
@@ -114,22 +114,39 @@ def _make_inputs(
     gen = torch.Generator(device="cpu")
     gen.manual_seed(seed)
     residual = (
-        torch.randn((tokens, 4, hidden_size), generator=gen, dtype=torch.float32).to(device)
+        torch.randn((tokens, 4, hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
         / 3
     ).to(torch.bfloat16)
     x = (
-        torch.randn((tokens, hidden_size), generator=gen, dtype=torch.float32).to(device)
+        torch.randn((tokens, hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
         / 4
     ).to(torch.bfloat16)
-    fn = torch.randn((24, 4 * hidden_size), generator=gen, dtype=torch.float32).to(device) / 64
+    fn = (
+        torch.randn((24, 4 * hidden_size), generator=gen, dtype=torch.float32).to(
+            device
+        )
+        / 64
+    )
     scale = torch.randn((3,), generator=gen, dtype=torch.float32).to(device) / 3
     bias = torch.randn((24,), generator=gen, dtype=torch.float32).to(device) / 5
-    return residual.contiguous(), x.contiguous(), fn.contiguous(), scale.contiguous(), bias.contiguous()
+    return (
+        residual.contiguous(),
+        x.contiguous(),
+        fn.contiguous(),
+        scale.contiguous(),
+        bias.contiguous(),
+    )
 
 
 def _error_stats(actual: torch.Tensor, expected: torch.Tensor) -> tuple[float, float]:
     diff = actual.float() - expected.float()
-    return float(diff.abs().max().item()), float(torch.sqrt(torch.mean(diff * diff)).item())
+    return float(diff.abs().max().item()), float(
+        torch.sqrt(torch.mean(diff * diff)).item()
+    )
 
 
 def _bench_graph(fn, *, warmup: int, iters: int, l2_flush) -> tuple[float, float]:
@@ -168,7 +185,9 @@ def _register_vllm_mhc_tilelang(vllm_path: pathlib.Path) -> None:
         ) from exc
 
     if not hasattr(torch.ops.vllm, "mhc_fused_post_pre_tilelang"):
-        raise RuntimeError("vLLM mhc_fused_post_pre_tilelang custom op was not registered")
+        raise RuntimeError(
+            "vLLM mhc_fused_post_pre_tilelang custom op was not registered"
+        )
 
     from vllm.utils.deep_gemm import is_deep_gemm_supported
 
@@ -323,10 +342,14 @@ def main() -> None:
         torch.empty(shape, dtype=dtype, device=device)
         for shape, dtype in fused_plan.shapes_and_dtypes()
     )
-    fused_y = torch.empty((args.tokens, args.hidden_size), dtype=torch.bfloat16, device=device)
+    fused_y = torch.empty(
+        (args.tokens, args.hidden_size), dtype=torch.bfloat16, device=device
+    )
     fused_post = torch.empty((args.tokens, 4), dtype=torch.float32, device=device)
     fused_comb = torch.empty((args.tokens, 4, 4), dtype=torch.float32, device=device)
-    fused_out = torch.empty((args.tokens, 4, args.hidden_size), dtype=torch.bfloat16, device=device)
+    fused_out = torch.empty(
+        (args.tokens, 4, args.hidden_size), dtype=torch.bfloat16, device=device
+    )
     fused_binding = fused_plan.bind(
         scratch=fused_scratch,
         tokens=args.tokens,
@@ -383,23 +406,25 @@ def main() -> None:
 
     def run_vllm_fused() -> None:
         nonlocal vllm_out, vllm_post, vllm_comb, vllm_y
-        vllm_out, vllm_post, vllm_comb, vllm_y = torch.ops.vllm.mhc_fused_post_pre_tilelang(
-            x,
-            residual,
-            prev_post,
-            prev_comb,
-            fn,
-            scale,
-            bias,
-            args.rms_eps,
-            args.hc_eps,
-            args.hc_eps,
-            2.0,
-            args.sinkhorn_iters,
-            1,
-            1,
-            norm_weight,
-            args.norm_eps if norm_weight is not None else 0.0,
+        vllm_out, vllm_post, vllm_comb, vllm_y = (
+            torch.ops.vllm.mhc_fused_post_pre_tilelang(
+                x,
+                residual,
+                prev_post,
+                prev_comb,
+                fn,
+                scale,
+                bias,
+                args.rms_eps,
+                args.hc_eps,
+                args.hc_eps,
+                2.0,
+                args.sinkhorn_iters,
+                1,
+                1,
+                norm_weight,
+                args.norm_eps if norm_weight is not None else 0.0,
+            )
         )
 
     run_fused()

--- a/docs/evidence/mhc_hidden4096_medium_prefill_sm120.md
+++ b/docs/evidence/mhc_hidden4096_medium_prefill_sm120.md
@@ -1,0 +1,81 @@
+# Hidden-size-4096 medium-row mHC projection qualification
+
+## Status and operation contract
+
+Status: **qualified** for the multi-head connection (mHC) TF32 projection on
+SM120 when the hidden size is 4096 and the live row count is 2,304 through
+3,583.
+
+The dispatch policy selects an M64/N24/K64 projection with eight K splits. It
+uses three pipeline stages for 2,304 through 3,071 rows and two stages for
+3,072 through 3,583 rows. At 3,584 rows the existing wide-CTA chunk geometry
+takes over. Hidden size 7168, decode dispatch, scratch ownership, output
+layout, and public operation signatures are unchanged.
+
+## Source and hardware
+
+- Comparison revision: `fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`,
+  tree `7fcb6afb69b04b6981060012e943e125e58168b4`.
+- Qualified implementation revision:
+  `f90d16ee6fadc0f56488df06a0e2fd9bbccdc265`, tree
+  `25f5d5c38d092931bd8e6df95eb6c01fea3c4680`.
+- Runtime image:
+  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r3`.
+- Physical GPU 0: `GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3`, NVIDIA RTX PRO
+  6000 Blackwell Workstation Edition, driver 610.57.04, PCIe Gen5 x16.
+- CUDA graph replay was used. Each process performed 20 warmups and 30 timed
+  iterations after kernel compilation.
+
+## Correctness
+
+The focused test command was:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 CUTE_DSL_ARCH=sm_120a \
+  /opt/venv/bin/python -B -m pytest -q \
+  tests/gemm/test_launch_custom_ops.py \
+  -k "mhc_prefill_tf32_projection_geometry_boundaries or mhc_prefill_tf32_optimized_geometry_matches_reference_under_graph_replay or mhc_launch_ops_have_fake_dispatch"
+```
+
+Result: `5 passed, 10 deselected`.
+
+The graph-replay cases cover 2,304, 3,072, and 3,583 rows. They mutate the
+input and poison the reduction workspace before replay, then compare the
+projection with `torch.nn.functional.linear`. The maximum absolute tolerance
+is 0.0625 and the relative tolerance is 0.02.
+
+## Performance
+
+Both revisions were measured with this command at the 3,072-row policy
+boundary:
+
+```bash
+/opt/venv/bin/python -B benchmarks/benchmark_residual.py \
+  --tokens 3072 \
+  --expected-m 4096 \
+  --hidden-size 4096 \
+  --split-k 64 \
+  --block-k 256 \
+  --block-h 512 \
+  --fuse-rmsnorm \
+  --prefill-tf32-mma \
+  --no-prefill-block-m \
+  --warmup 20 \
+  --iters 30
+```
+
+Five independent process-level medians were collected for each revision:
+
+| Revision | Geometry | Median samples, microseconds | Median |
+| --- | --- | --- | ---: |
+| Comparison | M16/N8/K256, one K split | 261.25, 263.09, 261.25, 260.02, 259.71 | 261.25 |
+| Qualified | M64/N24/K64, eight K splits, two stages | 198.27, 197.97, 196.74, 198.27, 198.27 | 198.27 |
+
+The fixed-work latency reduction is 24.11%. The equivalent throughput ratio is
+`261.25 / 198.27 = 1.317648`, or 31.76% higher projection throughput. The
+qualified output reported maximum projection error 0.0625 and projection RMSE
+0.000887; the comparison reported 0.0625 and 0.000902.
+
+This result qualifies the projection operation. End-to-end serving throughput
+depends on attention, index selection, communication, mixture-of-experts, and
+scheduler work and is therefore not inferred from this operation benchmark.

--- a/docs/evidence/mhc_hidden4096_medium_prefill_sm120.md
+++ b/docs/evidence/mhc_hidden4096_medium_prefill_sm120.md
@@ -19,12 +19,29 @@ layout, and public operation signatures are unchanged.
 - Qualified implementation revision:
   `f90d16ee6fadc0f56488df06a0e2fd9bbccdc265`, tree
   `25f5d5c38d092931bd8e6df95eb6c01fea3c4680`.
-- Runtime image:
-  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r3`.
+- Raw-sample benchmark instrumentation revision:
+  `168ca6bf712a8ef45f0225dfa6dfe5e79731e5bb`.
+- Comparison worktree:
+  `/root/vllm/worktrees/b12x-master-fc1d4b68-20260830`.
+- Qualified worktree: `/root/vllm/tmp/b12x-pr-mhc-medium-20260830`.
+- Runtime foundation image:
+  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r4`,
+  image ID
+  `sha256:0029fb596153966c997e1f09737e3ea7a547bf1c7a251f356e01c681c9f917d6`.
 - Physical GPU 0: `GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3`, NVIDIA RTX PRO
   6000 Blackwell Workstation Edition, driver 610.57.04, PCIe Gen5 x16.
-- CUDA graph replay was used. Each process performed 20 warmups and 30 timed
-  iterations after kernel compilation.
+- GPU-mode snapshots before and after collection were P1, persistence enabled,
+  default compute mode, 2,692 MHz SM clock, 13,365 MHz memory clock, active
+  throttle mask `0x0`, 37 C, and 84.67/84.81 W against a 600 W limit.
+- Toolchain map: `nvidia-cutlass-dsl==4.6.2` from
+  `/opt/venv/lib/python3.12/site-packages/nvidia_cutlass_dsl`, PyTorch 2.13.0,
+  and `/usr/local/cuda/bin/ptxas` build
+  `cuda_13.3.r13.3/compiler.38244171_0`; `CUTE_DSL_ARCH=sm_120a`.
+- Source-specific compile-cache manifests were fixed for every timed process.
+  The comparison cache contained 12 files with aggregate manifest SHA-256
+  `226560cd2787c5ce64420e8971e958d06ad4c7c44e9bda8492a8b60abce974c3`;
+  the qualified cache contained six files with aggregate manifest SHA-256
+  `f30d8076e47305c7a192bfbfb6141ad6e63e1fd09942a573f55e5938668f7687`.
 
 ## Correctness
 
@@ -50,7 +67,8 @@ Both revisions were measured with this command at the 3,072-row policy
 boundary:
 
 ```bash
-/opt/venv/bin/python -B benchmarks/benchmark_residual.py \
+CUDA_VISIBLE_DEVICES=0 CUTE_DSL_ARCH=sm_120a \
+  /opt/venv/bin/python -B benchmarks/benchmark_residual.py \
   --tokens 3072 \
   --expected-m 4096 \
   --hidden-size 4096 \
@@ -61,20 +79,37 @@ boundary:
   --prefill-tf32-mma \
   --no-prefill-block-m \
   --warmup 20 \
-  --iters 30
+  --iters 30 \
+  --raw-samples
 ```
 
-Five independent process-level medians were collected for each revision:
+Each arm first ran one zero-warmup replay and one 20-warmup preconditioning
+process. Five process-level medians per arm were then collected in the balanced
+order comparison, qualified, qualified, comparison, comparison, qualified,
+qualified, comparison, comparison, qualified. Every timed process loaded its
+arm's fixed cache objects before graph capture.
 
 | Revision | Geometry | Median samples, microseconds | Median |
 | --- | --- | --- | ---: |
-| Comparison | M16/N8/K256, one K split | 261.25, 263.09, 261.25, 260.02, 259.71 | 261.25 |
-| Qualified | M64/N24/K64, eight K splits, two stages | 198.27, 197.97, 196.74, 198.27, 198.27 | 198.27 |
+| Comparison | M16/N8/K256, one K split | 261.76, 261.07, 259.71, 259.73, 261.25 | 261.07 |
+| Qualified | M64/N24/K64, eight K splits, two stages | 198.27, 198.27, 198.27, 198.27, 198.27 | 198.27 |
 
-The fixed-work latency reduction is 24.11%. The equivalent throughput ratio is
-`261.25 / 198.27 = 1.317648`, or 31.76% higher projection throughput. The
-qualified output reported maximum projection error 0.0625 and projection RMSE
-0.000887; the comparison reported 0.0625 and 0.000902.
+The zero-warmup replay was 261.60 us for the comparison and 201.70 us for the
+qualified implementation. The preconditioning process medians were 260.53 us
+and 197.44 us, respectively.
+
+Representative 30-replay samples from the fixed cached objects, microseconds:
+
+```text
+comparison: 268.96,257.95,259.71,260.26,257.15,261.76,265.89,259.71,261.76,261.79,257.66,259.71,259.74,259.71,261.79,261.76,262.78,259.71,261.76,259.74,265.86,259.71,263.81,257.66,258.69,263.84,257.70,259.71,257.66,257.70
+qualified: 201.38,198.91,196.22,197.02,195.42,198.27,198.27,198.27,194.18,196.22,196.22,196.22,196.22,196.22,196.22,198.27,194.18,198.27,200.32,200.32,198.27,201.34,196.22,198.27,198.27,198.27,196.22,196.22,198.27,196.22
+```
+
+The fixed-work latency reduction is 24.05%. The ratio direction is comparison
+latency divided by qualified latency: `261.07 / 198.27 = 1.316740`, or 31.67%
+higher projection throughput. The qualified output reported maximum projection
+error 0.0625 and projection RMSE 0.000887; the comparison reported 0.0625 and
+0.000902.
 
 This result qualifies the projection operation. End-to-end serving throughput
 depends on attention, index selection, communication, mixture-of-experts, and

--- a/tests/gemm/test_launch_custom_ops.py
+++ b/tests/gemm/test_launch_custom_ops.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import pytest
 import torch
+import torch.nn.functional as F
 from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -55,6 +57,146 @@ def test_mhc_sm121_decode_finalize_policy(monkeypatch) -> None:
     assert select(num_tokens=16, hidden_size=4096, compute_capability=(12, 1)) == 128
     assert select(num_tokens=16, hidden_size=4096, compute_capability=(12, 0)) == 0
     assert select(num_tokens=16, hidden_size=7168, compute_capability=(12, 1)) == 0
+
+
+def test_mhc_prefill_tf32_projection_geometry_boundaries() -> None:
+    import b12x.norm.mhc._kernels as residual_kernels
+
+    select = residual_kernels._mhc_prefill_tf32_geometry
+    assert select(tokens=2303, hidden_size=4096) == (False, False, False, False)
+    assert select(tokens=2304, hidden_size=4096) == (True, False, False, False)
+    assert select(tokens=3071, hidden_size=4096) == (True, False, False, False)
+    assert select(tokens=3072, hidden_size=4096) == (True, True, False, False)
+    assert select(tokens=3583, hidden_size=4096) == (True, True, False, False)
+    assert select(tokens=3584, hidden_size=4096) == (False, False, True, False)
+    assert select(tokens=8191, hidden_size=4096) == (False, False, True, False)
+    assert select(tokens=8192, hidden_size=4096) == (False, False, True, True)
+    assert select(tokens=3584, hidden_size=7168) == (False, False, False, False)
+    assert select(tokens=4096, hidden_size=7168) == (False, False, True, False)
+
+    medium_kernel = residual_kernels._prefill_tf32_project_kernel(
+        4096,
+        64,
+        True,
+        False,
+        False,
+    )
+    assert (
+        medium_kernel.tile_m,
+        medium_kernel.tile_n,
+        medium_kernel.tile_k,
+        medium_kernel.num_stages,
+        medium_kernel.num_m_warps,
+        medium_kernel.num_n_warps,
+        medium_kernel.num_threads,
+        medium_kernel.k_splits,
+    ) == (64, 24, 64, 3, 4, 1, 160, 8)
+    medium_high_kernel = residual_kernels._prefill_tf32_project_kernel(
+        4096,
+        64,
+        True,
+        True,
+        False,
+        False,
+    )
+    assert medium_high_kernel.num_stages == 2
+
+    assert (
+        residual_kernels.mhc_prefill_tf32_project_splits(tokens=2303, hidden_size=4096)
+        == 1
+    )
+    assert (
+        residual_kernels.mhc_prefill_tf32_project_splits(tokens=2304, hidden_size=4096)
+        == 8
+    )
+    assert (
+        residual_kernels.mhc_prefill_tf32_project_splits(tokens=3583, hidden_size=4096)
+        == 8
+    )
+    assert (
+        residual_kernels.mhc_prefill_tf32_project_splits(tokens=3584, hidden_size=4096)
+        == 8
+    )
+    assert (
+        residual_kernels.mhc_prefill_tf32_project_splits(tokens=8192, hidden_size=4096)
+        == 4
+    )
+
+
+@pytest.mark.parametrize("tokens", [2304, 3072, 3583])
+def test_mhc_prefill_tf32_optimized_geometry_matches_reference_under_graph_replay(
+    tokens: int,
+) -> None:
+    """Validate the tuned medium-row projection geometries on SM120."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("the hidden-size-4096 projection geometry requires SM120")
+
+    import b12x.norm.mhc._kernels as residual_kernels
+
+    device = torch.device("cuda")
+    hidden_size = 4096
+    split_k = 64
+    generator = torch.Generator(device=device)
+    generator.manual_seed(23_040 + tokens)
+    residual = (
+        torch.randn(
+            (tokens, 4, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.02
+    ).contiguous()
+    projection = (
+        torch.randn(
+            (24, 4 * hidden_size),
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.02
+    ).contiguous()
+    partials = torch.empty((tokens, split_k, 25), device=device, dtype=torch.float32)
+    active_splits = residual_kernels.mhc_prefill_tf32_project_splits(
+        tokens=tokens,
+        hidden_size=hidden_size,
+    )
+
+    def launch() -> None:
+        residual_kernels.run_mhc_prefill_tf32_project(
+            out=residual,
+            fn=projection,
+            partials=partials,
+        )
+
+    launch()
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    residual.copy_(
+        torch.randn(
+            residual.shape,
+            device=device,
+            dtype=residual.dtype,
+            generator=generator,
+        )
+        * 0.02
+    )
+    partials.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    actual = partials[:, 0, 1:25].clone()
+    actual += partials[:, 2 : active_splits + 1, 1:25].sum(dim=1)
+    reference = F.linear(residual.flatten(1).float(), projection)
+    assert torch.isfinite(actual).all()
+    assert torch.count_nonzero(actual).item() > 0
+    torch.testing.assert_close(actual, reference, rtol=0.02, atol=0.0625)
 
 
 def test_mhc_sm121_decode_partial_group_policy(monkeypatch) -> None:


### PR DESCRIPTION
## Result

Status: **implemented and qualified** for the hidden-size-4096 multi-head
connection (mHC) TF32 projection on SM120.

Projection batches from 2,304 through 3,583 rows use an M64/N24/K64 geometry
with eight K splits. Three pipeline stages cover 2,304 through 3,071 rows and
two stages cover 3,072 through 3,583 rows. The wide-CTA chunk geometry starts
at 3,584 rows for hidden size 4096.

## Technical reason

The scalar M16/N8/K256 geometry exposes too few cooperative thread arrays for
medium prefill batches. The qualified geometry increases SM occupancy while
letting one thread block own all 24 mix columns, which avoids loading the same
input tile once per eight-column output tile.

## Operation contract and compatibility

- The policy applies only to hidden size 4096 on the TF32 prefill projection.
- Hidden size 7168 retains the generic 4,096-row chunk threshold.
- Decode dispatch, scratch ownership, output layout, numeric formats, and
  public operation signatures are unchanged.
- Environment overrides remain available for every threshold and geometry
  field. Resolved geometry and thresholds are part of the compile key.
- The benchmark resolves geometry through the same policy function used by the
  production launcher.

## Correctness validation

Source base: B12X `master` at
`fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`.

Hardware: physical GPU 0,
`GPU-d8438b2d-f000-a617-5dcc-0197ce0365a3`, NVIDIA RTX PRO 6000 Blackwell
Workstation Edition, PCIe Gen5 x16.

```bash
CUDA_VISIBLE_DEVICES=0 CUTE_DSL_ARCH=sm_120a \
  /opt/venv/bin/python -B -m pytest -q \
  tests/gemm/test_launch_custom_ops.py \
  -k "mhc_prefill_tf32_projection_geometry_boundaries or mhc_prefill_tf32_optimized_geometry_matches_reference_under_graph_replay or mhc_launch_ops_have_fake_dispatch"
```

Result: `5 passed, 10 deselected`.

The CUDA graph cases cover 2,304, 3,072, and 3,583 rows, mutate the input,
poison the reduction workspace, replay the captured operation, and compare
with `torch.nn.functional.linear`.

## Performance qualification

At 3,072 rows, five balanced process-level medians decreased from 261.07 µs on
`master` to 198.27 µs on the qualified implementation. The fixed-work latency
reduction is 24.05%; the equivalent projection-throughput increase is 31.67%.

The exact command, revisions, worktrees, GPU mode, CUTLASS/PTXAS map, fixed
cache manifests, cold and warm replay samples, correctness tolerances, and
ratio direction are recorded in
`docs/evidence/mhc_hidden4096_medium_prefill_sm120.md`.

This result qualifies the projection operation. It does not infer
end-to-end serving throughput from one kernel family.

## AI assistance disclosure

AI assistance was used to implement the policy and tests, perform correctness
and performance qualification, and prepare this pull-request description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Tunes SM120 TF32 mHC prefill projection for hidden size 4096.
- Uses M64/N24/K64 geometry with eight K splits for 2,304–3,583 rows.
- Uses three pipeline stages for 2,304–3,071 rows and two stages for 3,072–3,583 rows.
- Keeps wide-CTA geometry for 3,584+ rows.
- Centralizes geometry selection and includes configurable geometry values in compile-cache keys.
- Keeps hidden size 7168 and decode dispatch unchanged.
- Updates the benchmark to use production geometry selection and adds raw timing output.
- Adds boundary and CUDA graph replay tests.

## Performance

At 3,072 rows, median latency decreases from 261.07 µs to 198.27 µs, a 24.05% reduction. Projection throughput increases by 31.67%.

## Validation

Five focused tests pass, including CUDA graph replay cases for 2,304, 3,072, and 3,583 rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->