### PR TITLE
perf(gemm): quantize small-M MXFP8 linear activations inside the GEMM

### DIFF
--- a/b12x/gemm/blockscaled/_linear.py
+++ b/b12x/gemm/blockscaled/_linear.py
@@ -81,15 +81,32 @@ def _source_2d(source: torch.Tensor) -> torch.Tensor:
 _FUSED_QUANT_A_MAX_TOKENS = 8
 
 
+@functools.lru_cache(maxsize=1)
 def _fused_quant_a_max_n() -> int:
     """Widest N routed through the in-CTA activation quantization.
 
     B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N (default 4096): 0 keeps the
-    separate quantizer for every shape. The fused GEMM re-quantizes A in each
-    N tile and has no split-K, so above a few thousand columns the separate
-    quantizer plus split-K GEMM is faster on SM120 (measured at N = 7168).
+    separate quantizer for every shape. Every CTA of the fused GEMM
+    re-quantizes its A rows, so the quantization work grows with the number
+    of output tiles; beyond a few thousand columns that repeated work exceeds
+    the two scale fills and the row quantizer the fused path removes, and the
+    separate path stays faster. The value is process configuration: it is
+    read once and cached (``_fused_quant_a_max_n.cache_clear()`` re-reads
+    it), and it must be a non-negative integer.
     """
