### PR TITLE
perf(attention): fuse K3 four-query MLA verification

### DIFF
--- a/b12x/attention/dense_mla/__init__.py
+++ b/b12x/attention/dense_mla/__init__.py
@@ -13,6 +13,11 @@ are planned independently. Supported logical widths are ``(576, 512)`` and
 ``window_size=None`` attends to the full causal context. A positive
 ``window_size`` restricts query position ``p`` to the inclusive interval
 ``[max(0, p - window_size + 1), p]``. The attention scale is caller-provided.
+Experimental dynamic sparsity retains sink and recent 64-token chunks while
+striding the middle history after a configured threshold. ``sparse_stride=1``
+is the exact default; larger strides intentionally change model semantics and
+must be quality-qualified by the caller. Dynamic sparsity and local windows
+are deliberately mutually exclusive.
 BF16 and E4M3 records are supported. For E4M3 cache with BF16 query input,
 ``q_dtype=torch.bfloat16`` plans fixed query-quantization storage in the same
 caller-owned scratch buffer.
@@ -43,6 +48,7 @@ META = OpMeta(
         "plan",
         "bind",
         "compile",
+        "dynamic_sparse_chunk_indices",
         "run",
         "reference",
         "infer_mode",
@@ -81,6 +87,7 @@ if TYPE_CHECKING:
         bind,
         clear_caches,
         compile,
+        dynamic_sparse_chunk_indices,
         infer_mode,
         is_supported,
         plan,

--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -63,6 +63,12 @@ class DenseMlaForwardKernel:
         qk_dim: int,
         value_dim: int,
         window_size: int | None,
+        uses_query_cache_seqlens: bool,
+        sparse_stride: int,
+        sparse_min_tokens: int,
+        sparse_sink_chunks: int,
+        sparse_recent_chunks: int,
+        sparse_refresh_interval: int,
     ):
         self.layout = layout
         self.page_size = int(page_size)
@@ -75,6 +81,12 @@ class DenseMlaForwardKernel:
         self.qk_dim = int(qk_dim)
         self.value_dim = int(value_dim)
         self.window_size = None if window_size is None else int(window_size)
+        self.uses_query_cache_seqlens = bool(uses_query_cache_seqlens)
+        self.sparse_stride = int(sparse_stride)
+        self.sparse_min_tokens = int(sparse_min_tokens)
+        self.sparse_sink_chunks = int(sparse_sink_chunks)
+        self.sparse_recent_chunks = int(sparse_recent_chunks)
+        self.sparse_refresh_interval = int(sparse_refresh_interval)
         self.kv_stages = int(layout.kv_stages)
         self.math_warps = MATH_WARPS_PER_QUERY * self.query_tile
         self.math_threads = self.math_warps * 32
@@ -88,6 +100,7 @@ class DenseMlaForwardKernel:
         page_table: cute.Tensor,
         cache_seqlens: cute.Tensor,
         cu_seqlens_q: cute.Tensor,
+        query_cache_seqlens: cute.Tensor,
         output: cute.Tensor,
         final_lse: cute.Tensor,
         partial_output: cute.Tensor,
@@ -112,6 +125,7 @@ class DenseMlaForwardKernel:
             page_table,
             cache_seqlens,
             cu_seqlens_q,
+            query_cache_seqlens,
             output,
             final_lse,
             partial_output,
@@ -135,6 +149,34 @@ class DenseMlaForwardKernel:
         )
 
     @cute.jit
+    def _selected_chunk(
+        self,
+        selected_index: Int32,
+        valid_chunks: Int32,
+        sparse_active: Int32,
+    ) -> Int32:
+        chunk = selected_index
+        if sparse_active != Int32(0):
+            sink = Int32(self.sparse_sink_chunks)
+            if sink > valid_chunks:
+                sink = valid_chunks
+            recent = Int32(self.sparse_recent_chunks)
+            if recent > valid_chunks - sink:
+                recent = valid_chunks - sink
+            middle_end = valid_chunks - recent
+            middle_span = middle_end - sink
+            middle_count = (middle_span + Int32(self.sparse_stride - 1)) // Int32(
+                self.sparse_stride
+            )
+            if selected_index < sink:
+                chunk = selected_index
+            elif selected_index < sink + middle_count:
+                chunk = sink + (selected_index - sink) * Int32(self.sparse_stride)
+            else:
+                chunk = middle_end + selected_index - sink - middle_count
+        return chunk
+
+    @cute.jit
     def _run_math_group(
         self,
         q_smem_addr: Int32,
@@ -146,6 +188,8 @@ class DenseMlaForwardKernel:
         mbar_base,
         active_chunks: Int32,
         split_first_chunk: Int32,
+        valid_chunks: Int32,
+        sparse_active: Int32,
         visible_begin: Int32,
         visible_end: Int32,
         query_row: Int32,
@@ -180,7 +224,12 @@ class DenseMlaForwardKernel:
         kv_buffer_bytes = Int32(CANDIDATES_PER_CHUNK * self.layout.record_stride_bytes)
 
         for local_chunk in cutlass.range(active_chunks, unroll=1):
-            chunk = split_first_chunk + Int32(local_chunk)
+            selected_index = split_first_chunk + Int32(local_chunk)
+            chunk = self._selected_chunk(
+                selected_index,
+                valid_chunks,
+                sparse_active,
+            )
             chunk_begin = chunk * Int32(CANDIDATES_PER_CHUNK)
             buffer = Int32(0)
             if cutlass.const_expr(self.kv_stages == 2):
@@ -404,6 +453,7 @@ class DenseMlaForwardKernel:
         page_table: cute.Tensor,
         cache_seqlens: cute.Tensor,
         cu_seqlens_q: cute.Tensor,
+        query_cache_seqlens: cute.Tensor,
         output: cute.Tensor,
         final_lse: cute.Tensor,
         partial_output: cute.Tensor,
@@ -441,6 +491,8 @@ class DenseMlaForwardKernel:
                 else:
                     upper = middle
             request = lower
+        elif cutlass.const_expr(self.uses_query_cache_seqlens):
+            request = query_tile_index
         query_begin = Int32(cu_seqlens_q[request])
         query_end = Int32(cu_seqlens_q[request + Int32(1)])
         query_length = query_end - query_begin
@@ -464,10 +516,31 @@ class DenseMlaForwardKernel:
         valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
             CANDIDATES_PER_CHUNK
         )
