### PR TITLE
perf(gemm): exact split-K for narrow-N tiny-M FP8 projections

### DIFF
--- a/b12x/_lib/dense_gemm.py
+++ b/b12x/_lib/dense_gemm.py
@@ -228,7 +228,12 @@ def _reduce_split_k2_bf16(
                 partials, out, total, SLICES=slices, BLOCK=block
             )
     else:
-        out[:, :, 0].copy_(partials.float().sum(dim=2).to(out.dtype))
+        # Same arithmetic as the kernels: slices added in index order in
+        # FP32, one rounding at the final store.
+        accum = partials[:, :, 0].to(torch.float32).clone()
+        for s in range(1, slices):
+            accum += partials[:, :, s].to(torch.float32)
+        out[:, :, 0].copy_(accum.to(out.dtype))
 
 
 # @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
@@ -528,9 +533,12 @@ def _dense_gemm_policy_for(
         and k % 256 == 0
         and l == 1
     ):
-        # Narrow-N, deep-K decode projections (e.g. hidden -> latent, q_a,
-        # kv_a, shared-expert gate/up at TP8) launch only n / tile_n CTAs
-        # and stream their weights at a fraction of HBM bandwidth. Split K
+        # Narrow-N, deep-K decode projections -- the MLA down-projections
+        # from the hidden size to the small query / key-value latent widths
+        # (q_a_proj, kv_a_proj) and the shared-expert gate/up projections
+        # once tensor parallelism has split their N over eight ranks --
+        # launch only n / tile_n CTAs and stream their weights at a fraction
+        # of HBM bandwidth. Split K
         # across the widest slice count that keeps every (tile, slice) CTA
         # resident and divides the K tiles; partials are reduced exactly in
         # FP32 (never the bf16 atomic path), so the result rounds once.

--- a/b12x/_lib/dense_gemm.py
+++ b/b12x/_lib/dense_gemm.py
@@ -136,6 +136,9 @@ _B12X_TIMING_THRESHOLD_MS = float(
     )
 )
 _B12X_DENSE_SPLITK_TURBO = os.getenv("B12X_DENSE_SPLITK_TURBO", "1") == "1"
+# Widest split-K slice count for narrow-N (n < 4096) tiny-M FP8 projections;
+# 0 or 1 keeps the single-CTA-per-tile launch.
+_B12X_DENSE_NARROW_SPLITK_MAX = int(os.getenv("B12X_DENSE_NARROW_SPLITK_MAX", "8"))
 
 # MX-FP6 decode uses at most three mainloop stages when two CTAs share an SM.
 _FP6_DECODE_TILE = (16, 64)
