### PR TITLE
fix(dense_mla): keep one split for short requests, float32 split partials

### DIFF
--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -75,6 +75,16 @@ class DenseMlaForwardKernel:
         self.qk_dim = int(qk_dim)
         self.value_dim = int(value_dim)
         self.window_size = None if window_size is None else int(window_size)
+        # The windowed producer derives the gathered chunk range from the
+        # tile's first query row (see the range computation in the kernel);
+        # the later rows of a wider tile would see up to query_tile - 1 more
+        # tokens than that range covers. The planner keeps windowed plans at
+        # one row per tile; the kernel refuses anything else.
+        if self.window_size is not None and self.query_tile != 1:
+            raise ValueError(
+                "windowed dense MLA scans one query row per tile, got "
+                f"query_tile={self.query_tile}"
+            )
         self.kv_stages = int(layout.kv_stages)
         self.math_warps = MATH_WARPS_PER_QUERY * self.query_tile
         self.math_threads = self.math_warps * 32
@@ -449,6 +459,8 @@ class DenseMlaForwardKernel:
         first_valid_chunk = Int32(0)
         visible_chunks_end = cache_length
         if cutlass.const_expr(self.window_size is not None):
+            # query_tile == 1 here (enforced at construction), so the tile's
+            # first row is its only row and this range is exact for it.
             tile_local_query = query_start - query_begin
             visible_chunks_end = (
                 cache_length - query_length + tile_local_query + Int32(1)

--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -58,6 +58,7 @@ class DenseMlaForwardKernel:
         num_heads: int,
         num_splits: int,
         chunks_per_split: int,
+        single_split_chunks: int,
         query_tile: int,
         fp8: bool,
         qk_dim: int,
@@ -70,6 +71,7 @@ class DenseMlaForwardKernel:
         self.head_tiles = (self.num_heads + HEADS_PER_TILE - 1) // HEADS_PER_TILE
         self.num_splits = int(num_splits)
         self.chunks_per_split = int(chunks_per_split)
+        self.single_split_chunks = int(single_split_chunks)
         self.query_tile = int(query_tile)
         self.fp8 = bool(fp8)
         self.qk_dim = int(qk_dim)
@@ -464,11 +466,14 @@ class DenseMlaForwardKernel:
         valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
             CANDIDATES_PER_CHUNK
         )
-        # Balanced split ranges: the launched splits share this request's
-        # valid chunks (past any window start) evenly, so every launched CTA
-        # scans about (valid_chunks - first_valid_chunk) / active_splits
-        # chunks whatever the live length. The planned chunks_per_split only
-        # sizes the scratch; a fixed range of chunks per split would leave all
+        # Split ranges. A request whose scanned chunks (past any window
+        # start) fit within single_split_chunks is scanned by split 0 alone:
+        # one online-softmax chain in chunk order, written once, which is the
+        # fixed-range association of a kernel that scans chunks_per_split
+        # chunks per split, so those results match it bit for bit. Longer
+        # requests share their chunks evenly over the launched splits, so
+        # every launched CTA scans about scan_chunks / active_splits chunks
+        # whatever the live length; a fixed range per split would leave all
         # but the first few splits idle on sequences much shorter than the
         # planned capacity. Splits past the valid chunks stay empty and
         # publish -inf partials.
@@ -480,6 +485,9 @@ class DenseMlaForwardKernel:
         )
         if balanced_chunks_per_split < Int32(1):
             balanced_chunks_per_split = Int32(1)
+        if cutlass.const_expr(self.single_split_chunks > 0):
+            if scan_chunks <= Int32(self.single_split_chunks):
+                balanced_chunks_per_split = Int32(self.single_split_chunks)
         split_first_chunk = first_valid_chunk + split * balanced_chunks_per_split
         split_last_chunk = split_first_chunk + balanced_chunks_per_split
         if split_last_chunk > valid_chunks:

--- a/b12x/attention/dense_mla/_forward.py
+++ b/b12x/attention/dense_mla/_forward.py
@@ -464,8 +464,24 @@ class DenseMlaForwardKernel:
         valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
             CANDIDATES_PER_CHUNK
         )
-        split_first_chunk = first_valid_chunk + split * Int32(self.chunks_per_split)
-        split_last_chunk = split_first_chunk + Int32(self.chunks_per_split)
+        # Balanced split ranges: the launched splits share this request's
+        # valid chunks (past any window start) evenly, so every launched CTA
+        # scans about (valid_chunks - first_valid_chunk) / active_splits
+        # chunks whatever the live length. The planned chunks_per_split only
+        # sizes the scratch; a fixed range of chunks per split would leave all
+        # but the first few splits idle on sequences much shorter than the
+        # planned capacity. Splits past the valid chunks stay empty and
+        # publish -inf partials.
+        scan_chunks = valid_chunks - first_valid_chunk
+        if scan_chunks < Int32(0):
+            scan_chunks = Int32(0)
+        balanced_chunks_per_split = (scan_chunks + active_splits - Int32(1)) // (
+            active_splits
+        )
+        if balanced_chunks_per_split < Int32(1):
+            balanced_chunks_per_split = Int32(1)
+        split_first_chunk = first_valid_chunk + split * balanced_chunks_per_split
+        split_last_chunk = split_first_chunk + balanced_chunks_per_split
         if split_last_chunk > valid_chunks:
             split_last_chunk = valid_chunks
         active_chunks = split_last_chunk - split_first_chunk