+        sparse_active = Int32(0)
+        selected_chunks = valid_chunks
+        if cutlass.const_expr(self.sparse_stride > 1):
+            if cache_length > Int32(self.sparse_min_tokens):
+                sparse_active = Int32(1)
+            if cutlass.const_expr(self.sparse_refresh_interval > 0):
+                refresh_position = cache_length % Int32(self.sparse_refresh_interval)
+                if refresh_position < query_length:
+                    sparse_active = Int32(0)
+            if sparse_active != Int32(0):
+                sink = Int32(self.sparse_sink_chunks)
+                if sink > valid_chunks:
+                    sink = valid_chunks
+                recent = Int32(self.sparse_recent_chunks)
+                if recent > valid_chunks - sink:
+                    recent = valid_chunks - sink
+                middle_span = valid_chunks - recent - sink
+                middle_count = (middle_span + Int32(self.sparse_stride - 1)) // Int32(
+                    self.sparse_stride
+                )
+                selected_chunks = sink + middle_count + recent
         split_first_chunk = first_valid_chunk + split * Int32(self.chunks_per_split)
         split_last_chunk = split_first_chunk + Int32(self.chunks_per_split)
-        if split_last_chunk > valid_chunks:
-            split_last_chunk = valid_chunks
+        if split_last_chunk > selected_chunks:
+            split_last_chunk = selected_chunks
         active_chunks = split_last_chunk - split_first_chunk
         if active_chunks < Int32(0):
             active_chunks = Int32(0)
@@ -527,7 +600,12 @@ class DenseMlaForwardKernel:
                 CANDIDATES_PER_CHUNK * self.layout.record_stride_bytes
             )
             for local_chunk in cutlass.range(active_chunks, unroll=1):
-                chunk = split_first_chunk + Int32(local_chunk)
+                selected_index = split_first_chunk + Int32(local_chunk)
+                chunk = self._selected_chunk(
+                    selected_index,
+                    valid_chunks,
+                    sparse_active,
+                )
                 token_begin = chunk * Int32(CANDIDATES_PER_CHUNK)
                 buffer = Int32(0)
                 if cutlass.const_expr(self.kv_stages == 2):
@@ -585,6 +663,8 @@ class DenseMlaForwardKernel:
                 query_valid = Int32(0)
             local_query = query_row - query_begin
             visible_end = cache_length - query_length + local_query + Int32(1)
+            if cutlass.const_expr(self.uses_query_cache_seqlens):
+                visible_end = Int32(query_cache_seqlens[query_row])
             if visible_end < Int32(0):
                 visible_end = Int32(0)
             if visible_end > cache_length:
@@ -628,6 +708,8 @@ class DenseMlaForwardKernel:
                     mbar_base,
                     active_chunks,
                     split_first_chunk,
+                    valid_chunks,
+                    sparse_active,
                     visible_begin,
                     visible_end,
                     query_row,
@@ -657,6 +739,8 @@ class DenseMlaForwardKernel:
                     mbar_base,
                     active_chunks,
                     split_first_chunk,
+                    valid_chunks,
+                    sparse_active,
                     visible_begin,
                     visible_end,
                     query_row,
@@ -686,6 +770,8 @@ class DenseMlaForwardKernel:
                     mbar_base,
                     active_chunks,
                     split_first_chunk,
+                    valid_chunks,
+                    sparse_active,
                     visible_begin,
                     visible_end,
                     query_row,
@@ -715,6 +801,8 @@ class DenseMlaForwardKernel:
                     mbar_base,
                     active_chunks,
                     split_first_chunk,
+                    valid_chunks,
+                    sparse_active,
                     visible_begin,
                     visible_end,
                     query_row,

--- a/b12x/attention/dense_mla/_kernel.py
+++ b/b12x/attention/dense_mla/_kernel.py
@@ -87,6 +87,12 @@ def _signature(binding: Binding) -> tuple[object, ...]:
         scratch.head_dim,
         scratch.v_head_dim,
         scratch.window_size,
+        scratch.uses_query_cache_seqlens,
+        scratch.sparse_stride,
+        scratch.sparse_min_tokens,
+        scratch.sparse_sink_chunks,
+        scratch.sparse_recent_chunks,
+        scratch.sparse_refresh_interval,
         tuple(int(value) for value in binding.q.stride()),
         tuple(int(value) for value in binding.kv_cache.stride()),
         tuple(int(value) for value in binding.output.stride()),
@@ -131,6 +137,12 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         qk_dim=scratch.head_dim,
         value_dim=scratch.v_head_dim,
         window_size=scratch.window_size,
+        uses_query_cache_seqlens=scratch.uses_query_cache_seqlens,
+        sparse_stride=scratch.sparse_stride,
+        sparse_min_tokens=scratch.sparse_min_tokens,
+        sparse_sink_chunks=scratch.sparse_sink_chunks,
+        sparse_recent_chunks=scratch.sparse_recent_chunks,
+        sparse_refresh_interval=scratch.sparse_refresh_interval,
     )
 
     q_bytes = _byte_base_pointer(binding.q)
