### PR TITLE
perf(comm): CUDA-graph replay for eager PCIe DMA ring all-reduces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ Compressed transport requires BF16 input and a per-rank shard divisible by
 B12X_PCIE_DMA_FP8=i8_ring python -m your_server
 ```
 
+### Graph replay of eager ring all-reduces
+
+An eager `PCIeDmaAllReduce.all_reduce` call issues roughly 250 CUDA API calls
+from Python (per-piece copies, flag kernels, adds, cross-stream events). On a
+prefill-size tensor that host time (about 2.4 ms per 22 MiB call on a
+desktop-class host) exceeds the wire time, so a Python-driven serving loop
+becomes launch-bound. `B12X_PCIE_DMA_GRAPH_REPLAY=1` captures each eligible
+shape once into a CUDA graph over static input/output buffers (on the shape's
+second call, so one-off sizes stay eager) and replays it afterwards with a
+copy in and a copy out. The kernels and their order are unchanged, so the
+result is bit-identical to the eager call; calls made while an enclosing CUDA
+graph is being captured keep recording the eager sequence into that graph.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `B12X_PCIE_DMA_GRAPH_REPLAY` | `0` | `1` enables replay for eager calls |
+| `B12X_PCIE_DMA_GRAPH_REPLAY_MIN_BYTES` | `8388608` | Smallest tensor size that is captured |
+| `B12X_PCIE_DMA_GRAPH_REPLAY_MAX_ENTRIES` | `4` | Cached shapes; least recently used is dropped first. The static buffers for all entries (`2 x max_bytes` each) are reserved when the ring is constructed, so serving never allocates for a capture |
+
 Compilation happens lazily per shape/config and is cached. For serving, warm
 up the shapes you need, then freeze:
 

--- a/README.md
+++ b/README.md
@@ -154,15 +154,19 @@ B12X_PCIE_DMA_FP8=i8_ring python -m your_server
 ### Graph replay of eager ring all-reduces
 
 An eager `PCIeDmaAllReduce.all_reduce` call issues roughly 250 CUDA API calls
-from Python (per-piece copies, flag kernels, adds, cross-stream events). On a
-prefill-size tensor that host time (about 2.4 ms per 22 MiB call on a
-desktop-class host) exceeds the wire time, so a Python-driven serving loop
-becomes launch-bound. `B12X_PCIE_DMA_GRAPH_REPLAY=1` captures each eligible
-shape once into a CUDA graph over static input/output buffers (on the shape's
-second call, so one-off sizes stay eager) and replays it afterwards with a
-copy in and a copy out. The kernels and their order are unchanged, so the
-result is bit-identical to the eager call; calls made while an enclosing CUDA
-graph is being captured keep recording the eager sequence into that graph.
+from Python (per-piece copies, flag kernels, adds, cross-stream events), so a
+Python-driven serving loop that reduces prefill-size tensors is bound by that
+issue time rather than by the wire. `B12X_PCIE_DMA_GRAPH_REPLAY=1` captures
+each eligible shape once into a CUDA graph over static input/output buffers
+(on the shape's second call, so one-off sizes stay eager) and replays it
+afterward with a copy in and a copy out. The graph records the eager kernels
+in their eager order over the same flag counters, so a replay computes the
+same bits as the eager call (`tests/comm/test_pcie_dma_gpu.py` asserts
+`torch.equal` against the eager result across replays, shape reuse and an
+enclosing capture); calls made while an enclosing CUDA graph is being
+captured keep recording the eager sequence into that graph. A caller-supplied
+`out` must match the input shape and dtype, live on the ring's device and be
+contiguous on both paths.
 
 | Variable | Default | Meaning |
 |---|---|---|

--- a/b12x/comm/pcie/pcie_dma.py
+++ b/b12x/comm/pcie/pcie_dma.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections import OrderedDict
 from contextlib import suppress
 from functools import lru_cache
 from statistics import median
@@ -136,6 +137,43 @@ def _load_kernels():
     return DmaKernels(CudaRTLibrary())
 
 
+def _graph_replay_mode() -> bool:
+    """Opt-in CUDA-graph replay of eager ring all-reduces.
+
+    An eager call issues ~250 CUDA API calls from Python (per-piece copies,
+    flag kernels, adds and the cross-stream events), which costs more host
+    time than the transfer takes on the wire for prefill-size tensors. With
+    replay enabled, every shape at or above ``_graph_replay_min_bytes()``
+    is captured once into a CUDA graph over static input/output buffers and
+    later calls copy in, replay, and copy out. The kernels and their order
+    are unchanged, so the result is bit-identical to the eager path. The
+    static buffers for every cache entry are reserved when the ring is
+    constructed (max_entries x 2 x max_bytes), so serving never allocates
+    and never falls back for lack of device memory.
+    """
+    return os.getenv("B12X_PCIE_DMA_GRAPH_REPLAY", "0") == "1"
+
+
+def _graph_replay_min_bytes() -> int:
+    return int(os.getenv("B12X_PCIE_DMA_GRAPH_REPLAY_MIN_BYTES", str(8 << 20)))
+
+
+def _graph_replay_max_entries() -> int:
+    """Upper bound on cached shapes; the least recently used one is dropped
+    first. Each entry holds two static buffers of the tensor size."""
+    return max(1, int(os.getenv("B12X_PCIE_DMA_GRAPH_REPLAY_MAX_ENTRIES", "4")))
+
+
+class _ReplayEntry:
+    __slots__ = ("inp", "out", "graph", "slot")
+
+    def __init__(self, inp: torch.Tensor, out: torch.Tensor, graph, slot: int) -> None:
+        self.inp = inp
+        self.out = out
+        self.graph = graph
+        self.slot = slot
+
+
 def _align_up(value: int, alignment: int) -> int:
     return (value + alignment - 1) // alignment * alignment
 
@@ -229,6 +267,32 @@ class PCIeDmaAllReduce:
             )
             self._fp8_stage_stride = stride
         self.min_bytes = 0
+        self._graph_replay = _graph_replay_mode()
+        self._graph_replay_min_bytes = _graph_replay_min_bytes()
+        self._graph_replay_max_entries = _graph_replay_max_entries()
+        # Shape key -> captured graph with its static buffers (insertion
+        # order doubles as the LRU order); a shape is captured on its second
+        # eager-eligible call so one-off sizes (prefill tail chunks) stay
+        # eager instead of churning captures.
+        self._replay_entries: "OrderedDict[tuple[int, torch.dtype], _ReplayEntry]" = (
+            OrderedDict()
+        )
+        self._replay_seen: dict[tuple[int, torch.dtype], int] = {}
+        self._replay_capture_stream: torch.cuda.Stream | None = None
+        # Static input/output storage for every cached shape is reserved
+        # here, once, so a capture during serving never allocates device
+        # memory (and can never fail for lack of it): one slot of
+        # 2 x max_bytes per cache entry, carved into views per shape.
+        self._replay_slot_bytes = 2 * _align_up(self.max_bytes, SCRATCH_ALIGN)
+        self._replay_arena: torch.Tensor | None = None
+        self._replay_free_slots: list[int] = []
+        if self._graph_replay:
+            self._replay_arena = torch.empty(
+                self._graph_replay_max_entries * self._replay_slot_bytes,
+                dtype=torch.uint8,
+                device=self.device,
+            )
+            self._replay_free_slots = list(range(self._graph_replay_max_entries))
         wire_modes = {
             "i8": "int8-ag",
             "i8_ring": "int8-ring",
@@ -340,7 +404,94 @@ class PCIeDmaAllReduce:
         self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         with torch.cuda.device(self.device):
+            if self._graph_replay and self._graph_replay_eligible(inp):
+                return self._all_reduce_replayed(inp, out)
             return self._all_reduce_on_device(inp, out=out)
+
+    def _graph_replay_eligible(self, inp: torch.Tensor) -> bool:
+        # Inside an enclosing capture the eager sequence is recorded into
+        # that graph as before; a graph cannot be replayed while capturing.
+        if torch.cuda.is_current_stream_capturing():
+            return False
+        if inp.numel() * inp.element_size() < self._graph_replay_min_bytes:
+            return False
+        return self.should_allreduce(inp)
+
+    def _all_reduce_replayed(
+        self, inp: torch.Tensor, out: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        key = (inp.numel(), inp.dtype)
+        entry = self._replay_entries.get(key)
+        if entry is None:
+            seen = self._replay_seen.get(key, 0) + 1
+            if len(self._replay_seen) > 1024:
+                self._replay_seen.clear()
+            self._replay_seen[key] = seen
+            if seen < 2:
+                return self._all_reduce_on_device(inp, out=out)
+            entry = self._capture_replay_entry(inp)
+        else:
+            self._replay_entries.move_to_end(key)
+        # Entries are keyed by element count: the ring treats its input as a
+        # flat buffer, so tensors of different shapes but equal size share a
+        # graph. Copy through flat views so a [768, 7168] call can reuse the
+        # [1536, 3584] entry (and vice versa).
+        entry.inp.view(-1).copy_(inp.view(-1))
+        entry.graph.replay()
+        if out is None:
+            out = torch.empty_like(inp)
+        out.view(-1).copy_(entry.out.view(-1))
+        return out
+
+    def _capture_replay_entry(self, inp: torch.Tensor) -> _ReplayEntry:
+        """Capture the eager ring sequence for ``inp``'s shape over static
+        buffers. Every rank captures the same shape sequence, so the
+        cache contents stay symmetric across the group; nothing executes
+        during capture, and the device-side flag counters advance only when
+        the graph runs, exactly as the eager kernels would."""
+        while len(self._replay_entries) >= self._graph_replay_max_entries:
+            _, evicted = self._replay_entries.popitem(last=False)
+            self._replay_free_slots.append(evicted.slot)
+            del evicted
+        assert self._replay_arena is not None and self._replay_free_slots
+        slot = self._replay_free_slots.pop()
+        nbytes = inp.numel() * inp.element_size()
+        base = slot * self._replay_slot_bytes
+        half = self._replay_slot_bytes // 2
+        static_in = (
+            self._replay_arena[base : base + nbytes].view(inp.dtype).view(inp.shape)
+        )
+        static_out = (
+            self._replay_arena[base + half : base + half + nbytes]
+            .view(inp.dtype)
+            .view(inp.shape)
+        )
+        main = torch.cuda.current_stream(self.device)
+        side = self._replay_capture_stream
+        if side is None:
+            side = self._replay_capture_stream = torch.cuda.Stream(device=self.device)
+        # torch.cuda.graph() would also synchronize the device, run gc and
+        # empty the caching allocator; the ring allocates nothing inside the
+        # capture, so a bare capture on a joined side stream suffices.
+        side.wait_stream(main)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(side):
+            graph.capture_begin(capture_error_mode="thread_local")
+            try:
+                self._all_reduce_on_device(static_in, out=static_out)
+            finally:
+                graph.capture_end()
+        main.wait_stream(side)
+        entry = _ReplayEntry(static_in, static_out, graph, slot)
+        self._replay_entries[(inp.numel(), inp.dtype)] = entry
+        logger.debug(
+            "[PCIe DMA allreduce] captured replay graph for numel=%d dtype=%s "
+            "(%d cached)",
+            inp.numel(),
+            inp.dtype,
+            len(self._replay_entries),
+        )
+        return entry
 
     def _all_reduce_on_device(
         self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
@@ -806,6 +957,8 @@ class PCIeDmaAllReduce:
         if self._closed:
             return
         self._closed = True
+        self._replay_entries.clear()
+        self._replay_arena = None
         # Drain the main and four auxiliary streams before any rank unmaps a
         # peer allocation.  Every importer must unmap before its owner frees
         # the exported slab.

--- a/b12x/comm/pcie/pcie_dma.py
+++ b/b12x/comm/pcie/pcie_dma.py
@@ -141,12 +141,14 @@ def _graph_replay_mode() -> bool:
     """Opt-in CUDA-graph replay of eager ring all-reduces.
 
     An eager call issues ~250 CUDA API calls from Python (per-piece copies,
-    flag kernels, adds and the cross-stream events), which costs more host
-    time than the transfer takes on the wire for prefill-size tensors. With
-    replay enabled, every shape at or above ``_graph_replay_min_bytes()``
-    is captured once into a CUDA graph over static input/output buffers and
-    later calls copy in, replay, and copy out. The kernels and their order
-    are unchanged, so the result is bit-identical to the eager path. The
+    flag kernels, adds and the cross-stream events); on prefill-size
+    tensors a Python-driven serving loop is bound by that issue time rather
+    than by the transfer. With replay enabled, every shape at or above
+    ``_graph_replay_min_bytes()`` is captured once into a CUDA graph over
+    static input/output buffers and later calls copy in, replay, and copy
+    out. The graph records the eager kernels in their eager order over the
+    same flag counters, so a replay computes the same bits as the eager
+    call (tests/comm/test_pcie_dma_gpu.py checks torch.equal). The
     static buffers for every cache entry are reserved when the ring is
     constructed (max_entries x 2 x max_bytes), so serving never allocates
     and never falls back for lack of device memory.
@@ -417,9 +419,24 @@ class PCIeDmaAllReduce:
             return False
         return self.should_allreduce(inp)
 
+    def _check_out(self, inp: torch.Tensor, out: Optional[torch.Tensor]) -> None:
+        if out is not None and (
+            out.shape != inp.shape
+            or out.dtype != inp.dtype
+            or out.device != self.device
+            or not out.is_contiguous()
+        ):
+            raise ValueError(
+                "output must match input shape/dtype/device and be contiguous"
+            )
+
     def _all_reduce_replayed(
         self, inp: torch.Tensor, out: Optional[torch.Tensor]
     ) -> torch.Tensor:
+        # The replay path copies out of the static buffer, and copy_ would
+        # silently convert dtypes, cross devices and scatter into strided
+        # storage, so it enforces the same output contract as the eager call.
+        self._check_out(inp, out)
         key = (inp.numel(), inp.dtype)
         entry = self._replay_entries.get(key)
         if entry is None:
@@ -450,7 +467,11 @@ class PCIeDmaAllReduce:
         during capture, and the device-side flag counters advance only when
         the graph runs, exactly as the eager kernels would."""
         while len(self._replay_entries) >= self._graph_replay_max_entries:
-            _, evicted = self._replay_entries.popitem(last=False)
+            evicted_key, evicted = self._replay_entries.popitem(last=False)
+            # An evicted shape earns its capture again with one eager call,
+            # so a cycle of more shapes than entries alternates eager and
+            # capture instead of capturing on every call.
+            self._replay_seen.pop(evicted_key, None)
             self._replay_free_slots.append(evicted.slot)
             del evicted
         assert self._replay_arena is not None and self._replay_free_slots
@@ -475,12 +496,18 @@ class PCIeDmaAllReduce:
         # capture, so a bare capture on a joined side stream suffices.
         side.wait_stream(main)
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.stream(side):
-            graph.capture_begin(capture_error_mode="thread_local")
-            try:
-                self._all_reduce_on_device(static_in, out=static_out)
-            finally:
-                graph.capture_end()
+        try:
+            with torch.cuda.stream(side):
+                graph.capture_begin(capture_error_mode="thread_local")
+                try:
+                    self._all_reduce_on_device(static_in, out=static_out)
+                finally:
+                    graph.capture_end()
+        except BaseException:
+            # The slot is only owned by an entry once the capture succeeded;
+            # a failed capture returns it so later shapes can still capture.
+            self._replay_free_slots.append(slot)
+            raise
         main.wait_stream(side)
         entry = _ReplayEntry(static_in, static_out, graph, slot)
         self._replay_entries[(inp.numel(), inp.dtype)] = entry
@@ -501,19 +528,11 @@ class PCIeDmaAllReduce:
                 "input does not satisfy ring allreduce requirements "
                 f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
             )
+        self._check_out(inp, out)
         if out is None:
             # Preserve normal out-of-place collective semantics. Callers can
             # retain this result while a later collective is in flight.
             out = torch.empty_like(inp)
-        elif (
-            out.shape != inp.shape
-            or out.dtype != inp.dtype
-            or out.device != self.device
-            or not out.is_contiguous()
-        ):
-            raise ValueError(
-                "output must match input shape/dtype/device and be contiguous"
-            )
         kernels = self._kernels
         world = self.world_size
         rank = self.rank

--- a/tests/comm/test_pcie_dma_gpu.py
+++ b/tests/comm/test_pcie_dma_gpu.py
@@ -155,6 +155,133 @@ def test_pcie_dma_all_reduce_eager_and_graph() -> None:
     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
 
 
+def _replay_worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["B12X_PCIE_DMA_GRAPH_REPLAY"] = "1"
+    os.environ["B12X_PCIE_DMA_GRAPH_REPLAY_MIN_BYTES"] = "0"
+    os.environ["B12X_PCIE_DMA_GRAPH_REPLAY_MAX_ENTRIES"] = "1"
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    hidden = 6144
+    max_rows = 512
+    row_multiple = (world_size * 8) // gcd(hidden, world_size * 8)
+    rows_a = ((256 + row_multiple - 1) // row_multiple) * row_multiple
+    rows_b = ((64 + row_multiple - 1) // row_multiple) * row_multiple
+    ring = PCIeDmaAllReduce(
+        exchange_group=dist.group.WORLD,
+        device=device,
+        max_bytes=max_rows * hidden * 4,
+    )
+    try:
+        assert ring._graph_replay
+
+        def eager(inp: torch.Tensor) -> torch.Tensor:
+            ring._graph_replay = False
+            try:
+                out = ring.all_reduce(inp)
+            finally:
+                ring._graph_replay = True
+            torch.cuda.synchronize(device)
+            return out
+
+        inputs = [
+            _make_input(rows_a, hidden, torch.bfloat16, device, rank, it)
+            for it in range(4)
+        ]
+        expected = [eager(inp) for inp in inputs]
+
+        # First call of a shape stays eager, the second captures and replays,
+        # later ones replay; all bit-identical to the eager sequence.
+        assert not ring._replay_entries
+        out0 = ring.all_reduce(inputs[0])
+        torch.cuda.synchronize(device)
+        assert not ring._replay_entries
+        assert torch.equal(out0, expected[0])
+        allocated_before_capture = torch.cuda.memory_allocated(device)
+        out1 = ring.all_reduce(inputs[1])
+        torch.cuda.synchronize(device)
+        # The capture carves its static buffers out of the arena reserved at
+        # construction, so the allocator grows by the returned output plus at
+        # most the small launch bookkeeping of the captured kernels, never by
+        # another pair of tensor-sized buffers.
+        capture_growth = torch.cuda.memory_allocated(device) - allocated_before_capture
+        assert capture_growth <= out1.numel() * out1.element_size() + (4 << 20), (
+            f"capture allocated {capture_growth} bytes beyond the output"
+        )
+        assert len(ring._replay_entries) == 1
+        entry = next(iter(ring._replay_entries.values()))
+        arena_start = ring._replay_arena.data_ptr()
+        arena_end = arena_start + ring._replay_arena.numel()
+        assert arena_start <= entry.inp.data_ptr() < arena_end
+        assert arena_start <= entry.out.data_ptr() < arena_end
+        assert torch.equal(out1, expected[1])
+        assert out1.data_ptr() not in (entry.inp.data_ptr(), entry.out.data_ptr())
+        out2 = ring.all_reduce(inputs[2])
+        out3 = ring.all_reduce(inputs[3])
+        torch.cuda.synchronize(device)
+        assert torch.equal(out2, expected[2])
+        assert torch.equal(out3, expected[3])
+        # Retained outputs are independent of later replays.
+        assert torch.equal(out1, expected[1])
+        _assert_close(out3, _reference(inputs[3]), world_size)
+
+        # A tensor of another shape but the same element count reuses the
+        # entry (the ring is a flat all-reduce) and matches the eager result.
+        reshaped = inputs[2].view(rows_a * 2, hidden // 2)
+        out_reshaped = ring.all_reduce(reshaped)
+        torch.cuda.synchronize(device)
+        assert len(ring._replay_entries) == 1
+        assert out_reshaped.shape == reshaped.shape
+        assert torch.equal(out_reshaped.view(rows_a, hidden), expected[2])
+
+        # A second shape evicts the first at max_entries=1 and still matches.
+        small = [
+            _make_input(rows_b, hidden, torch.bfloat16, device, rank, it)
+            for it in range(2)
+        ]
+        small_expected = [eager(inp) for inp in small]
+        ring.all_reduce(small[0])
+        out_small = ring.all_reduce(small[1])
+        torch.cuda.synchronize(device)
+        assert list(ring._replay_entries) == [(small[1].numel(), torch.bfloat16)]
+        assert torch.equal(out_small, small_expected[1])
+
+        # Inside an enclosing capture the eager sequence is recorded as before.
+        static_in = inputs[0].clone()
+        static_out = torch.empty_like(static_in)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            ring.all_reduce(static_in, out=static_out)
+        for it in range(1, 3):
+            static_in.copy_(inputs[it])
+            graph.replay()
+            torch.cuda.synchronize(device)
+            assert torch.equal(static_out, expected[it])
+        dist.barrier()
+    finally:
+        ring.close()
+        dist.destroy_process_group()
+
+
+def test_pcie_dma_all_reduce_graph_replay_matches_eager() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    world_size = int(os.getenv("B12X_PCIE_DMA_WORLD_SIZE", "2"))
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(
+            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
+        )
+    _load_kernels()
+    mp.spawn(
+        _replay_worker, args=(world_size, _free_port()), nprocs=world_size, join=True
+    )
+
+
 def _fp8_worker(rank: int, world_size: int, port: int, mode: str) -> None:
     os.environ["B12X_PCIE_DMA_FP8"] = mode
     _worker(rank, world_size, port)

--- a/tests/comm/test_pcie_dma_replay_bookkeeping.py
+++ b/tests/comm/test_pcie_dma_replay_bookkeeping.py
@@ -1,0 +1,122 @@
+"""Replay-cache bookkeeping of PCIeDmaAllReduce on one GPU, without a ring.
+
+The ring's collective needs several GPUs; these tests drive the replay
+entry points of a bare instance whose eager collective is stubbed, so they
+check only the cache contract: the output contract holds on the replay
+path, an evicted shape earns its capture again with one eager call, and a
+capture that fails returns its static-buffer slot.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import pytest
+import torch
+
+from b12x.comm.pcie.pcie_dma import SCRATCH_ALIGN, PCIeDmaAllReduce, _align_up
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="needs one CUDA device"
+)
+
+
+def _bare_ring(*, max_entries: int, max_bytes: int = 1 << 16) -> PCIeDmaAllReduce:
+    ring = PCIeDmaAllReduce.__new__(PCIeDmaAllReduce)
+    ring.device = torch.device("cuda", torch.cuda.current_device())
+    ring.world_size = 2
+    ring.rank = 0
+    ring.max_bytes = max_bytes
+    ring.min_bytes = 0
+    ring._graph_replay = True
+    ring._graph_replay_min_bytes = 0
+    ring._graph_replay_max_entries = max_entries
+    ring._replay_entries = OrderedDict()
+    ring._replay_seen = {}
+    ring._replay_capture_stream = None
+    ring._replay_slot_bytes = 2 * _align_up(max_bytes, SCRATCH_ALIGN)
+    ring._replay_arena = torch.empty(
+        max_entries * ring._replay_slot_bytes, dtype=torch.uint8, device=ring.device
+    )
+    ring._replay_free_slots = list(range(max_entries))
+    ring.should_allreduce = lambda inp: True  # type: ignore[method-assign]
+    return ring
+
+
+def _stub_eager(ring: PCIeDmaAllReduce, calls: list) -> None:
+    """Record (numel, capturing) per eager call; the collective is a copy."""
+
+    def eager(inp, *, out=None):
+        calls.append((inp.numel(), torch.cuda.is_current_stream_capturing()))
+        if out is None:
+            out = torch.empty_like(inp)
+        out.copy_(inp)
+        return out
+
+    ring._all_reduce_on_device = eager  # type: ignore[method-assign]
+
+
+def test_replay_path_enforces_the_output_contract() -> None:
+    ring = _bare_ring(max_entries=2)
+    calls: list = []
+    _stub_eager(ring, calls)
+    inp = torch.ones(16, 64, dtype=torch.bfloat16, device=ring.device)
+    wrong_dtype = torch.empty(16, 64, dtype=torch.float16, device=ring.device)
+    cpu_out = torch.empty(16, 64, dtype=torch.bfloat16)
+    strided = torch.empty(16, 128, dtype=torch.bfloat16, device=ring.device)[:, :64]
+    for bad in (wrong_dtype, cpu_out, strided):
+        with pytest.raises(ValueError, match="output must match"):
+            ring._all_reduce_replayed(inp, bad)
+    assert not calls and not ring._replay_entries
+
+
+def test_evicted_shape_runs_eager_once_before_it_is_captured_again() -> None:
+    ring = _bare_ring(max_entries=1)
+    calls: list = []
+    _stub_eager(ring, calls)
+    a = torch.full((8, 64), 3.0, dtype=torch.bfloat16, device=ring.device)
+    b = torch.full((8, 128), 5.0, dtype=torch.bfloat16, device=ring.device)
+    eager, captured = (a.numel(), False), (a.numel(), True)
+    # a: eager, then captured. b: eager, then captured (evicts a). a again:
+    # eager first (its warm-up state was dropped with the eviction), then
+    # captured; the capture after that is a replay with no eager call.
+    ring._all_reduce_replayed(a, None)
+    assert calls == [eager]
+    out = ring._all_reduce_replayed(a, None)
+    assert calls == [eager, captured]
+    assert torch.equal(out, a)
+    ring._all_reduce_replayed(b, None)
+    ring._all_reduce_replayed(b, None)
+    assert calls[2:] == [(b.numel(), False), (b.numel(), True)]
+    assert list(ring._replay_entries) == [(b.numel(), b.dtype)]
+    assert (a.numel(), a.dtype) not in ring._replay_seen
+    ring._all_reduce_replayed(a, None)
+    assert calls[4:] == [eager]
+    out = ring._all_reduce_replayed(a, None)
+    assert calls[5:] == [captured]
+    assert torch.equal(out, a)
+    out = ring._all_reduce_replayed(a, None)
+    assert calls[6:] == []
+    assert torch.equal(out, a)
+    assert list(ring._replay_entries) == [(a.numel(), a.dtype)]
+    assert ring._replay_free_slots == []
+
+
+def test_failed_capture_returns_its_slot() -> None:
+    ring = _bare_ring(max_entries=1)
+
+    def failing_eager(inp, *, out=None):
+        raise RuntimeError("capture-time failure")
+
+    ring._all_reduce_on_device = failing_eager  # type: ignore[method-assign]
+    inp = torch.ones(8, 64, dtype=torch.bfloat16, device=ring.device)
+    with pytest.raises(RuntimeError, match="capture-time failure"):
+        ring._capture_replay_entry(inp)
+    assert ring._replay_free_slots == [0]
+    assert not ring._replay_entries
+    # The slot is usable again: a capture that completes owns it.
+    calls: list = []
+    _stub_eager(ring, calls)
+    entry = ring._capture_replay_entry(inp)
+    assert entry.slot == 0 and ring._replay_free_slots == []
+    assert list(ring._replay_entries) == [(inp.numel(), inp.dtype)]


### PR DESCRIPTION
## What

`B12X_PCIE_DMA_GRAPH_REPLAY=1` makes `PCIeDmaAllReduce.all_reduce` capture each eligible shape (>= `B12X_PCIE_DMA_GRAPH_REPLAY_MIN_BYTES`, default 8 MiB) into a CUDA graph over static input/output buffers on the shape's second call, and replay it afterwards (copy in, replay, copy out). One-off shapes stay eager; an LRU of `B12X_PCIE_DMA_GRAPH_REPLAY_MAX_ENTRIES` (default 4) bounds the cache. The static buffers of all entries come from one arena reserved when the ring is constructed (`max_entries x 2 x max_bytes`), so a capture during serving allocates nothing and cannot fail for lack of device memory — there is no request-time fallback; a deployment that cannot afford the arena fails at start-up. Calls made while an enclosing stream capture is active keep recording the eager sequence into that graph, as before. Default off.

## Why

An eager ring call issues ~250 CUDA API calls from Python (per-piece copies, flag kernels, adds, cross-stream events). For prefill-size tensors this host time exceeds the wire time: on a Kimi-K3 TP8 / PCIe Gen4 x16 target a 22 MiB call costs ~2.4 ms of worker-thread time against ~1.4 ms on the wire, and the ring driver is 49% of the worker thread's CPU time during a 1,536-token chunk (py-spy, 100 Hz). Replay removes that host cost without touching any kernel; the kernels and their order are unchanged, so results are bit-identical.

## Validation

- `tests/comm/test_pcie_dma_gpu.py::test_pcie_dma_all_reduce_graph_replay_matches_eager` (gated by `B12X_RUN_PCIE_DMA_TEST=1`): eager vs replayed outputs `torch.equal` across three inputs of one shape, no allocator growth at capture beyond the returned output, eviction at `max_entries=1` with a second shape, and the enclosing-capture path. Written with this change; not yet executed here because the only multi-GPU host is serving (to be run in the next maintenance window).
- Serving qualification on the Kimi-K3 target (TP8/DCP8, 1,536-token chunks, 2026-09-02, lazy-buffer revision): replay active (py-spy: eager driver 0% of worker time, `_all_reduce_replayed` 15%), greedy / JSON-schema / 11.8k-token lookup outputs correct, no CUDA errors, decode unchanged (c1 43.6-51.0 tok/s); prefill wall time unchanged (8k 1,492-1,499 tok/s, cold 1,536 tokens 0.877 s) because that target's chunk is GPU-bound once the host cost is removed — the change buys host headroom, not wall time, there.

AI assistance was used for this change (Claude Code); the submitter reviewed every line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`PCIeDmaAllReduce` supports optional CUDA-graph replay for eager PCIe DMA ring all-reduces. When `B12X_PCIE_DMA_GRAPH_REPLAY=1`, eligible shapes are captured on the second call and replayed with static input and output buffers. Shapes below the 8 MiB default threshold and one-off calls remain eager.

The replay cache uses LRU eviction and holds up to four entries by default. Static buffers are reserved in one arena when the ring is created. Insufficient device memory fails startup. Calls inside an enclosing CUDA graph capture continue to record the eager sequence.

The feature is disabled by default. Existing eager kernels and ordering remain unchanged. The README documents the replay controls and cache behavior.

## Validation

A gated multi-GPU test checks eager and replay output equality, capture timing, buffer allocation, LRU eviction, reshaping, and enclosing stream capture. The test has not run because a suitable multi-GPU host was unavailable.

Kimi-K3 serving qualification confirmed replay activity, correct outputs, no CUDA errors, and lower eager-driver worker time. Prefill wall time was unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->