### PR TITLE
perf(indexer): optimize paged top-k-512 selection

### DIFF
--- a/b12x/attention/dsa_indexer/fused_indexer.py
+++ b/b12x/attention/dsa_indexer/fused_indexer.py
@@ -58,7 +58,6 @@ from b12x.attention.dsa_indexer.persistent_topk import (
 )
 from b12x.attention.dsa_indexer.tiled_topk import (
     _SCAN_UNROLL,
-    _SMEM_CANDS,
     _SUPPORTED_TOPK,
     _THREADS_PER_CTA as _RADIX_THREADS,
     _convert_to_uint8,

--- a/b12x/attention/dsa_indexer/paged.py
+++ b/b12x/attention/dsa_indexer/paged.py
@@ -905,6 +905,7 @@ def index_topk_fp8(
     scratch_values, scratch_raw_indices = scratch.get_indexer_contiguous_topk_buffers(
         row_count=q_rows,
     )
+    write_final_values = out_scores is not None
     final_values = out_scores if out_scores is not None else scratch_values[:, :topk]
     final_raw_indices = (
         out_indices if out_indices is not None else scratch_raw_indices[:, :topk]
@@ -1136,6 +1137,7 @@ def index_topk_fp8(
                     output_values=final_values,
                     output_indices=final_raw_indices,
                     output_gather_table=fold_indices.view(q_rows, total_slices * topk),
+                    write_values=write_final_values,
                 )
         else:
             run_tiled_topk(
@@ -1161,6 +1163,7 @@ def index_topk_fp8(
                     else None
                 ),
                 output_page_size=page_size,
+                write_values=not is_last or write_final_values,
             )
 
     return final_raw_indices

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -47,15 +47,23 @@ _RADIX = 256
 _COARSE_RADIX_BITS = 10
 _COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
 _HIST_SLOTS = _COARSE_RADIX_BINS + 128
-# A 1024-thread selector CTA is already limited to one resident block per SM on
-# SM120 (1536 threads/SM).  Keeping 8192 candidates therefore avoids the common
-# long-context overflow without reducing occupancy; the complete shared-memory
-# allocation remains below the 99 KiB opt-in block limit.  The exact rescan below
-# still covers wider or degenerate threshold buckets.
-_SMEM_CANDS = 8192
+# Candidate storage is a compile-time kernel policy.  The SM120 top-k-512 path
+# uses a smaller buffer to reduce the selector's shared-memory footprint; its
+# exact overflow rescan preserves selection semantics when a threshold bucket is
+# wider than the buffer.  Larger top-k values retain enough buffered candidates
+# to avoid making that rescan the ordinary path.
+_DEFAULT_SMEM_CANDIDATES = 8192
+_SM120_TOPK512_SMEM_CANDIDATES = 1024
 _SCAN_UNROLL = 4
 _SUPERTILE_K_ENV = "B12X_DSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
+
+
+def _resolve_smem_candidate_capacity(*, topk: int, device: torch.device) -> int:
+    capability = torch.cuda.get_device_capability(device)
+    if capability == (12, 0) and int(topk) == 512:
+        return _SM120_TOPK512_SMEM_CANDIDATES
+    return _DEFAULT_SMEM_CANDIDATES
 
 
 @dsl_user_op
@@ -529,6 +537,7 @@ class DSATiledTopkKernel:
         is_first: bool = True,
         output_physical_slots: bool = False,
         extent_splits: int = 1,
+        smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
     ):
         self.extent_splits = int(extent_splits)
         self.is_tiled = is_tiled
@@ -543,6 +552,12 @@ class DSATiledTopkKernel:
         # or the user's final output.
         self.is_first = bool(is_first)
         self.output_physical_slots = bool(output_physical_slots)
+        self.smem_candidate_capacity = int(smem_candidate_capacity)
+        if self.smem_candidate_capacity < self.topk:
+            raise ValueError(
+                "shared candidate capacity must cover top-k output capacity, got "
+                f"{self.smem_candidate_capacity} < {self.topk}"
+            )
 
     @cute.jit
     def __call__(
@@ -692,6 +707,7 @@ class DSATiledTopkKernel:
             )
 
         smem_alloc = cutlass.utils.SmemAllocator()
+        smem_candidate_capacity = self.smem_candidate_capacity
 
         @cute.struct
         class SharedStorage:
@@ -710,10 +726,10 @@ class DSATiledTopkKernel:
             ni1: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
             last_rem: cute.struct.Align[cute.struct.MemRange[cutlass.Int32, 1], 128]
             cand0: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Int32, _SMEM_CANDS], 128
+                cute.struct.MemRange[cutlass.Int32, smem_candidate_capacity], 128
             ]
             cand1: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Int32, _SMEM_CANDS], 128
+                cute.struct.MemRange[cutlass.Int32, smem_candidate_capacity], 128
             ]
 
         storage = smem_alloc.allocate(SharedStorage)
@@ -728,10 +744,10 @@ class DSATiledTopkKernel:
             cute.make_layout((topk_capacity,), stride=(1,))
         )
         s_cand0 = storage.cand0.get_tensor(
-            cute.make_layout((_SMEM_CANDS,), stride=(1,))
+            cute.make_layout((smem_candidate_capacity,), stride=(1,))
         )
         s_cand1 = storage.cand1.get_tensor(
-            cute.make_layout((_SMEM_CANDS,), stride=(1,))
+            cute.make_layout((smem_candidate_capacity,), stride=(1,))
         )
 
         h0 = shared_ptr_to_u32(storage.hist0.data_ptr())
@@ -949,7 +965,7 @@ class DSATiledTopkKernel:
                         else:
                             if Int32(coarse_bin) == threshold_bin:
                                 cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
-                                if cand_pos < Int32(_SMEM_CANDS):
+                                if cand_pos < Int32(smem_candidate_capacity):
                                     s_cand0[cand_pos] = idx
                                     key32 = _convert_to_uint32(raw_input)
                                     sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
@@ -976,7 +992,7 @@ class DSATiledTopkKernel:
                     else:
                         if Int32(coarse_bin) == threshold_bin:
                             cand_pos = _smem_xadd(ni0, Int32(0), Int32(1))
-                            if cand_pos < Int32(_SMEM_CANDS):
+                            if cand_pos < Int32(smem_candidate_capacity):
                                 s_cand0[cand_pos] = idx_base
                                 key32 = _convert_to_uint32(raw_input)
                                 sub_bin = (key32 >> Uint32(24)) & Uint32(0xFF)
@@ -985,7 +1001,7 @@ class DSATiledTopkKernel:
 
                 cute.arch.sync_threads()
                 # ni0 now holds the FULL threshold-bin candidate count: the xadd
-                # ran for every bin-matching key, even past _SMEM_CANDS. Capture it
+                # ran for every bin-matching key, even past the buffer. Capture it
                 # before the round loop clobbers ni0, to detect when the threshold
                 # bucket overflowed the candidate buffer (winners dropped past the cap).
                 bin_count = Int32(_smem_ld(ni0, Int32(0)))
@@ -995,7 +1011,7 @@ class DSATiledTopkKernel:
                 # buffer first: none of those intermediate outputs survive.  This is
                 # a CTA-uniform branch because every thread reads the same shared
                 # counter after the barrier above.
-                if bin_count > Int32(_SMEM_CANDS):
+                if bin_count > Int32(smem_candidate_capacity):
                     topk = Int32(-1)
 
                 # Stage 2: refine with 8-bit radix passes
@@ -1011,8 +1027,8 @@ class DSATiledTopkKernel:
                         )
                         num_input = (
                             raw_num_input
-                            if raw_num_input < Int32(_SMEM_CANDS)
-                            else Int32(_SMEM_CANDS)
+                            if raw_num_input < Int32(smem_candidate_capacity)
+                            else Int32(smem_candidate_capacity)
                         )
 
                         # Prefix sum
@@ -1128,7 +1144,7 @@ class DSATiledTopkKernel:
                                                 if cutlass.const_expr(r_idx_next_is_0)
                                                 else _smem_xadd(ni1, Int32(0), Int32(1))
                                             )
-                                            if cand_pos < Int32(_SMEM_CANDS):
+                                            if cand_pos < Int32(smem_candidate_capacity):
                                                 if cutlass.const_expr(r_idx_next_is_0):
                                                     s_cand0[cand_pos] = c_idx
                                                 else:
@@ -1146,9 +1162,9 @@ class DSATiledTopkKernel:
                             cute.arch.sync_threads()
 
                 # Exact overflow fallback: the buffered refine above dropped
-                # winners when more than _SMEM_CANDS candidates shared the coarse
+                # winners when more candidates than the buffer shared the coarse
                 # threshold bucket. Redo the selection exactly by re-scanning.
