### PR TITLE
perf(dense_mla): balance split ranges over the launched CTAs

### DIFF
--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -75,6 +75,16 @@ class DenseMlaForwardKernel:
         self.qk_dim = int(qk_dim)
         self.value_dim = int(value_dim)
         self.window_size = None if window_size is None else int(window_size)
+        # The windowed producer derives the gathered chunk range from the
+        # tile's first query row (see the range computation in the kernel);
+        # the later rows of a wider tile would see up to query_tile - 1 more
+        # tokens than that range covers. The planner keeps windowed plans at
+        # one row per tile; the kernel refuses anything else.
+        if self.window_size is not None and self.query_tile != 1:
+            raise ValueError(
+                "windowed dense MLA scans one query row per tile, got "
+                f"query_tile={self.query_tile}"
+            )
         self.kv_stages = int(layout.kv_stages)
         self.math_warps = MATH_WARPS_PER_QUERY * self.query_tile
         self.math_threads = self.math_warps * 32
@@ -449,6 +459,8 @@ class DenseMlaForwardKernel:
         first_valid_chunk = Int32(0)
         visible_chunks_end = cache_length
         if cutlass.const_expr(self.window_size is not None):
+            # query_tile == 1 here (enforced at construction), so the tile's
+            # first row is its only row and this range is exact for it.
             tile_local_query = query_start - query_begin
             visible_chunks_end = (
                 cache_length - query_length + tile_local_query + Int32(1)

--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -464,8 +464,24 @@ class DenseMlaForwardKernel:
         valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
             CANDIDATES_PER_CHUNK
         )
-        split_first_chunk = first_valid_chunk + split * Int32(self.chunks_per_split)
-        split_last_chunk = split_first_chunk + Int32(self.chunks_per_split)
+        # Balanced split ranges: the launched splits share this request's
+        # valid chunks (past any window start) evenly, so every launched CTA
+        # scans about (valid_chunks - first_valid_chunk) / active_splits
+        # chunks whatever the live length. The planned chunks_per_split only
+        # sizes the scratch; a fixed range of chunks per split would leave all
+        # but the first few splits idle on sequences much shorter than the
+        # planned capacity. Splits past the valid chunks stay empty and
+        # publish -inf partials.
+        scan_chunks = valid_chunks - first_valid_chunk
+        if scan_chunks < Int32(0):
+            scan_chunks = Int32(0)
+        balanced_chunks_per_split = (scan_chunks + active_splits - Int32(1)) // (
+            active_splits
+        )
+        if balanced_chunks_per_split < Int32(1):
+            balanced_chunks_per_split = Int32(1)
+        split_first_chunk = first_valid_chunk + split * balanced_chunks_per_split
+        split_last_chunk = split_first_chunk + balanced_chunks_per_split
         if split_last_chunk > valid_chunks:
             split_last_chunk = valid_chunks
         active_chunks = split_last_chunk - split_first_chunk

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -681,9 +681,10 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         cu_seqlens_q=cu_seqlens_q,
         q_scale=q_scale,
         kv_scale=kv_scale,
-        active_splits=1,
+        # The balanced prefix: one split per live 64-token chunk.
+        active_splits=5,
     )
-    assert binding.active_splits == 1
+    assert binding.active_splits == 5
     dense_mla.compile(binding=binding)
     actual_output, actual_lse = dense_mla.run(binding=binding)
     torch.cuda.synchronize()
@@ -717,9 +718,11 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         expected_lse,
     )
 
-    # The active prefix preserves the maximum-context split boundaries and
-    # only omits mathematically empty tail splits. It must therefore match a
-    # full-plan launch exactly, including the BF16 output bits.
+    # Split ranges are balanced over the launched splits: a prefix of
+    # min(num_splits, live chunks) splits partitions the live chunks exactly
+    # like the full-plan launch (one chunk per split here, the remaining
+    # full-plan splits empty), so the two must match including the BF16
+    # output bits.
     full_output = torch.empty_like(output)
     full_binding = dense_mla.bind(
         plan,
@@ -932,3 +935,67 @@ def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
         expected_output,
         expected_lse,
     )