@@ -180,6 +192,12 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
             dynamic_layout=True,
         ),
         _to_cute(
+            binding.query_cache_seqlens,
+            cutlass.Int32,
+            align=4,
+            dynamic_layout=True,
+        ),
+        _to_cute(
             output,
             cutlass.BFloat16,
             align=16,
@@ -203,7 +221,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
     )
     spec = KernelCompileSpec.from_fields(
         "attention.dense_mla.forward",
-        4,
+        6,
         key_field("dtype", "fp8" if fp8 else "bf16"),
         key_field("heads", scratch.num_q_heads),
         key_field("page_size", scratch.page_size),
@@ -216,6 +234,15 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         key_field("head_dim", scratch.head_dim),
         key_field("v_head_dim", scratch.v_head_dim),
         key_field("window_size", scratch.window_size),
+        key_field(
+            "uses_query_cache_seqlens",
+            scratch.uses_query_cache_seqlens,
+        ),
+        key_field("sparse_stride", scratch.sparse_stride),
+        key_field("sparse_min_tokens", scratch.sparse_min_tokens),
+        key_field("sparse_sink_chunks", scratch.sparse_sink_chunks),
+        key_field("sparse_recent_chunks", scratch.sparse_recent_chunks),
+        key_field("sparse_refresh_interval", scratch.sparse_refresh_interval),
         key_field("record_stride_bytes", layout.record_stride_bytes),
         tensor_key(
             "q",

--- a/b12x/attention/dense_mla/_policy.py
+++ b/b12x/attention/dense_mla/_policy.py
@@ -64,10 +64,12 @@ class DenseMlaConfig:
 
 def _query_tile(query: DenseMlaQuery) -> int:
     if (
-        query.mode == "decode"
-        or query.max_batch != 1
-        or query.window_size is not None
+        query.mode == "verify"
+        and query.query_rows == query.max_batch * 4
+        and query.window_size is None
     ):
+        return 4 if query.kv_dtype == "float8_e4m3fn" else 1
+    if query.mode == "decode" or query.max_batch != 1 or query.window_size is not None:
         return 1
     if query.kv_dtype == "float8_e4m3fn" and query.query_rows >= 3:
         return 4
@@ -104,9 +106,7 @@ def _validate(
         raise ValueError("dense MLA max_splits must be positive")
     max_chunks = max(1, (query.cache_tokens + 63) // 64)
     if config.max_splits > max_chunks:
-        raise ValueError(
-            "dense MLA max_splits cannot exceed the cache chunk count"
-        )
+        raise ValueError("dense MLA max_splits cannot exceed the cache chunk count")
 
 
 DENSE_MLA_POLICY = ComponentPolicy(

--- a/b12x/attention/dense_mla/_reference.py
+++ b/b12x/attention/dense_mla/_reference.py
@@ -6,6 +6,8 @@ import math
 
 import torch
 
+from .planner import dynamic_sparse_chunk_indices
+
 K3_ABSORBED_DIM = 576
 K3_VALUE_DIM = 512
 K3_RAW_QK_DIM = 192
@@ -46,6 +48,12 @@ def dense_mla_reference(
     cache_seqlens: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     *,
+    query_cache_seqlens: torch.Tensor | None = None,
+    sparse_stride: int = 1,
+    sparse_min_tokens: int = 0,
+    sparse_sink_chunks: int = 0,
+    sparse_recent_chunks: int = 0,
+    sparse_refresh_interval: int = 0,
     kv_scale: torch.Tensor | float | None = None,
     q_scale: torch.Tensor | float | None = None,
     sm_scale: float = K3_SM_SCALE,
@@ -71,6 +79,25 @@ def dense_mla_reference(
         raise ValueError("v_head_dim must be in [1, head_dim]")
     if window_size is not None and int(window_size) <= 0:
         raise ValueError("window_size must be positive or None")
+    sparse_stride = int(sparse_stride)
+    sparse_min_tokens = int(sparse_min_tokens)
+    sparse_sink_chunks = int(sparse_sink_chunks)
+    sparse_recent_chunks = int(sparse_recent_chunks)
+    sparse_refresh_interval = int(sparse_refresh_interval)
+    if sparse_stride < 1:
+        raise ValueError("sparse_stride must be >= 1")
+    if (
+        min(
+            sparse_min_tokens,
+            sparse_sink_chunks,
+            sparse_recent_chunks,
+            sparse_refresh_interval,
+        )
+        < 0
+    ):
+        raise ValueError("sparse token, chunk, and refresh values must be non-negative")
+    if window_size is not None and sparse_stride > 1:
+        raise ValueError("dynamic sparsity cannot be combined with window_size")
     cache = _cache_rank3(kv_cache, head_dim=head_dim)
     if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
         raise TypeError("q must be BF16 or E4M3")
@@ -87,8 +114,20 @@ def dense_mla_reference(
         raise ValueError("cache_seqlens shape must match page_table batch")
     if tuple(cu_seqlens_q.shape) != (batch + 1,):
         raise ValueError("cu_seqlens_q shape must be [batch + 1]")
+    if query_cache_seqlens is not None and (
+        query_cache_seqlens.dtype != torch.int32
+        or tuple(query_cache_seqlens.shape) != (int(q.shape[0]),)
+    ):
+        raise TypeError("query_cache_seqlens must be int32 with shape [total_q]")
     if any(
-        t.device != q.device for t in (cache, page_table, cache_seqlens, cu_seqlens_q)
+        t.device != q.device
+        for t in (
+            cache,
+            page_table,
+            cache_seqlens,
+            cu_seqlens_q,
+            *(() if query_cache_seqlens is None else (query_cache_seqlens,)),
+        )
     ):
         raise ValueError("dense MLA reference tensors must be on one device")
 
@@ -148,14 +187,45 @@ def dense_mla_reference(
         )
         records = records[:, :head_dim]
         records = records[:kv_len].float() * kv_mul
+        sparse_active = sparse_stride > 1 and kv_len > sparse_min_tokens
+        if sparse_refresh_interval > 0 and kv_len % sparse_refresh_interval < q_len:
+            sparse_active = False
+        if sparse_active:
+            selected_chunks = dynamic_sparse_chunk_indices(
+                (kv_len + 63) // 64,
+                stride=sparse_stride,
+                sink_chunks=sparse_sink_chunks,
+                recent_chunks=sparse_recent_chunks,
+            )
+            selected_positions = torch.cat(
+                [
+                    torch.arange(
+                        chunk * 64,
+                        min((chunk + 1) * 64, kv_len),
+                        device=q.device,
+                    )
+                    for chunk in selected_chunks
+                ]
+            )
+        else:
+            selected_positions = torch.arange(kv_len, device=q.device)
 
         q_rows = q_f32[q_begin:q_end]
         for local_q in range(q_len):
-            visible = kv_len - q_len + local_q + 1
+            visible = (
+                int(query_cache_seqlens[q_begin + local_q])
+                if query_cache_seqlens is not None
+                else kv_len - q_len + local_q + 1
+            )
+            if not 0 < visible <= kv_len:
+                raise ValueError("per-query visible cache length is out of range")
             visible_begin = (
                 0 if window_size is None else max(0, visible - int(window_size))
             )
-            key = records[visible_begin:visible]
+            visible_positions = selected_positions[
+                (selected_positions >= visible_begin) & (selected_positions < visible)
+            ]
+            key = records.index_select(0, visible_positions)
             logits = torch.einsum("hd,kd->hk", q_rows[local_q], key)
             logits = logits * float(sm_scale)
             probs = torch.softmax(logits, dim=-1)

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -42,6 +42,12 @@ def _canonical_device(device: torch.device | str) -> torch.device:
 
 
 def _query_tile(caps: Caps) -> int:
+    if (
+        caps.mode == "verify"
+        and caps.max_total_q == caps.max_batch * 4
+        and caps.window_size is None
+    ):
+        return 4 if caps.kv_dtype == _FP8 else 1
     if caps.mode == "decode" or caps.max_batch != 1 or caps.window_size is not None:
         return 1
     if caps.kv_dtype == _FP8 and caps.max_total_q >= 3:
@@ -75,6 +81,12 @@ class Caps:
     physical_record_width: int = K3_ABSORBED_DIM
     window_size: int | None = None
     use_cuda_graph: bool = False
+    uses_query_cache_seqlens: bool = False
+    sparse_stride: int = 1
+    sparse_min_tokens: int = 0
+    sparse_sink_chunks: int = 0
+    sparse_recent_chunks: int = 0
+    sparse_refresh_interval: int = 0
     budget: Budget | None = None
 
     def __post_init__(self) -> None:
@@ -105,6 +117,24 @@ class Caps:
             raise ValueError("physical_record_width must cover the logical key record")
         if self.window_size is not None and int(self.window_size) <= 0:
             raise ValueError("window_size must be positive or None")
+        uses_query_cache_seqlens = bool(self.uses_query_cache_seqlens)
+        if uses_query_cache_seqlens and self.mode != "verify":
+            raise ValueError(
+                "per-query cache lengths are supported only by verify plans"
+            )
+        for name, minimum in (
+            ("sparse_stride", 1),
+            ("sparse_min_tokens", 0),
+            ("sparse_sink_chunks", 0),
+            ("sparse_recent_chunks", 0),
+            ("sparse_refresh_interval", 0),
+        ):
+            value = int(getattr(self, name))
+            if value < minimum:
+                raise ValueError(f"{name} must be >= {minimum}")
+            object.__setattr__(self, name, value)
+        if self.window_size is not None and self.sparse_stride > 1:
+            raise ValueError("dynamic sparsity cannot be combined with window_size")
         heads = int(self.num_q_heads)
         if heads <= 0:
             raise ValueError("num_q_heads must be positive")
@@ -144,6 +174,11 @@ class Caps:
         ):
             object.__setattr__(self, name, int(getattr(self, name)))
         object.__setattr__(self, "use_cuda_graph", bool(self.use_cuda_graph))
+        object.__setattr__(
+            self,
+            "uses_query_cache_seqlens",
+            uses_query_cache_seqlens,
+        )
         if self.window_size is not None:
             object.__setattr__(self, "window_size", int(self.window_size))
 
@@ -269,6 +304,12 @@ class Scratch:
     chunks_per_split: int
     query_tile: int
     use_cuda_graph: bool
+    uses_query_cache_seqlens: bool
+    sparse_stride: int
+    sparse_min_tokens: int
+    sparse_sink_chunks: int
+    sparse_recent_chunks: int
+    sparse_refresh_interval: int
     partial_output: torch.Tensor | None
     partial_lse: torch.Tensor | None
     final_lse: torch.Tensor
@@ -283,6 +324,7 @@ class Binding:
     output: torch.Tensor
     page_table: torch.Tensor
     cache_seqlens: torch.Tensor
+    query_cache_seqlens: torch.Tensor
     cu_seqlens_q: torch.Tensor
     kv_scale: torch.Tensor | None
     q_scale: torch.Tensor | None
@@ -397,6 +439,7 @@ def _validate_binding(
     output: torch.Tensor,
     page_table: torch.Tensor,
     cache_seqlens: torch.Tensor,
+    query_cache_seqlens: torch.Tensor | None,
     cu_seqlens_q: torch.Tensor,
     kv_scale: torch.Tensor | None,
     q_scale: torch.Tensor | None,
@@ -465,6 +508,34 @@ def _validate_binding(
             raise TypeError(f"{name} must be contiguous int32 with shape {shape}")
         if tensor.device != scratch.device or not tensor.is_contiguous():
             raise ValueError(f"{name} must be contiguous on the plan device")
+    if scratch.uses_query_cache_seqlens:
+        if query_cache_seqlens is None:
+            raise ValueError("verify plan requires per-query cache lengths")
+        if query_cache_seqlens.dtype != torch.int32 or tuple(
+            query_cache_seqlens.shape
+        ) != (int(q.shape[0]),):
+            raise TypeError(
+                "query_cache_seqlens must be contiguous int32 with shape [total_q]"
+            )
+        if (
+            query_cache_seqlens.device != scratch.device
+            or not query_cache_seqlens.is_contiguous()
+        ):
+            raise ValueError(
+                "query_cache_seqlens must be contiguous on the plan device"
+            )
+    elif query_cache_seqlens is not None:
+        raise ValueError("plan does not accept per-query cache lengths")
+    else:
+        query_cache_seqlens = cache_seqlens
+    if (
+        scratch.mode == "verify"
+        and scratch.query_tile > 1
+        and int(q.shape[0]) != batch * scratch.query_tile
+    ):
+        raise ValueError(
+            "tiled verify plan requires one complete query tile per request"
+        )
     if (
         page_table.ndim != 2
         or int(page_table.shape[0]) != batch
@@ -522,6 +593,7 @@ def _validate_binding(
         output=output,
         page_table=page_table.detach(),
         cache_seqlens=cache_seqlens.detach(),
+        query_cache_seqlens=query_cache_seqlens.detach(),
         cu_seqlens_q=cu_seqlens_q.detach(),
         kv_scale=kv_scale,
         q_scale=q_scale,
@@ -594,6 +666,12 @@ def _materialize(
         chunks_per_split=layout.chunks_per_split,
         query_tile=query_tile,
         use_cuda_graph=caps.use_cuda_graph,
+        uses_query_cache_seqlens=caps.uses_query_cache_seqlens,
+        sparse_stride=caps.sparse_stride,
+        sparse_min_tokens=caps.sparse_min_tokens,
+        sparse_sink_chunks=caps.sparse_sink_chunks,
+        sparse_recent_chunks=caps.sparse_recent_chunks,
+        sparse_refresh_interval=caps.sparse_refresh_interval,
         partial_output=partial_output,
         partial_lse=partial_lse,
         final_lse=final_lse,
@@ -635,6 +713,7 @@ class Plan:
         output: torch.Tensor,
         page_table: torch.Tensor,
         cache_seqlens: torch.Tensor,
+        query_cache_seqlens: torch.Tensor | None = None,
         cu_seqlens_q: torch.Tensor,
         kv_scale: torch.Tensor | None = None,
         q_scale: torch.Tensor | None = None,
@@ -654,6 +733,7 @@ class Plan:
             output=output,
             page_table=page_table,
             cache_seqlens=cache_seqlens,
+            query_cache_seqlens=query_cache_seqlens,
             cu_seqlens_q=cu_seqlens_q,
             kv_scale=kv_scale,
             q_scale=q_scale,

--- a/b12x/attention/dense_mla/api.py
+++ b/b12x/attention/dense_mla/api.py
@@ -21,6 +21,7 @@ from ._scratch import (
 from .planner import Budget
 from ._policy import DENSE_MLA_POLICY, DenseMlaConfig, DenseMlaQuery
 from .planner import (
+    dynamic_sparse_chunk_indices,
     infer_dense_mla_mode,
 )
 from ._reference import dense_mla_reference
@@ -122,6 +123,7 @@ __all__ = [
     "bind",
     "clear_caches",
     "compile",
+    "dynamic_sparse_chunk_indices",
     "infer_mode",
     "is_supported",
     "plan",

--- a/b12x/attention/dense_mla/planner.py
+++ b/b12x/attention/dense_mla/planner.py
@@ -13,6 +13,26 @@ _CANDIDATES_PER_CHUNK = 64
 _MAX_CEIL_WAVES = 3
 
 
+def dynamic_sparse_chunk_indices(
+    num_chunks: int,
+    *,
+    stride: int,
+    sink_chunks: int,
+    recent_chunks: int,
+) -> tuple[int, ...]:
+    """Return sorted sink/strided-history/recent chunk indices."""
+    num_chunks = max(int(num_chunks), 0)
+    stride = max(int(stride), 1)
+    sink = min(max(int(sink_chunks), 0), num_chunks)
+    recent = min(max(int(recent_chunks), 0), num_chunks - sink)
+    middle_end = num_chunks - recent
+    return tuple(
+        [*range(sink)]
+        + [*range(sink, middle_end, stride)]
+        + [*range(middle_end, num_chunks)]
+    )
+
+
 @dataclass(frozen=True, kw_only=True)
 class Budget:
     """Optional caller capacity clamps; B12X still chooses launch policy."""
@@ -119,5 +139,6 @@ __all__ = [
     "Budget",
     "Mode",
     "choose_num_splits",
+    "dynamic_sparse_chunk_indices",
     "infer_dense_mla_mode",
 ]

--- a/benchmarks/benchmark_dense_mla_verify.py
+++ b/benchmarks/benchmark_dense_mla_verify.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Compare deployed, row-specialized, and fused-q4 dense MLA plans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from b12x.attention import dense_mla
+
+FP8 = torch.float8_e4m3fn
+
+
+@dataclass
+class Arm:
+    name: str
+    plan: dense_mla.Plan
+    binding: dense_mla.Binding
+    graph: torch.cuda.CUDAGraph
+    output: torch.Tensor
+    lse: torch.Tensor
+    oracle_cosine: float
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--cache-tokens", type=int, default=131072)
+    parser.add_argument("--planned-cache-tokens", type=int, default=131072)
+    parser.add_argument("--page-size", type=int, default=1536)
+    parser.add_argument("--heads", type=int, default=96)
+    parser.add_argument("--query-len", type=int, default=4)
+    parser.add_argument("--deployed-max-rows", type=int, default=28)
+    parser.add_argument("--samples", type=int, default=21)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--sparse-stride", type=int, default=1)
+    parser.add_argument("--sparse-min-tokens", type=int, default=32768)
+    parser.add_argument("--sparse-sink-chunks", type=int, default=8)
+    parser.add_argument("--sparse-recent-chunks", type=int, default=64)
+    parser.add_argument("--sparse-refresh-interval", type=int, default=0)
+    parser.add_argument("--split-candidates", default="")
+    parser.add_argument("--seed", type=int, default=20260901)
+    return parser.parse_args()
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ("git", *args),
+            cwd=Path(__file__).resolve().parents[1],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _scratch(plan: dense_mla.Plan) -> torch.Tensor:
+    (spec,) = plan.scratch_specs()
+    return torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+
+
+def _make_plan(
+    *,
+    name: str,
+    device: torch.device,
+    batch: int,
+    heads: int,
+    query_len: int,
+    page_size: int,
+    planned_cache_tokens: int,
+    deployed_max_rows: int,
+    sparse_kwargs: dict[str, int],
+    max_splits: int | None,
+) -> dense_mla.Plan:
+    total_q = batch * query_len
+    planned_pages = (planned_cache_tokens + page_size - 1) // page_size
+    if name == "deployed":
+        mode = "decode"
+        max_total_q = deployed_max_rows
+        max_batch = deployed_max_rows
+        per_query_lens = False
+    elif name == "row_specialized":
+        mode = "decode"
+        max_total_q = total_q
+        max_batch = total_q
+        per_query_lens = False
+    elif name in ("tiled", "tiled_sparse") or name.startswith("tiled_s"):
+        mode = "verify"
+        max_total_q = total_q
+        max_batch = batch
+        per_query_lens = True
+    else:
+        raise ValueError(f"unknown benchmark arm: {name}")
+    return dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode=mode,
+            kv_dtype=FP8,
+            num_q_heads=heads,
+            page_size=page_size,
+            max_total_q=max_total_q,
+            max_batch=max_batch,
+            max_cache_tokens=planned_cache_tokens,
+            max_page_table_width=planned_pages,
+            num_cache_pages=torch.iinfo(torch.int32).max,
+            use_cuda_graph=True,
+            uses_query_cache_seqlens=per_query_lens,
+            budget=(
+                dense_mla.Budget(max_splits=max_splits)
+                if max_splits is not None
+                else None
+            ),
+            **(sparse_kwargs if name == "tiled_sparse" else {}),
+        )
+    )
+
+
+def _make_arm(
+    *,
+    name: str,
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    page_table: torch.Tensor,
+    query_cache_lens: torch.Tensor,
+    q_scale: torch.Tensor,
+    kv_scale: torch.Tensor,
+    planned_cache_tokens: int,
+    deployed_max_rows: int,
+    sparse_kwargs: dict[str, int],
+    max_splits: int | None = None,
+) -> Arm:
+    total_q, heads = int(q.shape[0]), int(q.shape[1])
+    batch, query_len = int(page_table.shape[0]), total_q // int(page_table.shape[0])
+    plan = _make_plan(
+        name=name,
+        device=q.device,
+        batch=batch,
+        heads=heads,
+        query_len=query_len,
+        page_size=int(cache.shape[1]),
+        planned_cache_tokens=planned_cache_tokens,
+        deployed_max_rows=deployed_max_rows,
+        sparse_kwargs=sparse_kwargs,
+        max_splits=max_splits,
+    )
+    output = torch.empty(
+        total_q,
+        heads,
+        512,
+        dtype=torch.bfloat16,
+        device=q.device,
+    )
+    tiled = name in ("tiled", "tiled_sparse") or name.startswith("tiled_s")
+    if tiled:
+        arm_table = page_table
+        cache_lens = query_cache_lens.view(batch, query_len)[:, -1].contiguous()
+        cu_seqlens_q = torch.arange(
+            0,
+            total_q + 1,
+            query_len,
+            dtype=torch.int32,
+            device=q.device,
+        )
+        per_query_lens = query_cache_lens
+    else:
+        arm_table = (
+            page_table[:, None, :]
+            .expand(-1, query_len, -1)
+            .reshape(total_q, -1)
+            .contiguous()
+        )
+        cache_lens = query_cache_lens
+        cu_seqlens_q = torch.arange(
+            total_q + 1,
+            dtype=torch.int32,
+            device=q.device,
+        )
+        per_query_lens = None
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=arm_table,
+        cache_seqlens=cache_lens,
+        query_cache_seqlens=per_query_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+    dense_mla.compile(binding=binding)
+    actual, lse = dense_mla.run(binding=binding)
+    expected, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        arm_table,
+        cache_lens,
+        cu_seqlens_q,
+        query_cache_seqlens=per_query_lens,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+        **(sparse_kwargs if name == "tiled_sparse" else {}),
+    )
+    torch.cuda.synchronize(q.device)
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().flatten(),
+        expected.float().flatten(),
+        dim=0,
+    )
+    if float(cosine) <= 0.999 or not torch.isfinite(lse).all():
+        raise RuntimeError(f"{name} correctness failed: cosine={float(cosine):.8f}")
+    torch.testing.assert_close(lse, expected_lse, rtol=2e-5, atol=2e-5)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        dense_mla.run(binding=binding)
+    return Arm(name, plan, binding, graph, actual, lse, float(cosine))
+
+
+def main() -> None:
+    args = _arguments()
+    if args.query_len != 4:
+        raise SystemExit("the fused verification benchmark requires --query-len 4")
+    if args.batch <= 0 or args.batch * args.query_len > args.deployed_max_rows:
+        raise SystemExit("batch/query rows exceed the deployed plan capacity")
+    device = torch.device("cuda")
+    capability = torch.cuda.get_device_capability(device)
+    if capability not in ((12, 0), (12, 1)):
+        raise SystemExit("SM120/SM121 is required")
+    torch.manual_seed(args.seed)
+    pages_per_request = (args.cache_tokens + args.page_size - 1) // args.page_size
+    total_pages = args.batch * pages_per_request
+    total_q = args.batch * args.query_len
+    q_float = torch.randn(total_q, args.heads, 576, device=device) * 0.1
+    cache_float = torch.randn(total_pages, args.page_size, 576, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.arange(
+        total_pages,
+        dtype=torch.int32,
+        device=device,
+    ).view(args.batch, pages_per_request)
+    one_request_lens = torch.arange(
+        args.cache_tokens - args.query_len + 1,
+        args.cache_tokens + 1,
+        dtype=torch.int32,
+        device=device,
+    )
+    query_cache_lens = one_request_lens.repeat(args.batch)
+    sparse_kwargs = {
+        "sparse_stride": args.sparse_stride,
+        "sparse_min_tokens": args.sparse_min_tokens,
+        "sparse_sink_chunks": args.sparse_sink_chunks,
+        "sparse_recent_chunks": args.sparse_recent_chunks,
+        "sparse_refresh_interval": args.sparse_refresh_interval,
+    }
+    arm_names = ["deployed", "row_specialized", "tiled"]
+    split_candidates = [
+        int(value) for value in args.split_candidates.split(",") if value.strip()
+    ]
+    arm_names.extend(f"tiled_s{value}" for value in split_candidates)
+    if args.sparse_stride > 1:
+        arm_names.append("tiled_sparse")
+    arms = [
+        _make_arm(
+            name=name,
+            q=q,
+            cache=cache,
+            page_table=page_table,
+            query_cache_lens=query_cache_lens,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
+            planned_cache_tokens=args.planned_cache_tokens,
+            deployed_max_rows=args.deployed_max_rows,
+            sparse_kwargs=sparse_kwargs,
+            max_splits=(
+                int(name.removeprefix("tiled_s"))
+                if name.startswith("tiled_s") and name != "tiled_sparse"
+                else None
+            ),
+        )
+        for name in arm_names
+    ]
+    for _ in range(args.warmup):
+        for arm in arms:
+            arm.graph.replay()
+    torch.cuda.synchronize(device)
+
+    flush = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device=device)
+    timings: dict[str, list[float]] = {arm.name: [] for arm in arms}
+    for sample in range(args.samples):
+        ordered = arms[sample % len(arms) :] + arms[: sample % len(arms)]
+        for arm in ordered:
+            flush.zero_()
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            arm.graph.replay()
+            end.record()
+            end.synchronize()
+            timings[arm.name].append(float(start.elapsed_time(end)))
+
+    medians = {name: statistics.median(values) for name, values in timings.items()}
+    baseline = medians["deployed"]
+    tiled_output = next(arm.output for arm in arms if arm.name == "tiled")
+    props = torch.cuda.get_device_properties(device)
+    result = {
+        "command": shlex.join([sys.executable, *sys.argv]),
+        "source_commit": os.environ.get(
+            "B12X_BENCHMARK_SOURCE_REVISION", _git("rev-parse", "HEAD")
+        ),
+        "source_tree": os.environ.get("B12X_BENCHMARK_SOURCE_TREE", _git("write-tree")),
+        "source_status": os.environ.get(
+            "B12X_BENCHMARK_SOURCE_STATUS", _git("status", "--short")
+        ),
+        "device": props.name,
+        "device_uuid": f"GPU-{props.uuid}",
+        "capability": list(capability),
+        "multiprocessor_count": int(props.multi_processor_count),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "batch": args.batch,
+        "cache_tokens": args.cache_tokens,
+        "planned_cache_tokens": args.planned_cache_tokens,
+        "page_size": args.page_size,
+        "heads": args.heads,
+        "query_len": args.query_len,
+        "samples": args.samples,
+        "cold_l2_flush_bytes": int(flush.numel()),
+        "arms": {
+            arm.name: {
+                "query_tile": arm.plan.query_tile,
+                "num_splits": arm.plan.num_splits,
+                "median_ms": medians[arm.name],
+                "speedup_vs_deployed": baseline / medians[arm.name],
+                "oracle_cosine": arm.oracle_cosine,
+                "cosine_vs_tiled": float(
+                    torch.nn.functional.cosine_similarity(
+                        arm.output.float().flatten(),
+                        tiled_output.float().flatten(),
+                        dim=0,
+                    )
+                ),
+                "raw_ms": timings[arm.name],
+            }
+            for arm in arms
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -196,6 +196,72 @@ def test_partial_row_budget_changes_native_split_policy() -> None:
     assert plan.chunks_per_split == 2
 
 
+def test_fp8_multi_request_verify_plan_tiles_four_queries() -> None:
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device="cpu",
+            mode="verify",
+            kv_dtype=FP8,
+            num_q_heads=HEADS,
+            page_size=16,
+            max_total_q=8,
+            max_batch=2,
+            max_cache_tokens=128,
+            max_page_table_width=8,
+            num_cache_pages=16,
+            uses_query_cache_seqlens=True,
+        )
+    )
+
+    assert plan.query_tile == 4
+    assert plan.policy_resolution is not None
+    assert plan.policy_resolution.config.max_splits == plan.num_splits
+
+
+def test_dynamic_sparse_chunk_policy_preserves_sink_and_recent_chunks() -> None:
+    assert dense_mla.dynamic_sparse_chunk_indices(
+        10,
+        stride=3,
+        sink_chunks=2,
+        recent_chunks=2,
+    ) == (0, 1, 2, 5, 8, 9)
+
+
+def test_verify_plan_requires_query_cache_lengths() -> None:
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device="cpu",
+            mode="verify",
+            kv_dtype=FP8,
+            num_q_heads=HEADS,
+            page_size=16,
+            max_total_q=4,
+            max_batch=1,
+            max_cache_tokens=64,
+            max_page_table_width=4,
+            num_cache_pages=4,
+            uses_query_cache_seqlens=True,
+        )
+    )
+    q = torch.empty(4, HEADS, QK_DIM, dtype=FP8)
+    cache = torch.empty(4, 16, QK_DIM, dtype=FP8)
+    output = torch.empty(4, HEADS, VALUE_DIM, dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="requires per-query cache lengths"):
+        dense_mla.bind(
+            plan,
+            scratch=_scratch(plan),
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=torch.arange(4, dtype=torch.int32).view(1, 4),
+            cache_seqlens=torch.tensor([64], dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 4], dtype=torch.int32),
+            q_scale=torch.tensor(0.01),
+            kv_scale=torch.tensor(0.01),
+        )
+
+
 @pytest.mark.parametrize("heads", [8, 12])
 @torch.inference_mode()
 def test_bf16_multi_request_decode_matches_reference(heads: int) -> None:
@@ -389,6 +455,179 @@ def test_fp8_query_tiled_causal_extend_matches_reference(heads: int) -> None:
         q_scale=q_scale,
         kv_scale=kv_scale,
     )
+    _assert_matches(
+        actual_output,
+        actual_lse,
+        expected_output,
+        expected_lse,
+    )
+
+
+@torch.inference_mode()
+def test_fp8_tiled_dcp_visibility_matches_reference() -> None:
+    device = require_b12x()
+    torch.manual_seed(20260901)
+    batch = 2
+    query_len = 4
+    total_q = batch * query_len
+    heads = 8
+    page_size = 16
+    pages = 8
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="verify",
+            kv_dtype=FP8,
+            num_q_heads=heads,
+            page_size=page_size,
+            max_total_q=total_q,
+            max_batch=batch,
+            max_cache_tokens=64,
+            max_page_table_width=4,
+            num_cache_pages=pages,
+            uses_query_cache_seqlens=True,
+        )
+    )
+    assert plan.query_tile == 4
+    q_float = torch.randn(total_q, heads, QK_DIM, device=device) * 0.14
+    cache_float = torch.randn(pages, page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.tensor(
+        [[4, 7, 1, 5], [0, 3, 6, 2]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cache_seqlens = torch.tensor([31, 47], dtype=torch.int32, device=device)
+    query_cache_seqlens = torch.tensor(
+        [28, 29, 30, 31, 44, 45, 46, 47],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_q = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
+    output = torch.empty(
+        total_q,
+        heads,
+        VALUE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        query_cache_seqlens=query_cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        query_cache_seqlens=query_cache_seqlens,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+
+    _assert_matches(
+        actual_output,
+        actual_lse,
+        expected_output,
+        expected_lse,
+    )
+
+
+@torch.inference_mode()
+def test_fp8_dynamic_sparse_verify_matches_sparse_reference() -> None:
+    device = require_b12x()
+    torch.manual_seed(20260902)
+    query_len = 4
+    heads = 8
+    page_size = 16
+    pages = 16
+    cache_len = 240
+    sparse_kwargs = {
+        "sparse_stride": 3,
+        "sparse_min_tokens": 64,
+        "sparse_sink_chunks": 1,
+        "sparse_recent_chunks": 1,
+    }
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="verify",
+            kv_dtype=FP8,
+            num_q_heads=heads,
+            page_size=page_size,
+            max_total_q=query_len,
+            max_batch=1,
+            max_cache_tokens=256,
+            max_page_table_width=16,
+            num_cache_pages=pages,
+            uses_query_cache_seqlens=True,
+            **sparse_kwargs,
+        )
+    )
+    q_float = torch.randn(query_len, heads, QK_DIM, device=device) * 0.14
+    cache_float = torch.randn(pages, page_size, QK_DIM, device=device) * 0.1
+    q_scale = (q_float.abs().max() / 400).reshape(1).float()
+    kv_scale = (cache_float.abs().max() / 400).reshape(1).float()
+    q = (q_float / q_scale).to(FP8)
+    cache = (cache_float / kv_scale).to(FP8)
+    page_table = torch.arange(pages, dtype=torch.int32, device=device).view(1, -1)
+    cache_seqlens = torch.tensor([cache_len], dtype=torch.int32, device=device)
+    query_cache_seqlens = torch.arange(
+        cache_len - query_len + 1,
+        cache_len + 1,
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_q = torch.tensor([0, query_len], dtype=torch.int32, device=device)
+    output = torch.empty(
+        query_len,
+        heads,
+        VALUE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    binding = dense_mla.bind(
+        plan,
+        scratch=_scratch(plan),
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        query_cache_seqlens=query_cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+    )
+
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache,
+        page_table,
+        cache_seqlens,
+        cu_seqlens_q,
+        query_cache_seqlens=query_cache_seqlens,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+        **sparse_kwargs,
+    )
+
     _assert_matches(
         actual_output,
         actual_lse,


### PR DESCRIPTION
## Summary

- add a fixed four-query verification specialization for DFlash `K=3`, including multi-request batches and per-query DCP-visible cache lengths
- reuse each loaded KV chunk across the four verification queries instead of flattening them into four independent decode rows
- retain capture-static split geometry, caller-owned scratch, physical-record padding, BF16-query quantization, and windowed-attention behavior
- add an opt-in sink/strided-history/recent sparse policy as experimental infrastructure; `sparse_stride=1` is the exact default and the production profile keeps it disabled
- add a graph-replay benchmark and GPU oracle coverage for fused verification, DCP visibility, extend tails, padded records, and the experimental sparse reference

## Correctness and compatibility

The default path is exact dense attention. The fused verifier preserves the original page table and supplies an `int32[total_q]` visibility vector, so each of the four causal rows sees exactly its rank-local DCP prefix. Existing decode/extend plans do not accept that metadata and retain their prior behavior.

Dynamic sparsity is deliberately opt-in and quality-changing. It is not enabled or presented as production-qualified by this PR. A model-level quality evaluation is required before any stride above one is used.

## Validation

SM120 GPU suite against the current `master` source:

```bash
python -m pytest -q -s tests/attention/test_dense_mla.py
# 20 passed

ruff check b12x/attention/dense_mla \
  tests/attention/test_dense_mla.py \
  benchmarks/benchmark_dense_mla_verify.py
# All checks passed
```

The test suite covers eager execution and CUDA Graph replay against the FP32 paged oracle. The fused and dense outputs pass cosine and LSE checks; the experimental sparse kernel is checked only against its explicitly sparse reference.

`benchmarks/benchmark_dense_mla_verify.py` records the source identity, device, correctness state, cold-L2 raw samples, split geometry, and ratio direction. No formal release performance number is claimed here: the operator is collecting the final serving receipt separately before a formal release performance claim can be made.

The exact production-generation backport loaded TP8/DCP8 Kimi-K3, captured all PIECEWISE/FULL CUDA graphs without eager fallback, served text canaries, and the operator reported that the prior long-context decode degradation was no longer observed.

## Duplicate check

Searches of open `local-inference-lab/b12x` PRs for `dense MLA verify`, `query tile`, and `K3 fused verification` found no PR implementing this path.

## Review status

AI assistance from OpenAI Codex was used to prepare this change. This PR is published for review at the operator’s request. The submitting human must review every changed line, rerun the relevant tests and final benchmark, and understand and defend the implementation before merge.


## Publication status

Published as a non-draft on 2026-09-07 at the operator’s explicit request to expose all prepared PRs in local-inference-lab. Research-only code is exposed for review; unmeasured/unsupported paths above remain unqualified. No code, deployment configuration, merge approval or automatic merge is changed by this status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxvNwugeU8RJFd7WRYwNLG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds fixed four-query FP8 verification for DFlash `K=3`, with multi-request batches and per-query cache lengths.
- Reuses KV chunks while preserving capture-static split geometry, caller-owned scratch, padded physical records, BF16 query quantization, and windowed attention.
- Adds opt-in sink, strided-history, and recent-token sparse selection. Dense attention remains the default, and existing decode and extend plans retain their behavior.
- Exposes `dynamic_sparse_chunk_indices` and extends planning, binding, reference, and kernel APIs for query cache lengths and sparse configuration.
- Adds graph-replay benchmarks and GPU oracle tests for fused verification, DCP visibility, extend tails, padded records, and sparse references.

## Validation

- 20 attention tests pass.
- Ruff checks pass.
- No formal release performance claim is made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->