### PR TITLE
feat(moe): B12X_W4A16_RESERVE_SMS keeps SMs free of the persistent fused MoE grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ Set `B12X_PRINT_COMPILE_PROGRESS=1` to log each compiler invocation with its
 cache-key parameters and duration — useful for figuring out what warmup
 actually covered. `B12X_TIMING=1` enables per-kernel timing logs.
 
+## Reserving SMs next to the persistent fused MoE grid
+
+`B12X_W4A16_RESERVE_SMS=N` sizes the W4A16 fused FC1+FC2 persistent grid to
+`(sms - N) x blocks_per_sm` CTAs. The prefill plan pins every SM's register
+file for the whole launch, so without a reservation no other kernel gets an
+SM until the MoE CTAs retire; with a small reservation the one-block kernels
+of a concurrently issued communication stream run alongside the MoE. Costs
+about `N / sms` of MoE throughput; default `0` (unchanged grid).
+
 ## Where to look next
 
 - `tests/` is the executable spec — per-group API and numerical-reference

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -10394,6 +10394,10 @@ def _w4a16_fused_moe_launch_flat(
     )
 
 
+def _w4a16_reserved_sms() -> int:
+    return max(0, int(os.getenv("B12X_W4A16_RESERVE_SMS", "0") or 0))
+
+
 def _w4a16_fused_persistent_grid_x(
     *,
     fused: W4A16FusedMoeCompileResult,
@@ -10418,7 +10422,12 @@ def _w4a16_fused_persistent_grid_x(
     barrier never deadlocks. Falls back to the default for the route-pack path
     where the host cannot know route_blocks ahead of the launch.
     """
-    cap = int(sms) * int(fused.blocks_per_sm)
+    # B12X_W4A16_RESERVE_SMS keeps that many SMs out of the persistent grid
+    # so one-block kernels of a concurrently issued stream (for example the
+    # PCIe ring's flag waits and adds under a compute/communication overlap)
+    # can run while the MoE executes; the prefill plan otherwise pins every
+    # SM's register file for the whole launch. Costs ~N/sms of MoE throughput.
+    cap = max(1, int(sms) - _w4a16_reserved_sms()) * int(fused.blocks_per_sm)
     if _w4a16_small_m_splitk_enabled():
         # Stripe split-K wants the full persistent grid: each small-M FC1
         # column's K range is fanned across many CTAs, so right-sizing the


### PR DESCRIPTION
## What

`B12X_W4A16_RESERVE_SMS=N` sizes the W4A16 fused FC1+FC2 persistent grid to `(sms - N) x blocks_per_sm` CTAs (`_w4a16_fused_persistent_grid_x`). The grid-stride tile loops and the grid barrier accept the smaller grid. Default `0` leaves the grid unchanged.

## Why

The prefill plan pins every SM's register file for the whole cooperative launch, so no other kernel is scheduled while it runs. Measured on an RTX PRO 6000 with the Kimi-K3 layer-1 shard (1,536 rows, block 48): a one-block probe issued on a second stream started only when the MoE CTAs retired, 3.0-3.4 ms after the 3.1-3.5 ms launch began (11 of 12 trials). With `B12X_W4A16_RESERVE_SMS=2` it started 0.8-2.4 ms in, while the MoE executed. A compute/communication overlap whose collectives need SM-side kernels — the PCIe DMA ring's flag waits and adds — needs that headroom, otherwise each ring sub-step waits for a whole MoE launch.

Cost: about `N / sms` of MoE throughput (2.72 -> 2.91 ms per launch in single runs, within run-to-run noise).

## Validation

GPU-0 harness with the real layer-1 shard, co-residency probe (`%globaltimer` stamps around the launch, one-block spin kernel on a side stream): 12 trials with and without the reservation, results above. The knob is dormant by default; serving qualification of the overlap schedule that uses it is tracked in the deployment ledger.

AI assistance was used for this change (Claude Code); the submitter reviewed every line.