### PR TITLE
perf(mhc): select the SM120 decode source split and prefill crossover

### DIFF
--- a/b12x/norm/mhc/_impl.py
+++ b/b12x/norm/mhc/_impl.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -875,6 +876,42 @@ def _b12x_mhc_pre_impl(
     )
 
 
+
+_DEFAULT_MHC_PREFILL_MIN_TOKENS = 96
+_SM120_MHC_PREFILL_MIN_TOKENS = 192
+
+
+def _mhc_prefill_min_tokens_for_capability(
+    compute_capability: tuple[int, int] | None,
+) -> int:
+    """Padded row count from which the prefill mHC kernels replace the decode
+    partial kernel when no override is configured.
+
+    On SM120 (RTX PRO 6000 Blackwell) the four-way decode source split is
+    faster than the block-M prefill kernel up to 128 padded rows (96 rows:
+    33.6 vs 43.0 us; 128 rows: 41 vs 45 us) and slower from 192 rows
+    (57 vs 47 us, measured 2026-09-01 on GLM-5.3 hidden size 4096), so the
+    crossover moves from 96 to 192 rows there.
+    """
+    if compute_capability == (12, 0):
+        return _SM120_MHC_PREFILL_MIN_TOKENS
+    return _DEFAULT_MHC_PREFILL_MIN_TOKENS
+
+
+@functools.lru_cache(maxsize=None)
+def _cuda_prefill_min_tokens(device_index: int) -> int:
+    return _mhc_prefill_min_tokens_for_capability(
+        tuple(torch.cuda.get_device_capability(device_index))
+    )
+
+
+def _default_mhc_prefill_min_tokens(device: torch.device) -> int:
+    if device.type != "cuda":
+        return _DEFAULT_MHC_PREFILL_MIN_TOKENS
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    return _cuda_prefill_min_tokens(int(index))
+
+
 def _b12x_mhc_post_pre_impl(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -1161,7 +1198,10 @@ def _b12x_mhc_post_pre_impl(
             )
 
         prefill_min_tokens = int(
-            os.environ.get("B12X_MHC_PREFILL_MIN_TOKENS", "96")
+            os.environ.get(
+                "B12X_MHC_PREFILL_MIN_TOKENS",
+                str(_default_mhc_prefill_min_tokens(residual.device)),
+            )
         )
         if planned_config is not None:
             tf32_enabled = planned_config.backend == "tf32_tma"

--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -45,6 +45,8 @@ from b12x.norm.mhc._policy import MhcConfig
 _MHC_MULT = 4
 _TOKENS = 1
 _HIDDEN = 4096
+# SM120 decode graphs use the four-way source split from this many padded rows.
+_SM120_DECODE_SPLIT_MIN_TOKENS = 32
 _TOTAL_K = _MHC_MULT * _HIDDEN
 _SPLIT_K = 64
 _SOURCE_TILE_H = 128
@@ -451,12 +453,29 @@ def _selected_post_pre_decode_split_n(
     else:
         if compute_capability is None and torch.cuda.is_available():
             compute_capability = tuple(torch.cuda.get_device_capability())
-        if compute_capability != (12, 1) or int(hidden_size) != _HIDDEN:
+        if int(hidden_size) != _HIDDEN:
             return 0, 0
-        if int(num_tokens) >= 10:
-            splits, tile_n = 8, 6
-        elif int(num_tokens) >= 8:
-            splits, tile_n = 4, 6
+        if compute_capability == (12, 1):
+            if int(num_tokens) >= 10:
+                splits, tile_n = 8, 6
+            elif int(num_tokens) >= 8:
+                splits, tile_n = 4, 6
+            else:
+                return 0, 0
+        elif compute_capability == (12, 0):
+            # RTX PRO 6000 Blackwell (SM120), measured 2026-09-01 on GLM-5.3
+            # decode graphs (hidden size 4096): the four-way source split is
+            # 19-24% faster from 32 padded rows up (32 rows 20.2 -> 16.4 us,
+            # 64 rows 35.1 -> 26.7, 96 rows 43.0 -> 33.3, 128 rows 44.8 ->
+            # 41.0) while at 8-16 rows the unsplit kernel is faster in-graph.
+            # The residual update is bitwise identical to the unsplit kernel;
+            # the fn partials are reduced over four source splits, so the
+            # gate/mix values differ by fp32 rounding (at most a few ulp) and
+            # y by at most one bf16 ulp.
+            if int(num_tokens) >= _SM120_DECODE_SPLIT_MIN_TOKENS:
+                splits, tile_n = 4, 6
+            else:
+                return 0, 0
         else:
             return 0, 0
     if splits <= 0 or splits > _SOURCE_TILES or int(hidden_size) % splits != 0:

--- a/tests/norm/test_mhc_sm120_decode_policy.py
+++ b/tests/norm/test_mhc_sm120_decode_policy.py
@@ -1,0 +1,161 @@
+"""SM120 (RTX PRO 6000 Blackwell) mHC decode policy: source-split selection and
+the prefill crossover, plus a bitwise check of the split decode kernel."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from b12x.norm import mhc
+from b12x.norm.mhc import _impl as mhc_impl
+from b12x.norm.mhc import _kernels as mhc_kernels
+
+from ..conftest import require_b12x as require_sm120
+from .test_mhc import _make_inputs, _make_mhc_binding, _mhc_pre_reference
+
+_HIDDEN = 4096
+
+
+@pytest.mark.parametrize(
+    ("tokens", "expected"),
+    [
+        (1, (0, 0)),
+        (8, (0, 0)),
+        (16, (0, 0)),
+        (31, (0, 0)),
+        (32, (4, 6)),
+        (64, (4, 6)),
+        (96, (4, 6)),
+        (128, (4, 6)),
+        (256, (4, 6)),
+    ],
+)
+def test_sm120_decode_split_policy(
+    monkeypatch: pytest.MonkeyPatch, tokens: int, expected: tuple[int, int]
+) -> None:
+    monkeypatch.delenv("B12X_MHC_DECODE_SPLITS", raising=False)
+    assert (
+        mhc_kernels._selected_post_pre_decode_split_n(
+            num_tokens=tokens, hidden_size=_HIDDEN, compute_capability=(12, 0)
+        )
+        == expected
+    )
+
+
+def test_sm120_decode_split_policy_requires_hidden_4096(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("B12X_MHC_DECODE_SPLITS", raising=False)
+    assert mhc_kernels._selected_post_pre_decode_split_n(
+        num_tokens=64, hidden_size=7168, compute_capability=(12, 0)
+    ) == (0, 0)
+
+
+def test_other_architectures_keep_their_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("B12X_MHC_DECODE_SPLITS", raising=False)
+    select = mhc_kernels._selected_post_pre_decode_split_n
+    assert select(num_tokens=8, hidden_size=_HIDDEN, compute_capability=(12, 1)) == (
+        4,
+        6,
+    )
+    assert select(num_tokens=10, hidden_size=_HIDDEN, compute_capability=(12, 1)) == (
+        8,
+        6,
+    )
+    assert select(num_tokens=7, hidden_size=_HIDDEN, compute_capability=(12, 1)) == (
+        0,
+        0,
+    )
+    assert select(num_tokens=64, hidden_size=_HIDDEN, compute_capability=(10, 0)) == (
+        0,
+        0,
+    )
+    assert select(num_tokens=64, hidden_size=_HIDDEN, compute_capability=(9, 0)) == (
+        0,
+        0,
+    )
+
+
+def test_explicit_split_override_wins_on_sm120(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("B12X_MHC_DECODE_SPLITS", "8")
+    monkeypatch.setenv("B12X_MHC_DECODE_TILE_N", "6")
+    assert mhc_kernels._selected_post_pre_decode_split_n(
+        num_tokens=8, hidden_size=_HIDDEN, compute_capability=(12, 0)
+    ) == (8, 6)
+    monkeypatch.setenv("B12X_MHC_DECODE_SPLITS", "0")
+    assert mhc_kernels._selected_post_pre_decode_split_n(
+        num_tokens=128, hidden_size=_HIDDEN, compute_capability=(12, 0)
+    ) == (0, 0)
+
+
+def test_prefill_crossover_default_moves_to_192_rows_on_sm120() -> None:
+    assert mhc_impl._mhc_prefill_min_tokens_for_capability((12, 0)) == 192
+    assert mhc_impl._mhc_prefill_min_tokens_for_capability((12, 1)) == 96
+    assert mhc_impl._mhc_prefill_min_tokens_for_capability((10, 0)) == 96
+    assert mhc_impl._mhc_prefill_min_tokens_for_capability(None) == 96
+    assert mhc_impl._default_mhc_prefill_min_tokens(torch.device("cpu")) == 96
+
+
+@pytest.mark.parametrize("tokens", [32, 64, 128])
+def test_sm120_split_decode_kernel_matches_unsplit_within_rounding(
+    monkeypatch: pytest.MonkeyPatch, tokens: int
+) -> None:
+    """The split kernel reduces the fn partials over four source splits in
+    the finalize, so gate/mix values may differ from the unsplit kernel by
+    fp32 rounding and y by one bf16 ulp; the residual update does not depend
+    on that reduction and must be bitwise identical."""
+    device = require_sm120()
+    if tuple(torch.cuda.get_device_capability(device)) != (12, 0):
+        pytest.skip("SM120 decode policy test")
+    monkeypatch.delenv("B12X_MHC_DECODE_SPLITS", raising=False)
+    assert mhc_kernels._selected_post_pre_decode_split_n(
+        num_tokens=tokens, hidden_size=_HIDDEN
+    ) == (4, 6)
+    residual, x, fn, scale, bias = _make_inputs(
+        tokens=tokens, hidden_size=_HIDDEN, seed=4_242 + tokens, device=device
+    )
+    _, prev_post, prev_comb = _mhc_pre_reference(
+        residual, fn, scale, bias, rms_eps=1e-6, hc_eps=1e-6, sinkhorn_iters=20
+    )
+    prev_post = prev_post.contiguous()
+    prev_comb = prev_comb.contiguous()
+
+    def run(splits_override: str | None) -> tuple[torch.Tensor, ...]:
+        if splits_override is None:
+            monkeypatch.delenv("B12X_MHC_DECODE_SPLITS", raising=False)
+        else:
+            monkeypatch.setenv("B12X_MHC_DECODE_SPLITS", splits_override)
+        binding = _make_mhc_binding(tokens=tokens, hidden_size=_HIDDEN, device=device)
+        mhc.run_post_pre(
+            x,
+            residual,
+            prev_post,
+            prev_comb,
+            fn,
+            scale,
+            bias,
+            rms_eps=1e-6,
+            hc_eps=1e-6,
+            sinkhorn_iters=20,
+            binding=binding,
+        )
+        torch.cuda.synchronize(device)
+        return (
+            binding.y.clone(),
+            binding.post_buffer.clone(),
+            binding.comb_buffer.clone(),
+            binding.out.clone(),
+        )
+
+    y_s, post_s, comb_s, out_s = run(None)
+    y_u, post_u, comb_u, out_u = run("0")
+    assert torch.equal(out_s, out_u), "residual update must not depend on the split"
+    assert torch.equal(y_s, run(None)[0]), "split kernel must be deterministic"
+    torch.testing.assert_close(y_s.float(), y_u.float(), rtol=2**-7, atol=2**-14)
+    torch.testing.assert_close(post_s, post_u, rtol=2**-20, atol=2**-22)
+    torch.testing.assert_close(comb_s, comb_u, rtol=2**-20, atol=2**-22)
+    assert torch.isfinite(y_s.float()).all()


### PR DESCRIPTION
## Purpose

Select the faster mHC decode schedule for RTX PRO 6000 Blackwell (SM120) on GLM-5.3 (hidden size 4096): the four-way source split of the post/pre partial kernel from 32 padded rows up, and a prefill crossover of 192 rows instead of 96, both measured on the GLM-5.3 TP4 decode graphs. This is the policy the R22 serving stack has run since 2026-09-01; it is filed so the maintainer can weigh it with the numerics note below.

## Behavior

- `_selected_post_pre_decode_split_n` returns the (4, 6) split for SM120 decode graphs with at least 32 rows and the unsplit kernel below; the GB10 (12, 1) policy and the `B12X_MHC_DECODE_SPLITS` / `B12X_MHC_DECODE_TILE_N` overrides are unchanged.
- The default `B12X_MHC_PREFILL_MIN_TOKENS` becomes 192 on SM120 (96 elsewhere); the environment override still wins. The value is resolved once per device and cached, so it is graph-capture safe.
- Nothing changes for other architectures or hidden sizes.

## Numerics (read this first)

The residual update (`out`) is bitwise identical to the unsplit kernel. The 25 fn partials and 10 Gram pairs are reduced over four source splits in the finalize, so the gate/mix values (`post`, `comb`) differ from the unsplit kernel by fp32 rounding (1 to 2 ulp measured at 32/64/128 rows) and `y` by at most one bf16 ulp. The new test pins that contract (`out` equal, `y` within one bf16 ulp, `post`/`comb` within a few fp32 ulp, deterministic). This is a summation-order change, not a precision loss, but it is not bit-exact; the C30 greedy gates of the serving stack use 240-row graphs, which take the prefill kernels, so they do not exercise the 32 to 191-row window this policy applies to (concurrency 4 to 23 at eight tokens per request).

## Compatibility

Merge simulation against #269, #270 and #279 (which touch the same files) completes without conflicts. No profile archives change.

## Validation

Tests inside the GLM-5.3 serving image on one RTX PRO 6000 Blackwell:

```text
python -m pytest tests/norm/test_mhc_sm120_decode_policy.py
16 passed
```

Policy selection for SM120, GB10 and other capabilities, the hidden-size guard, the override precedence, the crossover default, and the split-vs-unsplit contract at 32, 64 and 128 rows. The pre-existing `tests/norm/test_mhc.py` reference-tolerance failures at 3 and 8 rows and its graph-capture case fail identically on unmodified `master` and on the shipped image in this environment; this change does not alter them.

Kernel time, decode post/pre partial + finalize pair, unsplit vs split-4 (microseconds, same inputs): 32 rows 20.2 vs 16.4, 48 rows 28.1 vs 22.6, 64 rows 35.1 vs 26.7, 96 rows 43.0 vs 33.3, 128 rows 44.8 vs 41.0. Against the block-M prefill kernel: 96 rows 33.6 vs 43.0, 128 rows 41 vs 45, 192 rows 57 vs 47.1 (hence the crossover at 192).

Serving (GLM-5.3-Flash NVFP4 target, MXFP8 DFlash2 K7 draft, TP4, llm_decode_bench ctx0 30-second cells): the C12 step's mHC time fell from 61 us x 86 calls to 26 us x 86 calls (about 3 ms of a 42 ms step). Measured together with the exact 96/192 CUDA-graph sizes (`--cudagraph-capture-sizes 8 16 32 64 96 128 192 256`, a compose-level change worth another 4 ms per C12 step because padded rows no longer route to experts) and the bf16 two-shot all-reduce (#283): C8 617 to 659 tok/s (+7.2% verifier steps/s), C12 638 to 801 tok/s (+20.8%), C24 967 to 1108 tok/s (+15.2%), C1 and C32 unchanged (their graphs are outside the window).

Generated with Claude Code; the submitter reviewed the change and ran the validation on the listed hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resulting behavior

- On SM120, GLM-5.3 mHC decode with hidden size 4096 uses source split `(4, 6)` when the padded row count is at least 32.
- On SM120, prefill begins at 192 padded rows instead of 96.
- Other architectures and hidden sizes retain existing policies.
- Environment-variable overrides retain precedence.
- The prefill crossover value is cached per device for graph-capture safety.

## Compatibility and numerical impact

- The residual update remains bitwise identical.
- Reduction-order changes can alter `post` and `comb` by a few fp32 ulp.
- `y` can differ by at most one bf16 ulp.
- GB10 behavior remains unchanged.

## Validation

- Sixteen policy tests pass on an RTX PRO 6000 Blackwell.
- CUDA integration tests verify deterministic split and unsplit decode results within the defined tolerances.
- Benchmarks show lower kernel times for the selected split and higher serving throughput at C8, C12, and C24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->