-                if bin_count > Int32(_SMEM_CANDS):
+                if bin_count > Int32(smem_candidate_capacity):
                     _exact_overflow_fallback(
                         tx,
                         total_len,
@@ -1248,6 +1264,7 @@ def _build_tiled_topk_kernel(
     is_first: bool = True,
     output_physical_slots: bool = False,
     extent_splits: int = 1,
+    smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
 ):
     return DSATiledTopkKernel(
         is_tiled=True,
@@ -1258,11 +1275,16 @@ def _build_tiled_topk_kernel(
         is_first=is_first,
         output_physical_slots=output_physical_slots,
         extent_splits=extent_splits,
+        smem_candidate_capacity=smem_candidate_capacity,
     )
 
 
-@lru_cache(maxsize=8)
-def _build_row_topk_kernel(topk: int, output_physical_slots: bool = False):
+@lru_cache(maxsize=16)
+def _build_row_topk_kernel(
+    topk: int,
+    output_physical_slots: bool = False,
+    smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
+):
     return DSATiledTopkKernel(
         is_tiled=False,
         block_q=1,
@@ -1270,6 +1292,7 @@ def _build_row_topk_kernel(topk: int, output_physical_slots: bool = False):
         topk=topk,
         zero_row_start=True,
         output_physical_slots=output_physical_slots,
+        smem_candidate_capacity=smem_candidate_capacity,
     )
 
 
@@ -1494,6 +1517,10 @@ def run_tiled_topk(
     flat_carry_values = carry_values.reshape(-1).contiguous()
     flat_carry_indices = carry_indices.reshape(-1).contiguous()
 
+    smem_candidate_capacity = _resolve_smem_candidate_capacity(
+        topk=topk,
+        device=tile_logits.device,
+    )
     kernel = _build_tiled_topk_kernel(
         block_q,
         block_k,
@@ -1502,6 +1529,7 @@ def run_tiled_topk(
         bool(is_first),
         bool(output_physical_slots),
         extent_splits,
+        smem_candidate_capacity,
     )
     input_key_tensor = tile_logits
     lengths_key_tensor = lengths
@@ -1555,7 +1583,7 @@ def run_tiled_topk(
             "output_page_table", output_page_table_key_tensor, dynamic=True
         ),
         (
-            "tiled_topk_v27_runtime_page_stride",
+            "tiled_topk_v28_smem_candidate_policy",
             topk,
             block_q,
             block_k,
@@ -1563,6 +1591,7 @@ def run_tiled_topk(
             bool(is_first),
             bool(output_physical_slots),
             extent_splits,
+            smem_candidate_capacity,
         ),
     )
     compile_spec = KernelCompileSpec.from_key(
@@ -1685,7 +1714,15 @@ def run_row_topk(
     carry_indices = topk_indices
     flat_carry_values = carry_values.reshape(-1)
     flat_carry_indices = carry_indices.reshape(-1)
-    kernel = _build_row_topk_kernel(topk, output_gather_table is not None)
+    smem_candidate_capacity = _resolve_smem_candidate_capacity(
+        topk=topk,
+        device=row_logits.device,
+    )
+    kernel = _build_row_topk_kernel(
+        topk,
+        output_gather_table is not None,
+        smem_candidate_capacity,
+    )
     input_key_tensor = row_logits
     lengths_key_tensor = lengths
     values_key_tensor = topk_values
@@ -1734,9 +1771,10 @@ def run_row_topk(
             "output_gather_table", output_gather_table_for_kernel, dynamic=True
         ),
         (
-            "row_topk_v7_runtime_page_stride",
+            "row_topk_v8_smem_candidate_policy",
             topk,
             output_gather_table is not None,
+            smem_candidate_capacity,
         ),
     )
     compile_spec = KernelCompileSpec.from_key(

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -1147,7 +1147,9 @@ class DSATiledTopkKernel:
                                                 if cutlass.const_expr(r_idx_next_is_0)
                                                 else _smem_xadd(ni1, Int32(0), Int32(1))
                                             )
-                                            if cand_pos < Int32(smem_candidate_capacity):
+                                            if cand_pos < Int32(
+                                                smem_candidate_capacity
+                                            ):
                                                 if cutlass.const_expr(r_idx_next_is_0):
                                                     s_cand0[cand_pos] = c_idx
                                                 else:

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -59,11 +59,27 @@ _SUPERTILE_K_ENV = "B12X_DSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
 
 
-def _resolve_smem_candidate_capacity(*, topk: int, device: torch.device) -> int:
-    capability = torch.cuda.get_device_capability(device)
+@lru_cache(maxsize=32)
+def _resolve_smem_candidate_capacity_for_device(
+    topk: int,
+    device_index: int,
+) -> int:
+    """Resolve immutable selector geometry once per device and top-k."""
+    capability = torch.cuda.get_device_capability(device_index)
     if capability == (12, 0) and int(topk) == 512:
         return _SM120_TOPK512_SMEM_CANDIDATES
     return _DEFAULT_SMEM_CANDIDATES
+
+
+def _resolve_smem_candidate_capacity(*, topk: int, device: torch.device) -> int:
+    if device.type != "cuda":
+        raise ValueError(
+            f"top-k candidate capacity requires a CUDA device, got {device}"
+        )
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    return _resolve_smem_candidate_capacity_for_device(int(topk), int(device_index))
 
 
 @dsl_user_op
@@ -1319,6 +1335,7 @@ def _build_row_topk_kernel(
 def clear_tiled_topk_kernel_cache() -> None:
     _build_tiled_topk_kernel.cache_clear()
     _build_row_topk_kernel.cache_clear()
+    _resolve_smem_candidate_capacity_for_device.cache_clear()
 
 
 def _validate_supported_topk(topk: int, *, caller: str) -> int:

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -47,39 +47,23 @@ _RADIX = 256
 _COARSE_RADIX_BITS = 10
 _COARSE_RADIX_BINS = 1 << _COARSE_RADIX_BITS
 _HIST_SLOTS = _COARSE_RADIX_BINS + 128
-# Candidate storage is a compile-time kernel policy.  The SM120 top-k-512 path
+# Candidate storage is a compile-time top-k policy. The top-k-512 specialization
 # uses a smaller buffer to reduce the selector's shared-memory footprint; its
 # exact overflow rescan preserves selection semantics when a threshold bucket is
-# wider than the buffer.  Larger top-k values retain enough buffered candidates
+# wider than the buffer. Larger top-k values retain enough buffered candidates
 # to avoid making that rescan the ordinary path.
 _DEFAULT_SMEM_CANDIDATES = 8192
-_SM120_TOPK512_SMEM_CANDIDATES = 1024
+_TOPK512_SMEM_CANDIDATES = 1024
 _SCAN_UNROLL = 4
 _SUPERTILE_K_ENV = "B12X_DSA_TOPK_SUPERTILE_K"
 _SUPERTILE_K_DEFAULT = 32768
 
 
-@lru_cache(maxsize=32)
-def _resolve_smem_candidate_capacity_for_device(
-    topk: int,
-    device_index: int,
-) -> int:
-    """Resolve immutable selector geometry once per device and top-k."""
-    capability = torch.cuda.get_device_capability(device_index)
-    if capability == (12, 0) and int(topk) == 512:
-        return _SM120_TOPK512_SMEM_CANDIDATES
+def _resolve_smem_candidate_capacity(*, topk: int) -> int:
+    """Resolve the immutable candidate capacity for a top-k specialization."""
+    if int(topk) == 512:
+        return _TOPK512_SMEM_CANDIDATES
     return _DEFAULT_SMEM_CANDIDATES
-
-
-def _resolve_smem_candidate_capacity(*, topk: int, device: torch.device) -> int:
-    if device.type != "cuda":
-        raise ValueError(
-            f"top-k candidate capacity requires a CUDA device, got {device}"
-        )
-    device_index = device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-    return _resolve_smem_candidate_capacity_for_device(int(topk), int(device_index))
 
 
 @dsl_user_op
@@ -564,9 +548,9 @@ class DSATiledTopkKernel:
         self.zero_row_start = bool(zero_row_start)
         # When is_first the carry buffers are unread (the running-topk fold has no
         # predecessor for the first supertile chunk). There is no `is_last`: the
-        # kernel always emits (value, global index) topk into values/indices; the
-        # orchestrator decides whether that tensor is the next chunk's carry buffer
-        # or the user's final output.
+        # kernel always emits top-k indices and emits values when write_values is
+        # true. The orchestrator decides whether those tensors are the next chunk's
+        # carry buffers or the user's final outputs.
         self.is_first = bool(is_first)
         self.output_physical_slots = bool(output_physical_slots)
         self.smem_candidate_capacity = int(smem_candidate_capacity)
@@ -1335,7 +1319,6 @@ def _build_row_topk_kernel(
 def clear_tiled_topk_kernel_cache() -> None:
     _build_tiled_topk_kernel.cache_clear()
     _build_row_topk_kernel.cache_clear()
-    _resolve_smem_candidate_capacity_for_device.cache_clear()
 
 
 def _validate_supported_topk(topk: int, *, caller: str) -> int:
@@ -1561,10 +1544,7 @@ def run_tiled_topk(
     flat_carry_values = carry_values.reshape(-1).contiguous()
     flat_carry_indices = carry_indices.reshape(-1).contiguous()
 
-    smem_candidate_capacity = _resolve_smem_candidate_capacity(
-        topk=topk,
-        device=tile_logits.device,
-    )
+    smem_candidate_capacity = _resolve_smem_candidate_capacity(topk=topk)
     kernel = _build_tiled_topk_kernel(
         block_q,
         block_k,
@@ -1762,10 +1742,7 @@ def run_row_topk(
     carry_indices = topk_indices
     flat_carry_values = carry_values.reshape(-1)
     flat_carry_indices = carry_indices.reshape(-1)
-    smem_candidate_capacity = _resolve_smem_candidate_capacity(
-        topk=topk,
-        device=row_logits.device,
-    )
+    smem_candidate_capacity = _resolve_smem_candidate_capacity(topk=topk)
     kernel = _build_row_topk_kernel(
         topk,
         output_gather_table is not None,

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -1168,6 +1168,15 @@ class DSATiledTopkKernel:
                 # winners when more candidates than the buffer shared the coarse
                 # threshold bucket. Redo the selection exactly by re-scanning.
                 if bin_count > Int32(smem_candidate_capacity):
+                    # The buffered arm may already have populated a prefix of
+                    # s_out. Initialize every slot to a distinct in-range tail
+                    # candidate so an unselected padding tie cannot retain a
+                    # duplicate winner from that discarded prefix.
+                    reset_idx = Int32(tx)
+                    while reset_idx < topk_static:
+                        s_out[reset_idx] = total_len - topk_static + reset_idx
+                        reset_idx = reset_idx + Int32(_THREADS_PER_CTA)
+                    cute.arch.sync_threads()
                     _exact_overflow_fallback(
                         tx,
                         total_len,
@@ -1600,7 +1609,7 @@ def run_tiled_topk(
             "output_page_table", output_page_table_key_tensor, dynamic=True
         ),
         (
-            "tiled_topk_v29_optional_value_output",
+            "tiled_topk_v30_initialized_overflow_output",
             topk,
             block_q,
             block_k,
@@ -1792,7 +1801,7 @@ def run_row_topk(
             "output_gather_table", output_gather_table_for_kernel, dynamic=True
         ),
         (
-            "row_topk_v9_optional_value_output",
+            "row_topk_v10_initialized_overflow_output",
             topk,
             output_gather_table is not None,
             smem_candidate_capacity,

--- a/b12x/attention/dsa_indexer/tiled_topk.py
+++ b/b12x/attention/dsa_indexer/tiled_topk.py
@@ -538,6 +538,7 @@ class DSATiledTopkKernel:
         output_physical_slots: bool = False,
         extent_splits: int = 1,
         smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
+        write_values: bool = True,
     ):
         self.extent_splits = int(extent_splits)
         self.is_tiled = is_tiled
@@ -553,6 +554,7 @@ class DSATiledTopkKernel:
         self.is_first = bool(is_first)
         self.output_physical_slots = bool(output_physical_slots)
         self.smem_candidate_capacity = int(smem_candidate_capacity)
+        self.write_values = bool(write_values)
         if self.smem_candidate_capacity < self.topk:
             raise ValueError(
                 "shared candidate capacity must cover top-k output capacity, got "
@@ -769,23 +771,24 @@ class DSATiledTopkKernel:
             i = Int32(tx)
             while i < topk_static:
                 is_valid = i < total_len
-                values[out_base + i] = (
-                    _load_value_virtual(
-                        input_tensor,
-                        carry_values,
-                        row_base,
-                        row_start,
-                        out_base,
-                        length,
-                        i,
-                        self.block_q,
-                        self.block_k,
-                        self.is_tiled,
-                        self.is_first,
+                if cutlass.const_expr(self.write_values):
+                    values[out_base + i] = (
+                        _load_value_virtual(
+                            input_tensor,
+                            carry_values,
+                            row_base,
+                            row_start,
+                            out_base,
+                            length,
+                            i,
+                            self.block_q,
+                            self.block_k,
+                            self.is_tiled,
+                            self.is_first,
+                        )
+                        if is_valid
+                        else Float32(float("-inf"))
                     )
-                    if is_valid
-                    else Float32(float("-inf"))
-                )
                 indices[out_base + i] = (
                     _emit_global_index_virtual(
                         carry_indices,
@@ -1196,19 +1199,20 @@ class DSATiledTopkKernel:
             idx0 = Int32(tx)
             if idx0 < topk_static:
                 selected0 = Int32(s_out[idx0])
-                values[out_base + idx0] = _load_value_virtual(
-                    input_tensor,
-                    carry_values,
-                    row_base,
-                    row_start,
-                    out_base,
-                    length,
-                    selected0,
-                    self.block_q,
-                    self.block_k,
-                    self.is_tiled,
-                    self.is_first,
-                )
+                if cutlass.const_expr(self.write_values):
+                    values[out_base + idx0] = _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        selected0,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
                 indices[out_base + idx0] = _emit_global_index_virtual(
                     carry_indices,
                     output_page_table,
@@ -1226,19 +1230,20 @@ class DSATiledTopkKernel:
             idx1 = idx0 + Int32(_THREADS_PER_CTA)
             if idx1 < topk_static:
                 selected1 = Int32(s_out[idx1])
-                values[out_base + idx1] = _load_value_virtual(
-                    input_tensor,
-                    carry_values,
-                    row_base,
-                    row_start,
-                    out_base,
-                    length,
-                    selected1,
-                    self.block_q,
-                    self.block_k,
-                    self.is_tiled,
-                    self.is_first,
-                )
+                if cutlass.const_expr(self.write_values):
+                    values[out_base + idx1] = _load_value_virtual(
+                        input_tensor,
+                        carry_values,
+                        row_base,
+                        row_start,
+                        out_base,
+                        length,
+                        selected1,
+                        self.block_q,
+                        self.block_k,
+                        self.is_tiled,
+                        self.is_first,
+                    )
                 indices[out_base + idx1] = _emit_global_index_virtual(
                     carry_indices,
                     output_page_table,
@@ -1265,6 +1270,7 @@ def _build_tiled_topk_kernel(
     output_physical_slots: bool = False,
     extent_splits: int = 1,
     smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
+    write_values: bool = True,
 ):
     return DSATiledTopkKernel(
         is_tiled=True,
@@ -1276,6 +1282,7 @@ def _build_tiled_topk_kernel(
         output_physical_slots=output_physical_slots,
         extent_splits=extent_splits,
         smem_candidate_capacity=smem_candidate_capacity,
+        write_values=write_values,
     )
 
 
@@ -1284,6 +1291,7 @@ def _build_row_topk_kernel(
     topk: int,
     output_physical_slots: bool = False,
     smem_candidate_capacity: int = _DEFAULT_SMEM_CANDIDATES,
+    write_values: bool = True,
 ):
     return DSATiledTopkKernel(
         is_tiled=False,
@@ -1293,6 +1301,7 @@ def _build_row_topk_kernel(
         zero_row_start=True,
         output_physical_slots=output_physical_slots,
         smem_candidate_capacity=smem_candidate_capacity,
+        write_values=write_values,
     )
 
 
@@ -1335,7 +1344,14 @@ def run_tiled_topk(
     extent_splits: int = 1,
     output_row_stride: int | None = None,
     output_row_base: int = 0,
+    write_values: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """Select tiled row top-k indices and optionally materialize their scores.
+
+    ``write_values=False`` leaves ``output_values`` untouched. It is valid when
+    the caller consumes only indices; carry-producing launches must keep value
+    writes enabled because later folds read the selected scores.
+    """
     topk = _validate_supported_topk(topk, caller="run_tiled_topk")
     extent_splits = int(extent_splits)
     if extent_splits > 1:
@@ -1530,6 +1546,7 @@ def run_tiled_topk(
         bool(output_physical_slots),
         extent_splits,
         smem_candidate_capacity,
+        bool(write_values),
     )
     input_key_tensor = tile_logits
     lengths_key_tensor = lengths
@@ -1583,7 +1600,7 @@ def run_tiled_topk(
             "output_page_table", output_page_table_key_tensor, dynamic=True
         ),
         (
-            "tiled_topk_v28_smem_candidate_policy",
+            "tiled_topk_v29_optional_value_output",
             topk,
             block_q,
             block_k,
@@ -1592,6 +1609,7 @@ def run_tiled_topk(
             bool(output_physical_slots),
             extent_splits,
             smem_candidate_capacity,
+            bool(write_values),
         ),
     )
     compile_spec = KernelCompileSpec.from_key(
@@ -1628,13 +1646,15 @@ def run_row_topk(
     output_indices: torch.Tensor | None = None,
     output_index_offset: int = 0,
     output_gather_table: torch.Tensor | None = None,
+    write_values: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Exact row-wise topk over a dense row-major logits tile.
 
-    output_gather_table: optional int32 (rows, width) table; selected logical
-    positions are remapped through it (out = table[row, pos]), turning the
-    pass into a fold over (value, index) candidate pairs. Padded candidates
-    (-inf value, -1 index) propagate -1 naturally.
+    ``output_gather_table`` is an optional int32 ``(rows, width)`` table. Selected
+    logical positions are remapped through it, turning the pass into a fold over
+    value-index candidate pairs. Padded candidates propagate ``-1`` naturally.
+    ``write_values=False`` leaves ``output_values`` untouched for indices-only
+    consumers.
     """
     topk = _validate_supported_topk(topk, caller="run_row_topk")
     if row_logits.ndim != 2:
@@ -1722,6 +1742,7 @@ def run_row_topk(
         topk,
         output_gather_table is not None,
         smem_candidate_capacity,
+        bool(write_values),
     )
     input_key_tensor = row_logits
     lengths_key_tensor = lengths
@@ -1771,10 +1792,11 @@ def run_row_topk(
             "output_gather_table", output_gather_table_for_kernel, dynamic=True
         ),
         (
-            "row_topk_v8_smem_candidate_policy",
+            "row_topk_v9_optional_value_output",
             topk,
             output_gather_table is not None,
             smem_candidate_capacity,
+            bool(write_values),
         ),
     )
     compile_spec = KernelCompileSpec.from_key(

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import torch
 
 from benchmarks.common import make_l2_flush_fn
+import b12x.attention.dsa_indexer.tiled_topk as tiled_topk_module
 from b12x.attention.dsa_indexer._impl import uses_paged_mqa_schedule
 from b12x.attention.dsa_indexer.kernel import (
     run_paged_supertile_logits_kernel,
@@ -270,6 +271,15 @@ def main() -> None:
     )
     parser.add_argument("--topk", type=int, default=512)
     parser.add_argument(
+        "--topk-candidate-capacity",
+        type=int,
+        choices=(1024, 8192),
+        help=(
+            "benchmark-only override for the compile-time shared candidate "
+            "capacity"
+        ),
+    )
+    parser.add_argument(
         "--output-index-space",
         choices=("logical", "physical"),
         default="logical",
@@ -366,6 +376,28 @@ def main() -> None:
 
     if args.check and args.indices_only:
         raise ValueError("--check requires score output and cannot use --indices-only")
+    if (
+        args.topk_candidate_capacity is not None
+        and args.topk_candidate_capacity < args.topk
+    ):
+        raise ValueError(
+            "top-k candidate capacity must cover the requested top-k width, got "
+            f"{args.topk_candidate_capacity} < {args.topk}"
+        )
+    if args.topk_candidate_capacity is not None:
+        candidate_capacity = int(args.topk_candidate_capacity)
+
+        def resolve_candidate_capacity(*, topk: int) -> int:
+            if candidate_capacity < int(topk):
+                raise ValueError(
+                    "top-k candidate capacity must cover the requested width, got "
+                    f"{candidate_capacity} < {topk}"
+                )
+            return candidate_capacity
+
+        tiled_topk_module._resolve_smem_candidate_capacity = (
+            resolve_candidate_capacity
+        )
 
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
@@ -892,7 +924,9 @@ def main() -> None:
         f"page_stride={page_stride} cache_page_stride_bytes={cache_page_stride_bytes} "
         f"cache_num_pages={cache_num_pages} "
         f"cache_span_mib={((cache_num_pages - 1) * cache_page_stride_bytes + logical_cache_page_bytes) / (1024 * 1024):.2f} "
-        f"topk={topk} supertile_k={supertile_k} "
+        f"topk={topk} "
+        f"topk_candidate_capacity={args.topk_candidate_capacity or 'policy'} "
+        f"supertile_k={supertile_k} "
         f"output_index_space={args.output_index_space} "
         f"requested_supertile_k={requested_supertile_k} "
         f"route={plan.layout.route} prefill_block_k={plan.layout.prefill_block_k} "

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -274,10 +274,7 @@ def main() -> None:
         "--topk-candidate-capacity",
         type=int,
         choices=(1024, 8192),
-        help=(
-            "benchmark-only override for the compile-time shared candidate "
-            "capacity"
-        ),
+        help=("benchmark-only override for the compile-time shared candidate capacity"),
     )
     parser.add_argument(
         "--output-index-space",
@@ -395,9 +392,7 @@ def main() -> None:
                 )
             return candidate_capacity
 
-        tiled_topk_module._resolve_smem_candidate_capacity = (
-            resolve_candidate_capacity
-        )
+        tiled_topk_module._resolve_smem_candidate_capacity = resolve_candidate_capacity
 
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -473,9 +473,9 @@ def main() -> None:
         )
         if args.input_pattern == "random":
             k_source = (
-                torch.randn(
-                    (cache_tokens, 128), generator=gen, dtype=torch.float32
-                ).to(device)
+                torch.randn((cache_tokens, 128), generator=gen, dtype=torch.float32).to(
+                    device
+                )
                 / 3
             )
         else:

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -94,11 +94,13 @@ def _validate_analytic_topk(
     )
     expected_page_cols = torch.div(expected_logical, 64, rounding_mode="floor")
     expected_page_offsets = torch.remainder(expected_logical, 64)
-    expected_page_ids = torch.gather(
-        real_page_table,
-        1,
-        expected_page_cols.clamp_(min=0).to(torch.int64),
+    page_table_width = int(real_page_table.shape[1])
+    if page_table_width <= 0:
+        raise ValueError("analytic top-k validation requires a non-empty page table")
+    safe_page_cols = expected_page_cols.clamp(min=0, max=page_table_width - 1).to(
+        torch.int64
     )
+    expected_page_ids = torch.gather(real_page_table, 1, safe_page_cols)
     expected_physical = expected_page_ids * 64 + expected_page_offsets
     expected_indices = expected_physical if output_physical_slots else expected_logical
     expected_indices = torch.where(
@@ -382,6 +384,10 @@ def main() -> None:
             "top-k candidate capacity must cover the requested top-k width, got "
             f"{args.topk_candidate_capacity} < {args.topk}"
         )
+    if args.topk_candidate_capacity is not None and args.mode != "supertile-topk":
+        raise ValueError(
+            "--topk-candidate-capacity applies only to --mode supertile-topk"
+        )
     if args.topk_candidate_capacity is not None:
         candidate_capacity = int(args.topk_candidate_capacity)
 
@@ -629,17 +635,22 @@ def main() -> None:
 
     out_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
     out_scores = torch.empty((rows, topk), dtype=torch.float32, device=device)
-    untouched_scores = None
-    if args.check and args.indices_only:
-        # The indices-only serving contract must not mutate caller score storage.
-        # A distinct value per element detects partial writes as well as full
-        # materialization without relying on NaN comparison behavior.
-        out_scores.copy_(
+    indices_only_scratch_scores = None
+    untouched_scratch_scores = None
+    if args.check and args.indices_only and bench_mode == "supertile-topk":
+        # index_topk_fp8 receives no output score tensor in indices-only mode.
+        # Its terminal fold instead targets the binding-owned workspace slice,
+        # so validate that exact slice rather than unrelated caller storage.
+        scratch_scores, _ = binding.scratch.get_indexer_contiguous_topk_buffers(
+            row_count=rows
+        )
+        indices_only_scratch_scores = scratch_scores[:, :topk]
+        indices_only_scratch_scores.copy_(
             torch.arange(rows * topk, dtype=torch.float32, device=device).view(
                 rows, topk
             )
         )
-        untouched_scores = out_scores.clone()
+        untouched_scratch_scores = indices_only_scratch_scores.clone()
     fused_ctas = int(args.fused_ctas) if int(args.fused_ctas) > 0 else None
     fused_cache = None
     if bench_mode == "fused-topk":
@@ -859,12 +870,18 @@ def main() -> None:
             output_physical_slots=output_physical_slots,
         )
         if args.indices_only:
-            assert untouched_scores is not None
-            if not torch.equal(out_scores, untouched_scores):
-                raise AssertionError(
-                    "indices-only selector must leave the score buffer untouched"
-                )
-            oracle_state = "analytic_indices_pass(scores_untouched)"
+            if indices_only_scratch_scores is not None:
+                assert untouched_scratch_scores is not None
+                if not torch.equal(
+                    indices_only_scratch_scores, untouched_scratch_scores
+                ):
+                    raise AssertionError(
+                        "indices-only selector must leave its terminal workspace "
+                        "score slice untouched"
+                    )
+                oracle_state = "analytic_indices_pass(workspace_scores_untouched)"
+            else:
+                oracle_state = "analytic_indices_pass"
         else:
             assert oracle_max_abs is not None
             oracle_state = f"analytic_pass(max_abs={oracle_max_abs:.3g})"

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -62,6 +62,14 @@ def _make_page_table(
     return table.contiguous()
 
 
+def _physical_slots(
+    page_ids: torch.Tensor,
+    page_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Return page-based token slots without 32-bit offset overflow."""
+    return page_ids.to(torch.int64) * 64 + page_offsets.to(torch.int64)
+
+
 def _validate_analytic_topk(
     *,
     indices: torch.Tensor,
@@ -101,7 +109,7 @@ def _validate_analytic_topk(
         torch.int64
     )
     expected_page_ids = torch.gather(real_page_table, 1, safe_page_cols)
-    expected_physical = expected_page_ids * 64 + expected_page_offsets
+    expected_physical = _physical_slots(expected_page_ids, expected_page_offsets)
     expected_indices = expected_physical if output_physical_slots else expected_logical
     expected_indices = torch.where(
         expected_valid, expected_indices, torch.full_like(expected_indices, -1)
@@ -135,7 +143,7 @@ def _validate_analytic_topk(
         actual_page_ids = torch.gather(
             real_page_table, 1, actual_page_cols.to(torch.int64)
         )
-        score_indices = actual_page_ids * 64 + actual_page_offsets
+        score_indices = _physical_slots(actual_page_ids, actual_page_offsets)
     expected_scores = analytic_scores[score_indices.to(torch.int64)]
     actual_valid_scores = scores[valid_mask]
     expected_valid_scores = expected_scores[valid_mask]

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -338,6 +338,15 @@ def main() -> None:
         help="use analytic inputs and validate every output row before timing",
     )
     parser.add_argument(
+        "--input-pattern",
+        choices=("random", "low-contrast", "equal"),
+        default="random",
+        help=(
+            "score-distribution stress case used when --check is absent; "
+            "low-contrast and equal inputs exercise crowded radix buckets"
+        ),
+    )
+    parser.add_argument(
         "--nsys-capture",
         action="store_true",
         help="bracket one warmed graph replay with cudaProfilerStart/Stop",
@@ -454,12 +463,27 @@ def main() -> None:
         weights = torch.randn((rows, num_heads), generator=gen, dtype=torch.float32).to(
             device
         )
-        k_source = (
-            torch.randn((cache_tokens, 128), generator=gen, dtype=torch.float32).to(
-                device
+        if args.input_pattern == "random":
+            k_source = (
+                torch.randn(
+                    (cache_tokens, 128), generator=gen, dtype=torch.float32
+                ).to(device)
+                / 3
             )
-            / 3
-        )
+        else:
+            k_source = torch.full(
+                (cache_tokens, 128),
+                0.25,
+                dtype=torch.float32,
+                device=device,
+            )
+            if args.input_pattern == "low-contrast":
+                k_source.add_(
+                    torch.randn(
+                        (cache_tokens, 128), generator=gen, dtype=torch.float32
+                    ).to(device)
+                    / 4096
+                )
         packed_index_k_cache = pack_paged_index_k_cache_reference(k_source)
     # Match vLLM's rank-3 allocation, whose page bytes are planar
     # [64*128 quant][64*4 scales], then reproduce its zero-copy flattening for
@@ -864,6 +888,7 @@ def main() -> None:
         f"output_index_space={args.output_index_space} "
         f"requested_supertile_k={requested_supertile_k} "
         f"route={plan.layout.route} prefill_block_k={plan.layout.prefill_block_k} "
+        f"input_pattern={'analytic' if args.check else args.input_pattern} "
         f"scratch_mib={plan.layout.nbytes / (1024 * 1024):.2f} "
         f"output_shape={tuple(out.shape)} correctness={oracle_state} "
         f"median_us={median_us:.2f} min_us={min_us:.2f}"

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -347,6 +347,11 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--indices-only",
+        action="store_true",
+        help="omit final top-k score output, matching sparse-attention serving",
+    )
+    parser.add_argument(
         "--nsys-capture",
         action="store_true",
         help="bracket one warmed graph replay with cudaProfilerStart/Stop",
@@ -358,6 +363,9 @@ def main() -> None:
     )
     parser.add_argument("--seed", type=int, default=91_100)
     args = parser.parse_args()
+
+    if args.check and args.indices_only:
+        raise ValueError("--check requires score output and cannot use --indices-only")
 
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
@@ -662,7 +670,7 @@ def main() -> None:
                 num_heads=num_heads,
                 topk=topk,
                 out_indices=out_indices,
-                out_values=out_scores,
+                out_values=None if args.indices_only else out_scores,
                 ctas_per_group=fused_ctas,
                 merge_threshold=(
                     None
@@ -683,7 +691,7 @@ def main() -> None:
             topk=topk,
             expected_num_q_heads=num_heads,
             out_indices=out_indices,
-            out_scores=out_scores,
+            out_scores=None if args.indices_only else out_scores,
             supertile_k=supertile_k,
         )
 
@@ -889,6 +897,7 @@ def main() -> None:
         f"requested_supertile_k={requested_supertile_k} "
         f"route={plan.layout.route} prefill_block_k={plan.layout.prefill_block_k} "
         f"input_pattern={'analytic' if args.check else args.input_pattern} "
+        f"indices_only={bool(args.indices_only)} "
         f"scratch_mib={plan.layout.nbytes / (1024 * 1024):.2f} "
         f"output_shape={tuple(out.shape)} correctness={oracle_state} "
         f"median_us={median_us:.2f} min_us={min_us:.2f}"

--- a/benchmarks/benchmark_paged_indexer.py
+++ b/benchmarks/benchmark_paged_indexer.py
@@ -65,13 +65,13 @@ def _make_page_table(
 def _validate_analytic_topk(
     *,
     indices: torch.Tensor,
-    scores: torch.Tensor,
+    scores: torch.Tensor | None,
     seqlens: torch.Tensor,
     topk: int,
     analytic_scores: torch.Tensor,
     real_page_table: torch.Tensor,
     output_physical_slots: bool,
-) -> float:
+) -> float | None:
     """Validate every target-shape row against a cheap analytic top-k oracle."""
     columns = torch.arange(topk, dtype=torch.int32, device=indices.device)
     valid_counts = torch.minimum(seqlens, torch.full_like(seqlens, int(topk)))
@@ -120,6 +120,9 @@ def _validate_analytic_topk(
             f"row={row} missing={missing} extra={extra} "
             f"actual_unique={len(actual_set)} expected_unique={len(expected_set)}"
         )
+
+    if scores is None:
+        return None
 
     safe_indices = indices.clamp(min=0)
     if output_physical_slots:
@@ -371,8 +374,6 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=91_100)
     args = parser.parse_args()
 
-    if args.check and args.indices_only:
-        raise ValueError("--check requires score output and cannot use --indices-only")
     if (
         args.topk_candidate_capacity is not None
         and args.topk_candidate_capacity < args.topk
@@ -628,6 +629,17 @@ def main() -> None:
 
     out_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
     out_scores = torch.empty((rows, topk), dtype=torch.float32, device=device)
+    untouched_scores = None
+    if args.check and args.indices_only:
+        # The indices-only serving contract must not mutate caller score storage.
+        # A distinct value per element detects partial writes as well as full
+        # materialization without relying on NaN comparison behavior.
+        out_scores.copy_(
+            torch.arange(rows * topk, dtype=torch.float32, device=device).view(
+                rows, topk
+            )
+        )
+        untouched_scores = out_scores.clone()
     fused_ctas = int(args.fused_ctas) if int(args.fused_ctas) > 0 else None
     fused_cache = None
     if bench_mode == "fused-topk":
@@ -834,18 +846,28 @@ def main() -> None:
     # First call compiles the CuTe DSL kernel before timing or capture.
     out = run()
     torch.cuda.synchronize()
-    oracle_max_abs = None
+    oracle_state = "not_run"
     if args.check:
         assert analytic_scores is not None
         oracle_max_abs = _validate_analytic_topk(
             indices=out_indices,
-            scores=out_scores,
+            scores=None if args.indices_only else out_scores,
             seqlens=seqlens,
             topk=topk,
             analytic_scores=analytic_scores,
             real_page_table=metadata.real_page_table,
             output_physical_slots=output_physical_slots,
         )
+        if args.indices_only:
+            assert untouched_scores is not None
+            if not torch.equal(out_scores, untouched_scores):
+                raise AssertionError(
+                    "indices-only selector must leave the score buffer untouched"
+                )
+            oracle_state = "analytic_indices_pass(scores_untouched)"
+        else:
+            assert oracle_max_abs is not None
+            oracle_state = f"analytic_pass(max_abs={oracle_max_abs:.3g})"
     l2_flush = make_l2_flush_fn(not args.no_l2_flush)
     if args.eager:
         samples_us = _event_time_us(
@@ -904,11 +926,6 @@ def main() -> None:
 
     median_us = statistics.median(samples_us)
     min_us = min(samples_us)
-    oracle_state = (
-        f"analytic_pass(max_abs={oracle_max_abs:.3g})"
-        if oracle_max_abs is not None
-        else "not_run"
-    )
     raw_us = ",".join(f"{sample:.2f}" for sample in samples_us)
 
     print(

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -23,23 +23,23 @@ gated.
 
 ## Source, hardware, and command
 
-- B12X source revision: `a232cfe96c340bfcaebe61644b069e3a7b789b3a`,
+- B12X source revision: `03ba9855d28717096135f675852a8888fa79c189`,
   based on `master` revision `a45d3f7690e5b2f2e9bdcc0f76d76a48a0c490aa`.
-- Worktree: `/root/vllm/worktrees/b12x-glm53-merged-260-20260831`.
+- Worktree: `/root/vllm/tmp/b12x-pr-paged-topk-20260830`.
 - Physical GPU 2: `GPU-167fbc3f-fd06-7f08-9e06-ee02946d041c`, NVIDIA RTX PRO
   6000 Blackwell Workstation Edition, compute capability 12.0, 188 SMs, PCIe
   Gen5 x16, stock clocks, and a 600 W power limit.
-- Toolchain: CUDA 13.3, PyTorch 2.13.0, CUTLASS DSL 4.6.2, and
+- Toolchain: CUDA Python 13.3.1, PyTorch 2.13.0+cu130, CUTLASS DSL 4.6.2, and
   `CUTE_DSL_ARCH=sm_120a`.
-- Runtime image: `local/jovian-judgement-community-20260831-r8-reviewed`.
+- Python environment: the worktree `.venv`.
 
-Both arms used the same source, random seed, graph-replay path, inputs,
+Both arms used the same source, analytic inputs, graph-replay path,
 indices-only output contract, and cache state. The benchmark-only
 `--topk-candidate-capacity` argument selected the compile-time capacity:
 
 ```bash
 CUDA_VISIBLE_DEVICES=2 CUTE_DSL_ARCH=sm_120a \
-  /opt/venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
+  .venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
   --rows 4080 \
   --global-heads 64 \
   --tp-size 4 \
@@ -50,6 +50,7 @@ CUDA_VISIBLE_DEVICES=2 CUTE_DSL_ARCH=sm_120a \
   --topk 512 \
   --topk-candidate-capacity 1024 \
   --indices-only \
+  --check \
   --warmup 10 \
   --iters 30
 ```
@@ -58,7 +59,9 @@ The 8,192-entry arm changed only
 `--topk-candidate-capacity 1024` to
 `--topk-candidate-capacity 8192`. One preconditioning process per arm preceded
 five measured processes per arm. Measured processes ran in balanced order, and
-each process reported the median of 30 graph replays.
+each process first passed the analytic top-k oracle and verified that the
+indices-only launch left a caller-owned score buffer unchanged. Each process
+then reported the median of 30 graph replays.
 
 ## Correctness
 
@@ -80,16 +83,40 @@ replay with changing live inputs.
 
 | Candidate capacity | Process medians, microseconds | Median |
 | ---: | --- | ---: |
-| 1,024 | 1029.38, 1029.73, 1030.16, 1030.14, 1031.10 | 1030.14 us |
-| 8,192 | 1044.19, 1045.50, 1044.48, 1045.74, 1044.48 | 1044.48 us |
+| 1,024 | 967.66, 961.54, 969.73, 961.54, 961.54 | 961.54 us |
+| 8,192 | 974.18, 984.86, 985.44, 986.05, 970.77 | 984.86 us |
 
-The 1,024-entry policy reduces selector latency by 1.37%. The ratio direction is
+The 1,024-entry policy reduces selector latency by 2.37%. The ratio direction is
 8,192-entry latency divided by 1,024-entry latency:
-`1044.48 / 1030.14 = 1.01392`, or 1.39% higher selector throughput.
+`984.86 / 961.54 = 1.02425`, or 2.43% higher selector throughput.
 
 This comparison isolates candidate capacity. It does not attribute the separate
 gain from omitting unused terminal score writes, because both arms use the same
 indices-only contract.
+
+### Raw graph-replay samples
+
+Arm A is the 1,024-entry candidate capacity and arm B is the 8,192-entry
+candidate capacity. `pre-A` and `pre-B` are the independent preconditioning
+processes. The measured process order was A1, B1, B2, A2, A3, B3, B4, A4, A5,
+B5. Every value below is one graph-replay latency in microseconds; each line
+contains all 30 replay samples from that process. The benchmark computed each
+median before rounding individual samples to two decimal places for display.
+
+```text
+pre-A (median 973.39): 974.85,974.94,975.46,973.76,975.42,974.43,973.44,973.63,973.44,973.41,974.50,973.38,970.37,973.50,976.67,972.70,971.81,970.78,971.81,972.83,970.78,971.81,972.83,971.81,970.75,973.86,972.83,971.78,972.83,973.82
+pre-B (median 980.00): 978.94,981.76,981.57,979.90,980.93,979.97,979.52,979.71,982.94,982.98,982.85,978.85,980.80,978.85,980.61,980.93,979.97,978.94,980.00,980.00,978.94,980.00,981.02,980.00,978.98,979.97,980.99,979.94,978.94,981.02
+A1 (median 967.66): 968.70,968.45,968.64,968.26,968.51,967.65,968.80,968.32,968.61,968.48,966.59,966.69,965.54,966.66,967.58,966.66,967.68,966.66,965.63,964.61,965.63,966.69,968.70,967.68,968.70,967.65,966.66,965.63,968.70,967.68
+B1 (median 974.18): 976.93,975.94,975.42,975.81,974.78,973.89,975.42,975.55,975.52,972.74,974.46,974.82,974.46,972.67,974.46,974.75,971.78,972.83,973.82,974.88,972.83,973.86,972.83,973.86,972.83,971.81,972.80,971.78,970.75,975.90
+B2 (median 984.86): 987.14,986.98,987.78,985.92,987.87,985.95,985.12,983.78,983.84,985.02,984.74,985.12,986.75,985.02,984.74,984.99,984.06,983.04,983.04,984.06,983.07,984.10,985.09,982.05,983.04,984.06,983.07,985.09,984.10,985.09
+A2 (median 961.54): 962.56,964.38,963.14,961.60,963.14,964.22,963.14,962.08,962.53,961.47,962.53,961.06,961.54,963.10,961.54,962.46,961.54,960.48,961.54,962.56,959.46,960.48,960.51,960.51,960.48,961.54,960.51,959.49,960.51,959.49
+A3 (median 969.73): 970.75,973.66,973.38,971.81,971.33,971.74,971.33,969.63,971.39,969.57,970.37,968.61,969.73,972.70,971.78,968.48,969.73,968.70,967.68,970.75,968.70,969.70,968.70,969.73,968.70,967.68,968.70,967.71,968.70,969.73
+B3 (median 985.44): 987.14,987.81,987.71,986.88,987.71,986.05,985.73,986.05,985.73,984.96,984.06,987.04,986.75,985.12,986.78,985.15,984.06,985.09,983.04,984.06,985.12,984.06,985.09,984.06,985.09,986.11,985.09,985.12,988.16,987.14
+B4 (median 986.05): 985.09,983.90,987.17,984.64,989.28,988.74,985.02,984.77,989.09,989.82,987.94,987.78,985.98,985.73,985.86,987.81,986.11,985.09,985.09,986.11,987.14,984.06,985.09,986.11,985.09,988.19,989.18,987.10,984.06,985.09
+A4 (median 961.54): 964.61,963.42,963.36,963.30,963.17,964.16,963.17,962.30,964.61,961.44,960.51,963.30,961.57,963.10,961.50,964.51,959.49,960.51,961.54,960.51,961.54,960.51,960.51,960.51,960.51,961.54,962.56,959.49,960.51,959.49
+A5 (median 961.54): 964.61,962.56,961.09,961.47,963.14,960.22,963.14,961.44,961.15,962.11,962.53,963.10,961.54,965.15,961.54,962.46,961.54,962.56,961.54,960.54,959.49,962.56,961.54,962.56,962.56,961.54,960.51,959.49,960.48,959.49
+B5 (median 970.77): 972.80,971.74,971.39,972.38,971.42,972.51,971.33,972.45,970.72,970.37,970.27,971.42,972.32,971.39,971.74,971.39,969.73,970.75,967.68,968.74,968.70,969.73,970.78,969.76,968.74,971.81,968.70,967.68,970.75,969.73
+```
 
 ## Compiled-resource evidence
 

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -3,7 +3,7 @@
 ## Status and operation contract
 
 Status: **implemented** as an architecture-neutral top-k policy and
-**qualified** on NVIDIA SM120.
+**qualified** on NVIDIA compute capability 12.0 (SM120).
 
 The top-k-512 selector uses a 1,024-entry shared candidate buffer. Selectors
 with top-k 1,024 or 2,048 use an 8,192-entry buffer. Candidate capacity is an
@@ -31,7 +31,10 @@ gated.
   Gen5 x16, stock clocks, and a 600 W power limit.
 - Toolchain: CUDA Python 13.3.1, PyTorch 2.13.0+cu130, CUTLASS DSL 4.6.2, and
   `CUTE_DSL_ARCH=sm_120a`.
-- Python environment: the worktree `.venv`.
+- Performance environment: the worktree `.venv`.
+- Correctness environment: `/opt/venv` from
+  `voipmonitor/vllm:jovian-judgement-community-20260831-r10`, with the B12X
+  checkout mounted read-only at `/src`.
 
 Both arms used the same source, analytic inputs, graph-replay path,
 indices-only output contract, and cache state. The benchmark-only
@@ -60,24 +63,45 @@ The 8,192-entry arm changed only
 `--topk-candidate-capacity 8192`. One preconditioning process per arm preceded
 five measured processes per arm. Measured processes ran in balanced order, and
 each process first passed the analytic top-k oracle and verified that the
-indices-only launch left a caller-owned score buffer unchanged. Each process
-then reported the median of 30 graph replays.
+indices-only launch left the binding-owned terminal workspace score slice
+unchanged. Each process then reported the median of 30 graph replays.
 
 ## Correctness
 
-The focused selector suite used the production source and 1,024-entry policy:
+The focused selector suite used the production source and 1,024-entry policy.
+The command ran from the B12X repository root and exposed physical GPU 2 as
+CUDA device 0 in the container:
 
 ```bash
-CUDA_VISIBLE_DEVICES=2 CUTE_DSL_ARCH=sm_120a \
-  /opt/venv/bin/python -B -m pytest -q \
-  tests/attention/test_attention_dsa_indexer_api.py \
-  tests/attention/test_paged_prefill_topk_long_context.py \
-  -k "topk_candidate_capacity or row_topk or paged_prefill_topk"
+docker run --rm --gpus '"device=2"' --ipc=host --shm-size 16g \
+  --entrypoint /bin/bash \
+  -e CUDA_VISIBLE_DEVICES=0 \
+  -e CUTE_DSL_ARCH=sm_120a \
+  -e PYTHONPATH=/src \
+  -v "$PWD:/src:ro" \
+  -w /src \
+  voipmonitor/vllm:jovian-judgement-community-20260831-r10 \
+  -lc '/opt/venv/bin/python -B -m pytest -q \
+    tests/attention/test_attention_dsa_indexer_api.py \
+    tests/attention/test_paged_prefill_topk_long_context.py \
+    -k "topk_candidate_capacity or row_topk or paged_prefill_topk"'
 ```
 
 Result: `16 passed, 29 deselected`. The selection covers top-k policy,
 indices-only output, short-row padding, exact overflow selection, and CUDA graph
 replay with changing live inputs.
+
+The benchmark oracle also passed the following graph-replay smoke cases after
+the score sentinel was moved to the terminal workspace slice actually consumed
+by `index_topk_fp8`. These samples are correctness evidence, not performance
+qualification:
+
+| Rows | Visible tokens | Page-table width | Candidate capacity | Chunks | Oracle state |
+| ---: | ---: | ---: | ---: | ---: | --- |
+| 4,080 | 8,192 | 128 | 1,024 | 1 | indices and untouched terminal scores pass |
+| 4,080 | 8,192 | 128 | 8,192 | 1 | indices and untouched terminal scores pass |
+| 1 | 64 | 1 | 1,024 | 1 | short-row padding and untouched terminal scores pass |
+| 32 | 16,384 | 256 | 1,024 | 2 | carry fold, indices, and untouched terminal scores pass |
 
 ## Selector performance
 

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -1,0 +1,106 @@
+# SM120 paged top-k prefill qualification
+
+## Status and operation contract
+
+Status: **qualified** for the paged SM120 top-k selector used by GLM-5.3 C4
+prefill.
+
+The selector admits the largest shared-memory candidate capacity supported by
+the device, omits the final score write when the caller requests indices only,
+and initializes padding candidates before an exact overflow rescan. The public
+indexer interfaces, logical-index output contract, page layout, top-k value,
+and supported input layouts are unchanged.
+
+For a row with fewer live candidates than `topk`, the result contains every
+live candidate at most once and fills remaining entries with `-1`. CUDA graph
+replay may change live lengths and logits without retaining a stale padded
+winner.
+
+## Source and hardware
+
+- Comparison revision: `fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`,
+  tree `7fcb6afb69b04b6981060012e943e125e58168b4`.
+- Qualified implementation revision:
+  `5a24588f1a6846a03fb4ca65debc868a5efee7d8`, tree
+  `b7ef58e13e4057810bdd6b64170e7c93e711a300`.
+- Runtime image:
+  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r3`.
+- Physical GPU 1: `GPU-3747d42a-c416-459c-cf88-bc2e84f471b1`, NVIDIA RTX PRO
+  6000 Blackwell Workstation Edition, driver 610.57.04, PCIe Gen5 x16.
+- Performance measurements used CUDA graph replay with L2 flushing, 10
+  warmups, and 30 timed iterations.
+
+## Correctness
+
+The focused suite was:
+
+```bash
+CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
+  /opt/venv/bin/python -B -m pytest -q \
+  tests/attention/test_attention_dsa_indexer_api.py \
+  tests/attention/test_paged_prefill_topk_long_context.py \
+  -k "row_topk or paged_prefill_topk"
+```
+
+Result: `15 passed, 29 deselected`.
+
+A production-geometry analytic run used 4,080 query rows, 64 replicated
+indexer heads, an 8,192-token visible cache, top-k 512, and a shared paged
+table. Every selected index matched the exact FP32 top-k membership and the
+maximum valid-score error was 0.000488.
+
+## Performance
+
+The comparison revision always materializes final scores. The qualified
+revision used the serving contract in which sparse attention consumes only
+selected indices:
+
+```bash
+/opt/venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
+  --rows 4080 \
+  --global-heads 64 \
+  --tp-size 4 \
+  --page-table-width 128 \
+  --seq-len 8192 \
+  --mode supertile-topk \
+  --route paged-tiled \
+  --topk 512 \
+  --indices-only \
+  --warmup 10 \
+  --iters 30
+```
+
+The comparison command omitted `--indices-only` because that revision does not
+implement the indices-only contract.
+
+| Revision | Median | Minimum |
+| --- | ---: | ---: |
+| Comparison | 1,074.18 us | 1,072.13 us |
+| Qualified | 1,053.70 us | 1,052.22 us |
+
+The fixed-work latency reduction is 1.91%. The equivalent throughput ratio is
+`1074.18 / 1053.70 = 1.019436`, or 1.94% higher selector throughput.
+
+Comparison raw samples, microseconds:
+
+```text
+1073.15, 1073.73, 1075.78, 1074.75, 1075.17, 1073.73, 1074.94,
+1073.15, 1074.72, 1073.79, 1073.70, 1074.85, 1077.79, 1074.18,
+1077.15, 1075.84, 1074.18, 1073.15, 1076.22, 1073.15, 1074.18,
+1074.18, 1075.20, 1074.18, 1075.20, 1072.13, 1074.18, 1075.20,
+1074.18, 1075.20
+```
+
+Qualified raw samples, microseconds:
+
+```text
+1052.67, 1052.22, 1052.70, 1054.40, 1052.74, 1054.30, 1053.79,
+1055.52, 1053.60, 1055.36, 1053.60, 1054.37, 1056.70, 1053.70,
+1054.69, 1054.50, 1052.67, 1052.67, 1053.70, 1054.72, 1053.70,
+1052.67, 1053.70, 1053.70, 1054.72, 1053.70, 1052.67, 1053.70,
+1052.67, 1052.67
+```
+
+The operation result does not by itself establish an end-to-end serving gain.
+The release-level benchmark must include page-table preparation, C4 scoring,
+communication, attention, and all remaining model work.

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -27,7 +27,7 @@ gated.
   `03ba9855d28717096135f675852a8888fa79c189`, based on `master` revision
   `a45d3f7690e5b2f2e9bdcc0f76d76a48a0c490aa`.
 - Correctness and benchmark-oracle revision:
-  `c2b4b20170477d12b139d7853a3903a43fca07ab`.
+  `a8306ab1d117bb53285b511c71ba4bcb5aad4f18`.
 - Worktree: `/root/vllm/tmp/b12x-pr-paged-topk-20260830`.
 - Physical GPU 2: `GPU-167fbc3f-fd06-7f08-9e06-ee02946d041c`, NVIDIA RTX PRO
   6000 Blackwell Workstation Edition, compute capability 12.0, 188 SMs, PCIe

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -21,14 +21,29 @@ winner.
 - Comparison revision: `fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`,
   tree `7fcb6afb69b04b6981060012e943e125e58168b4`.
 - Qualified implementation revision:
-  `5a24588f1a6846a03fb4ca65debc868a5efee7d8`, tree
-  `b7ef58e13e4057810bdd6b64170e7c93e711a300`.
-- Runtime image:
-  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r3`.
+  `ee611d20258b00a976123d4fead0a218de04a709`, tree
+  `20f47518383665eeab46bfca5a6ceda7d117063d`.
+- Comparison worktree:
+  `/root/vllm/worktrees/b12x-master-fc1d4b68-20260830`.
+- Qualified worktree: `/root/vllm/tmp/b12x-pr-paged-topk-20260830`.
+- Runtime foundation image:
+  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r4`,
+  image ID
+  `sha256:0029fb596153966c997e1f09737e3ea7a547bf1c7a251f356e01c681c9f917d6`.
 - Physical GPU 1: `GPU-3747d42a-c416-459c-cf88-bc2e84f471b1`, NVIDIA RTX PRO
   6000 Blackwell Workstation Edition, driver 610.57.04, PCIe Gen5 x16.
-- Performance measurements used CUDA graph replay with L2 flushing, 10
-  warmups, and 30 timed iterations.
+- GPU-mode snapshots before and after collection were P1, persistence enabled,
+  default compute mode, 2,692 MHz SM clock, 13,365 MHz memory clock, active
+  throttle mask `0x0`, 38 C, and 77.88/78.84 W against a 600 W limit.
+- Toolchain map: `nvidia-cutlass-dsl==4.6.2` from
+  `/opt/venv/lib/python3.12/site-packages/nvidia_cutlass_dsl`, PyTorch 2.13.0,
+  and `/usr/local/cuda/bin/ptxas` build
+  `cuda_13.3.r13.3/compiler.38244171_0`; `CUTE_DSL_ARCH=sm_120a`.
+- Source-specific compile-cache manifests were fixed for every timed process.
+  The comparison cache contained four files with aggregate manifest SHA-256
+  `ad17d606754fdf21f11bc4e32be598ea49eb0bcde8b8964e8ee0b228b1716a3d`;
+  the qualified cache contained six files with aggregate manifest SHA-256
+  `dab33ecfbeb248a2b90b2b6768ddb969acc089a842165bf792dabd267afc8abd`.
 
 ## Correctness
 
@@ -42,12 +57,15 @@ CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
   -k "row_topk or paged_prefill_topk"
 ```
 
-Result: `15 passed, 29 deselected`.
+Result: `15 passed, 30 deselected`. The capacity-cache unit selection produced
+`7 passed, 29 deselected` and verifies one capability query for each immutable
+device/top-k pair.
 
 A production-geometry analytic run used 4,080 query rows, 64 replicated
 indexer heads, an 8,192-token visible cache, top-k 512, and a shared paged
-table. Every selected index matched the exact FP32 top-k membership and the
-maximum valid-score error was 0.000488.
+table. It reported `analytic_pass(max_abs=0.000488)`. The indices-only contract
+is covered by the GPU suite above because analytic score comparison requires
+score materialization.
 
 ## Performance
 
@@ -56,7 +74,8 @@ revision used the serving contract in which sparse attention consumes only
 selected indices:
 
 ```bash
-/opt/venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
+CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
+  /opt/venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
   --rows 4080 \
   --global-heads 64 \
   --tp-size 4 \
@@ -71,34 +90,44 @@ selected indices:
 ```
 
 The comparison command omitted `--indices-only` because that revision does not
-implement the indices-only contract.
+implement the indices-only contract. Each arm first ran one zero-warmup replay
+and one 10-warmup preconditioning process. Five process-level medians per arm
+were then collected in the balanced order comparison, qualified, qualified,
+comparison, comparison, qualified, qualified, comparison, comparison,
+qualified. Every timed process loaded its arm's fixed cache objects before
+graph capture.
 
-| Revision | Median | Minimum |
-| --- | ---: | ---: |
-| Comparison | 1,074.18 us | 1,072.13 us |
-| Qualified | 1,053.70 us | 1,052.22 us |
+| Revision | Process medians, microseconds | Median |
+| --- | --- | ---: |
+| Comparison | 1,074.18, 1,074.18, 1,073.15, 1,073.20, 1,073.86 | 1,073.86 us |
+| Qualified | 1,052.50, 1,052.67, 1,052.67, 1,053.57, 1,052.67 | 1,052.67 us |
 
-The fixed-work latency reduction is 1.91%. The equivalent throughput ratio is
-`1074.18 / 1053.70 = 1.019436`, or 1.94% higher selector throughput.
+The zero-warmup replay was 1,073.15 us for the comparison and 1,050.62 us for
+the qualified implementation. The preconditioning process medians were
+1,074.18 us and 1,052.67 us, respectively.
+
+The fixed-work latency reduction is 1.97%. The ratio direction is comparison
+latency divided by qualified latency: `1073.86 / 1052.67 = 1.020130`, or 2.01%
+higher selector throughput.
 
 Comparison raw samples, microseconds:
 
 ```text
-1073.15, 1073.73, 1075.78, 1074.75, 1075.17, 1073.73, 1074.94,
-1073.15, 1074.72, 1073.79, 1073.70, 1074.85, 1077.79, 1074.18,
-1077.15, 1075.84, 1074.18, 1073.15, 1076.22, 1073.15, 1074.18,
-1074.18, 1075.20, 1074.18, 1075.20, 1072.13, 1074.18, 1075.20,
-1074.18, 1075.20
+1074.66, 1072.77, 1071.68, 1072.70, 1073.73, 1073.73, 1072.10,
+1073.15, 1072.00, 1071.10, 1075.10, 1074.82, 1073.09, 1074.18,
+1077.09, 1074.43, 1074.18, 1071.10, 1074.18, 1073.15, 1072.13,
+1074.18, 1075.20, 1074.18, 1075.20, 1074.18, 1074.18, 1075.20,
+1074.18, 1073.15
 ```
 
 Qualified raw samples, microseconds:
 
 ```text
-1052.67, 1052.22, 1052.70, 1054.40, 1052.74, 1054.30, 1053.79,
-1055.52, 1053.60, 1055.36, 1053.60, 1054.37, 1056.70, 1053.70,
-1054.69, 1054.50, 1052.67, 1052.67, 1053.70, 1054.72, 1053.70,
-1052.67, 1053.70, 1053.70, 1054.72, 1053.70, 1052.67, 1053.70,
-1052.67, 1052.67
+1050.62, 1050.46, 1050.53, 1050.21, 1050.69, 1052.22, 1051.81,
+1052.67, 1051.55, 1051.26, 1051.36, 1050.24, 1050.56, 1051.65,
+1052.42, 1054.34, 1052.67, 1054.72, 1053.70, 1052.67, 1053.70,
+1052.67, 1053.70, 1053.70, 1052.67, 1053.70, 1052.67, 1053.70,
+1054.72, 1052.67
 ```
 
 The operation result does not by itself establish an end-to-end serving gain.

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -1,80 +1,44 @@
-# SM120 paged top-k prefill qualification
+# Paged top-k-512 candidate-capacity qualification
 
 ## Status and operation contract
 
-Status: **qualified** for the paged SM120 top-k selector used by GLM-5.3 C4
-prefill.
+Status: **implemented** as an architecture-neutral top-k policy and
+**qualified** on NVIDIA SM120.
 
-The selector admits the largest shared-memory candidate capacity supported by
-the device, omits the final score write when the caller requests indices only,
-and initializes padding candidates before an exact overflow rescan. The public
-indexer interfaces, logical-index output contract, page layout, top-k value,
-and supported input layouts are unchanged.
+The top-k-512 selector uses a 1,024-entry shared candidate buffer. Selectors
+with top-k 1,024 or 2,048 use an 8,192-entry buffer. Candidate capacity is an
+immutable compile-time property derived only from top-k width; selector launch
+does not query CUDA capability or request state.
 
-For a row with fewer live candidates than `topk`, the result contains every
-live candidate at most once and fills remaining entries with `-1`. CUDA graph
-replay may change live lengths and logits without retaining a stale padded
-winner.
+The exact overflow rescan preserves selection semantics when a threshold bucket
+contains more candidates than the shared buffer. For a row with fewer live
+candidates than top-k, each live candidate appears at most once and unused
+entries are `-1`. An indices-only terminal fold leaves the score output buffer
+untouched. Intermediate folds continue writing scores because later folds read
+them.
 
-## Source and hardware
+Performance qualification is specific to the hardware and production geometry
+below. The operation contract and compile-time policy are not architecture
+gated.
 
-- Comparison revision: `fc1d4b68f7a5b0cfdb88bf06abccd869f5c589d5`,
-  tree `7fcb6afb69b04b6981060012e943e125e58168b4`.
-- Qualified implementation revision:
-  `ee611d20258b00a976123d4fead0a218de04a709`, tree
-  `20f47518383665eeab46bfca5a6ceda7d117063d`.
-- Comparison worktree:
-  `/root/vllm/worktrees/b12x-master-fc1d4b68-20260830`.
-- Qualified worktree: `/root/vllm/tmp/b12x-pr-paged-topk-20260830`.
-- Runtime foundation image:
-  `local/vllm:glm53-flash-nvfp4-dcp4-dflash2-flashkda-bt4096-20260830-r4`,
-  image ID
-  `sha256:0029fb596153966c997e1f09737e3ea7a547bf1c7a251f356e01c681c9f917d6`.
-- Physical GPU 1: `GPU-3747d42a-c416-459c-cf88-bc2e84f471b1`, NVIDIA RTX PRO
-  6000 Blackwell Workstation Edition, driver 610.57.04, PCIe Gen5 x16.
-- GPU-mode snapshots before and after collection were P1, persistence enabled,
-  default compute mode, 2,692 MHz SM clock, 13,365 MHz memory clock, active
-  throttle mask `0x0`, 38 C, and 77.88/78.84 W against a 600 W limit.
-- Toolchain map: `nvidia-cutlass-dsl==4.6.2` from
-  `/opt/venv/lib/python3.12/site-packages/nvidia_cutlass_dsl`, PyTorch 2.13.0,
-  and `/usr/local/cuda/bin/ptxas` build
-  `cuda_13.3.r13.3/compiler.38244171_0`; `CUTE_DSL_ARCH=sm_120a`.
-- Source-specific compile-cache manifests were fixed for every timed process.
-  The comparison cache contained four files with aggregate manifest SHA-256
-  `ad17d606754fdf21f11bc4e32be598ea49eb0bcde8b8964e8ee0b228b1716a3d`;
-  the qualified cache contained six files with aggregate manifest SHA-256
-  `dab33ecfbeb248a2b90b2b6768ddb969acc089a842165bf792dabd267afc8abd`.
+## Source, hardware, and command
 
-## Correctness
+- B12X source revision: `a232cfe96c340bfcaebe61644b069e3a7b789b3a`,
+  based on `master` revision `a45d3f7690e5b2f2e9bdcc0f76d76a48a0c490aa`.
+- Worktree: `/root/vllm/worktrees/b12x-glm53-merged-260-20260831`.
+- Physical GPU 2: `GPU-167fbc3f-fd06-7f08-9e06-ee02946d041c`, NVIDIA RTX PRO
+  6000 Blackwell Workstation Edition, compute capability 12.0, 188 SMs, PCIe
+  Gen5 x16, stock clocks, and a 600 W power limit.
+- Toolchain: CUDA 13.3, PyTorch 2.13.0, CUTLASS DSL 4.6.2, and
+  `CUTE_DSL_ARCH=sm_120a`.
+- Runtime image: `local/jovian-judgement-community-20260831-r8-reviewed`.
 
-The focused suite was:
+Both arms used the same source, random seed, graph-replay path, inputs,
+indices-only output contract, and cache state. The benchmark-only
+`--topk-candidate-capacity` argument selected the compile-time capacity:
 
 ```bash
-CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
-  /opt/venv/bin/python -B -m pytest -q \
-  tests/attention/test_attention_dsa_indexer_api.py \
-  tests/attention/test_paged_prefill_topk_long_context.py \
-  -k "row_topk or paged_prefill_topk"
-```
-
-Result: `15 passed, 30 deselected`. The capacity-cache unit selection produced
-`7 passed, 29 deselected` and verifies one capability query for each immutable
-device/top-k pair.
-
-A production-geometry analytic run used 4,080 query rows, 64 replicated
-indexer heads, an 8,192-token visible cache, top-k 512, and a shared paged
-table. It reported `analytic_pass(max_abs=0.000488)`. The indices-only contract
-is covered by the GPU suite above because analytic score comparison requires
-score materialization.
-
-## Performance
-
-The comparison revision always materializes final scores. The qualified
-revision used the serving contract in which sparse attention consumes only
-selected indices:
-
-```bash
-CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
+CUDA_VISIBLE_DEVICES=2 CUTE_DSL_ARCH=sm_120a \
   /opt/venv/bin/python -B benchmarks/benchmark_paged_indexer.py \
   --rows 4080 \
   --global-heads 64 \
@@ -84,52 +48,69 @@ CUDA_VISIBLE_DEVICES=1 CUTE_DSL_ARCH=sm_120a \
   --mode supertile-topk \
   --route paged-tiled \
   --topk 512 \
+  --topk-candidate-capacity 1024 \
   --indices-only \
   --warmup 10 \
   --iters 30
 ```
 
-The comparison command omitted `--indices-only` because that revision does not
-implement the indices-only contract. Each arm first ran one zero-warmup replay
-and one 10-warmup preconditioning process. Five process-level medians per arm
-were then collected in the balanced order comparison, qualified, qualified,
-comparison, comparison, qualified, qualified, comparison, comparison,
-qualified. Every timed process loaded its arm's fixed cache objects before
-graph capture.
+The 8,192-entry arm changed only
+`--topk-candidate-capacity 1024` to
+`--topk-candidate-capacity 8192`. One preconditioning process per arm preceded
+five measured processes per arm. Measured processes ran in balanced order, and
+each process reported the median of 30 graph replays.
 
-| Revision | Process medians, microseconds | Median |
-| --- | --- | ---: |
-| Comparison | 1,074.18, 1,074.18, 1,073.15, 1,073.20, 1,073.86 | 1,073.86 us |
-| Qualified | 1,052.50, 1,052.67, 1,052.67, 1,053.57, 1,052.67 | 1,052.67 us |
+## Correctness
 
-The zero-warmup replay was 1,073.15 us for the comparison and 1,050.62 us for
-the qualified implementation. The preconditioning process medians were
-1,074.18 us and 1,052.67 us, respectively.
+The focused selector suite used the production source and 1,024-entry policy:
 
-The fixed-work latency reduction is 1.97%. The ratio direction is comparison
-latency divided by qualified latency: `1073.86 / 1052.67 = 1.020130`, or 2.01%
-higher selector throughput.
-
-Comparison raw samples, microseconds:
-
-```text
-1074.66, 1072.77, 1071.68, 1072.70, 1073.73, 1073.73, 1072.10,
-1073.15, 1072.00, 1071.10, 1075.10, 1074.82, 1073.09, 1074.18,
-1077.09, 1074.43, 1074.18, 1071.10, 1074.18, 1073.15, 1072.13,
-1074.18, 1075.20, 1074.18, 1075.20, 1074.18, 1074.18, 1075.20,
-1074.18, 1073.15
+```bash
+CUDA_VISIBLE_DEVICES=2 CUTE_DSL_ARCH=sm_120a \
+  /opt/venv/bin/python -B -m pytest -q \
+  tests/attention/test_attention_dsa_indexer_api.py \
+  tests/attention/test_paged_prefill_topk_long_context.py \
+  -k "topk_candidate_capacity or row_topk or paged_prefill_topk"
 ```
 
-Qualified raw samples, microseconds:
+Result: `16 passed, 29 deselected`. The selection covers top-k policy,
+indices-only output, short-row padding, exact overflow selection, and CUDA graph
+replay with changing live inputs.
 
-```text
-1050.62, 1050.46, 1050.53, 1050.21, 1050.69, 1052.22, 1051.81,
-1052.67, 1051.55, 1051.26, 1051.36, 1050.24, 1050.56, 1051.65,
-1052.42, 1054.34, 1052.67, 1054.72, 1053.70, 1052.67, 1053.70,
-1052.67, 1053.70, 1053.70, 1052.67, 1053.70, 1052.67, 1053.70,
-1054.72, 1052.67
-```
+## Selector performance
 
-The operation result does not by itself establish an end-to-end serving gain.
-The release-level benchmark must include page-table preparation, C4 scoring,
-communication, attention, and all remaining model work.
+| Candidate capacity | Process medians, microseconds | Median |
+| ---: | --- | ---: |
+| 1,024 | 1029.38, 1029.73, 1030.16, 1030.14, 1031.10 | 1030.14 us |
+| 8,192 | 1044.19, 1045.50, 1044.48, 1045.74, 1044.48 | 1044.48 us |
+
+The 1,024-entry policy reduces selector latency by 1.37%. The ratio direction is
+8,192-entry latency divided by 1,024-entry latency:
+`1044.48 / 1030.14 = 1.01392`, or 1.39% higher selector throughput.
+
+This comparison isolates candidate capacity. It does not attribute the separate
+gain from omitting unused terminal score writes, because both arms use the same
+indices-only contract.
+
+## Compiled-resource evidence
+
+The B12X compile manifests and the embedded `sm_120a` fatbins identify the exact
+selector objects:
+
+| Candidate capacity | Object SHA-256 | Object bytes | Dynamic shared memory | Registers/thread | Stack | Local memory | Static shared memory |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,024 | `771c9ddf8f831bff42c45846744167faf9e51134cc15c297fc2df48632bf55ce` | 61,288 | 20,096 B | 27 | 0 B | 0 B | 1,024 B |
+| 8,192 | `3302781c9b37e18662de61381d25bdf4db96c1b4366da7ac30ab90772760b5e3` | 63,576 | 77,440 B | 27 | 0 B | 0 B | 1,024 B |
+
+`cuobjdump --dump-resource-usage` reports no stack, spill, or local-memory use
+for either object. The GPU permits 1,536 threads, 65,536 registers, and 102,400
+shared-memory bytes per SM. Each selector CTA has 1,024 threads, so both objects
+are limited to one resident CTA per SM by the thread limit. Both therefore have
+32 active warps out of 48, or 66.7% theoretical warp occupancy. The smaller
+candidate buffer improves latency without changing CTA occupancy, register use,
+or spill behavior.
+
+## Scope
+
+The selector result does not establish end-to-end serving throughput. GLM-5.3
+qualification must also include C4 scoring, page-table preparation,
+communication, attention, MoE, and the remaining model work.

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -106,10 +106,10 @@ Result: `17 passed, 29 deselected`. The selection covers top-k policy,
 64-bit physical-slot oracle arithmetic, indices-only output, short-row padding,
 exact overflow selection, and CUDA graph replay with changing live inputs.
 
-The benchmark oracle also passed the following graph-replay smoke cases after
-the score sentinel was moved to the terminal workspace slice actually consumed
-by `index_topk_fp8`. These samples are correctness evidence, not performance
-qualification:
+For indices-only `index_topk_fp8` runs, the benchmark initializes the
+binding-owned terminal workspace score slice and verifies that the selector
+leaves it unchanged. The following graph-replay samples provide correctness
+evidence, not performance qualification:
 
 | Rows | Visible tokens | Page-table width | Candidate capacity | Chunks | Oracle state |
 | ---: | ---: | ---: | ---: | ---: | --- |

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -23,8 +23,11 @@ gated.
 
 ## Source, hardware, and command
 
-- B12X source revision: `03ba9855d28717096135f675852a8888fa79c189`,
-  based on `master` revision `a45d3f7690e5b2f2e9bdcc0f76d76a48a0c490aa`.
+- Selector performance source revision:
+  `03ba9855d28717096135f675852a8888fa79c189`, based on `master` revision
+  `a45d3f7690e5b2f2e9bdcc0f76d76a48a0c490aa`.
+- Correctness and benchmark-oracle revision:
+  `c2b4b20170477d12b139d7853a3903a43fca07ab`.
 - Worktree: `/root/vllm/tmp/b12x-pr-paged-topk-20260830`.
 - Physical GPU 2: `GPU-167fbc3f-fd06-7f08-9e06-ee02946d041c`, NVIDIA RTX PRO
   6000 Blackwell Workstation Edition, compute capability 12.0, 188 SMs, PCIe

--- a/docs/evidence/paged_topk_sm120_prefill.md
+++ b/docs/evidence/paged_topk_sm120_prefill.md
@@ -39,6 +39,17 @@ gated.
   `voipmonitor/vllm:jovian-judgement-community-20260831-r10`, with the B12X
   checkout mounted read-only at `/src`.
 
+The timed selector objects share source revision
+`03ba9855d28717096135f675852a8888fa79c189`, package fingerprint
+`351a2593b55428b9d81840384e4cddcf34a2fc76e3be8b5628366d451655a2e0`,
+CUTLASS DSL 4.6.2, and PTXAS 13.3.73. The PTXAS executable has SHA-256
+`afd8d1e1fa6e310f7faee44f6621e4c1315fb7fd6da7d4d87414358e12a651dc`.
+
+| Candidate capacity | Compile manifest cache key | Compile manifest SHA-256 | Compile specification SHA-256 | Object SHA-256 |
+| ---: | --- | --- | --- | --- |
+| 1,024 | `377868b15c4457c61e769a9534df456d8f2cc067857bb977363aaed549d55f7a` | `153be41d246f0a8f70dc28b7f553766004a778b80027b57600dc461746d6af5c` | `75e920ecbecdc715ccc4061644e1370f66afc778d876909c791663bfe1871806` | `771c9ddf8f831bff42c45846744167faf9e51134cc15c297fc2df48632bf55ce` |
+| 8,192 | `a77894d49ebd74b4d94927aff50f109effb6fc348540cbf855e1542eb707e31f` | `42bf35cb808e4771d005680c4e5c598cb98aa7824e82587ace50a4fd214a92ab` | `4044c4e1510075ae5f8b62e2eba1cc903b677c5713e6e70597a7a0eac0a64b08` | `3302781c9b37e18662de61381d25bdf4db96c1b4366da7ac30ab90772760b5e3` |
+
 Both arms used the same source, analytic inputs, graph-replay path,
 indices-only output contract, and cache state. The benchmark-only
 `--topk-candidate-capacity` argument selected the compile-time capacity:
@@ -85,14 +96,15 @@ docker run --rm --gpus '"device=2"' --ipc=host --shm-size 16g \
   -w /src \
   voipmonitor/vllm:jovian-judgement-community-20260831-r10 \
   -lc '/opt/venv/bin/python -B -m pytest -q \
+    tests/attention/test_benchmark_paged_indexer.py \
     tests/attention/test_attention_dsa_indexer_api.py \
     tests/attention/test_paged_prefill_topk_long_context.py \
-    -k "topk_candidate_capacity or row_topk or paged_prefill_topk"'
+    -k "analytic_topk or topk_candidate_capacity or row_topk or paged_prefill_topk"'
 ```
 
-Result: `16 passed, 29 deselected`. The selection covers top-k policy,
-indices-only output, short-row padding, exact overflow selection, and CUDA graph
-replay with changing live inputs.
+Result: `17 passed, 29 deselected`. The selection covers top-k policy,
+64-bit physical-slot oracle arithmetic, indices-only output, short-row padding,
+exact overflow selection, and CUDA graph replay with changing live inputs.
 
 The benchmark oracle also passed the following graph-replay smoke cases after
 the score sentinel was moved to the terminal workspace slice actually consumed

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.attention.dsa_indexer import tiled_topk as tiled_topk_module
 from b12x.attention.dsa_indexer.kernel import (
     PAGED_MQA_LOGITS_SCHEDULE_PAGES_PER_SPLIT,
     _split_index_k_cache_runtime_views,
@@ -46,6 +47,41 @@ from b12x._lib.compiler import clear_compile_cache, compile_cache_info
 
 
 _FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+
+
+def test_topk_candidate_capacity_is_cached_by_device_and_topk(monkeypatch) -> None:
+    capability_calls: list[int] = []
+
+    def fake_get_device_capability(device_index: int) -> tuple[int, int]:
+        capability_calls.append(device_index)
+        return (12, 0) if device_index == 3 else (9, 0)
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", fake_get_device_capability)
+    tiled_topk_module.clear_tiled_topk_kernel_cache()
+
+    sm120 = torch.device("cuda:3")
+    sm90 = torch.device("cuda:4")
+    assert (
+        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
+        == 1024
+    )
+    assert (
+        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
+        == 1024
+    )
+    assert (
+        tiled_topk_module._resolve_smem_candidate_capacity(topk=1024, device=sm120)
+        == 8192
+    )
+    assert (
+        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm90)
+        == 8192
+    )
+    assert capability_calls == [3, 3, 4]
+
+    tiled_topk_module.clear_tiled_topk_kernel_cache()
+    tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
+    assert capability_calls == [3, 3, 4, 3]
 
 
 def _make_real_page_table(

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -49,39 +49,10 @@ from b12x._lib.compiler import clear_compile_cache, compile_cache_info
 _FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
 
 
-def test_topk_candidate_capacity_is_cached_by_device_and_topk(monkeypatch) -> None:
-    capability_calls: list[int] = []
-
-    def fake_get_device_capability(device_index: int) -> tuple[int, int]:
-        capability_calls.append(device_index)
-        return (12, 0) if device_index == 3 else (9, 0)
-
-    monkeypatch.setattr(torch.cuda, "get_device_capability", fake_get_device_capability)
-    tiled_topk_module.clear_tiled_topk_kernel_cache()
-
-    sm120 = torch.device("cuda:3")
-    sm90 = torch.device("cuda:4")
-    assert (
-        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
-        == 1024
-    )
-    assert (
-        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
-        == 1024
-    )
-    assert (
-        tiled_topk_module._resolve_smem_candidate_capacity(topk=1024, device=sm120)
-        == 8192
-    )
-    assert (
-        tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm90)
-        == 8192
-    )
-    assert capability_calls == [3, 3, 4]
-
-    tiled_topk_module.clear_tiled_topk_kernel_cache()
-    tiled_topk_module._resolve_smem_candidate_capacity(topk=512, device=sm120)
-    assert capability_calls == [3, 3, 4, 3]
+def test_topk_candidate_capacity_is_compile_time_topk_policy() -> None:
+    assert tiled_topk_module._resolve_smem_candidate_capacity(topk=512) == 1024
+    assert tiled_topk_module._resolve_smem_candidate_capacity(topk=1024) == 8192
+    assert tiled_topk_module._resolve_smem_candidate_capacity(topk=2048) == 8192
 
 
 def _make_real_page_table(

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -1460,6 +1460,41 @@ def test_contiguous_tiled_topk_live_rows_do_not_resolve_new_kernel(
     not torch.cuda.is_available(),
     reason="CUDA required for indexer compile-cache coverage",
 )
+def test_row_topk_indices_only_preserves_value_buffer() -> None:
+    device = torch.device("cuda")
+    generator = torch.Generator(device="cpu").manual_seed(73_621)
+    rows, width, topk = 17, 1024, 512
+    row_logits = torch.randn(
+        (rows, width), generator=generator, dtype=torch.float32
+    ).to(device)
+    lengths = torch.full((rows,), width, dtype=torch.int32, device=device)
+    output_values = torch.full(
+        (rows, topk), 12345.0, dtype=torch.float32, device=device
+    )
+    output_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
+
+    run_row_topk(
+        row_logits=row_logits,
+        lengths=lengths,
+        topk=topk,
+        output_values=output_values,
+        output_indices=output_indices,
+        write_values=False,
+    )
+    torch.cuda.synchronize(device)
+
+    expected = torch.topk(row_logits, k=topk, dim=1, largest=True, sorted=False)
+    assert bool((output_values == 12345.0).all())
+    assert torch.equal(
+        torch.sort(output_indices, dim=1).values.to(torch.long),
+        torch.sort(expected.indices, dim=1).values,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA required for indexer compile-cache coverage",
+)
 def test_row_topk_graph_replay_tracks_live_logits_and_lengths() -> None:
     device = torch.device("cuda")
     gen = torch.Generator(device="cpu")

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -1503,7 +1503,7 @@ def test_row_topk_indices_only_preserves_value_buffer() -> None:
     reason="CUDA required for padded row top-k coverage",
 )
 def test_row_topk_padded_overflow_is_unique_and_graph_safe() -> None:
-    """Qualify a compressed-key fold with fewer than top-k live candidates."""
+    """Validate a gathered row fold with fewer than top-k live candidates."""
     device = torch.device("cuda")
     generator = torch.Generator(device="cpu").manual_seed(73_623)
     rows, width, topk = 2304, 2560, 512

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -1493,6 +1493,79 @@ def test_row_topk_indices_only_preserves_value_buffer() -> None:
 
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
+    reason="CUDA required for padded row top-k coverage",
+)
+def test_row_topk_padded_overflow_is_unique_and_graph_safe() -> None:
+    """Qualify a compressed-key fold with fewer than top-k live candidates."""
+    device = torch.device("cuda")
+    generator = torch.Generator(device="cpu").manual_seed(73_623)
+    rows, width, topk = 2304, 2560, 512
+    live_counts = (
+        torch.arange(rows, dtype=torch.int64, device=device)
+        .div(4, rounding_mode="floor")
+        .clamp(min=1)
+    )
+    columns = torch.arange(width, dtype=torch.int64, device=device).view(1, -1)
+    live_mask = columns < live_counts.view(-1, 1)
+    row_logits = torch.randn(
+        (rows, width), generator=generator, dtype=torch.float32
+    ).to(device)
+    row_logits.masked_fill_(~live_mask, float("-inf"))
+    gather_table = torch.arange(width, dtype=torch.int32, device=device).expand(
+        rows, -1
+    ).contiguous()
+    gather_table.masked_fill_(~live_mask, -1)
+    lengths = torch.full((rows,), width, dtype=torch.int32, device=device)
+    output_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
+
+    run_row_topk(
+        row_logits=row_logits,
+        lengths=lengths,
+        topk=topk,
+        output_indices=output_indices,
+        output_gather_table=gather_table,
+        write_values=False,
+    )
+    torch.cuda.synchronize(device)
+
+    freeze_kernel_resolution("padded row top-k graph replay must use the warmed kernel")
+    try:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            run_row_topk(
+                row_logits=row_logits,
+                lengths=lengths,
+                topk=topk,
+                output_indices=output_indices,
+                output_gather_table=gather_table,
+                write_values=False,
+            )
+    finally:
+        unfreeze_kernel_resolution()
+    for _ in range(8):
+        graph.replay()
+    torch.cuda.synchronize(device)
+
+    logical = output_indices.to(torch.int64)
+    valid = logical >= 0
+    assert torch.equal(valid.sum(dim=1), live_counts.clamp(max=topk))
+    assert not bool(((logical >= live_counts.view(-1, 1)) & valid).any())
+    occurrences = torch.zeros((rows, width), dtype=torch.int16, device=device)
+    occurrences.scatter_add_(1, logical.clamp_min(0), valid.to(torch.int16))
+    assert int(occurrences.max()) == 1
+
+    full_rows = live_counts >= topk
+    expected = torch.topk(
+        row_logits[full_rows], k=topk, dim=1, largest=True, sorted=False
+    ).indices
+    assert torch.equal(
+        torch.sort(logical[full_rows], dim=1).values,
+        torch.sort(expected, dim=1).values,
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
     reason="CUDA required for indexer compile-cache coverage",
 )
 def test_row_topk_graph_replay_tracks_live_logits_and_lengths() -> None:

--- a/tests/attention/test_attention_dsa_indexer_api.py
+++ b/tests/attention/test_attention_dsa_indexer_api.py
@@ -1511,9 +1511,11 @@ def test_row_topk_padded_overflow_is_unique_and_graph_safe() -> None:
         (rows, width), generator=generator, dtype=torch.float32
     ).to(device)
     row_logits.masked_fill_(~live_mask, float("-inf"))
-    gather_table = torch.arange(width, dtype=torch.int32, device=device).expand(
-        rows, -1
-    ).contiguous()
+    gather_table = (
+        torch.arange(width, dtype=torch.int32, device=device)
+        .expand(rows, -1)
+        .contiguous()
+    )
     gather_table.masked_fill_(~live_mask, -1)
     lengths = torch.full((rows,), width, dtype=torch.int32, device=device)
     output_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)

--- a/tests/attention/test_benchmark_paged_indexer.py
+++ b/tests/attention/test_benchmark_paged_indexer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import torch
+
+from benchmarks.benchmark_paged_indexer import (
+    _physical_slots,
+    _validate_analytic_topk,
+)
+
+
+def test_analytic_topk_uses_64_bit_physical_slot_arithmetic() -> None:
+    page_id = 33_554_432
+    physical_slot = page_id * 64
+    page_ids = torch.tensor([[page_id]], dtype=torch.int32)
+    offsets = torch.zeros((1, 1), dtype=torch.int32)
+
+    converted = _physical_slots(page_ids, offsets)
+
+    assert converted.dtype == torch.int64
+    assert converted.tolist() == [[physical_slot]]
+    assert (
+        _validate_analytic_topk(
+            indices=converted,
+            scores=None,
+            seqlens=torch.ones(1, dtype=torch.int32),
+            topk=1,
+            analytic_scores=torch.empty(0),
+            real_page_table=page_ids,
+            output_physical_slots=True,
+        )
+        is None
+    )

--- a/tests/attention/test_paged_prefill_topk_long_context.py
+++ b/tests/attention/test_paged_prefill_topk_long_context.py
@@ -1,19 +1,14 @@
-"""Regression test: paged prefill indexer top-k must stay correct on low-contrast rows.
+"""Correctness coverage for paged prefill top-k on crowded score buckets.
 
-The tiled radix-select top-k (``DSATiledTopkKernel``, reached via ``index_topk_fp8``
-/ ``packed_contiguous``) buckets candidates by the top bits of the score and stores the
-threshold bucket in a fixed shared buffer (``_SMEM_CANDS``). When a single bucket
-holds more candidates than that buffer -- e.g. many tokens with near-equal scores, as
-happens on low-contrast attention rows at longer context -- the pre-fix code silently
-dropped the overflow and kept the lowest-indexed (here lowest-scoring) survivors, so it
-selected tokens far below the true top-k threshold. The fix re-runs an exact, buffer-free
-MSD radix (``_exact_overflow_fallback``) whenever the bucket overflows.
+``DSATiledTopkKernel``, reached through ``index_topk_fp8`` with the
+``packed_contiguous`` route, stores a radix threshold bucket in bounded shared
+memory. A bucket wider than that capacity must use the buffer-free exact MSD
+radix rescan rather than dropping candidates.
 
 Cases (verified by score, not index, so a miss is genuine and not a tie-break):
 
-* ``seq_len`` sweep: 32768 and 32832 straddle the old 8-bit/8192-candidate
-  boundary, while 65536 verifies that the wider coarse radix remains exact at long
-  context without relying on the historical truncated result.
+* ``seq_len`` sweep: 32768, 32832, and 65536 cover long-context threshold
+  buckets on both sides of a page boundary.
 * all-equal scores: one coarse+fine bucket holds every token, so the fallback's tie-fill
   branch must fill the whole top-k from a single pivot key.
 * logical output (``output_physical_slots=False``): exercises the two-level fold, whose
@@ -46,7 +41,13 @@ _TOPK = 2048
 _PAGE_START = 3
 
 
-def _build_scene(device: torch.device, seq_len: int, scores: str) -> dict:
+def _build_scene(
+    device: torch.device,
+    seq_len: int,
+    scores: str,
+    *,
+    topk: int = _TOPK,
+) -> dict:
     """Build a paged prefill scene plus its fp32 reference top-k threshold.
 
     ``scores="monotonic"`` gives each token a strictly increasing score so the true
@@ -95,9 +96,10 @@ def _build_scene(device: torch.device, seq_len: int, scores: str) -> dict:
         real_page_table=real_page_table,
         seqlens=seqlens,
     )
-    kth_score = torch.topk(ref_logits, _TOPK, dim=1).values[:, -1]
+    kth_score = torch.topk(ref_logits, topk, dim=1).values[:, -1]
     return {
         "seq_len": seq_len,
+        "topk": topk,
         "width_blocks": width_blocks,
         "q_fp8": q_fp8,
         "weights": weights,
@@ -118,13 +120,14 @@ def _run_indexer(
 ) -> torch.Tensor:
     monkeypatch.setenv("B12X_PAGED_INDEX_SUPERTILE_K", str(supertile_k))
     seqlens = scene["seqlens"]
+    topk = int(scene["topk"])
     shared_page_table = scene["shared_page_table"]
     binding = _bind_paged_indexer(
         device=scene["q_fp8"].device,
         num_heads=_NUM_HEADS,
         rows=_ROWS,
         width_blocks=scene["width_blocks"],
-        topk=_TOPK,
+        topk=topk,
         real_page_table=shared_page_table.expand(_ROWS, -1),
         seqlens=seqlens,
         supertile_k=supertile_k,
@@ -140,14 +143,14 @@ def _run_indexer(
         shared_page_table=True,
     )
     selected = torch.empty(
-        (_ROWS, _TOPK), dtype=torch.int32, device=scene["q_fp8"].device
+        (_ROWS, topk), dtype=torch.int32, device=scene["q_fp8"].device
     )
     clear_indexer_caches()
     index_topk_fp8(
         q_fp8=scene["q_fp8"],
         weights=scene["weights"].unsqueeze(-1),
         index_k_cache=scene["index_k_cache"],
-        topk=_TOPK,
+        topk=topk,
         expected_num_q_heads=_NUM_HEADS,
         binding=binding,
         out_indices=selected,
@@ -161,6 +164,7 @@ def _assert_selects_true_topk(
     scene: dict, selected: torch.Tensor, *, output_physical_slots: bool
 ) -> None:
     seq_len = scene["seq_len"]
+    topk = int(scene["topk"])
     if output_physical_slots:
         # Physical slot -> logical (contiguous page table starting at _PAGE_START).
         raw_logical = selected.long() - _PAGE_START * _PAGE
@@ -182,7 +186,7 @@ def _assert_selects_true_topk(
     selected_score = torch.gather(scene["ref_logits"], 1, logical)
     n_below = int((selected_score < (scene["kth_score"][:, None] - 1e-4)).sum().item())
     assert n_below == 0, (
-        f"{n_below}/{_ROWS * _TOPK} selected tokens score below the true top-{_TOPK} "
+        f"{n_below}/{_ROWS * topk} selected tokens score below the true top-{topk} "
         f"threshold at seq_len={seq_len}"
     )
 
@@ -205,6 +209,16 @@ def test_paged_prefill_topk_all_equal_scores_tie_fill(monkeypatch) -> None:
     scene = _build_scene(device, 32768, "equal")
     selected = _run_indexer(
         monkeypatch, scene, supertile_k=32768, output_physical_slots=True
+    )
+    _assert_selects_true_topk(scene, selected, output_physical_slots=True)
+
+
+def test_paged_prefill_topk_512_all_equal_scores_tie_fill(monkeypatch) -> None:
+    """The SM120 top-k-512 buffer policy preserves exact tie-fill semantics."""
+    device = torch.device("cuda")
+    scene = _build_scene(device, 8192, "equal", topk=512)
+    selected = _run_indexer(
+        monkeypatch, scene, supertile_k=8192, output_physical_slots=True
     )
     _assert_selects_true_topk(scene, selected, output_physical_slots=True)
 

--- a/tests/attention/test_paged_prefill_topk_long_context.py
+++ b/tests/attention/test_paged_prefill_topk_long_context.py
@@ -214,7 +214,7 @@ def test_paged_prefill_topk_all_equal_scores_tie_fill(monkeypatch) -> None:
 
 
 def test_paged_prefill_topk_512_all_equal_scores_tie_fill(monkeypatch) -> None:
-    """The SM120 top-k-512 buffer policy preserves exact tie-fill semantics."""
+    """The top-k-512 buffer policy preserves exact tie-fill semantics."""
     device = torch.device("cuda")
     scene = _build_scene(device, 8192, "equal", topk=512)
     selected = _run_indexer(


### PR DESCRIPTION
## Result

Status: **implemented and qualified** for the paged sparse-attention index
selector used by GLM-5.3 prefill.

Top-k 512 uses a 1,024-entry shared candidate buffer. Top-k 1,024 and 2,048
retain an 8,192-entry buffer. The policy depends only on the compiled top-k
specialization; it is not gated by GPU architecture and does not query device
state while serving a request.

An indices-only terminal fold omits its unused FP32 score write. Every
intermediate fold still writes scores because the following fold consumes
them.

## Technical reason

The exact overflow rescan preserves top-k membership when a threshold bucket
contains more candidates than the shared candidate buffer. Reducing the buffer
for top-k 512 therefore lowers shared-memory traffic without changing selection
semantics.

Rows with fewer live candidates than `topk` initialize overflow padding before
the exact rescan. Each live index can appear at most once, and unused result
positions contain `-1`.

## Operation contract and compatibility

- Logical and physical output-index modes retain their existing semantics.
- The paged FP8 cache layout, page-table contract, supported top-k widths, and
  input layouts are unchanged.
- Score-producing callers receive the same terminal score output.
- Indices-only callers receive selected indices without a terminal score write.
- Candidate capacity remains an immutable part of the compiled kernel key.

The low-level tiled selector treats `write_values=False` as a terminal-output
contract. The paged orchestrator always enables score writes for carry-producing
launches and disables them only for the final indices-only launch.

## Correctness validation

Tests ran on an NVIDIA RTX PRO 6000 Blackwell Workstation Edition GPU with
NVIDIA compute capability 12.0 and `CUTE_DSL_ARCH=sm_120a`.

```bash
/opt/venv/bin/python -B -m pytest -q \
  tests/attention/test_benchmark_paged_indexer.py \
  tests/attention/test_attention_dsa_indexer_api.py \
  tests/attention/test_paged_prefill_topk_long_context.py \
  -k "analytic_topk or topk_candidate_capacity or row_topk or paged_prefill_topk"
```

Result: `17 passed, 29 deselected`.

The analytic benchmark oracle additionally passed:

- both 1,024- and 8,192-entry capacities at 4,080 rows and 8,192 visible
  tokens;
- a 64-token row with a one-page table and top-k 512;
- physical page-to-token arithmetic above the signed 32-bit multiplication
  boundary;
- a two-chunk 16,384-token fold, proving that intermediate carry scores remain
  usable while the terminal workspace score slice remains untouched.

The benchmark rejects `--topk-candidate-capacity` in modes that do not consume
the tiled-selector capacity policy.

## Performance qualification

The comparison used 4,080 query rows, 64 replicated indexer heads, 8,192
visible tokens, top-k 512, indices-only output, and CUDA graph replay. Both
arms used identical code, inputs, cache state, and output semantics; only the
compile-time candidate capacity differed.

| Candidate capacity | Median latency | Relative selector throughput |
|---:|---:|---:|
| 1,024 | 961.54 us | 1.0243x |
| 8,192 | 984.86 us | 1.0000x |

Both kernels use 27 registers per thread, zero stack bytes, zero local-memory
bytes, and one 1,024-thread cooperative thread array per streaming
multiprocessor. Dynamic shared memory is 20,096 bytes for 1,024 candidates and
77,440 bytes for 8,192 candidates. The smaller policy improves selector
throughput by 2.43% without changing occupancy, register use, or spill behavior.

The commands, source revisions, hardware identity, raw graph-replay samples,
balanced process ordering, and compiled-resource evidence are recorded in
`docs/evidence/paged_topk_sm120_prefill.md`.

This evidence qualifies the selector operation. It does not infer end-to-end
model throughput from one kernel family.

## AI assistance disclosure

AI assistance was used to implement and validate the selector changes and to
prepare this pull-request description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Selects shared candidate capacity by compile-time `topk`: 1,024 entries for top-k 512 and 8,192 entries for top-k 1,024 and 2,048.
- Skips terminal FP32 score writes for indices-only requests. Intermediate fold scores remain available for later folds.
- Preserves existing output modes, cache layout, page-table contract, input layouts, supported top-k widths, and score-producing behavior.
- Adds overflow and padding handling that produces distinct, valid candidates before rescanning.
- Adds bounded page-table validation and 64-bit physical-slot arithmetic.
- Adds correctness coverage for candidate capacities, indices-only output, CUDA graph replay, tie filling, long-context rows, and large page IDs.
- Validation passed 17 tests, with 29 deselected. Benchmarking measured 961.54 µs for 1,024 candidates versus 984.86 µs for 8,192 candidates, or 1.0243× relative selector throughput.
- Adds reproducible SM120 qualification evidence, including latency, resource measurements, oracle cases, and remaining end-to-end scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->