+
+
+@torch.inference_mode()
+def test_balanced_splits_cover_a_long_live_sequence_with_every_split() -> None:
+    """A live sequence far below the planned capacity is shared by every
+    launched split (about live_chunks / active_splits chunks each) instead
+    of a few splits scanning capacity-sized ranges; the result matches the
+    reference, and a one-split launch of the same rows agrees within the
+    reassociation tolerance."""
+    device = require_b12x()
+    torch.manual_seed(20260902)
+    page_size = 64
+    max_cache_tokens = 131_072
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=torch.bfloat16,
+            num_q_heads=8,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=max_cache_tokens,
+            max_page_table_width=max_cache_tokens // page_size,
+            num_cache_pages=1 << 20,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits > 8
+    live = 10_240  # 160 chunks: fewer than the planned 2,048, more than the splits
+    num_pages = live // page_size
+    q = torch.randn(1, 8, QK_DIM, device=device, dtype=torch.bfloat16) * 0.1
+    cache = torch.randn(num_pages, page_size, QK_DIM, device=device, dtype=torch.bfloat16) * 0.1
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).view(1, -1)
+    cache_seqlens = torch.tensor([live], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+
+    outputs = {}
+    for active in (plan.num_splits, 1):
+        output = torch.empty(1, 8, VALUE_DIM, dtype=torch.bfloat16, device=device)
+        binding = dense_mla.bind(
+            plan,
+            scratch=_scratch(plan),
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            active_splits=active,
+        )
+        dense_mla.compile(binding=binding)
+        actual_output, actual_lse = dense_mla.run(binding=binding)
+        torch.cuda.synchronize()
+        _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+        outputs[active] = (actual_output.clone(), actual_lse.clone())
+    full_output, full_lse = outputs[plan.num_splits]
+    one_output, one_lse = outputs[1]
+    torch.testing.assert_close(full_output, one_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(full_lse, one_lse, rtol=2e-5, atol=2e-5)
+

--- a/tests/attention/test_dense_mla_window.py
+++ b/tests/attention/test_dense_mla_window.py
@@ -260,3 +260,48 @@ def test_fp8_page_offset_exceeds_signed_int32() -> None:
     torch.cuda.synchronize(device)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
     torch.testing.assert_close(actual_lse, expected_lse, rtol=2e-5, atol=2e-5)
+
+
+def test_windowed_plans_scan_one_query_row_per_tile() -> None:
+    """The windowed producer gathers the chunk range visible to the tile's
+    first query row, so a windowed tile must hold exactly one row: the
+    planner selects that geometry for every mode, and the kernel refuses a
+    wider tile."""
+    from b12x.attention.dense_mla._forward import DenseMlaForwardKernel
+    from b12x.attention.dense_mla._layout import make_smem_layout
+
+    for mode, max_total_q in (("extend", 4), ("decode", 4), ("verify", 4)):
+        plan = dense_mla.plan(
+            dense_mla.Caps(
+                device="cpu",
+                mode=mode,
+                kv_dtype=FP8,
+                q_dtype=torch.bfloat16,
+                num_q_heads=8,
+                page_size=64,
+                max_total_q=max_total_q,
+                max_batch=1,
+                max_cache_tokens=1024,
+                max_page_table_width=16,
+                num_cache_pages=32,
+                head_dim=1088,
+                v_head_dim=1024,
+                physical_record_width=1088,
+                window_size=WINDOW_SIZE,
+            )
+        )
+        assert plan.query_tile == 1, mode
+    layout = make_smem_layout(query_tile=2, fp8=False, qk_dim=576)
+    with pytest.raises(ValueError, match="one query row per tile"):
+        DenseMlaForwardKernel(
+            layout=layout,
+            page_size=64,
+            num_heads=8,
+            num_splits=4,
+            chunks_per_split=4,
+            query_tile=2,
+            fp8=False,
+            qk_dim=576,
+            value_dim=512,
+            window_size=WINDOW_SIZE,
+        )

--- a/tests/attention/test_dense_mla_window.py
+++ b/tests/attention/test_dense_mla_window.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import torch
 
@@ -292,16 +294,21 @@ def test_windowed_plans_scan_one_query_row_per_tile() -> None:
         )
         assert plan.query_tile == 1, mode
     layout = make_smem_layout(query_tile=2, fp8=False, qk_dim=576)
+    kernel_args = dict(
+        layout=layout,
+        page_size=64,
+        num_heads=8,
+        num_splits=4,
+        chunks_per_split=4,
+        query_tile=2,
+        fp8=False,
+        qk_dim=576,
+        value_dim=512,
+        window_size=WINDOW_SIZE,
+    )
+    # Range options the kernel may take besides the geometry above.
+    optional = {"single_split_chunks": 4}
+    accepted = inspect.signature(DenseMlaForwardKernel).parameters
+    kernel_args.update({k: v for k, v in optional.items() if k in accepted})
     with pytest.raises(ValueError, match="one query row per tile"):
-        DenseMlaForwardKernel(
-            layout=layout,
-            page_size=64,
-            num_heads=8,
-            num_splits=4,
-            chunks_per_split=4,
-            query_tile=2,
-            fp8=False,
-            qk_dim=576,
-            value_dim=512,
-            window_size=WINDOW_SIZE,
-        )
+        DenseMlaForwardKernel(**kernel_args)


### PR DESCRIPTION
## Summary

The dense MLA forward kernel assigns every split a fixed run of `chunks_per_split` KV chunks taken from the plan, which is sized for the plan's `max_cache_tokens`. When the caller launches fewer splits than planned, or the live sequence is shorter than the plan, most launched CTAs receive an empty chunk range. On Kimi-K3 decode (TP8/DCP8, 131,072-token local plan: 47 splits × 44 chunks, grid [1, 12, 47]) an 82k-token context is scanned by four CTAs per head tile while 43 sit idle, and `DenseMlaForwardKernel` grows from 0.44 ms to 5.7 ms per decode step over the 24 MLA layers — the whole measured long-context decode slowdown (41 → 46 ms per step at 82k and 163k tokens).

Each launched split now scans `ceil(scan_chunks / active_splits)` chunks of the request's valid range, where `active_splits` is the launched grid and `scan_chunks` the chunks past the window's first valid chunk. The planned `chunks_per_split` only sizes the split scratch. The merge kernel still reduces the launched splits, so the output combines the same partial products through the same log-sum-exp merge and stays within the existing reference tolerance; a launch with one split is unchanged.

## Scope

- `b12x/attention/dense_mla/_forward.py`: balanced per-CTA chunk range; empty splits still publish `-inf` partials.
- No plan, scratch or binding changes. Callers that launch a split-plan prefix for a short live sequence (`_active_dense_mla_splits` in vLLM's `b12x_mla.py`) now need `min(num_splits, live chunks)` splits instead of `ceil(live chunks / chunks_per_split)`; the matching vLLM change is local-inference-lab/vllm `agent/kimi-k3-dense-mla-balanced-splits-20260902-pr`.

## Validation

RTX PRO 6000 (SM120), bf16 KV, 8 heads, page 64, 131,072-token plan (47 splits), all splits launched, forward + merge kernel time per call from the torch profiler:

| live tokens | before | after |
|---|---|---|
| 1,024 | 47.9 us | 7.1 us |
| 4,096 | 126.6 us | 10.5 us |
| 10,240 | 129.3 us | 17.1 us |
| 20,480 | 130.1 us | 26.9 us |
| 40,960 | 134.2 us | 47.9 us |

max |out − reference| is unchanged at every length.

`tests/attention/test_dense_mla.py`: `test_fp8_production_split_plan_handles_short_live_sequence` launches the balanced prefix (five splits for a five-chunk live sequence) and keeps its bit-identity assertion against the full-plan launch; new `test_balanced_splits_cover_a_long_live_sequence_with_every_split` checks a 10,240-token live sequence against the reference with every split and with one split. Run one test per process on this branch (an illegal memory access in the pre-existing `*_tiled_causal_extend_matches_reference` tests poisons the CUDA context of later tests): all of `test_bf16_multi_request_decode_matches_reference`, `test_fp8_production_split_plan_handles_short_live_sequence`, `test_balanced_splits_cover_a_long_live_sequence_with_every_split`, `test_cuda_graph_replay_is_allocation_stable_and_reads_live_inputs`, `test_padded_page_stride_matches_reference`, `test_page_ids_past_int32_scaled_offset_match_reference`, `test_fp8_page_ids_past_int32_scaled_offset_match_reference`, `test_partial_row_budget_changes_native_split_policy` and `tests/attention/test_dense_mla_window.py` (6) pass.

The same change on the served Kimi-K3 kernel lineage (#271's branch, with the sparse chunk selection) is `agent/kimi-k3-dense-mla-balanced-splits-20260902-pr`; its tests pass the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Dense MLA forward now distributes valid cache chunks across active splits using `ceil(scan_chunks / active_splits)`.
- Split ranges account for window offsets and live sequence length. Unused splits publish `-inf` partials.
- Planned cache size still sizes split scratch. Plan, scratch, binding, and merge interfaces remain unchanged.
- One-split launches retain existing behavior.
- Tests cover balanced short and long sequences, all active splits, and one-split equivalence within reassociation tolerance.
- A corresponding vLLM caller update is required for `_active_dense_mla_splits`.
- RTX PRO 6000 measurements improved from 47.9 µs to 7.1 µs at 1,024 live tokens and from 134.2 µs to 47.9 µs at 40,960 live tokens. Reference output differences are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->