### PR TITLE
perf(moe): direct SQG-XOR-Cheb-T12 rate table in shared memory for W4A16 trellis decode

### DIFF
--- a/b12x/_lib/intrinsics.py
+++ b/b12x/_lib/intrinsics.py
@@ -7159,6 +7159,89 @@ def packed_decode_trellis_sqg_state_smem_to_e4m3x8(
 
 
 @dsl_user_op
+def packed_decode_trellis_sqg_direct_lut_smem_to_e4m3x8(
+    win_a,
+    win_b,
+    direct_lut_smem_addr,
+    bits: int = 3,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Decode eight L16 windows through a direct E4M3 table in shared memory.
+
+    Shared-memory form of ``packed_decode_trellis_sqg_direct_lut_to_e4m3x8``:
+    the caller stages the 64 KiB rate slice of the direct table
+    (``byte(state) = table[state]``, the frozen XOR-Cheb rank map composed
+    with the modal T12 staircase, so lookups are bit-identical to the T12
+    decode) at a 32-bit shared byte offset. Per weight: one ``bfe``, one
+    ``add``, one ``ld.shared.u8`` and the pack, versus the twelve-instruction
+    bijection the T12 path evaluates before its lookup.
+    """
+    bits = int(bits)
+    if bits not in (2, 3, 4):
+        raise ValueError(
+            f"unsupported SQG-normal trellis bitrate {bits}; expected 2, 3, or 4"
+        )
+    extract_lines: list[str] = []
+    load_lines: list[str] = []
+    pack_lines: list[str] = []
+    for index in range(8):
+        source = "$3" if index < 4 else "$2"
+        shift = (3 - (index & 3)) * bits
+        target = "out0" if index < 4 else "out1"
+        byte_shift = 8 * (index & 3)
+        if shift:
+            extract_lines.append(f"bfe.u32 w{index}, {source}, {shift}, 16;")
+        else:
+            extract_lines.append(f"and.b32 w{index}, {source}, 0xffff;")
+        load_lines.append(
+            f"""
+                add.u32 addr{index}, w{index}, $4;
+                ld.shared.u8 w{index}, [addr{index}];
+            """
+        )
+        if byte_shift:
+            pack_lines.append(f"shl.b32 w{index}, w{index}, {byte_shift};")
+        pack_lines.append(f"or.b32 {target}, {target}, w{index};")
+    asm = (
+        """
+        {
+            .reg .b32 out0,out1;
+            .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7;
+            .reg .b32 addr0,addr1,addr2,addr3,addr4,addr5,addr6,addr7;
+            mov.b32 out0, 0;
+            mov.b32 out1, 0;
+    """
+        + "\n".join(extract_lines)
+        + "\n".join(load_lines)
+        + "\n".join(pack_lines)
+        + """
+            mov.b32 $0, out0;
+            mov.b32 $1, out1;
+        }"""
+    )
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [
+            Uint32(win_a).ir_value(loc=loc, ip=ip),
+            Uint32(win_b).ir_value(loc=loc, ip=ip),
+            Int32(direct_lut_smem_addr).ir_value(loc=loc, ip=ip),
+        ],
+        asm,
+        "=r,=r,r,r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
+    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
+    return Uint32(lo), Uint32(hi)
+
+
+@dsl_user_op
 def packed_decode_trellis_sqg_direct_lut_to_e4m3x8(
     win_a,
     win_b,

--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, replace
 from functools import partial
@@ -63,6 +64,7 @@ from b12x._lib.intrinsics import (
     packed_decode_sqg_fp16_d3l_to_bfloat2x4,
     packed_decode_sqg_fp16_d3l_to_half2x4,
     packed_decode_sqg_xor_cheb_t12_to_e4m3x8,
+    packed_decode_trellis_sqg_direct_lut_smem_to_e4m3x8,
     ld_global_nc_v4_u32,
     pack_f32x2_to_bfloat2,
     pack_f32x2_to_f16x2,
@@ -84,7 +86,10 @@ from b12x._lib.intrinsics import (
     trellis_align_stream_u32x2,
     warp_reduce,
 )
-from b12x._lib.quant.sqg_e4m3 import sqg_xor_cheb_t12_lut
+from b12x._lib.quant.sqg_e4m3 import (
+    sqg_xor_cheb_t12_direct_lut,
+    sqg_xor_cheb_t12_lut,
+)
 from b12x.moe._shared.kernels.trellis_ring import (
     trellis256_lane_geom_bits as _trellis_ring_lane_geom_bits,
 )
@@ -157,6 +162,49 @@ def _w4a16_small_m_splitk_enabled() -> bool:
     return os.environ.get("B12X_W4A16_SMALL_M_SPLITK", "0") == "1"
 
 
+logger = logging.getLogger(__name__)
+
+# Direct-table fallbacks already reported, keyed by (bits, route block rows,
+# pipeline bytes, device limit): the fallback costs throughput on the launch
+# it affects, so it is logged once per distinct kernel footprint rather than
+# once per layer.
+_SQG_XOR_CHEB_T12_DIRECT_SMEM_FALLBACKS_REPORTED: set[tuple[int, int, int, int]] = set()
+
+
+def _report_sqg_xor_cheb_t12_direct_smem_fallback(
+    bits: int, moe_block_size: int, pipeline_bytes: int, max_shared_mem: int
+) -> None:
+    key = (int(bits), int(moe_block_size), int(pipeline_bytes), int(max_shared_mem))
+    if key in _SQG_XOR_CHEB_T12_DIRECT_SMEM_FALLBACKS_REPORTED:
+        return
+    _SQG_XOR_CHEB_T12_DIRECT_SMEM_FALLBACKS_REPORTED.add(key)
+    logger.warning(
+        "B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM=1 requested but the 64 KiB direct "
+        "table does not fit: %d-bit trellis pipeline at %d route rows per "
+        "block uses %d bytes of shared memory, table needs %d more, device "
+        "limit %d; this launch keeps the 4 KiB modal table (bit-identical)",
+        key[0],
+        key[1],
+        key[2],
+        _SQG_XOR_CHEB_T12_DIRECT_SMEM_REGION_BYTES,
+        key[3],
+    )
+
+
+def _sqg_xor_cheb_t12_direct_smem_enabled() -> bool:
+    """Stage the 64 KiB direct (precomposed) SQG-XOR-Cheb-T12 rate table.
+
+    The direct table maps a raw 16-bit trellis window straight to its E4M3
+    byte, so the decode drops the twelve-instruction rank bijection and pays
+    one shared byte load per weight. It costs 64 KiB of shared memory per
+    CTA (one CTA per SM at the 99 KiB opt-in limit) and applies to
+    uniform-rate layers only; pair-rate kernels keep the modal table.
+    Off by default; participates in the kernel cache key.
+    """
+
+    return os.environ.get("B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM", "0") == "1"
+
+
 def _sqg_xor_cheb_t12_smem_enabled() -> bool:
     """Stage the 4 KiB SQG-XOR-Cheb-T12 staircase once per fused CTA.
 
@@ -180,6 +228,7 @@ _TRELLIS256_BITS = (2, 3, 4, 5, 6)
 _TRELLIS256_CODEBOOKS = {MCG, SQG_E4M3, SQG_FP16}
 _SQG_XOR_CHEB_T12_LUT_ENTRIES = 1 << 12
 _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES = _SQG_XOR_CHEB_T12_LUT_ENTRIES
+_SQG_XOR_CHEB_T12_DIRECT_SMEM_REGION_BYTES = 1 << 16
 _SCALE_FORMATS = {
     "e4m3_k16": "e4m3_k16",
     "e8m0_k32": "e8m0_k32",
@@ -692,6 +741,9 @@ class W4A16FusedMoeCompileResult:
     full_rotation: bool = False
     coupled_hadamard: bool = False
     rotation_input_dtype: str = "fp16"
+    # The kernel staged the 64 KiB direct rate table instead of the 4 KiB
+    # modal table; the launch must pass the matching rate slice.
+    sqg_xor_cheb_t12_direct_smem: bool = False
     cta_threads: int = -1
     shared_memory_bytes: int = -1
 
@@ -1012,6 +1064,7 @@ class W4A16GemmKernel:
             static_pair_rates.get(trellis_pair_kind, (3, 3))
         )
         self.sqg_xor_cheb_t12_smem = False
+        self.sqg_xor_cheb_t12_direct_smem = False
         # Small-M stripe split-K: opt out of the one-tile-per-CTA fast path
         # so decode-heavy small-M phases spread each mn-tile's K range across
         # multiple CTAs (existing tail scheduling plus cross-CTA finalize).
@@ -1117,6 +1170,7 @@ class W4A16GemmKernel:
         else:
             self.sms = 120
             max_shared_mem = _DEFAULT_MAX_SHARED_MEM
+        self.max_shared_mem = int(max_shared_mem)
         self.blocks_per_sm = _determine_blocks_per_sm(
             problem_m=self.size_m,
             problem_n=self.covered_size_n,
@@ -3562,6 +3616,19 @@ class W4A16GemmKernel:
                 o0, o1, o2, o3 = packed_decode_sqg_fp16_d3l_to_bfloat2x4(
                     win_a, win_b, trellis_lut_addr, int(bits)
                 )
+        elif cutlass.const_expr(self.sqg_xor_cheb_t12_direct_smem):
+            e_lo, e_hi = packed_decode_trellis_sqg_direct_lut_smem_to_e4m3x8(
+                win_a,
+                win_b,
+                Int32(trellis_lut_addr),
+                int(bits),
+            )
+            if cutlass.const_expr(self.is_fp16):
+                o0, o1 = fp8x4_e4m3_to_half2x2(e_lo)
+                o2, o3 = fp8x4_e4m3_to_half2x2(e_hi)
+            else:
+                o0, o1 = fp8x4_e4m3_to_bfloat2x2_native_sm120(e_lo)
+                o2, o3 = fp8x4_e4m3_to_bfloat2x2_native_sm120(e_hi)
         else:
             e_lo, e_hi = packed_decode_sqg_xor_cheb_t12_to_e4m3x8(
                 win_a,
@@ -5599,6 +5666,7 @@ class W4A16FusedMoeKernel:
         coupled_hadamard: bool = False,
         rotation_input_dtype: str = "fp16",
         broadcast_suh: bool = False,
+        sqg_xor_cheb_t12_direct_smem: bool | None = None,
     ):
         activation = normalize_moe_activation(activation)
         is_gated = validate_activation(activation)
@@ -5884,17 +5952,66 @@ class W4A16FusedMoeKernel:
             self.trellis_codebook == SQG_E4M3
             and _sqg_xor_cheb_t12_smem_enabled()
         )
+        # Direct table: uniform-rate trellis_t256 layers only (the staged
+        # slice is one rate); requires the modal staging path to be on. ``None`` reads
+        # the environment switch; kernels that are composed into a launch which
+        # stages its own table (the mixed-rate tiers) pass ``False`` because
+        # their host side never stages the direct slice.
+        self.sqg_xor_cheb_t12_direct_smem = (
+            self.sqg_xor_cheb_t12_smem
+            and (
+                _sqg_xor_cheb_t12_direct_smem_enabled()
+                if sqg_xor_cheb_t12_direct_smem is None
+                else bool(sqg_xor_cheb_t12_direct_smem)
+            )
+            and self.weight_layout == "trellis_t256"
+            and self.fc1.trellis_pair_kind is None
+            and self.fc2.trellis_pair_kind is None
+            and int(self.fc1.trellis_bits) == int(self.fc2.trellis_bits)
+            and int(self.fc1.trellis_bits) in (2, 3, 4)
+            # The grid is sized before the table is added: two CTAs per SM
+            # cannot both hold a 64 KiB table, so only the one-CTA-per-SM
+            # (decode) grid stages it.
+            and int(self.blocks_per_sm) == 1
+        )
         self.sqg_xor_cheb_t12_smem_off = 0
         if self.sqg_xor_cheb_t12_smem:
-            self.sqg_xor_cheb_t12_smem_off = (
-                self.shared_words * 4 + 15
-            ) // 16 * 16
+            self.sqg_xor_cheb_t12_smem_off = (self.shared_words * 4 + 15) // 16 * 16
+            # The direct table only fits next to the small-M pipeline footprint;
+            # launches whose working set leaves no room (large-M prefill tiles)
+            # keep the 4 KiB modal table. Both decode paths are bit-identical.
+            if (
+                self.sqg_xor_cheb_t12_direct_smem
+                and self.sqg_xor_cheb_t12_smem_off
+                + _SQG_XOR_CHEB_T12_DIRECT_SMEM_REGION_BYTES
+                > int(self.fc1.max_shared_mem)
+            ):
+                self.sqg_xor_cheb_t12_direct_smem = False
+                _report_sqg_xor_cheb_t12_direct_smem_fallback(
+                    int(self.fc1.trellis_bits),
+                    int(self.moe_block_size),
+                    self.sqg_xor_cheb_t12_smem_off,
+                    int(self.fc1.max_shared_mem),
+                )
+        self.sqg_xor_cheb_t12_smem_region_bytes = (
+            _SQG_XOR_CHEB_T12_DIRECT_SMEM_REGION_BYTES
+            if self.sqg_xor_cheb_t12_direct_smem
+            else _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES
+        )
+        if self.sqg_xor_cheb_t12_smem:
             self.shared_words = (
-                self.sqg_xor_cheb_t12_smem_off
-                + _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES
+                self.sqg_xor_cheb_t12_smem_off + self.sqg_xor_cheb_t12_smem_region_bytes
             ) // 4
+            if self.shared_words * 4 > int(self.fc1.max_shared_mem):
+                raise ValueError(
+                    "fused W4A16 trellis kernel shared memory "
+                    f"{self.shared_words * 4} > {int(self.fc1.max_shared_mem)} bytes "
+                    "with the staged SQG-XOR-Cheb-T12 table"
+                )
             self.fc1.sqg_xor_cheb_t12_smem = True
             self.fc2.sqg_xor_cheb_t12_smem = True
+            self.fc1.sqg_xor_cheb_t12_direct_smem = self.sqg_xor_cheb_t12_direct_smem
+            self.fc2.sqg_xor_cheb_t12_direct_smem = self.sqg_xor_cheb_t12_direct_smem
         self.barrier_count_off = self.sms * 4
         self.barrier_sense_off = self.sms * 4 + 1
 
@@ -5936,6 +6053,7 @@ class W4A16FusedMoeKernel:
             self.broadcast_suh,
             self.rotation_input_dtype,
             self.sqg_xor_cheb_t12_smem,
+            self.sqg_xor_cheb_t12_direct_smem,
             self.small_m_splitk,
             self.fc1.__cache_key__,
             self.fc2.__cache_key__,
@@ -6311,7 +6429,7 @@ class W4A16FusedMoeKernel:
             self._sqg_smem_copy(
                 fc1_trellis_lut_addr,
                 smem_base + Int32(self.sqg_xor_cheb_t12_smem_off),
-                _SQG_XOR_CHEB_T12_SMEM_REGION_BYTES,
+                self.sqg_xor_cheb_t12_smem_region_bytes,
                 tid,
             )
             cute.arch.sync_threads()
@@ -9566,6 +9684,9 @@ def compile_w4a16_fused_moe(
         dual_a=kernel.dual_a,
         trellis_bits=trellis_bits,
         trellis_codebook=kernel.trellis_codebook,
+        sqg_xor_cheb_t12_direct_smem=bool(
+            getattr(kernel, "sqg_xor_cheb_t12_direct_smem", False)
+        ),
         fc1_trellis_pair_kind=kernel.fc1_trellis_pair_kind,
         fc2_trellis_pair_kind=kernel.fc2_trellis_pair_kind,
         full_rotation=full_rotation,
@@ -10255,9 +10376,19 @@ def _w4a16_fused_moe_launch_flat(
     )
     route_num_experts = 0 if expert_map is None else int(expert_map.numel())
     if weight_layout == "trellis_t256" and trellis_codebook != "mcg":
-        trellis_rank_lut = _trellis256_execution_lut(
-            a_input.device, trellis_codebook
-        )
+        if fused.sqg_xor_cheb_t12_direct_smem:
+            # The kernel stages the 64 KiB rate slice of the precomposed
+            # direct table (byte(state, bits) = table[((bits-2) << 16) | state]).
+            direct_bits = int(fused.trellis_bits)
+            trellis_rank_lut = sqg_xor_cheb_t12_direct_lut(a_input.device)[
+                (direct_bits - 2) << 16 : (direct_bits - 1) << 16
+            ]
+            if not trellis_rank_lut.is_contiguous():
+                trellis_rank_lut = trellis_rank_lut.contiguous()
+        else:
+            trellis_rank_lut = _trellis256_execution_lut(
+                a_input.device, trellis_codebook
+            )
         fc1_trellis_lut_addr = trellis_rank_lut.data_ptr()
         fc2_trellis_lut_addr = trellis_rank_lut.data_ptr()
     else:

--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -176,6 +176,22 @@ class MixedTrellisTier(Protocol):
     w2_global_scale: torch.Tensor
 
 
+def _require_modal_t12_table(*kernels: W4A16FusedMoeKernel) -> None:
+    """Mixed-rate launches stage the 4 KiB modal SQG-XOR-Cheb-T12 table only.
+
+    The fused kernel can decode from a 64 KiB single-rate direct table
+    instead; a tier compiled that way would read the modal bytes as the
+    direct table and produce wrong weights, so composition refuses it.
+    """
+    for kernel in kernels:
+        if getattr(kernel, "sqg_xor_cheb_t12_direct_smem", False):
+            raise ValueError(
+                "mixed Trellis tiers must be compiled with "
+                "sqg_xor_cheb_t12_direct_smem=False; the mixed kernel stages "
+                "the modal table only"
+            )
+
+
 class W4A16MixedTrellisKernel:
     """One cooperative grid over two native Trellis bitrates."""
 
@@ -268,6 +284,7 @@ class W4A16MixedTrellisKernel:
             tier0.sqg_xor_cheb_t12_smem_off,
             tier1.sqg_xor_cheb_t12_smem_off,
         )
+        _require_modal_t12_table(driver, tier0, tier1)
 
     @property
     def __cache_key__(self) -> tuple[object, ...]:
@@ -1021,6 +1038,7 @@ class W4A16MixedTrellis3Kernel(W4A16MixedTrellisKernel):
         self.sqg_xor_cheb_t12_smem_off = max(
             tier.sqg_xor_cheb_t12_smem_off for tier in kernels
         )
+        _require_modal_t12_table(*kernels)
 
     @property
     def __cache_key__(self) -> tuple[object, ...]:
@@ -1798,6 +1816,10 @@ def compile_mixed_trellis(
             rotation_input_dtype=rotation_input_dtype,
             broadcast_suh=broadcast_suh,
             schedule_whole_tiles=True,
+            # The mixed kernel stages one 4 KiB modal table shared by every
+            # rate; the 64 KiB direct table is a single-rate slice and is
+            # never staged here, so the tiers must keep the modal decode.
+            sqg_xor_cheb_t12_direct_smem=False,
         )
 
     kernel = W4A16MixedTrellisKernel(
@@ -2060,6 +2082,10 @@ def compile_mixed_trellis3(
             rotation_input_dtype=rotation_input_dtype,
             broadcast_suh=broadcast_suh,
             schedule_whole_tiles=True,
+            # The mixed kernel stages one 4 KiB modal table shared by every
+            # rate; the 64 KiB direct table is a single-rate slice and is
+            # never staged here, so the tiers must keep the modal decode.
+            sqg_xor_cheb_t12_direct_smem=False,
         )
 
     kernel = W4A16MixedTrellis3Kernel(

--- a/tests/moe/test_w4a16_direct_table_smem.py
+++ b/tests/moe/test_w4a16_direct_table_smem.py
@@ -1,0 +1,282 @@
+"""The staged direct SQG-XOR-Cheb-T12 table decodes bit-identically.
+
+``B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM=1`` makes the fused W4A16 trellis kernel
+stage the 64 KiB precomposed rate table (raw 16-bit window -> E4M3 byte)
+instead of the 4 KiB modal staircase and skip the per-weight rank bijection.
+Both decode paths produce the same bytes, so the fused kernel output must
+match bit for bit across the flag for every supported uniform bitrate and
+decode batch size, eagerly and under CUDA-graph capture. The flag is part of
+the kernel cache key, so both variants coexist in one process.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from b12x.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
+from b12x.moe._shared.kernels.w4a16.host import make_w4a16_packed_buffers
+from b12x.moe._shared.kernels.w4a16.kernel import (
+    W4A16FusedMoeKernel,
+    compile_w4a16_fused_moe,
+    run_w4a16_moe,
+)
+from b12x.moe._shared.kernels.w4a16.mixed_trellis import (
+    W4A16MixedTrellisKernel,
+    compile_mixed_trellis,
+)
+from b12x.moe._shared.kernels.w4a16.prepare import prepare_trellis256_moe_weights
+
+TILE = (128, 128, 128, 128)
+FLAG = "B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM"
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _minor = torch.cuda.get_device_capability()
+    return major == 12
+
+
+def _prepared(*, experts: int, hidden: int, intermediate: int, bits: int, seed: int,
+              device: torch.device):
+    generator = torch.Generator(device=device).manual_seed(seed)
+
+    def scales(shape: tuple[int, ...]) -> torch.Tensor:
+        return (0.875 + 0.25 * torch.rand(shape, generator=generator, device=device)).to(
+            torch.float16
+        )
+
+    return prepare_trellis256_moe_weights(
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        num_experts=experts,
+        activation="silu",
+        fc1_tile_n=TILE[1],
+        fc2_tile_n=TILE[3],
+        device=device,
+        seed=seed,
+        params_dtype=torch.float16,
+        w13_layout="trellis_t256_proj",
+        trellis_bits=bits,
+        codebook="sqg_e4m3",
+        gate_suh=scales((experts, hidden)),
+        up_suh=scales((experts, hidden)),
+        intermediate_rotations=scales((experts, 3 * intermediate)),
+        down_svh=scales((experts, hidden)),
+        tile_config=TILE,
+    )
+
+
+def _run(x: torch.Tensor, prepared, topk_weights: torch.Tensor, topk_ids: torch.Tensor,
+         expert_map: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    m, topk = int(topk_ids.shape[0]), int(topk_ids.shape[1])
+    buffers = make_w4a16_packed_buffers(
+        prepared, m=m, topk=topk, dtype=torch.float16, device=x.device,
+        route_num_experts=int(expert_map.numel()), full_rotation=True, block_size_m=8,
+    )
+
+    def launch() -> torch.Tensor:
+        return run_w4a16_moe(
+            x, prepared, topk_weights, topk_ids, activation="silu",
+            intermediate_cache13=buffers.intermediate_cache13,
+            intermediate_cache2=buffers.intermediate_cache2,
+            output=buffers.output,
+            fc1_c_tmp=buffers.fc1_c_tmp,
+            fc2_c_tmp=buffers.fc2_c_tmp,
+            packed_route_indices=buffers.packed_route_indices,
+            block_expert_ids=buffers.block_expert_ids,
+            packed_route_count=buffers.packed_route_count,
+            expert_offsets=buffers.expert_offsets,
+            expert_counts=buffers.expert_counts,
+            expert_map=expert_map,
+            output_expert_map=expert_map,
+            route_block_size_m=8,
+            intermediate_rotation_scales=prepared.intermediate_rotations,
+            full_rotation=True,
+            suh_gate_table=prepared.gate_suh,
+            suh_up_table=prepared.up_suh,
+            svh_table=prepared.down_svh,
+            rotation_a_gate=buffers.rotation_a_gate,
+            rotation_a_up=buffers.rotation_a_up,
+        )
+
+    eager = launch().clone()
+    torch.cuda.synchronize(x.device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = launch()
+    graph.replay()
+    torch.cuda.synchronize(x.device)
+    return eager, captured.clone()
+
+
+def _compile_common(*, bits: int) -> dict:
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return dict(
+        size_m=8, hidden_size=128, intermediate_size=128, num_experts=16, top_k=16,
+        activation="silu", apply_router_weight_on_input=False, element_dtype="fp16",
+        fast_math=True, sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        weight_layout="trellis_t256", w13_layout="trellis_t256_proj", scale_format="e4m3_k32",
+        force_tile_config=TILE, trellis_bits=bits, trellis_codebook="sqg_e4m3",
+        zero_fc2_output=False, moe_block_size=8, max_m_blocks=8 * 16,
+        direct_topk_routes=True, use_expert_map=True, intermediate_rotation=True,
+        full_rotation=True,
+    )
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("m", [1, 4, 8])
+def test_direct_table_matches_modal_table_bitwise(
+    monkeypatch: pytest.MonkeyPatch, m: int
+) -> None:
+    """2-bit trellis pipelines leave room for the 64 KiB table next to the
+    GEMM stages; the direct decode must reproduce the modal decode exactly."""
+    bits = 2
+    device = torch.device("cuda", torch.cuda.current_device())
+    experts, topk, hidden, intermediate = 16, 16, 128, 128
+    prepared = _prepared(
+        experts=experts, hidden=hidden, intermediate=intermediate, bits=bits,
+        seed=20260902 + bits, device=device,
+    )
+    gen = torch.Generator(device="cpu").manual_seed(7 + m)
+    x = (torch.randn((m, hidden), generator=gen) * 1.0e-3).to(torch.bfloat16).to(device)
+    topk_ids = torch.stack(
+        [torch.randperm(experts, generator=gen)[:topk] for _ in range(m)]
+    ).to(torch.int32).to(device)
+    topk_weights = torch.rand((m, topk), generator=gen).to(device)
+    topk_weights /= topk_weights.sum(dim=1, keepdim=True)
+    expert_map = torch.arange(experts, dtype=torch.int32, device=device)
+
+    monkeypatch.setenv(FLAG, "0")
+    assert not w4a16_kernel._sqg_xor_cheb_t12_direct_smem_enabled()
+    modal_eager, modal_graph = _run(x, prepared, topk_weights, topk_ids, expert_map)
+
+    monkeypatch.setenv(FLAG, "1")
+    assert w4a16_kernel._sqg_xor_cheb_t12_direct_smem_enabled()
+    assert compile_w4a16_fused_moe(**_compile_common(bits=bits)).sqg_xor_cheb_t12_direct_smem
+    direct_eager, direct_graph = _run(x, prepared, topk_weights, topk_ids, expert_map)
+
+    assert torch.isfinite(modal_eager).all()
+    assert torch.equal(modal_eager, direct_eager)
+    assert torch.equal(modal_graph, direct_graph)
+    assert torch.equal(modal_eager, modal_graph)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_direct_table_is_part_of_the_compiled_launch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Compiling with the flag on yields a launch that staged the 64 KiB table
+    (and needs the matching rate slice); compiling with it off does not."""
+    staged = {}
+    for flag in ("0", "1"):
+        monkeypatch.setenv(FLAG, flag)
+        launch = compile_w4a16_fused_moe(**_compile_common(bits=2))
+        staged[flag] = bool(launch.sqg_xor_cheb_t12_direct_smem)
+    assert staged == {"0": False, "1": True}
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("bits", [3, 4])
+def test_direct_table_falls_back_to_modal_when_pipeline_leaves_no_room(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, bits: int
+) -> None:
+    """3- and 4-bit pipelines hold wider weight stages; with the 128x128 tile
+    the 64 KiB table exceeds the 99 KiB opt-in limit, so the launch keeps the
+    modal table and reports the fallback once."""
+    monkeypatch.setenv(FLAG, "1")
+    w4a16_kernel._SQG_XOR_CHEB_T12_DIRECT_SMEM_FALLBACKS_REPORTED.clear()
+    with caplog.at_level("WARNING", logger=w4a16_kernel.__name__):
+        launch = compile_w4a16_fused_moe(**_compile_common(bits=bits))
+    assert not launch.sqg_xor_cheb_t12_direct_smem
+    assert launch.shared_memory_bytes < 1 << 16
+    fallbacks = [r for r in caplog.records if "direct table does not fit" in r.getMessage()]
+    assert len(fallbacks) == 1
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_direct_table_skips_multi_cta_grids(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The grid is sized before the table is added; a two-CTA-per-SM prefill
+    grid cannot hold two 64 KiB tables, so those launches keep the modal
+    table without a fallback report (the table targets the decode grid)."""
+    monkeypatch.setenv(FLAG, "1")
+    w4a16_kernel._SQG_XOR_CHEB_T12_DIRECT_SMEM_FALLBACKS_REPORTED.clear()
+    common = _compile_common(bits=2)
+    # 64-wide N tiles at 16 route rows per block fit two CTAs per SM
+    common.update(size_m=512, moe_block_size=16, max_m_blocks=512 * 16 // 16,
+                  force_tile_config=(128, 64, 128, 64),
+                  direct_topk_routes=False, use_expert_map=False)
+    with caplog.at_level("WARNING", logger=w4a16_kernel.__name__):
+        launch = compile_w4a16_fused_moe(**common)
+    assert launch.blocks_per_sm > 1
+    assert not launch.sqg_xor_cheb_t12_direct_smem
+    assert not [r for r in caplog.records if "direct table does not fit" in r.getMessage()]
+
+
+def _uniform_rate_tier(*, bits: int, direct: bool, num_experts: int) -> W4A16FusedMoeKernel:
+    """A tier-shaped fused kernel (the argument set ``compile_mixed_trellis``
+    builds its driver and tiers from), with the direct table forced on or off."""
+    return W4A16FusedMoeKernel(
+        size_m=8, hidden_size=128, intermediate_size=128, num_experts=num_experts,
+        top_k=4, activation="silu", apply_router_weight_on_input=False,
+        zero_fc2_output=False,
+        fc1_tile_n=128, fc1_tile_k=128, fc2_tile_n=128, fc2_tile_k=128,
+        moe_block_size=8, max_m_blocks=8, fc2_moe_block_size=8,
+        fc2_schedule_route_block_factor=1, element_dtype="fp16",
+        weight_layout="trellis_t256", scale_format="e4m3_k32",
+        w13_layout="trellis_t256_proj", trellis_bits=bits,
+        trellis_codebook="sqg_e4m3", intermediate_rotation=True,
+        full_rotation=True, rotation_input_dtype="bf16", broadcast_suh=False,
+        schedule_whole_tiles=True,
+        sqg_xor_cheb_t12_direct_smem=direct,
+    )
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_mixed_rate_tiers_keep_the_modal_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The mixed-rate kernel stages one 4 KiB modal table for all of its
+    tiers, so its tiers are compiled with the direct table off even when the
+    environment switch is on: the launch compiles with the same shared-memory
+    footprint as with the switch off."""
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    footprint = {}
+    for flag in ("0", "1"):
+        monkeypatch.setenv(FLAG, flag)
+        launch = compile_mixed_trellis(
+            size_m=8, hidden_size=128, intermediate_size=128,
+            tier0_num_experts=2, tier1_num_experts=2, top_k=4, max_m_blocks=8,
+            sms=int(props.multi_processor_count),
+            max_shared_mem=int(props.shared_memory_per_block_optin),
+            force_tile_config=TILE, tier0_bits=2, tier1_bits=3,
+            trellis_codebook="sqg_e4m3",
+        )
+        footprint[flag] = int(launch.shared_memory_bytes)
+    assert footprint["0"] == footprint["1"]
+    assert footprint["1"] < 1 << 16
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+def test_mixed_rate_composition_rejects_direct_table_tiers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tier compiled for the direct table would read the modal bytes the
+    mixed kernel stages as if they were the 64 KiB rate slice, so composing
+    such a tier is refused up front."""
+    monkeypatch.setenv(FLAG, "1")
+    # driver (all experts, rate of tier 0), tier 0, tier 1; the 2-bit tier is
+    # the one whose pipeline leaves room for the direct table
+    modal = [
+        _uniform_rate_tier(bits=bits, direct=False, num_experts=experts)
+        for bits, experts in ((2, 4), (2, 2), (3, 2))
+    ]
+    assert not any(k.sqg_xor_cheb_t12_direct_smem for k in modal)
+    W4A16MixedTrellisKernel(driver=modal[0], tier0=modal[1], tier1=modal[2])
+
+    direct_tier = _uniform_rate_tier(bits=2, direct=True, num_experts=2)
+    assert direct_tier.sqg_xor_cheb_t12_direct_smem
+    with pytest.raises(ValueError, match="sqg_xor_cheb_t12_direct_smem=False"):
+        W4A16MixedTrellisKernel(driver=modal[0], tier0=modal[1], tier1=direct_tier)

--- a/tests/moe/test_w4a16_direct_table_smem.py
+++ b/tests/moe/test_w4a16_direct_table_smem.py
@@ -161,6 +161,7 @@ def test_direct_table_matches_modal_table_bitwise(
     direct_eager, direct_graph = _run(x, prepared, topk_weights, topk_ids, expert_map)
 
     assert torch.isfinite(modal_eager).all()
+    assert torch.count_nonzero(modal_eager).item() > 0
     assert torch.equal(modal_eager, direct_eager)
     assert torch.equal(modal_graph, direct_graph)
     assert torch.equal(modal_eager, modal_graph)
@@ -169,13 +170,21 @@ def test_direct_table_matches_modal_table_bitwise(
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
 def test_direct_table_is_part_of_the_compiled_launch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Compiling with the flag on yields a launch that staged the 64 KiB table
-    (and needs the matching rate slice); compiling with it off does not."""
+    (and needs the matching rate slice) and whose shared-memory footprint grew
+    by that table; compiling with it off does not."""
     staged = {}
     for flag in ("0", "1"):
         monkeypatch.setenv(FLAG, flag)
         launch = compile_w4a16_fused_moe(**_compile_common(bits=2))
-        staged[flag] = bool(launch.sqg_xor_cheb_t12_direct_smem)
-    assert staged == {"0": False, "1": True}
+        staged[flag] = (
+            bool(launch.sqg_xor_cheb_t12_direct_smem),
+            int(launch.shared_memory_bytes),
+        )
+    assert staged["0"][0] is False
+    assert staged["1"][0] is True
+    direct_table_bytes = 1 << 16
+    assert staged["1"][1] >= direct_table_bytes
+    assert staged["1"][1] - staged["0"][1] >= direct_table_bytes - 4096
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")


### PR DESCRIPTION
## Summary

The fused W4A16 trellis MoE kernel decodes every weight by ranking its 16-bit window with a twelve-instruction integer bijection and then reading the 4 KiB modal T12 staircase staged in shared memory. On the one-CTA-per-SM decode grid the kernel is instruction-bound (RTX PRO 6000 / GB202: 188 persistent CTAs, 255 registers, 0.5–0.7 TB/s of 1.8 TB/s HBM), so the bijection dominates its time.

This change adds an opt-in decode path that stages the 64 KiB rate slice of the precomposed direct table (`byte(state, bits) = table[((bits - 2) << 16) | state]`, `sqg_xor_cheb_t12_direct_lut`) in shared memory and decodes each weight with one `ld.shared.u8` through a new intrinsic, `packed_decode_trellis_sqg_direct_lut_smem_to_e4m3x8`. The bytes are the same as the modal path, so the kernel output is bit-identical.

`B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM=1` turns it on; off by default. The switch is part of the kernel cache key and is reported on the compile result (`sqg_xor_cheb_t12_direct_smem`), and launches pass the matching rate slice.

## Scope

- Uniform-rate `trellis_t256` kernels on a one-CTA-per-SM grid whose pipeline leaves 64 KiB under the per-block shared-memory limit. At 128x128 tiles that is the 2-bit pipeline: 34,944 B at route block 8 (100,480 B with the table under the 101,376 B SM120 limit) and 35,072 B at block 16.
- 3- and 4-bit pipelines (43,136 / 51,328 B) and wider route blocks (32: 51,712 B; 48: 68,352 B) keep the modal table and log one warning per footprint (`... direct table does not fit ...`).
- Multi-CTA grids keep the modal table (the grid is sized before the table is added; two CTAs cannot both hold 64 KiB).
- Pair-rate kernels keep the modal table.
- The mixed-rate kernels (`mixed_trellis.py`) stage the modal table only: their tiers are compiled with the new constructor argument `sqg_xor_cheb_t12_direct_smem=False`, and composing a direct-table tier is refused with a `ValueError`.

## Validation

RTX PRO 6000 (SM120), Kimi-K3 QSRT K2 coupled expert weights (`k2_coupled_h512_h128`, H=7168, I=384 per TP8 rank, 112 experts per rank, top-16):

| launch | modal (us) | direct (us) | output |
|---|---|---|---|
| decode, route block 8, m=8 (layers 1/50/92) | 145 | 99 (-32 %) | bit-identical, m=1/4/8 |
| decode, route block 8, m=4 | 99 | 68 | bit-identical |
| route block 16, m=256 | 1,941 | 1,296 | bit-identical |
| route block 16, m=1536 | 4,263 | 2,918 | bit-identical (m=256, 1536) |
| route block 48, m=1536 (does not fit) | 2,510 | 2,510 (fallback) | unchanged |

`tests/moe/test_w4a16_direct_table_smem.py` (9 tests, all pass with the switch on): bitwise equality against the modal path eagerly and under CUDA-graph capture at m=1/4/8; cache-key participation; 3/4-bit fallback with a single warning; multi-CTA grid skip; mixed-rate composition guard. W4A16 suites (`test_w4a16_{reference,mixed_trellis,packed_format,route_pack,tile_selection,e2e}.py`) with the switch on have the same failure set as without it.

The same change on the served production snapshot (46c84bab lineage) is branch `agent/kimi-k3-w4a16-direct-t12-table-20260902-served`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds an opt-in shared-memory decode path for uniform-rate W4A16 `trellis_t256` MoE kernels.

- `B12X_SQG_XOR_CHEB_T12_DIRECT_SMEM=1` stages a 64 KiB direct rate-table slice in shared memory.
- The new `packed_decode_trellis_sqg_direct_lut_smem_to_e4m3x8` intrinsic decodes weights with shared-byte lookups.
- The option is included in kernel cache keys and compile results.
- Launches pass the selected bitrate slice to the kernel.
- Multi-CTA, pair-rate, mixed-rate, unsupported-bitrate, and insufficient-shared-memory configurations use the existing modal table.
- Mixed-rate kernels reject direct-table tiers and compile their tiers with the modal table.
- The shared-memory path is compatible with eager and CUDA-graph execution.

The direct table reduces decode overhead by replacing modal-table decoding with direct lookups. Validation shows bit-identical output and improved RTX PRO 6000/SM120 performance, including 145 µs to 99 µs for route block 8 with `m=8`.

Nine SM120/SM121 tests cover eager and CUDA-graph correctness, cache keys, launch staging, fallback behavior, grid selection, and mixed-rate guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->