--- a/b12x/attention/dense_mla/_kernel.py
+++ b/b12x/attention/dense_mla/_kernel.py
@@ -53,6 +53,21 @@ def _to_cute(
     return converted
 
 
+def _partial_dtype_name(scratch) -> str:
+    return "fp32" if scratch.partial_dtype == torch.float32 else "bf16"
+
+
+def _partial_cute_dtype(scratch):
+    """Element type of the split-partial operand handed to the kernels.
+
+    A one-split plan has no partial buffer; the forward kernel then receives
+    the bf16 output tensor as a never-written placeholder.
+    """
+    if scratch.partial_output is None:
+        return cutlass.BFloat16
+    return cutlass.Float32 if scratch.partial_dtype == torch.float32 else cutlass.BFloat16
+
+
 def _byte_base_pointer(tensor: torch.Tensor) -> torch.Tensor:
     """Return a one-element byte view at the tensor's physical base.
 
@@ -83,6 +98,8 @@ def _signature(binding: Binding) -> tuple[object, ...]:
         scratch.query_tile,
         scratch.num_splits,
         scratch.chunks_per_split,
+        scratch.single_split_chunks,
+        str(scratch.partial_dtype),
         scratch.physical_record_width,
         scratch.head_dim,
         scratch.v_head_dim,
@@ -126,6 +143,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         num_heads=scratch.num_q_heads,
         num_splits=scratch.num_splits,
         chunks_per_split=scratch.chunks_per_split,
+        single_split_chunks=scratch.single_split_chunks,
         query_tile=scratch.query_tile,
         fp8=fp8,
         qk_dim=scratch.head_dim,
@@ -186,7 +204,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
             dynamic_layout=True,
         ),
         _to_cute(final_lse, cutlass.Float32, align=4),
-        _to_cute(partial_output, cutlass.BFloat16, align=16),
+        _to_cute(partial_output, _partial_cute_dtype(scratch), align=16),
         _to_cute(partial_lse, cutlass.Float32, align=4),
         _to_cute(kv_scale, cutlass.Float32, align=4),
         _to_cute(q_scale, cutlass.Float32, align=4),
@@ -203,7 +221,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
     )
     spec = KernelCompileSpec.from_fields(
         "attention.dense_mla.forward",
-        4,
+        5,
         key_field("dtype", "fp8" if fp8 else "bf16"),
         key_field("heads", scratch.num_q_heads),
         key_field("page_size", scratch.page_size),
@@ -212,6 +230,8 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
         key_field("query_tile", scratch.query_tile),
         key_field("num_splits", scratch.num_splits),
         key_field("chunks_per_split", scratch.chunks_per_split),
+        key_field("single_split_chunks", scratch.single_split_chunks),
+        key_field("partial_dtype", _partial_dtype_name(scratch)),
         key_field("physical_record_width", scratch.physical_record_width),
         key_field("head_dim", scratch.head_dim),
         key_field("v_head_dim", scratch.v_head_dim),
@@ -254,12 +274,16 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
         return None
     assert scratch.partial_output is not None
     assert scratch.partial_lse is not None
-    entry = DenseMlaMergeKernel(scratch.num_splits, scratch.v_head_dim)
+    entry = DenseMlaMergeKernel(
+        scratch.num_splits,
+        scratch.v_head_dim,
+        partial_fp32=scratch.partial_dtype == torch.float32,
+    )
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
     args = (
         _to_cute(
             scratch.partial_output,
-            cutlass.BFloat16,
+            _partial_cute_dtype(scratch),
             align=16,
         ),
         _to_cute(scratch.partial_lse, cutlass.Float32, align=4),
@@ -275,10 +299,11 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
     )
     spec = KernelCompileSpec.from_fields(
         "attention.dense_mla.merge",
-        4,
+        5,
         key_field("num_splits", scratch.num_splits),
         key_field("heads", scratch.num_q_heads),
         key_field("v_head_dim", scratch.v_head_dim),
+        key_field("partial_dtype", _partial_dtype_name(scratch)),
         tensor_key(
             "partial_output",
             scratch.partial_output,

--- a/b12x/attention/dense_mla/_merge.py
+++ b/b12x/attention/dense_mla/_merge.py
@@ -1,4 +1,10 @@
-"""Base-2 split reduction for standalone dense MLA."""
+"""Base-2 split reduction for standalone dense MLA.
+
+Split partials are normalized per split and stored either as bf16 (two
+roundings between the fp32 accumulators and the merged bf16 output) or as
+float32 (one rounding, at the merged output, so the merged value of a
+single valid split is bit-identical to the direct one-split write).
+"""
 
 from __future__ import annotations
 
@@ -11,6 +17,7 @@ from b12x._lib.intrinsics import (
     bfloat2_to_float2_scaled,
     get_ptr_as_int64,
     ld_global_v2_u32,
+    ld_global_v4_f32,
     pack_f32x2_to_bfloat2,
     st_global_v2_u32,
 )
@@ -19,11 +26,12 @@ from ._math import exp2_approx, log2_approx
 
 
 class DenseMlaMergeKernel:
-    """Merge normalized BF16 split partials and emit natural-log LSE."""
+    """Merge normalized split partials and emit natural-log LSE."""
 
-    def __init__(self, num_splits: int, value_dim: int):
+    def __init__(self, num_splits: int, value_dim: int, *, partial_fp32: bool = False):
         self.num_splits = int(num_splits)
         self.value_dim = int(value_dim)
+        self.partial_fp32 = bool(partial_fp32)
 
     def _get_shared_storage_cls(self):
         """Return the per-CTA split-weight storage.
@@ -166,21 +174,30 @@ class DenseMlaMergeKernel:
                         * Int64(self.num_splits)
                         + Int64(split)
                     ) * Int64(self.value_dim) + Int64(dimension)
