### PR TITLE
perf(moe): gate the W4A16 stripe split-K to decode-sized launches

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -1015,9 +1015,9 @@ class W4A16GemmKernel:
         # Small-M stripe split-K: opt out of the one-tile-per-CTA fast path
         # so decode-heavy small-M phases spread each mn-tile's K range across
         # multiple CTAs (existing tail scheduling plus cross-CTA finalize).
-        # Stripe only decode-sized launches;
-        # large-M prefill keeps the whole-tile wave schedule (stripe
-        # finalize regressed prefill 902->782 tok/s on 2026-08-28).
+        # Only decode-sized launches (size_m <= 16) stripe: at larger M the
+        # whole-tile wave schedule already fills the device, and the stripe
+        # finalize would add a cross-CTA reduction to every tile.
         self.small_m_splitk = (
             _w4a16_small_m_splitk_enabled() and int(size_m) <= 16
         )
@@ -5659,10 +5659,10 @@ class W4A16FusedMoeKernel:
         self.moe_block_size = int(moe_block_size)
         # Stripe split-K spreads each mn-tile's K range across many CTAs for
         # decode-heavy small-M phases. It is incompatible with whole-tile
-        # scheduling and grouped FC2 route subtiles.
-        # Stripe only decode-sized launches;
-        # large-M prefill keeps the whole-tile wave schedule (stripe
-        # finalize regressed prefill 902->782 tok/s on 2026-08-28).
+        # scheduling and grouped FC2 route subtiles. Only decode-sized
+        # launches (size_m <= 16) stripe: at larger M the whole-tile wave
+        # schedule already fills the device, and the stripe finalize would
+        # add a cross-CTA reduction to every tile.
         self.small_m_splitk = (
             _w4a16_small_m_splitk_enabled() and int(size_m) <= 16
         )

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -1015,7 +1015,12 @@ class W4A16GemmKernel:
         # Small-M stripe split-K: opt out of the one-tile-per-CTA fast path
         # so decode-heavy small-M phases spread each mn-tile's K range across
         # multiple CTAs (existing tail scheduling plus cross-CTA finalize).
-        self.small_m_splitk = _w4a16_small_m_splitk_enabled()
+        # Stripe only decode-sized launches;
+        # large-M prefill keeps the whole-tile wave schedule (stripe
+        # finalize regressed prefill 902->782 tok/s on 2026-08-28).
+        self.small_m_splitk = (
+            _w4a16_small_m_splitk_enabled() and int(size_m) <= 16
+        )
         self.weight_layout_trellis256 = weight_layout == "trellis_t256"
         self.weight_layout_trellis256_proj = (
             self.weight_layout_trellis256 and w13_layout == "trellis_t256_proj"
@@ -5655,7 +5660,12 @@ class W4A16FusedMoeKernel:
         # Stripe split-K spreads each mn-tile's K range across many CTAs for
         # decode-heavy small-M phases. It is incompatible with whole-tile
         # scheduling and grouped FC2 route subtiles.
-        self.small_m_splitk = _w4a16_small_m_splitk_enabled()
+        # Stripe only decode-sized launches;
+        # large-M prefill keeps the whole-tile wave schedule (stripe
+        # finalize regressed prefill 902->782 tok/s on 2026-08-28).
+        self.small_m_splitk = (
+            _w4a16_small_m_splitk_enabled() and int(size_m) <= 16
+        )
         if self.small_m_splitk:
             schedule_whole_tiles = False
             fc2_schedule_route_block_factor = 1


### PR DESCRIPTION
## Summary

`B12X_W4A16_SMALL_M_SPLITK=1` swaps the one-tile-per-CTA small-M schedule for the stripe split-K partition in both W4A16 kernel classes. On Kimi-K3 QSRT trellis experts (TP8, 2026-08-28) that is a decode win (MoE kernel 235.2 → 198.5 µs, −2.9 ms per step) but the flag also stripped the large-M prefill launches, where the whole-tile wave schedule is already grid-saturated and the stripe finalize is pure overhead: prefill regressed 902 → 782 tok/s.

This applies the stripe only when the compiled `size_m` is ≤ 16 (decode/verification shapes); prefill buckets (≥ 512 tokens) keep the whole-tile schedule. `size_m` is already part of the kernel cache key, so per-M variants compile independently.

Served in production since 2026-08-28 as a boot-time patch on the f25c8bdd-based tree; this branch applies the identical gate on `master` (both anchors present, module compiles). No kernel math changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates comments for the existing `size_m <= 16` stripe split-K gate in both W4A16 kernel classes.
- Keeps stripe split-K for decode-sized launches.
- Keeps the whole-tile schedule for larger launches to avoid cross-CTA reduction overhead.
- Makes no executable or kernel-math changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->