### PR TITLE
perf(moe): overlap M1 FC2 row-pair loads

### DIFF
--- a/b12x/moe/_shared/kernels/micro.py
+++ b/b12x/moe/_shared/kernels/micro.py
@@ -1323,14 +1323,6 @@ class MoEMicroKernelBackend:
                         if w_valid > Int32(0)
                         else Float32(0.0)
                     )
-                if route_active > Int32(0):
-                    out_acc0 = (
-                        out_acc0
-                        + bsf_f0
-                        * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
-                        * scale_lane
-                    )
-
                 u_packed1 = (
                     ld_global_nc_u32(
                         w2_base_addr
@@ -1385,6 +1377,16 @@ class MoEMicroKernelBackend:
                         self._scale_byte_to_f32(bsf_byte1)
                         if w_valid > Int32(0)
                         else Float32(0.0)
+                    )
+                # Issue both independent row loads before consuming either
+                # value. This preserves each row's accumulation order while
+                # exposing sibling-row memory-level parallelism.
+                if route_active > Int32(0):
+                    out_acc0 = (
+                        out_acc0
+                        + bsf_f0
+                        * self._fp4_dot4_for_math(u_packed0, xh0, xh1, xh2, xh3)
+                        * scale_lane
                     )
                 if route_active > Int32(0):
                     out_acc1 = (

--- a/tests/moe/test_cute_migration_moe_standard_corpus.py
+++ b/tests/moe/test_cute_migration_moe_standard_corpus.py
@@ -423,7 +423,13 @@ def _run_live_graph_check(
     initial.a.copy_(changed.a)
     initial.topk_ids.copy_(changed.topk_ids)
     initial.topk_weights.copy_(changed.topk_weights)
-    live_tensors = (*case.scratch, initial.a, initial.topk_ids, initial.topk_weights, output)
+    live_tensors = (
+        *case.scratch,
+        initial.a,
+        initial.topk_ids,
+        initial.topk_weights,
+        output,
+    )
     live_addresses = tuple(tensor.data_ptr() for tensor in live_tensors)
     replay_output = None
     for replay_idx in range(replay_count):
@@ -445,7 +451,9 @@ def _run_live_graph_check(
                 replay_idx,
                 "live CUDA bytes changed during graph replay",
             )
-            assert tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses, (
+            assert (
+                tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses
+            ), (
                 context,
                 replay_idx,
                 "serving tensor address changed during graph replay",
@@ -537,6 +545,81 @@ def test_standard_moe_micro_live_graph_oracle(
         context="standard-moe-micro",
         min_cos=0.999,
         max_normalized_rmse=0.03,
+    )
+
+
+def test_standard_moe_glm53_m1_rowpair_live_graph_oracle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise GLM-5.3's native M1 row-pair FC2 path through dispatch."""
+
+    num_experts = 16
+    hidden_size = 4096
+    intermediate_size = 512
+    topk = 8
+    device = require_b12x()
+    _reset_dispatch_environment(monkeypatch)
+    weights = _make_nvfp4_weights(
+        device,
+        seed=104,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    initial = _make_inputs(
+        device,
+        m=1,
+        seed=105,
+        route_shift=0,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        topk=topk,
+    )
+    changed = _make_inputs(
+        device,
+        m=1,
+        seed=106,
+        route_shift=5,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        topk=topk,
+    )
+    initial_reference = _nvfp4_oracle(
+        weights,
+        initial,
+        quant_scale_math="reciprocal_multiply",
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    changed_reference = _nvfp4_oracle(
+        weights,
+        changed,
+        quant_scale_math="reciprocal_multiply",
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    case = _prepare_and_bind(
+        weights,
+        initial,
+        quant_mode="nvfp4",
+        source_format="modelopt_nvfp4",
+        num_topk=topk,
+    )
+    assert case.scratch_plan.launch_plan.implementation == "micro"
+    assert case.binding.implementation == "micro"
+    _run_live_graph_check(
+        case,
+        initial=initial,
+        changed=changed,
+        initial_reference=initial_reference,
+        changed_reference=changed_reference,
+        context="standard-moe-glm53-m1-rowpair",
+        min_cos=0.999,
+        max_normalized_rmse=0.03,
+        replay_count=3,
+        assert_no_replay_allocations=True,
     )
 
 


### PR DESCRIPTION
## Summary

- issue both independent FC2 row-pair weight/scale loads before consuming either row in the native M=1 NVFP4 microkernel
- preserve accumulation order, launch geometry, routing, policy, and cache keys
- add CUDA-graph oracle coverage through the planned production dispatch path

This is an instruction-scheduling change: it exposes memory-level parallelism without changing kernel math.

## Isolated performance evidence

The real serving shape was GLM-5.3-Flash-NVFP4 target MoE (`M=1, K=4096, N=512, E=288, top-k=8`). Hardware was four NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition GPUs, tensor parallel size 4, decode-context parallel size 1, 300 W per GPU, and a persistent +6000 MHz memory-clock offset in both arms.

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| Cold-L2 CUDA-graph kernel | 38.9 us | 32.7 us | -15.9% |
| NCU kernel | 34.59 us | 28.96 us | -16.3% |
| Registers/thread | 126 | 96 | -23.8% |
| TP4 single-request, context-zero decode | 144.1 tok/s | 148.127 tok/s | +2.8% |

The end-to-end row is a historical isolated A/B on vLLM `dev/jovian-judgement` revision `883d104a3` with B12X `2fcf23a0`. Both arms used the same model, clocks, 30-second sustained-decode contract, and ordinary model sampling. These numbers are isolated evidence for this reorder; they are not attribution for the combined MTP3 result below.

## Validation status

The committed CUDA-graph test exercises the exact `M/K/N/top-k` production dispatch but uses `E=16` as a reduced expert-count proxy, not the production `E=288` allocation. It checks an independent NVFP4 oracle, mutated live inputs, three graph replays, stable addresses, and zero replay allocations. A current-head `E=288` GPU oracle and matched serving rerun remain required before merge qualification.

Static checks pass: `ruff check`, `ruff format --check`, and `git diff --check`.

## Combined-stack integration qualification

This PR was also exercised through a code-equivalent version in the frozen combined deployment; the matrix qualifies the composition and is **not** isolated attribution to this PR.

Stack inventory:

- vLLM `ba494904b`, based on merged [vLLM #537](https://github.com/local-inference-lab/vllm/pull/537), including the code-equivalent merged MTP correctness fix [#539](https://github.com/local-inference-lab/vllm/pull/539), and containing code-equivalent versions of [#542](https://github.com/local-inference-lab/vllm/pull/542), [#543](https://github.com/local-inference-lab/vllm/pull/543), and [#544](https://github.com/local-inference-lab/vllm/pull/544)
- B12X master `a45d3f7` plus code-equivalent versions of B12X #261 and #262 and the launch choices subsequently represented through typed policies in B12X #263 and #264
- the frozen image predates the final typed-policy plumbing in #263/#264; those exact PR heads still require their own Linux/CUDA qualification
- the rejected 512-KiB PCIe all-reduce experiment is not present

Configuration: GLM-5.3-Flash-NVFP4, four Max-Q cards at TP4/DCP1, 300 W each, +6000 MHz memory offset, native B12X target W4A4, FP8 KV cache, CUDA graphs, one-million-token model length, maximum 32 sequences, 8192 batched tokens, online dense MXFP8 disabled, and probabilistic MTP3 with standard rejection (Marlin MXFP8 draft MoE and B12X draft attention).

`llm_decode_bench.py` ran 30-second sustained cells with ordinary model sampling, no temperature override, and an 8192-token output limit. All 35 cells completed without request errors or capacity limits:

| Context | C1 | C2 | C4 | C8 | C12 | C24 | C32 |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 251.7 | 384.8 | 555.8 | 808.9 | 995.7 | 1,341.3 | 1,615.6 |
| 16K | 227.8 | 373.0 | 552.1 | 806.8 | 970.9 | 1,359.0 | 1,642.4 |
| 32K | 224.1 | 366.7 | 545.4 | 814.6 | 994.0 | 1,372.8 | 1,612.9 |
| 64K | 220.7 | 370.1 | 556.2 | 796.0 | 982.7 | 1,340.4 | 1,636.1 |
| 128K | 245.3 | 374.6 | 542.5 | 811.5 | 952.0 | 1,298.3 | 1,553.8 |

The 251.7 tok/s C1 cell is retained as raw evidence, not promoted as a stable headline; same-stack C1 repeats were 218.3/221.7/225.3 tok/s. Acceptance-normalized verifier throughput was 92.0--95.7 steps/s at C1, 315.2--328.2 at C8, and 600.4--644.3 at C32, confirming an engine-speed improvement rather than acceptance alone.

The exact boot passed Estonia max C30/R30 30/30 and LAVD max C30/R30 30 exact / 0 near / 0 wrong with no token caps. Startup KV capacity was 4,592,497 tokens; exported capacity was 4,783,104 tokens. No eager or backend fallback was used.

## Portability

The reorder is not GLM-specific. It can benefit other native NVFP4 MoE models that dispatch through the same M=1 FC2 row-pair kernel; other paths are unchanged.

## AI assistance

OpenAI Codex assisted with source analysis, implementation, test construction, profiling interpretation, benchmarking, and PR preparation. The commit includes a `Co-authored-by: OpenAI Codex <codex@openai.com>` trailer. The human submitter reviewed the claims and remains responsible for the change.