-                    packed0, packed1 = ld_global_v2_u32(
-                        get_ptr_as_int64(partial_output, partial_offset)
-                    )
-                    value0, value1 = bfloat2_to_float2_scaled(
-                        packed0,
-                        weight,
-                    )
-                    value2, value3 = bfloat2_to_float2_scaled(
-                        packed1,
-                        weight,
-                    )
-                    accumulator[0] += value0
-                    accumulator[1] += value1
-                    accumulator[2] += value2
-                    accumulator[3] += value3
+                    if cutlass.const_expr(self.partial_fp32):
+                        value0, value1, value2, value3 = ld_global_v4_f32(
+                            get_ptr_as_int64(partial_output, partial_offset)
+                        )
+                        accumulator[0] += value0 * weight
+                        accumulator[1] += value1 * weight
+                        accumulator[2] += value2 * weight
+                        accumulator[3] += value3 * weight
+                    else:
+                        packed0, packed1 = ld_global_v2_u32(
+                            get_ptr_as_int64(partial_output, partial_offset)
+                        )
+                        value0, value1 = bfloat2_to_float2_scaled(
+                            packed0,
+                            weight,
+                        )
+                        value2, value3 = bfloat2_to_float2_scaled(
+                            packed1,
+                            weight,
+                        )
+                        accumulator[0] += value0
+                        accumulator[1] += value1
+                        accumulator[2] += value2
+                        accumulator[3] += value3
                 split += Int32(1)
 
             inverse = Float32(inverse_storage[0])

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -76,6 +76,17 @@ class Caps:
     window_size: int | None = None
     use_cuda_graph: bool = False
     budget: Budget | None = None
+    # Element type of the per-split partial outputs a multi-split launch
+    # writes for the merge. bf16 halves the scratch; float32 keeps the split
+    # partials exact, so a merged result is rounded once, like a one-split
+    # result, and the answer no longer depends on how the chunks were split.
+    partial_dtype: torch.dtype = torch.bfloat16
+    # A request whose scanned chunks number at most this many is scanned by
+    # split 0 alone (the fixed-range association a plan-run kernel used, so the
+    # bits match it there); longer requests spread their chunks evenly over
+    # the launched splits. None resolves to the plan's chunks_per_split; 0
+    # balances every request.
+    single_split_chunks: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "device", _canonical_device(self.device))
@@ -130,6 +141,13 @@ class Caps:
             raise ValueError("num_cache_pages must be positive")
         if self.budget is not None and not isinstance(self.budget, Budget):
             raise TypeError("budget must be dense_mla.Budget or None")