-    return int(os.environ.get("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096"))
+    raw = os.environ.get("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096")
+    try:
+        limit = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N must be an integer, "
+            f"got {raw!r}"
+        ) from exc
+    if limit < 0:
+        raise ValueError(
+            f"B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N must be >= 0, got {limit}"
+        )
+    return limit
 
 
 def _use_fused_quant_a(

--- a/b12x/gemm/blockscaled/_linear.py
+++ b/b12x/gemm/blockscaled/_linear.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, TypeAlias
@@ -13,6 +14,7 @@ import torch
 from b12x._lib.dense_gemm import (
     _dense_spark_policy_for_sm_count,
     dense_gemm,
+    dense_gemm_fused_quant_a,
 )
 from b12x._lib.intrinsics import as_grouped_scale_view, as_grouped_scale_view_mx
 from b12x._lib.utils import cuda_stream_to_int, get_num_sm
@@ -74,6 +76,45 @@ def _source_2d(source: torch.Tensor) -> torch.Tensor:
     if source.ndim < 2:
         raise ValueError(f"source must have at least 2 dims, got {tuple(source.shape)}")
     return source.reshape(-1, source.shape[-1]).contiguous()
+
+
+_FUSED_QUANT_A_MAX_TOKENS = 8
+
+
+def _fused_quant_a_max_n() -> int:
+    """Widest N routed through the in-CTA activation quantization.
+
+    B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N (default 4096): 0 keeps the
+    separate quantizer for every shape. The fused GEMM re-quantizes A in each
+    N tile and has no split-K, so above a few thousand columns the separate
+    quantizer plus split-K GEMM is faster on SM120 (measured at N = 7168).
+    """
+    return int(os.environ.get("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096"))
+
+
+def _use_fused_quant_a(
+    tokens: int,
+    dtype: torch.dtype,
+    in_features: int,
+    padded_in_features: int,
+    out_features: int,
+) -> bool:
+    """Whether the linear runs as one small-M GEMM quantizing BF16 A in-CTA.
+
+    The in-CTA quantization computes the same UE8M0 scales and E4M3 values as
+    the standalone row quantizer, so the output is bit-identical; the fused
+    path only drops the two scale-buffer fills and the quantization kernel.
+    K padding is left to the separate path (the padded source would need its
+    own copy), and so is any N that is not a whole number of 64-wide output
+    tiles: the fused kernel has no N tail handling.
+    """
+    return (
+        tokens <= _FUSED_QUANT_A_MAX_TOKENS
+        and dtype == torch.bfloat16
+        and int(in_features) == int(padded_in_features)
+        and int(out_features) % 64 == 0
+        and 0 < int(out_features) <= _fused_quant_a_max_n()
+    )
 
 
 def _pad_k(tensor: torch.Tensor, padded_k: int) -> torch.Tensor:
@@ -533,8 +574,18 @@ def _packed_mxfp8_op(
     expected_m: int,
     stream_int: int | None,
 ) -> torch.Tensor:
-    del weight_scale_rows, in_features
+    del weight_scale_rows
     tokens = int(source_2d.shape[0])
+    if _use_fused_quant_a(
+        tokens, source_2d.dtype, in_features, padded_in_features, out_features
+    ):
+        return dense_gemm_fused_quant_a(
+            source_2d,
+            weight_values.reshape(out_features, padded_in_features, 1),
+            weight_scale_mma,
+            expected_m=expected_m,
+            stream=stream_int,
+        )[:, :, 0]
     source_for_quant = _pad_k(source_2d, int(padded_in_features))
     from b12x.gemm._shared.block_fp8 import (
         quantize_block_fp8_linear_input_mxfp8,

--- a/tests/gemm/test_mxfp8_linear_fused_quant_a.py
+++ b/tests/gemm/test_mxfp8_linear_fused_quant_a.py
@@ -1,0 +1,95 @@
+"""Small-M MXFP8 linears quantize their BF16 activations inside the GEMM.
+
+For up to eight tokens, an unpadded K and N up to
+B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N, `mxfp8_linear` runs one GEMM that
+quantizes A in each CTA instead of the two scale-buffer fills, the row
+quantization kernel and the GEMM. The in-CTA quantization computes the same
+UE8M0 scales and E4M3 values, so the output must be bit-identical to the
+separate path, eagerly and under CUDA-graph capture.
+
+Bit identity holds when the separate path reduces split-K partials in FP32
+(B12X_DENSE_SPLITK_TURBO=0, the production setting); the bf16 atomic
+split-K accumulation is itself order-dependent, so the module constant is
+pinned before the GEMM module is imported.
+"""
+import os
+
+os.environ.setdefault("B12X_DENSE_SPLITK_TURBO", "0")
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("cutlass")
+
+from b12x.gemm.blockscaled import _linear as kernel_module
+from b12x.gemm.blockscaled._linear import mxfp8_linear, pack_mxfp8_linear_weight
+
+from ..conftest import require_b12x
+
+SHAPES = [(7168, 1536), (7168, 576), (7168, 3584), (4096, 4096), (2048, 512), (128, 64)]
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] == 12
+
+
+def _packed(n: int, k: int, gen: torch.Generator, device: torch.device):
+    weight = (torch.randn((n, k), generator=gen, device=device) * 0.02).to(
+        torch.float8_e4m3fn
+    )
+    scale = (
+        127 + torch.randint(-3, 4, (n, k // 32), generator=gen, device=device)
+    ).to(torch.uint8)
+    return pack_mxfp8_linear_weight(weight, scale)
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize(("k", "n"), SHAPES)
+@pytest.mark.parametrize("m", [1, 3, 8])
+def test_fused_quant_a_matches_separate_quantizer(
+    monkeypatch: pytest.MonkeyPatch, k: int, n: int, m: int
+) -> None:
+    require_b12x()
+    device = torch.device("cuda", torch.cuda.current_device())
+    gen = torch.Generator(device=device).manual_seed(20260902 + k + n)
+    packed = _packed(n, k, gen, device)
+    x = (torch.randn((m, k), generator=gen, device=device) * 0.5).to(torch.bfloat16)
+
+    monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "0")
+    assert not kernel_module._use_fused_quant_a(m, x.dtype, k, k, n)
+    separate = mxfp8_linear(x, packed).clone()
+
+    monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", str(n))
+    assert kernel_module._use_fused_quant_a(m, x.dtype, k, k, n)
+    fused = mxfp8_linear(x, packed).clone()
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = mxfp8_linear(x, packed)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.isfinite(separate).all()
+    assert torch.equal(separate, fused)
+    assert torch.equal(separate, captured)
+
+
+def test_fused_quant_a_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096")
+    use = kernel_module._use_fused_quant_a
+    assert use(8, torch.bfloat16, 7168, 7168, 4096)
+    # More than eight tokens, FP16 activations, padded K or a wider N stay on
+    # the separate quantizer.
+    assert not use(9, torch.bfloat16, 7168, 7168, 4096)
+    assert not use(8, torch.float16, 7168, 7168, 4096)
+    assert not use(8, torch.bfloat16, 7136, 7168, 4096)
+    assert not use(8, torch.bfloat16, 7168, 7168, 7168)
+    # N tails (not a multiple of 64) have no fused handling.
+    assert not use(8, torch.bfloat16, 7168, 7168, 132)
+    assert not use(8, torch.bfloat16, 7168, 7168, 32)
+    monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "0")
+    assert not use(1, torch.bfloat16, 7168, 7168, 64)

--- a/tests/gemm/test_mxfp8_linear_fused_quant_a.py
+++ b/tests/gemm/test_mxfp8_linear_fused_quant_a.py
@@ -12,11 +12,11 @@ Bit identity holds when the separate path reduces split-K partials in FP32
 split-K accumulation is itself order-dependent, so the module constant is
 pinned before the GEMM module is imported.
 """
+from __future__ import annotations
+
 import os
 
-os.environ.setdefault("B12X_DENSE_SPLITK_TURBO", "0")
-
-from __future__ import annotations
+os.environ["B12X_DENSE_SPLITK_TURBO"] = "0"
 
 import pytest
 import torch
@@ -60,10 +60,12 @@ def test_fused_quant_a_matches_separate_quantizer(
     x = (torch.randn((m, k), generator=gen, device=device) * 0.5).to(torch.bfloat16)
 
     monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "0")
+    kernel_module._fused_quant_a_max_n.cache_clear()
     assert not kernel_module._use_fused_quant_a(m, x.dtype, k, k, n)
     separate = mxfp8_linear(x, packed).clone()
 
     monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", str(n))
+    kernel_module._fused_quant_a_max_n.cache_clear()
     assert kernel_module._use_fused_quant_a(m, x.dtype, k, k, n)
     fused = mxfp8_linear(x, packed).clone()
     torch.cuda.synchronize(device)
@@ -74,12 +76,14 @@ def test_fused_quant_a_matches_separate_quantizer(
     torch.cuda.synchronize(device)
 
     assert torch.isfinite(separate).all()
+    assert torch.count_nonzero(separate).item() > 0
     assert torch.equal(separate, fused)
     assert torch.equal(separate, captured)
 
 
 def test_fused_quant_a_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096")
+    kernel_module._fused_quant_a_max_n.cache_clear()
     use = kernel_module._use_fused_quant_a
     assert use(8, torch.bfloat16, 7168, 7168, 4096)
     # More than eight tokens, FP16 activations, padded K or a wider N stay on
@@ -92,4 +96,17 @@ def test_fused_quant_a_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not use(8, torch.bfloat16, 7168, 7168, 132)
     assert not use(8, torch.bfloat16, 7168, 7168, 32)
     monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "0")
+    kernel_module._fused_quant_a_max_n.cache_clear()
     assert not use(1, torch.bfloat16, 7168, 7168, 64)
+    # The limit is process configuration: it is read once, and it must be a
+    # non-negative integer.
+    monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", "4096")
+    assert not use(1, torch.bfloat16, 7168, 7168, 64)
+    kernel_module._fused_quant_a_max_n.cache_clear()
+    assert use(1, torch.bfloat16, 7168, 7168, 64)
+    for bad in ("-1", "many"):
+        monkeypatch.setenv("B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N", bad)
+        kernel_module._fused_quant_a_max_n.cache_clear()
+        with pytest.raises(ValueError, match="B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N"):
+            use(1, torch.bfloat16, 7168, 7168, 64)
+    kernel_module._fused_quant_a_max_n.cache_clear()


### PR DESCRIPTION
## Summary

The MXFP8 dense linear (ModelOpt/serialized MXFP8 weights with dynamic MXFP8 activations, `b12x.gemm.blockscaled` / `mxfp8_linear`) ran the standalone activation quantizer before every GEMM: two E8M0 scale-buffer fills, the row quantization kernel, then the dense GEMM. For up to eight tokens with BF16 activations, an unpadded K and an N that is a whole number of 64-wide tiles and at most `B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N` (default 4096), the linear now runs `dense_gemm_fused_quant_a` — the small-M GEMM that quantizes A in each CTA, which the block-FP8 linear already uses for the same token range. The in-CTA quantization computes the same UE8M0 scales and E4M3 values, so the output is bit-identical; three launches per projection disappear.

Wider N keeps the separate path: the fused GEMM re-quantizes A per N tile and has no split-K, and at N = 7168 it is slower than the quantizer plus the split-K GEMM (18.6 vs 15.7 µs on SM120). `B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N=0` disables the routing.

## Validation (RTX PRO 6000, SM120)

Kimi-K3 decode projection shapes (K 7168/4096/3584/2048, N 512..7168) at 1/2/4/8 tokens are bit-identical between the two paths (with FP32 split-K reduction, `B12X_DENSE_SPLITK_TURBO=0`; the bf16 atomic split-K is itself order-dependent). GPU time per projection at 8 tokens (profiler kernel time, i.e. what a CUDA graph pays):

| K x N | separate (us / kernels) | fused (us / kernels) |
|---|---|---|
| 7168 x 1536 | 13.0 / 5 | 10.0 / 2 |
| 7168 x 576 | 9.3 / 5 | 6.4 / 2 |
| 7168 x 896 | 12.6 / 5 | 6.6 / 2 |
| 7168 x 2304 | 10.0 / 5 | 7.2 / 2 |
| 7168 x 3584 | 11.8 / 5 | 10.8 / 2 |
| 7168 x 7168 (stays separate) | 15.7 / 5 | 18.6 / 2 |

`tests/gemm/test_mxfp8_linear_fused_quant_a.py`: bitwise equality eagerly and under CUDA-graph capture across the shapes above and the routing policy (token count, dtype, K padding, N alignment and width, the off switch). The MXFP8/block-FP8 linear suites keep their existing failure set (`test_mm_writes_all_rows_for_unaligned_output_width` at N=132 with more than eight tokens fails before and after; those shapes never take the fused path).

The same change on the Kimi-K3 production snapshot lineage (46c84bab, `b12x/gemm/mxfp8_linear/_kernel.py`) is branch `agent/kimi-k3-mxfp8-linear-fused-quant-a-20260902-served`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fuses BF16 activation quantization into `dense_gemm_fused_quant_a` for eligible MXFP8 linear operations.
- Enables the fused path for up to eight tokens, unpadded `K`, and `N` values aligned to 64 tiles up to `B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N` (default: 4096).
- Preserves bit-identical UE8M0 scales and E4M3 values while reducing eligible projections from five kernel launches to two.
- Keeps the existing quantizer and GEMM path for unsupported shapes. Set `B12X_MXFP8_LINEAR_FUSED_QUANT_A_MAX_N=0` to disable the fused path.
- Tests cover eager execution, CUDA-graph capture, routing conditions, and multiple `K`, `N`, and token configurations on SM120/SM121 GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->