@@ -182,17 +185,35 @@ def _reduce_split_k2_bf16_kernel(
     tl.store(out + offs, accum, mask=mask)
 
 
+@triton.jit
+def _reduce_split_kn_bf16_kernel(
+    partials, out, total: tl.constexpr, SLICES: tl.constexpr, BLOCK: tl.constexpr
+) -> None:
+    # Fixed slice order (0..SLICES-1) in FP32, one rounding at the store:
+    # the result does not depend on CTA scheduling.
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+    accum = tl.load(partials + offs, mask=mask).to(tl.float32)
+    for s in tl.static_range(1, SLICES):
+        accum += tl.load(partials + s * total + offs, mask=mask).to(tl.float32)
+    tl.store(out + offs, accum, mask=mask)
+
+
 def _reduce_split_k2_bf16(
     partials: torch.Tensor, out: torch.Tensor, *, m: int, n: int
 ) -> None:
-    """Fused 2-way split-K FP32-partials reduction (exact); faster than torch.add.
+    """Fused split-K FP32-partials reduction (exact); faster than torch.add.
 
-    Falls back to torch.add when the scratch/output layout is not the expected
-    [m, n, 2] / [m, n, 1] contiguous-row form.
+    ``partials`` is the ``[m, n, slices]`` view of the ``[slices, m, n]``
+    FP32 scratch. Any slice count is reduced in fixed slice order with one
+    rounding at the store. Falls back to torch when the scratch/output
+    layout is not the expected contiguous-row form.
     """
     total = int(m) * int(n)
+    slices = int(partials.shape[2])
     if (
-        partials.shape == (m, n, 2)
+        partials.shape == (m, n, slices)
         and partials.stride() == (n, 1, total)
         and out.shape == (m, n, 1)
         and out.stride()[0] == n
@@ -200,9 +221,14 @@ def _reduce_split_k2_bf16(
     ):
         block = 1024
         grid = (triton.cdiv(total, block),)
-        _reduce_split_k2_bf16_kernel[grid](partials, out, total, BLOCK=block)
+        if slices == 2:
+            _reduce_split_k2_bf16_kernel[grid](partials, out, total, BLOCK=block)
+        else:
+            _reduce_split_kn_bf16_kernel[grid](
+                partials, out, total, SLICES=slices, BLOCK=block
+            )
     else:
-        torch.add(partials[:, :, 0], partials[:, :, 1], out=out[:, :, 0])
+        out[:, :, 0].copy_(partials.float().sum(dim=2).to(out.dtype))
 
 
 # @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
@@ -489,6 +515,34 @@ def _dense_gemm_policy_for(
                 and mma_tiler_mn == (16, 128)
                 else 2
             )
+    split_k_atomic_bf16 = _B12X_DENSE_SPLITK_TURBO
+    if (
+        split_k_slices == 1
+        and _B12X_DENSE_NARROW_SPLITK_MAX > 1
+        and single_work_tile_per_cta
+        and ab_dtype == cutlass.Float8E4M3FN
+        and c_dtype == cutlass.BFloat16
+        and m <= 8
+        and n < 4096
+        and k >= 4096
+        and k % 256 == 0
+        and l == 1
+    ):
+        # Narrow-N, deep-K decode projections (e.g. hidden -> latent, q_a,
+        # kv_a, shared-expert gate/up at TP8) launch only n / tile_n CTAs
+        # and stream their weights at a fraction of HBM bandwidth. Split K
+        # across the widest slice count that keeps every (tile, slice) CTA
+        # resident and divides the K tiles; partials are reduced exactly in
+        # FP32 (never the bf16 atomic path), so the result rounds once.
+        k_tiles = k // 128
+        n_tiles = (n + tile_n - 1) // tile_n
+        for candidate in (8, 4, 2):
+            if candidate > _B12X_DENSE_NARROW_SPLITK_MAX:
+                continue
+            if k_tiles % candidate == 0 and n_tiles * candidate <= max_active_clusters:
+                split_k_slices = candidate
+                split_k_atomic_bf16 = False
+                break
     # A declared expected_m owns compile-time tuning for its regime. Without a
     # hint, keep the unroll choice stable throughout the persistent scheduler
     # regime so one warmed kernel covers every live M in that regime.
@@ -536,7 +590,7 @@ def _dense_gemm_policy_for(
         direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
         use_m1_non_tma=use_m1_non_tma,
         split_k_slices=split_k_slices,
-        split_k_atomic_bf16=_B12X_DENSE_SPLITK_TURBO,
+        split_k_atomic_bf16=split_k_atomic_bf16,
         large_m_unroll=(
             ab_dtype == cutlass.Float8E4M3FN and use_large_m_unroll and l == 1
         ),

--- a/tests/gemm/test_dense_split_k_reduce.py
+++ b/tests/gemm/test_dense_split_k_reduce.py
@@ -1,0 +1,48 @@
+"""The split-K partial reduction rounds once and does not depend on the
+scratch layout: the Triton kernels (two slices and any slice count) and the
+torch fallback for other layouts add the FP32 slices in index order and round
+to the output dtype at the store, so their results are bit-identical."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from b12x._lib.dense_gemm import _reduce_split_k2_bf16
+
+from ..conftest import require_b12x
+
+
+def _ordered_reference(partials: torch.Tensor) -> torch.Tensor:
+    accum = partials[:, :, 0].to(torch.float32).clone()
+    for s in range(1, partials.shape[2]):
+        accum += partials[:, :, s].to(torch.float32)
+    return accum.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("slices", [2, 3, 4, 8])
+def test_kernel_and_fallback_reduce_slices_in_order(slices: int) -> None:
+    device = require_b12x()
+    torch.manual_seed(20260903)
+    m, n = 8, 1536
+    # Partial magnitudes spanning several binades so that reassociation
+    # changes low bits.
+    scratch = torch.randn(slices, m, n, device=device, dtype=torch.float32)
+    scratch *= torch.logspace(-3, 3, slices, device=device).view(slices, 1, 1)
+    kernel_view = scratch.permute(1, 2, 0)  # [m, n, slices], stride (n, 1, m*n)
+    assert kernel_view.stride() == (n, 1, m * n)
+    kernel_out = torch.empty(m, n, 1, device=device, dtype=torch.bfloat16)
+    _reduce_split_k2_bf16(kernel_view, kernel_out, m=m, n=n)
+
+    # A strided copy of the same partials takes the torch fallback.
+    padded = torch.zeros(slices, m, n + 64, device=device, dtype=torch.float32)
+    padded[:, :, :n].copy_(scratch)
+    fallback_view = padded[:, :, :n].permute(1, 2, 0)
+    assert fallback_view.stride() != (n, 1, m * n)
+    fallback_out = torch.empty(m, n, 1, device=device, dtype=torch.bfloat16)
+    _reduce_split_k2_bf16(fallback_view, fallback_out, m=m, n=n)
+
+    expected = _ordered_reference(kernel_view)
+    assert torch.count_nonzero(expected).item() == expected.numel()
+    assert torch.equal(kernel_out[:, :, 0], expected)
+    assert torch.equal(fallback_out[:, :, 0], expected)


### PR DESCRIPTION
## Summary

Tiny-M (≤ 8), deep-K (≥ 4096), narrow-N (< 4096) FP8 dense projections launch only `n / tile_n` CTAs and stream weights at a fraction of HBM bandwidth (Kimi-K3 at TP8: hidden→latent, MLA q_a/kv_a, shared-expert gate/up, several per layer per decode step). The split-K policy only covered `n >= 4096`.

This splits K for those shapes across the widest slice count in {8, 4, 2} that divides the K tiles and keeps every (tile, slice) CTA resident (`B12X_DENSE_NARROW_SPLITK_MAX`, 0/1 disables), with partials reduced in FP32 in fixed slice order by a generalized reduction kernel (any slice count, one rounding) — never the bf16 atomic path.

## Evidence

RTX PRO 6000 Blackwell, M=4, graph replay, L2 flushed (µs): k7168 n1536 20.5 → 12.7, n896 20.0 → 11.1, n576 19.4 → 9.1, n2304 25.2 → 17.2, n3584 25.1 → 22.5; n ≥ 4096 and k < 4096 unchanged. Reference check stays at cos = 1.0 (max_abs one bf16 ulp from the changed summation order).

Serving Kimi-K3 (TP8/DCP8, K=3 DFlash): decode c1 46.0/49.2 → 49.0/51.7 tok/s (ITL 21.3/19.8 → 20.0/19.2 ms), prefill unchanged.

Note on the existing path: the bf16 atomic accumulation (`B12X_DENSE_SPLITK_TURBO=1` default) rounds each partial to bf16 before adding; at k7168 n7168 M=4 the benchmark check reports max_abs 0.125 / cos 0.9999957 versus 0.0625 / 1.0 with the FP32 reduction at identical time (38.9 µs). The served configuration runs with `B12X_DENSE_SPLITK_TURBO=0`; this PR leaves the default unchanged. Ported onto `master` from the served f25c8bdd-based tree (same policy site; `_dense_gemm_policy_for`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds exact split-K support for FP8 dense projections when `M ≤ 8`, `K ≥ 4096`, and `N < 4096`.

The selector chooses the widest supported slice count from `8`, `4`, and `2` when the count divides the K-tile count and fits resident CTA capacity. `B12X_DENSE_NARROW_SPLITK_MAX` controls the limit. Values `0` and `1` disable narrow-N split-K.

Partial results use a generalized Triton reduction kernel with fixed-order FP32 accumulation and one rounding step. The implementation avoids the BF16 atomic reduction path and uses a Torch fallback when required. The existing `B12X_DENSE_SPLITK_TURBO` default remains unchanged.

## Compatibility

The change does not alter exported or public declarations. Shapes with `N ≥ 4096` or `K < 4096` retain existing behavior.

## Validation

Reported RTX PRO 6000 Blackwell benchmarks show lower latency for tested narrow-N shapes and unchanged performance for unaffected shapes. Results match the FP32 reference with cosine similarity `1.0`. Kimi-K3 decode throughput improves, while prefill throughput remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->