+        if self.partial_dtype not in (torch.bfloat16, torch.float32):
+            raise TypeError("partial_dtype must be torch.bfloat16 or torch.float32")
+        if self.single_split_chunks is not None:
+            single_split_chunks = int(self.single_split_chunks)
+            if single_split_chunks < 0:
+                raise ValueError("single_split_chunks must be >= 0 or None")
+            object.__setattr__(self, "single_split_chunks", single_split_chunks)
         for name in (
             "num_q_heads",
             "page_size",
@@ -153,6 +171,7 @@ class _ScratchLayout:
     nbytes: int
     num_splits: int
     chunks_per_split: int
+    single_split_chunks: int
     partial_output_offset_bytes: int | None
     partial_lse_offset_bytes: int | None
     final_lse_offset_bytes: int
@@ -191,6 +210,11 @@ def _dense_mla_scratch_layout(
     )
     num_chunks = (max_attended_tokens + 63) // 64
     chunks_per_split = (num_chunks + num_splits - 1) // num_splits
+    single_split_chunks = (
+        chunks_per_split
+        if caps.single_split_chunks is None
+        else int(caps.single_split_chunks)
+    )
     partial_rows = caps.max_total_q * num_splits
     if (
         caps.budget is not None
@@ -214,7 +238,7 @@ def _dense_mla_scratch_layout(
             * caps.num_q_heads
             * num_splits
             * caps.v_head_dim
-            * dtype_nbytes(torch.bfloat16)
+            * dtype_nbytes(caps.partial_dtype)
         )
         cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
         partial_lse_offset_bytes = cursor
@@ -240,6 +264,7 @@ def _dense_mla_scratch_layout(
         nbytes=max(cursor, SCRATCH_ALIGN_BYTES),
         num_splits=num_splits,
         chunks_per_split=chunks_per_split,
+        single_split_chunks=single_split_chunks,
         partial_output_offset_bytes=partial_output_offset_bytes,
         partial_lse_offset_bytes=partial_lse_offset_bytes,
         final_lse_offset_bytes=final_lse_offset_bytes,
@@ -267,6 +292,8 @@ class Scratch:
     window_size: int | None
     num_splits: int
     chunks_per_split: int
+    single_split_chunks: int
+    partial_dtype: torch.dtype
     query_tile: int
     use_cuda_graph: bool
     partial_output: torch.Tensor | None
@@ -550,7 +577,7 @@ def _materialize(
                 layout.num_splits,
                 caps.v_head_dim,
             ),
-            dtype=torch.bfloat16,
+            dtype=caps.partial_dtype,
         )
         partial_lse, _ = materialize_scratch_view(
             scratch_storage,
@@ -592,6 +619,8 @@ def _materialize(
         window_size=caps.window_size,
         num_splits=layout.num_splits,
         chunks_per_split=layout.chunks_per_split,
+        single_split_chunks=layout.single_split_chunks,
+        partial_dtype=caps.partial_dtype,
         query_tile=query_tile,
         use_cuda_graph=caps.use_cuda_graph,
         partial_output=partial_output,
@@ -625,6 +654,15 @@ class Plan:
     @property
     def chunks_per_split(self) -> int:
         return int(self.layout.chunks_per_split)
+
+    @property
+    def single_split_chunks(self) -> int:
+        """Largest scanned-chunk count that split 0 scans alone."""
+        return int(self.layout.single_split_chunks)
+
+    @property
+    def partial_dtype(self) -> torch.dtype:
+        return self.caps.partial_dtype
 
     def bind(
         self,

--- a/b12x/attention/dense_mla/_scratch.py
+++ b/b12x/attention/dense_mla/_scratch.py
@@ -79,7 +79,9 @@ class Caps:
     # Element type of the per-split partial outputs a multi-split launch
     # writes for the merge. bf16 halves the scratch; float32 keeps the split
     # partials exact, so a merged result is rounded once, like a one-split
-    # result, and the answer no longer depends on how the chunks were split.
+    # result. The split assignment still determines the online-softmax
+    # chains and the FP32 merge order, so multi-split results differ from a
+    # one-split result at the FP32 level.
     partial_dtype: torch.dtype = torch.bfloat16
     # A request whose scanned chunks number at most this many is scanned by
     # split 0 alone (the fixed-range association a plan-run kernel used, so the

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -682,10 +682,13 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         cu_seqlens_q=cu_seqlens_q,
         q_scale=q_scale,
         kv_scale=kv_scale,
-        # The balanced prefix: one split per live 64-token chunk.
+        # One launched split per live 64-token chunk. The five chunks fit
+        # the plan's single-split threshold (chunks_per_split = 22), so
+        # split 0 scans all of them and splits 1-4 publish empty partials.
         active_splits=5,
     )
     assert binding.active_splits == 5
+    assert plan.single_split_chunks == plan.chunks_per_split == 22
     dense_mla.compile(binding=binding)
     actual_output, actual_lse = dense_mla.run(binding=binding)
     torch.cuda.synchronize()
@@ -719,11 +722,10 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         expected_lse,
     )
 
-    # Split ranges are balanced over the launched splits: a prefix of
-    # min(num_splits, live chunks) splits partitions the live chunks exactly
-    # like the full-plan launch (one chunk per split here, the remaining
-    # full-plan splits empty), so the two must match including the BF16
-    # output bits.
+    # A prefix of min(num_splits, live chunks) launched splits assigns the
+    # live chunks exactly like the full-plan launch (here split 0 takes all
+    # five chunks under either launch and every other split stays empty),
+    # so the two must match including the BF16 output bits.
     full_output = torch.empty_like(output)
     full_binding = dense_mla.bind(
         plan,
@@ -742,6 +744,8 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
     torch.cuda.synchronize()
     torch.testing.assert_close(full_actual, captured_output, rtol=0, atol=0)
     torch.testing.assert_close(full_lse, captured_lse, rtol=0, atol=0)
+    finite_partials = torch.isfinite(full_binding.scratch.partial_lse[0]).sum(dim=-1)
+    assert int(finite_partials.max().item()) == 1
 
 
 @torch.inference_mode()

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -681,9 +681,10 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         cu_seqlens_q=cu_seqlens_q,
         q_scale=q_scale,
         kv_scale=kv_scale,
-        active_splits=1,
+        # The balanced prefix: one split per live 64-token chunk.
+        active_splits=5,
     )
-    assert binding.active_splits == 1
+    assert binding.active_splits == 5
     dense_mla.compile(binding=binding)
     actual_output, actual_lse = dense_mla.run(binding=binding)
     torch.cuda.synchronize()
@@ -717,9 +718,11 @@ def test_fp8_production_split_plan_handles_short_live_sequence() -> None:
         expected_lse,
     )
 
-    # The active prefix preserves the maximum-context split boundaries and
-    # only omits mathematically empty tail splits. It must therefore match a
-    # full-plan launch exactly, including the BF16 output bits.
+    # Split ranges are balanced over the launched splits: a prefix of
+    # min(num_splits, live chunks) splits partitions the live chunks exactly
+    # like the full-plan launch (one chunk per split here, the remaining
+    # full-plan splits empty), so the two must match including the BF16
+    # output bits.
     full_output = torch.empty_like(output)
     full_binding = dense_mla.bind(
         plan,
@@ -932,3 +935,67 @@ def test_fp8_page_ids_past_int32_scaled_offset_match_reference() -> None:
         expected_output,
         expected_lse,
     )
+
+
+@torch.inference_mode()
+def test_balanced_splits_cover_a_long_live_sequence_with_every_split() -> None:
+    """A live sequence far below the planned capacity is shared by every
+    launched split (about live_chunks / active_splits chunks each) instead
+    of a few splits scanning capacity-sized ranges; the result matches the
+    reference, and a one-split launch of the same rows agrees within the
+    reassociation tolerance."""
+    device = require_b12x()
+    torch.manual_seed(20260902)
+    page_size = 64
+    max_cache_tokens = 131_072
+    plan = dense_mla.plan(
+        dense_mla.Caps(
+            device=device,
+            mode="decode",
+            kv_dtype=torch.bfloat16,
+            num_q_heads=8,
+            page_size=page_size,
+            max_total_q=1,
+            max_batch=1,
+            max_cache_tokens=max_cache_tokens,
+            max_page_table_width=max_cache_tokens // page_size,
+            num_cache_pages=1 << 20,
+            use_cuda_graph=True,
+        )
+    )
+    assert plan.num_splits > 8
+    live = 10_240  # 160 chunks: fewer than the planned 2,048, more than the splits
+    num_pages = live // page_size
+    q = torch.randn(1, 8, QK_DIM, device=device, dtype=torch.bfloat16) * 0.1
+    cache = torch.randn(num_pages, page_size, QK_DIM, device=device, dtype=torch.bfloat16) * 0.1
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).view(1, -1)
+    cache_seqlens = torch.tensor([live], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    expected_output, expected_lse = dense_mla.reference(
+        q, cache, page_table, cache_seqlens, cu_seqlens_q
+    )
+
+    outputs = {}
+    for active in (plan.num_splits, 1):
+        output = torch.empty(1, 8, VALUE_DIM, dtype=torch.bfloat16, device=device)
+        binding = dense_mla.bind(
+            plan,
+            scratch=_scratch(plan),
+            q=q,
+            kv_cache=cache,
+            output=output,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+            active_splits=active,
+        )
+        dense_mla.compile(binding=binding)
+        actual_output, actual_lse = dense_mla.run(binding=binding)
+        torch.cuda.synchronize()
+        _assert_matches(actual_output, actual_lse, expected_output, expected_lse)
+        outputs[active] = (actual_output.clone(), actual_lse.clone())
+    full_output, full_lse = outputs[plan.num_splits]
+    one_output, one_lse = outputs[1]
+    torch.testing.assert_close(full_output, one_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(full_lse, one_lse, rtol=2e-5, atol=2e-5)
+

--- a/tests/attention/test_dense_mla.py
+++ b/tests/attention/test_dense_mla.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from b12x.attention import dense_mla
+from b12x.attention.dense_mla._reference import K3_SM_SCALE
 
 from ..conftest import require_b12x
 
@@ -999,3 +1000,200 @@ def test_balanced_splits_cover_a_long_live_sequence_with_every_split() -> None:
     torch.testing.assert_close(full_output, one_output, rtol=2e-2, atol=2e-2)
     torch.testing.assert_close(full_lse, one_lse, rtol=2e-5, atol=2e-5)
 
+
+def _plan_131k(device, **overrides) -> dense_mla.Plan:
+    """A decode plan sized for one DCP-8 shard of a 1M-token window with four
+    query rows (one 8-head tile each), which the wave-balanced planner maps
+    to 47 splits of 44 chunks on a 188-SM device."""
+    page_size = 64
+    max_cache_tokens = 131_072
+    caps = dict(
+        device=device,
+        mode="decode",
+        kv_dtype=torch.bfloat16,
+        num_q_heads=8,
+        page_size=page_size,
+        max_total_q=4,
+        max_batch=4,
+        max_cache_tokens=max_cache_tokens,
+        max_page_table_width=max_cache_tokens // page_size,
+        num_cache_pages=1 << 20,
+        use_cuda_graph=True,
+    )
+    caps.update(overrides)
+    return dense_mla.plan(dense_mla.Caps(**caps))
+
+
+def _run_131k(plan, scratch, q, cache, live, *, active_splits=None):
+    device = q.device
+    page_size = 64
+    num_pages = (live + page_size - 1) // page_size
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).view(1, -1)
+    cache_seqlens = torch.tensor([live], dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    output = torch.empty(1, 8, VALUE_DIM, dtype=torch.bfloat16, device=device)
+    kwargs = {} if active_splits is None else {"active_splits": active_splits}
+    binding = dense_mla.bind(
+        plan,
+        scratch=scratch,
+        q=q,
+        kv_cache=cache,
+        output=output,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        **kwargs,
+    )
+    dense_mla.compile(binding=binding)
+    actual_output, actual_lse = dense_mla.run(binding=binding)
+    torch.cuda.synchronize()
+    return actual_output.clone(), actual_lse.clone(), binding
+
+
+def test_partial_dtype_and_single_split_chunks_are_validated() -> None:
+    common = dict(
+        device="cpu",
+        mode="decode",
+        kv_dtype=torch.bfloat16,
+        num_q_heads=HEADS,
+        page_size=16,
+        max_total_q=1,
+        max_batch=1,
+        max_cache_tokens=128,
+        max_page_table_width=8,
+        num_cache_pages=8,
+    )
+    with pytest.raises(TypeError, match="partial_dtype"):
+        dense_mla.Caps(partial_dtype=torch.float16, **common)
+    with pytest.raises(ValueError, match="single_split_chunks"):
+        dense_mla.Caps(single_split_chunks=-1, **common)
+    plan = dense_mla.plan(dense_mla.Caps(**common))
+    assert plan.single_split_chunks == plan.chunks_per_split
+    assert plan.partial_dtype == torch.bfloat16
+    balanced = dense_mla.plan(dense_mla.Caps(single_split_chunks=0, **common))
+    assert balanced.single_split_chunks == 0
+
+
+def test_fp32_partials_double_the_partial_scratch() -> None:
+    """The partial-output region is the only scratch that scales with the
+    partial element type; the LSE regions keep their float32 size."""
+    device = require_b12x()
+    bf16_plan = _plan_131k(device)
+    fp32_plan = _plan_131k(device, partial_dtype=torch.float32)
+    assert bf16_plan.num_splits == fp32_plan.num_splits > 1
+    (bf16_spec,) = bf16_plan.scratch_specs()
+    (fp32_spec,) = fp32_plan.scratch_specs()
+    rows = bf16_plan.caps.max_total_q
+    partial_bf16_bytes = rows * 8 * bf16_plan.num_splits * VALUE_DIM * 2
+    grown = fp32_spec.shape[0] * fp32_spec.dtype.itemsize - (
+        bf16_spec.shape[0] * bf16_spec.dtype.itemsize
+    )
+    assert grown == partial_bf16_bytes
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("partial_dtype", [torch.bfloat16, torch.float32])
+def test_single_split_requests_match_the_one_split_launch_bitwise(
+    partial_dtype: torch.dtype,
+) -> None:
+    """A request with at most single_split_chunks live chunks is scanned by
+    split 0 alone under a full-plan launch, so its merged result equals the
+    direct one-split write bit for bit (the fixed-range association a
+    chunks_per_split-run kernel produces); the 44-chunk run boundary is the
+    last such length. One chunk past it the request is balanced over the
+    launched splits, which the full-plan and eager launches partition
+    identically."""
+    device = require_b12x()
+    torch.manual_seed(20260903)
+    plan = _plan_131k(device, partial_dtype=partial_dtype)
+    assert plan.num_splits > 8
+    run = plan.chunks_per_split
+    assert plan.single_split_chunks == run
+    scratch = _scratch(plan)
+    q = torch.randn(1, 8, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+    cache = torch.randn(2_048, 64, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+    for live in (1, 63, 64, 65, run * 64 // 2, run * 64 - 1, run * 64):
+        full_output, full_lse, binding = _run_131k(plan, scratch, q, cache, live)
+        finite = torch.isfinite(binding.scratch.partial_lse[0]).sum(dim=-1)
+        assert int(finite.max().item()) == 1, live
+        one_output, one_lse, _ = _run_131k(
+            plan, scratch, q, cache, live, active_splits=1
+        )
+        assert torch.equal(full_output, one_output), live
+        assert torch.equal(full_lse, one_lse), live
+    live = run * 64 + 1
+    full_output, full_lse, binding = _run_131k(plan, scratch, q, cache, live)
+    finite = torch.isfinite(binding.scratch.partial_lse[0]).sum(dim=-1)
+    assert int(finite.min().item()) == min(plan.num_splits, run + 1)
+    eager_output, eager_lse, _ = _run_131k(
+        plan, scratch, q, cache, live, active_splits=min(plan.num_splits, run + 1)
+    )
+    assert torch.equal(full_output, eager_output)
+    assert torch.equal(full_lse, eager_lse)
+
+
+@torch.inference_mode()
+def test_single_split_chunks_zero_balances_short_requests() -> None:
+    device = require_b12x()
+    torch.manual_seed(20260903)
+    plan = _plan_131k(device, single_split_chunks=0)
+    assert plan.single_split_chunks == 0
+    scratch = _scratch(plan)
+    q = torch.randn(1, 8, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+    cache = torch.randn(64, 64, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+    output, lse, binding = _run_131k(plan, scratch, q, cache, 1_000)
+    finite = torch.isfinite(binding.scratch.partial_lse[0]).sum(dim=-1)
+    assert int(finite.min().item()) == 16  # one split per live chunk
+    page_table = torch.arange(16, dtype=torch.int32, device=device).view(1, -1)
+    expected_output, expected_lse = dense_mla.reference(
+        q,
+        cache[:16],
+        page_table,
+        torch.tensor([1_000], dtype=torch.int32, device=device),
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+    )
+    _assert_matches(output, lse, expected_output, expected_lse)
+
+
+@torch.inference_mode()
+def test_fp32_partials_remove_the_second_rounding() -> None:
+    """With bf16 partials a merged result is rounded twice, so balancing a
+    short request over many one-chunk splits is measurably less accurate
+    than the one-split scan; float32 partials bring the merged result back
+    to the one-split accuracy, and improve every multi-split result."""
+    device = require_b12x()
+    torch.manual_seed(20260903)
+    q = torch.randn(1, 8, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+    cache = torch.randn(2_048, 64, QK_DIM, device=device, dtype=torch.bfloat16) * 0.3
+
+    def relative_error(output, live):
+        num_pages = (live + 63) // 64
+        page_table = torch.arange(num_pages, dtype=torch.int32, device=device).view(1, -1)
+        records = cache[:num_pages].reshape(-1, QK_DIM)[:live].double()
+        scores = (q[0].double() @ records.t()) * K3_SM_SCALE
+        probabilities = torch.softmax(scores, dim=-1)
+        reference = probabilities @ records[:, :VALUE_DIM]
+        error = output[0].double() - reference
+        return float(error.norm() / reference.norm())
+
+    plans = {
+        dtype: _plan_131k(device, single_split_chunks=0, partial_dtype=dtype)
+        for dtype in (torch.bfloat16, torch.float32)
+    }
+    one_split = _plan_131k(device)
+    assert one_split.chunks_per_split * 64 >= 2_816
+    scratch = _scratch(plans[torch.float32])
+    for live in (1_000, 2_816):
+        one_output, _, _ = _run_131k(one_split, scratch, q, cache, live)
+        bf16_output, _, _ = _run_131k(plans[torch.bfloat16], scratch, q, cache, live)
+        fp32_output, _, _ = _run_131k(plans[torch.float32], scratch, q, cache, live)
+        single = relative_error(one_output, live)
+        bf16 = relative_error(bf16_output, live)
+        fp32 = relative_error(fp32_output, live)
+        assert bf16 > single * 1.05, (live, single, bf16)
+        assert fp32 < bf16 * 0.95, (live, bf16, fp32)
+        assert abs(fp32 - single) < single * 0.05, (live, single, fp32)
+    live = 10_240  # 160 chunks: every plan merges several partials
+    bf16_output, _, _ = _run_131k(plans[torch.bfloat16], scratch, q, cache, live)
+    fp32_output, _, _ = _run_131k(plans[torch.float32], scratch, q, cache, live)
+    assert relative_error(fp32_output, live) < relative_error(bf16_output, live) * 0.95

--- a/tests/attention/test_dense_mla_window.py
+++ b/tests/attention/test_dense_mla_window.py
@@ -260,3 +260,48 @@ def test_fp8_page_offset_exceeds_signed_int32() -> None:
     torch.cuda.synchronize(device)
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
     torch.testing.assert_close(actual_lse, expected_lse, rtol=2e-5, atol=2e-5)
+
+
+def test_windowed_plans_scan_one_query_row_per_tile() -> None:
+    """The windowed producer gathers the chunk range visible to the tile's
+    first query row, so a windowed tile must hold exactly one row: the
+    planner selects that geometry for every mode, and the kernel refuses a
+    wider tile."""
+    from b12x.attention.dense_mla._forward import DenseMlaForwardKernel
+    from b12x.attention.dense_mla._layout import make_smem_layout
+
+    for mode, max_total_q in (("extend", 4), ("decode", 4), ("verify", 4)):
+        plan = dense_mla.plan(
+            dense_mla.Caps(
+                device="cpu",
+                mode=mode,
+                kv_dtype=FP8,
+                q_dtype=torch.bfloat16,
+                num_q_heads=8,
+                page_size=64,
+                max_total_q=max_total_q,
+                max_batch=1,
+                max_cache_tokens=1024,
+                max_page_table_width=16,
+                num_cache_pages=32,
+                head_dim=1088,
+                v_head_dim=1024,
+                physical_record_width=1088,
+                window_size=WINDOW_SIZE,
+            )
+        )
+        assert plan.query_tile == 1, mode
+    layout = make_smem_layout(query_tile=2, fp8=False, qk_dim=576)
+    with pytest.raises(ValueError, match="one query row per tile"):
+        DenseMlaForwardKernel(
+            layout=layout,
+            page_size=64,
+            num_heads=8,
+            num_splits=4,
+            chunks_per_split=4,
+            query_tile=2,
+            fp8=False,
+            qk_dim=576,
+            value_dim=512,
+            window_size=WINDOW_SIZE,
+        )

--- a/tests/attention/test_dense_mla_window.py
+++ b/tests/attention/test_dense_mla_window.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import torch
 
@@ -292,16 +294,21 @@ def test_windowed_plans_scan_one_query_row_per_tile() -> None:
         )
         assert plan.query_tile == 1, mode
     layout = make_smem_layout(query_tile=2, fp8=False, qk_dim=576)
+    kernel_args = dict(
+        layout=layout,
+        page_size=64,
+        num_heads=8,
+        num_splits=4,
+        chunks_per_split=4,
+        query_tile=2,
+        fp8=False,
+        qk_dim=576,
+        value_dim=512,
+        window_size=WINDOW_SIZE,
+    )
+    # Range options the kernel may take besides the geometry above.
+    optional = {"single_split_chunks": 4}
+    accepted = inspect.signature(DenseMlaForwardKernel).parameters
+    kernel_args.update({k: v for k, v in optional.items() if k in accepted})
     with pytest.raises(ValueError, match="one query row per tile"):
-        DenseMlaForwardKernel(
-            layout=layout,
-            page_size=64,
-            num_heads=8,
-            num_splits=4,
-            chunks_per_split=4,
-            query_tile=2,
-            fp8=False,
-            qk_dim=576,
-            value_dim=512,
-            window_size=WINDOW_SIZE,
-        )
+        DenseMlaForwardKernel(**kernel_args)


### PR DESCRIPTION
Stacked on #291 (balanced split ranges); the first commit is #291's.

## Behaviour

Dense MLA decode results depend on how a request's 64-token chunks are split over CTAs, because the multi-split path stores each split's normalized partial output in **bf16** before the merge (`_scratch.py` sizes `partial_output` in bf16, `write_partial_or_final` casts to it): a merged result is rounded twice, a one-split result once. Balancing the chunks over the launched splits (#291) therefore lowered the accuracy of requests short enough for the fixed-range kernel to scan with a single split (≤ `chunks_per_split` live chunks, 44 for a 131,072-token plan): relative error against an fp64 reference +9…+19 %, about 40 % of output elements moved by one bf16 ulp; requests above that length became 1–12 % *more* accurate (shorter online-softmax chains).

Two plan options:

- `Caps.single_split_chunks` (default: the plan's `chunks_per_split`) — a request whose scanned chunks (past any window start) fit this count is scanned by split 0 alone, reproducing the fixed-range kernel's association and its bits exactly (`torch.equal` on output and LSE); longer requests keep the balanced ranges. `0` balances every request.
- `Caps.partial_dtype` (`bf16` default, `float32` optional) — float32 partials keep the split partials exact, so the merged result is rounded once and is 5–25 % closer to the fp64 reference than the bf16-partial result at every length; a single valid partial merges to the same bits as the direct one-split write. Partial scratch doubles (`max_total_q × heads × splits × v_head_dim × 4 B`).

Both are compile-key fields (spec versions bumped); the merge kernel loads float32 partials with `ld.global.v4.f32`. Existing plans are unchanged (bf16 partials, plan-run threshold).

## Measurements (SM120, bf16 KV, 47 × 44 plan, 4 rows × 8 heads, fp64 reference)

Relative L2 error, flat logits (peaky in brackets) — `static` = fixed-range kernel, `balanced` = #291, `hybrid` = this PR's default, `/fp32` = `partial_dtype=float32`:

| live tokens | static | balanced | hybrid | hybrid/fp32 | balanced/fp32 |
|---:|---:|---:|---:|---:|---:|
| 1,000 | 2.35e-3 | 2.79e-3 | = static (bitwise) | = static (bitwise) | 2.24e-3 |
| 2,816 | 2.30e-3 | 2.65e-3 | = static (bitwise) | = static (bitwise) | 2.18e-3 |
| 2,817 | 2.45e-3 | 2.66e-3 | = balanced (bitwise) | 2.19e-3 | 2.19e-3 |
| 5,633 | 2.86e-3 | 2.64e-3 | = balanced | 2.19e-3 | 2.19e-3 |
| 10,240 | 2.63e-3 | 2.55e-3 | = balanced | 2.14e-3 | 2.14e-3 |
| 40,960 | 2.27e-3 | 2.24e-3 | = balanced | 1.98e-3 | 1.98e-3 |
| 131,072 | 1.92e-3 | = static | = static | 1.80e-3 | 1.80e-3 |

Kernel time, forward + merge (µs): 1,024 tokens static 47.6 / balanced 9.3 / hybrid 47.0 / hybrid-fp32 45.3 / balanced-fp32 7.7; 2,817 tokens 125.0 / 10.6 / 10.7 / 9.2 / 9.3; 10,240 tokens 123.2 / 20.0 / 19.7 / 18.7 / 18.3; 40,960 tokens 129.7 / 50.6 / 49.2 / 48.3 / 49.2.

## Validation

`tests/attention/test_dense_mla.py` + `test_dense_mla_window.py`: 28 passed. New tests: single-split requests equal the eager one-split launch bitwise for both partial dtypes at 1…44 chunks and the balanced partition at 45; `single_split_chunks=0` spreads 16 chunks over 16 splits; float32 partials reduce the fp64 relative error at 1,000 / 2,816 / 10,240 tokens; Caps validation; scratch growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWxmKzfikaemyykd3p89D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Dense MLA keeps short requests within one split by default, preserving fixed-range kernel output and bitwise-equivalent LSE results.
- Longer requests use balanced chunk ranges across active splits to reduce unnecessary work.
- `Caps.single_split_chunks` configures the short-request threshold. A value of `0` enables balancing for every request.
- `Caps.partial_dtype` selects `torch.bfloat16` or `torch.float32` partial storage. `torch.bfloat16` remains the default.
- Float32 partials reduce intermediate rounding error during split merges. The merge kernel and scratch layout now support both formats.
- `single_split_chunks` and `partial_dtype` are compile-key fields. Forward and merge specification versions increase from 4 to 5.
- Public constructors and plan data now expose the new configuration. Existing defaults preserve prior behavior.
- Validation covers dense MLA and window cases, split balancing, scratch sizing, single-split equivalence, zero-threshold balancing, and float32 accuracy. 28 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->