### PR TITLE
comm.roce: RoCEnante, one-shot RoCE all-reduce/all-gather for multi-node DGX Spark TP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ parallel).
 quantized lookup, and short-convolution state), `sequence.gdn_decode` (packed
 recurrent decode),
 `sequence.mtp_feedback` (MTP token/multi-stream feedback fusion),
-`quantization.{nvfp4,mxfp8}` (row quantizers), and `comm.pcie` (IPC-backed PCIe
+`quantization.{nvfp4,mxfp8}` (row quantizers), `comm.roce` (RoCEnante: one-shot
+RDMA all-reduce/all-gather for multi-node DGX Spark TP, see `docs/rocenante.md`),
+and `comm.pcie` (IPC-backed PCIe
 collectives). The Qwen3.8-Flash-Next QSA, HyperConnection, PLE, GDN decode,
 and MTP feedback Triton implementations are correctness references and are
 not throughput-qualified production kernels.

--- a/b12x/comm/roce/__init__.py
+++ b/b12x/comm/roce/__init__.py
@@ -1,0 +1,15 @@
+"""``b12x.comm.roce``: one-shot all-reduce over RoCE for multi-node TP.
+
+Target: clusters of DGX Spark nodes joined by their ConnectX-7 200 GbE ports,
+one GPU per node.  The GB10's unified memory lets the NIC RDMA-write straight
+into pinned host memory that the GPU kernel then reads in place, so no
+GPUDirect RDMA (dmabuf/peermem) support is required.
+
+``AllReduce`` mirrors the ``comm.pcie.AllReduce`` surface (``from_exchange_group``,
+``should_allreduce``, ``all_reduce``, ``for_stream``, ``capture``, ``close``) so
+integrations can dispatch to it behind the same adapter.  See
+``roce_oneshot.py`` for the protocol and constraints.
+"""
+
+from .api import *  # noqa: F401,F403
+from .api import __all__  # noqa: F401

--- a/b12x/comm/roce/__init__.py
+++ b/b12x/comm/roce/__init__.py
@@ -1,4 +1,4 @@
-"""``b12x.comm.roce``: one-shot all-reduce over RoCE for multi-node TP.
+"""``b12x.comm.roce``: one-shot all-reduce and all-gather over RoCE for multi-node TP.
 
 Target: clusters of DGX Spark nodes joined by their ConnectX-7 200 GbE ports,
 one GPU per node.  The GB10's unified memory lets the NIC RDMA-write straight
@@ -6,7 +6,8 @@ into pinned host memory that the GPU kernel then reads in place, so no
 GPUDirect RDMA (dmabuf/peermem) support is required.
 
 ``AllReduce`` mirrors the ``comm.pcie.AllReduce`` surface (``from_exchange_group``,
-``should_allreduce``, ``all_reduce``, ``for_stream``, ``capture``, ``close``) so
+``should_allreduce``, ``all_reduce``, ``for_stream``, ``capture``, ``close``) plus
+``should_all_gather``/``all_gather`` for dim-0 and last-dim concatenation, so
 integrations can dispatch to it behind the same adapter.  See
 ``roce_oneshot.py`` for the protocol and constraints.
 """

--- a/b12x/comm/roce/__init__.py
+++ b/b12x/comm/roce/__init__.py
@@ -1,4 +1,4 @@
-"""``b12x.comm.roce``: one-shot all-reduce and all-gather over RoCE for multi-node TP.
+"""``b12x.comm.roce`` (RoCEnante): one-shot all-reduce and all-gather over RoCE for multi-node TP.
 
 Target: clusters of DGX Spark nodes joined by their ConnectX-7 200 GbE ports,
 one GPU per node.  The GB10's unified memory lets the NIC RDMA-write straight

--- a/b12x/comm/roce/_allgather_cute.py
+++ b/b12x/comm/roce/_allgather_cute.py
@@ -1,0 +1,277 @@
+"""CuTe DSL kernel for the RoCE one-shot all-gather.
+
+Same transport and protocol as the one-shot all-reduce (stage, doorbell,
+wait on per-peer flags, advance the epoch) with the reduction replaced by a
+strided copy that writes the concatenated output directly:
+
+* ``dim == 0`` concat: ``rows == 1``, output is shard 0, shard 1, ... in order;
+* last-dim concat: each shard is ``rows`` rows of ``row_packs`` 16-byte packs
+  and shard ``s`` lands at column block ``s`` of every output row, so no
+  separate reshape/copy is needed after the collective.
+
+The local shard is copied from the input; peer shards are read in place from
+the NIC-written slots with system-scope loads.  Every launch of one runtime
+uses the same grid (shared counters with the all-reduce kernel).
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Uint32
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import current_cuda_stream, make_ptr
+
+from ._cute_intrinsics import (
+    atomic_add_relaxed_gpu_u32,
+    fence_sc_gpu,
+    fence_sc_sys,
+    ld_global_v4_u32,
+    ld_relaxed_gpu_u32,
+    ld_relaxed_sys_v4_u32,
+    spin_until_eq_acquire_sys,
+    st_global_v4_u32,
+    st_release_gpu_u32,
+    st_relaxed_sys_u32,
+)
+
+PACK_BYTES = 16
+_PREPARED_LAUNCHERS: set[tuple[object, ...]] = set()
+
+
+class _RoceAllGatherLaunch:
+    def __init__(
+        self, world_size: int, rank: int, threads: int, slots: int, flag_stride: int
+    ) -> None:
+        self._world_size = int(world_size)
+        self._rank = int(rank)
+        self._threads = int(threads)
+        self._slots = int(slots)
+        self._flag_stride = int(flag_stride)
+
+    @cute.jit
+    def __call__(
+        self,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        shard_packs: Int32,
+        nbytes: Int32,
+        row_packs: Int32,
+        recv_base: Int64,
+        flag_base: Int64,
+        send_base: Int64,
+        ctrl_base: Int64,
+        slot_bytes: Int64,
+        epoch_ptr: Int64,
+        spin_limit: Uint32,
+        grid_x: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            input_ptr,
+            output_ptr,
+            shard_packs,
+            nbytes,
+            row_packs,
+            recv_base,
+            flag_base,
+            send_base,
+            ctrl_base,
+            slot_bytes,
+            epoch_ptr,
+            spin_limit,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        shard_packs: Int32,
+        nbytes: Int32,
+        row_packs: Int32,
+        recv_base: Int64,
+        flag_base: Int64,
+        send_base: Int64,
+        ctrl_base: Int64,
+        slot_bytes: Int64,
+        epoch_ptr: Int64,
+        spin_limit: Uint32,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        input_base = Int64(input_ptr.toint())
+        output_base = Int64(output_ptr.toint())
+        stage_counter_ptr = epoch_ptr + Int64(4)
+        tail_counter_ptr = epoch_ptr + Int64(8)
+
+        epoch = ld_relaxed_gpu_u32(epoch_ptr)
+        seq = epoch + Uint32(1)
+        slot = Int64(seq & Uint32(1))
+        send_slot = send_base + slot * slot_bytes
+
+        index = Int32(bidx) * Int32(self._threads) + Int32(tidx)
+        stride = Int32(gdim) * Int32(self._threads)
+
+        # 1. stage the local shard into the pinned send slot
+        stage_index = index
+        while stage_index < shard_packs:
+            words = ld_global_v4_u32(input_base + Int64(stage_index) * Int64(PACK_BYTES))
+            st_global_v4_u32(
+                send_slot + Int64(stage_index) * Int64(PACK_BYTES),
+                words[0],
+                words[1],
+                words[2],
+                words[3],
+            )
+            stage_index += stride
+        fence_sc_sys()
+        cute.arch.sync_threads()
+
+        # 2. the last block to finish staging rings the proxy doorbell
+        if Int32(tidx) == Int32(0):
+            prior = atomic_add_relaxed_gpu_u32(stage_counter_ptr, Uint32(1))
+            if (prior + Uint32(1)) % Uint32(gdim) == Uint32(0):
+                st_relaxed_sys_u32(ctrl_base + Int64(4), Uint32(nbytes))
+                fence_sc_sys()
+                st_relaxed_sys_u32(ctrl_base, seq)
+
+        # 3. wait for every peer's payload flag
+        if Int32(tidx) < Int32(self._world_size):
+            if Int32(tidx) != Int32(self._rank):
+                flag_addr = flag_base + (
+                    Int64(tidx) * Int64(self._slots) + slot
+                ) * Int64(self._flag_stride)
+                timed_out = spin_until_eq_acquire_sys(flag_addr, seq, spin_limit)
+                if timed_out != Uint32(0):
+                    st_relaxed_sys_u32(ctrl_base + Int64(12), Uint32(tidx))
+                    st_relaxed_sys_u32(ctrl_base + Int64(8), seq)
+        cute.arch.sync_threads()
+
+        # 4. concatenate: shard s occupies column block s of every output row
+        out_row_packs = Int32(self._world_size) * row_packs
+        for source in cutlass.range_constexpr(self._world_size):
+            copy_index = index
+            while copy_index < shard_packs:
+                row = copy_index // row_packs
+                col = copy_index - row * row_packs
+                dest = output_base + (
+                    Int64(row) * Int64(out_row_packs)
+                    + Int64(source) * Int64(row_packs)
+                    + Int64(col)
+                ) * Int64(PACK_BYTES)
+                if cutlass.const_expr(source == self._rank):
+                    words = ld_global_v4_u32(
+                        input_base + Int64(copy_index) * Int64(PACK_BYTES)
+                    )
+                else:
+                    peer_slot = recv_base + (
+                        Int64(source) * Int64(self._slots) + slot
+                    ) * slot_bytes
+                    words = ld_relaxed_sys_v4_u32(
+                        peer_slot + Int64(copy_index) * Int64(PACK_BYTES)
+                    )
+                st_global_v4_u32(dest, words[0], words[1], words[2], words[3])
+                copy_index += stride
+
+        # 5. the last block to finish publishes the next epoch
+        fence_sc_gpu()
+        cute.arch.sync_threads()
+        if Int32(tidx) == Int32(0):
+            prior = atomic_add_relaxed_gpu_u32(tail_counter_ptr, Uint32(1))
+            if (prior + Uint32(1)) % Uint32(gdim) == Uint32(0):
+                st_release_gpu_u32(epoch_ptr, seq)
+
+
+def _dummy(dtype, alignment: int):
+    return make_ptr(dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment)
+
+
+def _process_key(
+    world_size: int, rank: int, threads: int, slots: int, flag_stride: int, device_index: int
+) -> tuple[object, ...]:
+    return (int(world_size), int(rank), int(threads), int(slots), int(flag_stride), int(device_index))
+
+
+def is_launcher_prepared(*key) -> bool:
+    return _process_key(*key) in _PREPARED_LAUNCHERS
+
+
+@functools.cache
+def get_launcher(
+    world_size: int, rank: int, threads: int, slots: int, flag_stride: int, device_index: int
+) -> Callable[..., None]:
+    process_key = _process_key(world_size, rank, threads, slots, flag_stride, device_index)
+    del device_index
+    launch = _RoceAllGatherLaunch(world_size, rank, threads, slots, flag_stride)
+    cache_key = (int(world_size), int(rank), int(threads), int(slots), int(flag_stride))
+    raise_if_kernel_resolution_frozen("cute.compile", target=launch, cache_key=cache_key)
+    raw = b12x_compile(
+        launch,
+        _dummy(cutlass.Uint32, 16),
+        _dummy(cutlass.Uint32, 16),
+        1,
+        16,
+        1,
+        16,
+        16,
+        16,
+        16,
+        4096,
+        16,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key("comm.roce.allgather", 1, cache_key),
+    )
+
+    def run(
+        input_address: int,
+        output_address: int,
+        shard_packs: int,
+        nbytes: int,
+        row_packs: int,
+        recv_base: int,
+        flag_base: int,
+        send_base: int,
+        ctrl_base: int,
+        slot_bytes: int,
+        epoch_address: int,
+        spin_limit: int,
+        grid_x: int,
+    ) -> None:
+        raw(
+            make_ptr(cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16),
+            int(shard_packs),
+            int(nbytes),
+            int(row_packs),
+            int(recv_base),
+            int(flag_base),
+            int(send_base),
+            int(ctrl_base),
+            int(slot_bytes),
+            int(epoch_address),
+            int(spin_limit),
+            int(grid_x),
+            current_cuda_stream(),
+        )
+
+    _PREPARED_LAUNCHERS.add(process_key)
+    return run
+
+
+__all__ = ["PACK_BYTES", "get_launcher", "is_launcher_prepared"]

--- a/b12x/comm/roce/_cute_intrinsics.py
+++ b/b12x/comm/roce/_cute_intrinsics.py
@@ -1,0 +1,303 @@
+"""PTX intrinsics for the RoCE one-shot all-reduce kernel.
+
+Payload slots and flags live in pinned host memory that the NIC writes by
+RDMA and the GPU reads in place, so every access to them is spelled out with
+system scope: ``ld.relaxed.sys`` for payload packs, ``ld.acquire.sys`` for the
+arrival flag, ``st.relaxed.sys`` plus ``fence.sc.sys`` for the doorbell the
+proxy thread polls.  Keeping them as small user ops makes the protocol
+explicit and independent of compiler defaults.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from cutlass import Float32, Int64, Uint32
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+
+def _asm(result_type, operands, text, constraints, *, side_effects=True, loc=None, ip=None):
+    return llvm.inline_asm(
+        result_type,
+        operands,
+        text,
+        constraints,
+        has_side_effects=side_effects,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_relaxed_gpu_u32(addr: Int64, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        _asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip)],
+            "ld.relaxed.gpu.global.u32 $0, [$1];",
+            "=r,l",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def atomic_add_relaxed_gpu_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        _asm(
+            T.i32(),
+            [Int64(addr).ir_value(loc=loc, ip=ip), Uint32(value).ir_value(loc=loc, ip=ip)],
+            "atom.relaxed.gpu.global.add.u32 $0, [$1], $2;",
+            "=r,l,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def st_release_gpu_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> None:
+    _asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Uint32(value).ir_value(loc=loc, ip=ip)],
+        "st.release.gpu.global.u32 [$0], $1;",
+        "l,r",
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def st_relaxed_sys_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> None:
+    _asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Uint32(value).ir_value(loc=loc, ip=ip)],
+        "st.relaxed.sys.global.u32 [$0], $1;",
+        "l,r",
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def fence_sc_sys(*, loc=None, ip=None) -> None:
+    _asm(None, [], "fence.sc.sys;", "", loc=loc, ip=ip)
+
+
+@dsl_user_op
+def fence_sc_gpu(*, loc=None, ip=None) -> None:
+    _asm(None, [], "fence.sc.gpu;", "", loc=loc, ip=ip)
+
+
+@dsl_user_op
+def spin_until_eq_acquire_sys(
+    addr: Int64, expected: Uint32, limit: Uint32, *, loc=None, ip=None
+) -> Uint32:
+    """Spin until the word at ``addr`` equals ``expected`` (system scope).
+
+    Returns 0 on success and 1 after ``limit`` polls without a match, so a
+    dead peer or proxy surfaces as an error instead of a hung kernel.
+    """
+    return Uint32(
+        _asm(
+            T.i32(),
+            [
+                Int64(addr).ir_value(loc=loc, ip=ip),
+                Uint32(expected).ir_value(loc=loc, ip=ip),
+                Uint32(limit).ir_value(loc=loc, ip=ip),
+            ],
+            """
+            {
+                .reg .pred pending, expired;
+                .reg .b32 seen, polls;
+                mov.u32 polls, 0;
+                mov.u32 $0, 0;
+            roce_wait:
+                ld.acquire.sys.global.u32 seen, [$1];
+                setp.ne.u32 pending, seen, $2;
+                @!pending bra roce_done;
+                add.u32 polls, polls, 1;
+                setp.ge.u32 expired, polls, $3;
+                @!expired bra roce_wait;
+                mov.u32 $0, 1;
+            roce_done:
+            }
+            """,
+            "=r,l,r,r",
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ld_relaxed_sys_v4_u32(
+    addr: Int64, *, loc=None, ip=None
+) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    """Load one 16-byte pack from NIC-written pinned memory without caching it."""
+    result = _asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int64(addr).ir_value(loc=loc, ip=ip)],
+        "ld.relaxed.sys.global.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Uint32(llvm.extractvalue(T.i32(), result, [i], loc=loc, ip=ip)) for i in range(4)
+    )
+
+
+@dsl_user_op
+def ld_global_v4_u32(addr: Int64, *, loc=None, ip=None) -> Tuple[Uint32, Uint32, Uint32, Uint32]:
+    result = _asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [Int64(addr).ir_value(loc=loc, ip=ip)],
+        "ld.global.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Uint32(llvm.extractvalue(T.i32(), result, [i], loc=loc, ip=ip)) for i in range(4)
+    )
+
+
+@dsl_user_op
+def st_global_v4_u32(
+    addr: Int64, v0: Uint32, v1: Uint32, v2: Uint32, v3: Uint32, *, loc=None, ip=None
+) -> None:
+    _asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Uint32(v0).ir_value(loc=loc, ip=ip),
+            Uint32(v1).ir_value(loc=loc, ip=ip),
+            Uint32(v2).ir_value(loc=loc, ip=ip),
+            Uint32(v3).ir_value(loc=loc, ip=ip),
+        ],
+        "st.global.v4.u32 [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def u32_as_f32(value: Uint32, *, loc=None, ip=None) -> Float32:
+    return Float32(
+        _asm(
+            T.f32(),
+            [Uint32(value).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=f,r",
+            side_effects=False,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def f32_as_u32(value: Float32, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        _asm(
+            T.i32(),
+            [Float32(value).ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=r,f",
+            side_effects=False,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    result = _asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(value).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.bf16 $0, lo;
+            cvt.f32.bf16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        side_effects=False,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def unpack_f16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    result = _asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Uint32(value).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b16 lo, hi;
+            mov.b32 {lo, hi}, $2;
+            cvt.f32.f16 $0, lo;
+            cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,r",
+        side_effects=False,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+    """Match two scalar ``__float2bfloat16`` conversions without saturation."""
+    return Uint32(
+        _asm(
+            T.i32(),
+            [Float32(lo).ir_value(loc=loc, ip=ip), Float32(hi).ir_value(loc=loc, ip=ip)],
+            """
+            {
+                .reg .b16 blo, bhi;
+                cvt.rn.bf16.f32 blo, $1;
+                cvt.rn.bf16.f32 bhi, $2;
+                mov.b32 $0, {blo, bhi};
+            }
+            """,
+            "=r,f,f",
+            side_effects=False,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def pack_f32x2_to_f16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+    return Uint32(
+        _asm(
+            T.i32(),
+            [Float32(lo).ir_value(loc=loc, ip=ip), Float32(hi).ir_value(loc=loc, ip=ip)],
+            "cvt.rn.f16x2.f32 $0, $2, $1;",
+            "=r,f,f",
+            side_effects=False,
+            loc=loc,
+            ip=ip,
+        )
+    )

--- a/b12x/comm/roce/_oneshot_cute.py
+++ b/b12x/comm/roce/_oneshot_cute.py
@@ -1,0 +1,369 @@
+"""CuTe DSL kernel for the RoCE one-shot all-reduce.
+
+One launch performs a complete all-reduce for one message:
+
+1. stage: copy the device input into ``send[seq & 1]`` in pinned host memory;
+2. doorbell: the last block to finish staging publishes ``nbytes`` and ``seq``
+   in the control record that the RDMA proxy thread polls;
+3. wait: spin on ``flag[peer][seq & 1] == seq`` for every peer (the peer's
+   proxy writes the flag after the payload on the same reliable QP); a wait
+   that exceeds ``spin_limit`` polls records ``seq`` in the control record's
+   error word and the host raises instead of hanging;
+4. reduce: sum the local input and every peer slot in fixed rank order, so all
+   ranks produce bit-identical output, and store the result;
+5. epoch: the last block to finish reduction advances the device-resident
+   epoch, which makes the sequence number a runtime value rather than a launch
+   argument and keeps CUDA-graph replay correct.
+
+Staging arrivals and tail arrivals use two separate counters.  A block that
+stages nothing can pass the peer wait (peers do not depend on our doorbell)
+and reach the tail before a slower block has staged, so one shared counter
+would ring the doorbell early and publish stale bytes.
+
+Every launch of one runtime uses the same grid, which both counters' moduli
+rely on.  Message size is a runtime scalar.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Int64, Uint32
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import current_cuda_stream, make_ptr
+
+from ._cute_intrinsics import (
+    atomic_add_relaxed_gpu_u32,
+    f32_as_u32,
+    fence_sc_gpu,
+    fence_sc_sys,
+    ld_global_v4_u32,
+    ld_relaxed_gpu_u32,
+    ld_relaxed_sys_v4_u32,
+    pack_f32x2_to_bf16x2,
+    pack_f32x2_to_f16x2,
+    spin_until_eq_acquire_sys,
+    st_global_v4_u32,
+    st_release_gpu_u32,
+    st_relaxed_sys_u32,
+    u32_as_f32,
+    unpack_bf16x2,
+    unpack_f16x2,
+)
+
+PACK_BYTES = 16
+_DTYPE_PACK_ELEMS = {"float32": 4, "float16": 8, "bfloat16": 8}
+_PREPARED_LAUNCHERS: set[tuple[object, ...]] = set()
+
+
+class _RoceOneshotLaunch:
+    def __init__(
+        self,
+        dtype_name: str,
+        world_size: int,
+        rank: int,
+        threads: int,
+        slots: int,
+        flag_stride: int,
+    ) -> None:
+        if dtype_name not in _DTYPE_PACK_ELEMS:
+            raise ValueError(f"unsupported RoCE one-shot dtype {dtype_name!r}")
+        self._dtype_name = dtype_name
+        self._pack_elems = _DTYPE_PACK_ELEMS[dtype_name]
+        self._world_size = int(world_size)
+        self._rank = int(rank)
+        self._threads = int(threads)
+        self._slots = int(slots)
+        self._flag_stride = int(flag_stride)
+
+    @cute.jit
+    def _accumulate_words(
+        self,
+        accumulator: cute.Tensor,
+        words,
+        initialize: cutlass.Constexpr[bool],
+    ) -> None:
+        if cutlass.const_expr(self._dtype_name == "float32"):
+            for word in cutlass.range_constexpr(4):
+                value = u32_as_f32(words[word])
+                if cutlass.const_expr(initialize):
+                    accumulator[word] = value
+                else:
+                    accumulator[word] = accumulator[word] + value
+        else:
+            for word in cutlass.range_constexpr(4):
+                if cutlass.const_expr(self._dtype_name == "float16"):
+                    lo, hi = unpack_f16x2(words[word])
+                else:
+                    lo, hi = unpack_bf16x2(words[word])
+                lane = word * 2
+                if cutlass.const_expr(initialize):
+                    accumulator[lane] = lo
+                    accumulator[lane + 1] = hi
+                else:
+                    accumulator[lane] = accumulator[lane] + lo
+                    accumulator[lane + 1] = accumulator[lane + 1] + hi
+
+    @cute.jit
+    def _store_accumulator(self, address: Int64, accumulator: cute.Tensor) -> None:
+        packed = cute.make_rmem_tensor((4,), cutlass.Uint32)
+        if cutlass.const_expr(self._dtype_name == "float32"):
+            for word in cutlass.range_constexpr(4):
+                packed[word] = f32_as_u32(accumulator[word])
+        else:
+            for word in cutlass.range_constexpr(4):
+                lane = word * 2
+                if cutlass.const_expr(self._dtype_name == "float16"):
+                    packed[word] = pack_f32x2_to_f16x2(
+                        accumulator[lane], accumulator[lane + 1]
+                    )
+                else:
+                    packed[word] = pack_f32x2_to_bf16x2(
+                        accumulator[lane], accumulator[lane + 1]
+                    )
+        st_global_v4_u32(address, packed[0], packed[1], packed[2], packed[3])
+
+    @cute.jit
+    def __call__(
+        self,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        size_packs: Int32,
+        nbytes: Int32,
+        recv_base: Int64,
+        flag_base: Int64,
+        send_base: Int64,
+        ctrl_base: Int64,
+        slot_bytes: Int64,
+        epoch_ptr: Int64,
+        spin_limit: Uint32,
+        grid_x: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            input_ptr,
+            output_ptr,
+            size_packs,
+            nbytes,
+            recv_base,
+            flag_base,
+            send_base,
+            ctrl_base,
+            slot_bytes,
+            epoch_ptr,
+            spin_limit,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        size_packs: Int32,
+        nbytes: Int32,
+        recv_base: Int64,
+        flag_base: Int64,
+        send_base: Int64,
+        ctrl_base: Int64,
+        slot_bytes: Int64,
+        epoch_ptr: Int64,
+        spin_limit: Uint32,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        input_base = Int64(input_ptr.toint())
+        output_base = Int64(output_ptr.toint())
+        stage_counter_ptr = epoch_ptr + Int64(4)
+        tail_counter_ptr = epoch_ptr + Int64(8)
+
+        # Every block reads the epoch before any block can advance it: the
+        # advance happens only after all blocks arrived at the tail counter.
+        epoch = ld_relaxed_gpu_u32(epoch_ptr)
+        seq = epoch + Uint32(1)
+        slot = Int64(seq & Uint32(1))
+        send_slot = send_base + slot * slot_bytes
+
+        index = Int32(bidx) * Int32(self._threads) + Int32(tidx)
+        stride = Int32(gdim) * Int32(self._threads)
+
+        # 1. stage the input into the pinned send slot
+        stage_index = index
+        while stage_index < size_packs:
+            words = ld_global_v4_u32(input_base + Int64(stage_index) * Int64(PACK_BYTES))
+            st_global_v4_u32(
+                send_slot + Int64(stage_index) * Int64(PACK_BYTES),
+                words[0],
+                words[1],
+                words[2],
+                words[3],
+            )
+            stage_index += stride
+        fence_sc_sys()
+        cute.arch.sync_threads()
+
+        # 2. the last block to finish staging rings the proxy doorbell
+        if Int32(tidx) == Int32(0):
+            prior = atomic_add_relaxed_gpu_u32(stage_counter_ptr, Uint32(1))
+            if (prior + Uint32(1)) % Uint32(gdim) == Uint32(0):
+                st_relaxed_sys_u32(ctrl_base + Int64(4), Uint32(nbytes))
+                fence_sc_sys()
+                st_relaxed_sys_u32(ctrl_base, seq)
+
+        # 3. wait for every peer's payload flag
+        if Int32(tidx) < Int32(self._world_size):
+            if Int32(tidx) != Int32(self._rank):
+                flag_addr = flag_base + (
+                    Int64(tidx) * Int64(self._slots) + slot
+                ) * Int64(self._flag_stride)
+                timed_out = spin_until_eq_acquire_sys(flag_addr, seq, spin_limit)
+                if timed_out != Uint32(0):
+                    st_relaxed_sys_u32(ctrl_base + Int64(12), Uint32(tidx))
+                    st_relaxed_sys_u32(ctrl_base + Int64(8), seq)
+        cute.arch.sync_threads()
+
+        # 4. reduce in fixed rank order so every rank stores identical bits
+        reduce_index = index
+        while reduce_index < size_packs:
+            accumulator = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+            offset = Int64(reduce_index) * Int64(PACK_BYTES)
+            for source in cutlass.range_constexpr(self._world_size):
+                if cutlass.const_expr(source == self._rank):
+                    words = ld_global_v4_u32(input_base + offset)
+                else:
+                    peer_slot = recv_base + (
+                        Int64(source) * Int64(self._slots) + slot
+                    ) * slot_bytes
+                    words = ld_relaxed_sys_v4_u32(peer_slot + offset)
+                self._accumulate_words(accumulator, words, source == 0)
+            self._store_accumulator(output_base + offset, accumulator)
+            reduce_index += stride
+
+        # 5. the last block to finish reduction publishes the next epoch
+        fence_sc_gpu()
+        cute.arch.sync_threads()
+        if Int32(tidx) == Int32(0):
+            prior = atomic_add_relaxed_gpu_u32(tail_counter_ptr, Uint32(1))
+            if (prior + Uint32(1)) % Uint32(gdim) == Uint32(0):
+                st_release_gpu_u32(epoch_ptr, seq)
+
+
+def _dummy(dtype, alignment: int):
+    return make_ptr(dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment)
+
+
+def _process_key(
+    dtype_name: str,
+    world_size: int,
+    rank: int,
+    threads: int,
+    slots: int,
+    flag_stride: int,
+    device_index: int,
+) -> tuple[object, ...]:
+    return (
+        str(dtype_name),
+        int(world_size),
+        int(rank),
+        int(threads),
+        int(slots),
+        int(flag_stride),
+        int(device_index),
+    )
+
+
+def is_launcher_prepared(*key) -> bool:
+    """Return whether this exact process-local launcher is already loaded."""
+
+    return _process_key(*key) in _PREPARED_LAUNCHERS
+
+
+@functools.cache
+def get_launcher(
+    dtype_name: str,
+    world_size: int,
+    rank: int,
+    threads: int,
+    slots: int,
+    flag_stride: int,
+    device_index: int,
+) -> Callable[..., None]:
+    process_key = _process_key(
+        dtype_name, world_size, rank, threads, slots, flag_stride, device_index
+    )
+    del device_index  # retained in the functools and preparation keys only
+    launch = _RoceOneshotLaunch(dtype_name, world_size, rank, threads, slots, flag_stride)
+    cache_key = (
+        str(dtype_name),
+        int(world_size),
+        int(rank),
+        int(threads),
+        int(slots),
+        int(flag_stride),
+    )
+    raise_if_kernel_resolution_frozen("cute.compile", target=launch, cache_key=cache_key)
+    raw = b12x_compile(
+        launch,
+        _dummy(cutlass.Uint32, 16),
+        _dummy(cutlass.Uint32, 16),
+        1,
+        16,
+        16,
+        16,
+        16,
+        16,
+        4096,
+        16,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key("comm.roce.oneshot", 1, cache_key),
+    )
+
+    def run(
+        input_address: int,
+        output_address: int,
+        size_packs: int,
+        nbytes: int,
+        recv_base: int,
+        flag_base: int,
+        send_base: int,
+        ctrl_base: int,
+        slot_bytes: int,
+        epoch_address: int,
+        spin_limit: int,
+        grid_x: int,
+    ) -> None:
+        raw(
+            make_ptr(cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16),
+            make_ptr(cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16),
+            int(size_packs),
+            int(nbytes),
+            int(recv_base),
+            int(flag_base),
+            int(send_base),
+            int(ctrl_base),
+            int(slot_bytes),
+            int(epoch_address),
+            int(spin_limit),
+            int(grid_x),
+            current_cuda_stream(),
+        )
+
+    _PREPARED_LAUNCHERS.add(process_key)
+    return run
+
+
+__all__ = ["PACK_BYTES", "get_launcher", "is_launcher_prepared"]

--- a/b12x/comm/roce/_proxy.py
+++ b/b12x/comm/roce/_proxy.py
@@ -8,6 +8,7 @@ the interpreter on its critical path.
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import hashlib
 import os
@@ -233,10 +234,8 @@ class Proxy:
             self._lib.roce_destroy(ctx)
 
     def __del__(self) -> None:  # pragma: no cover - defensive teardown
-        try:
+        with contextlib.suppress(Exception):
             self.close()
-        except Exception:
-            pass
 
 
 __all__ = ["Layout", "Proxy", "load"]

--- a/b12x/comm/roce/_proxy.py
+++ b/b12x/comm/roce/_proxy.py
@@ -1,0 +1,242 @@
+"""Build and bind the RDMA proxy shared library (``_roce_proxy.c``).
+
+The proxy is plain C over libibverbs.  It is compiled once per source hash
+with the host C compiler into the b12x cache directory, so the package stays
+pure Python for packaging purposes while the RDMA posting loop runs without
+the interpreter on its critical path.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+_SOURCE = Path(__file__).with_name("_roce_proxy.c")
+_LOCK = threading.Lock()
+_LIB: ctypes.CDLL | None = None
+
+BLOB_STRUCT_ERR = "roce proxy blob size mismatch"
+
+
+def _cache_dir() -> Path:
+    override = os.getenv("B12X_ROCE_CACHE_DIR")
+    if override:
+        return Path(override)
+    root = os.getenv("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache")
+    return Path(root) / "b12x" / "roce"
+
+
+def _compiler() -> str:
+    for candidate in (os.getenv("CC"), "gcc", "cc", "clang"):
+        if candidate and shutil.which(candidate):
+            return candidate
+    raise RuntimeError(
+        "b12x.comm.roce needs a C compiler (gcc/cc/clang) and libibverbs headers "
+        "to build its RDMA proxy"
+    )
+
+
+def _build() -> Path:
+    source = _SOURCE.read_bytes()
+    digest = hashlib.sha256(source).hexdigest()[:16]
+    cache = _cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    target = cache / f"roce_proxy-{digest}.so"
+    if target.exists():
+        return target
+    tmp = cache / f".roce_proxy-{digest}-{os.getpid()}.so"
+    cmd = [
+        _compiler(),
+        "-O2",
+        "-std=gnu11",
+        "-shared",
+        "-fPIC",
+        "-o",
+        str(tmp),
+        str(_SOURCE),
+        "-libverbs",
+        "-lpthread",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "failed to build the b12x RoCE proxy: " + " ".join(cmd) + "\n" + proc.stderr
+        )
+    os.replace(tmp, target)
+    return target
+
+
+def load() -> ctypes.CDLL:
+    """Return the bound proxy library, building it on first use."""
+
+    global _LIB
+    with _LOCK:
+        if _LIB is not None:
+            return _LIB
+        lib = ctypes.CDLL(str(_build()), use_errno=True)
+        u64 = ctypes.c_uint64
+        p = ctypes.c_void_p
+        lib.roce_abi_version.restype = ctypes.c_int
+        lib.roce_abi_version.argtypes = []
+        lib.roce_layout.restype = ctypes.c_int
+        lib.roce_layout.argtypes = [ctypes.c_int, u64, ctypes.POINTER(u64)]
+        lib.roce_blob_bytes.restype = u64
+        lib.roce_blob_bytes.argtypes = []
+        lib.roce_create.restype = p
+        lib.roce_create.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+            ctypes.c_int,
+            ctypes.c_int,
+            p,
+            u64,
+            u64,
+            ctypes.c_char_p,
+            u64,
+        ]
+        lib.roce_local_blob.restype = ctypes.c_int
+        lib.roce_local_blob.argtypes = [p, p, u64]
+        lib.roce_connect.restype = ctypes.c_int
+        lib.roce_connect.argtypes = [p, p, u64]
+        lib.roce_start.restype = ctypes.c_int
+        lib.roce_start.argtypes = [p]
+        lib.roce_stop.restype = None
+        lib.roce_stop.argtypes = [p]
+        lib.roce_failed.restype = ctypes.c_int
+        lib.roce_failed.argtypes = [p]
+        lib.roce_error.restype = ctypes.c_char_p
+        lib.roce_error.argtypes = [p]
+        lib.roce_stat.restype = u64
+        lib.roce_stat.argtypes = [p, ctypes.c_int]
+        lib.roce_peer_hca.restype = ctypes.c_int
+        lib.roce_peer_hca.argtypes = [p, ctypes.c_int]
+        lib.roce_destroy.restype = None
+        lib.roce_destroy.argtypes = [p]
+        if lib.roce_abi_version() != 1:
+            raise RuntimeError("unexpected b12x RoCE proxy ABI version")
+        _LIB = lib
+        return lib
+
+
+class Layout:
+    """Byte offsets of the pinned region shared by the kernel and the proxy."""
+
+    __slots__ = (
+        "recv_off",
+        "flag_off",
+        "send_off",
+        "ctrl_off",
+        "total_bytes",
+        "flag_stride",
+        "slots",
+    )
+
+    def __init__(self, world_size: int, slot_bytes: int) -> None:
+        out = (ctypes.c_uint64 * 7)()
+        if load().roce_layout(int(world_size), int(slot_bytes), out) != 0:
+            raise ValueError(
+                f"unsupported RoCE geometry: world_size={world_size} slot_bytes={slot_bytes} "
+                "(2..16 ranks, slot_bytes a positive multiple of 4096)"
+            )
+        (
+            self.recv_off,
+            self.flag_off,
+            self.send_off,
+            self.ctrl_off,
+            self.total_bytes,
+            self.flag_stride,
+            self.slots,
+        ) = (int(v) for v in out)
+
+
+class Proxy:
+    """Owns one RDMA proxy context for one rank."""
+
+    def __init__(
+        self,
+        *,
+        world_size: int,
+        rank: int,
+        hca_names: tuple[str, ...],
+        gid_index: int,
+        region_ptr: int,
+        region_bytes: int,
+        slot_bytes: int,
+    ) -> None:
+        self._lib = load()
+        names = (ctypes.c_char_p * len(hca_names))(*[n.encode() for n in hca_names])
+        err = ctypes.create_string_buffer(512)
+        self._ctx = self._lib.roce_create(
+            int(world_size),
+            int(rank),
+            names,
+            len(hca_names),
+            int(gid_index),
+            ctypes.c_void_p(int(region_ptr)),
+            int(region_bytes),
+            int(slot_bytes),
+            err,
+            len(err),
+        )
+        if not self._ctx:
+            raise RuntimeError(f"RoCE proxy setup failed: {err.value.decode(errors='replace')}")
+        self.world_size = int(world_size)
+        self.rank = int(rank)
+        self.hca_names = tuple(hca_names)
+
+    def local_blob(self) -> bytes:
+        n = int(self._lib.roce_blob_bytes())
+        buf = ctypes.create_string_buffer(n)
+        if self._lib.roce_local_blob(self._ctx, buf, n) != 0:
+            raise RuntimeError(BLOB_STRUCT_ERR)
+        return buf.raw
+
+    def connect(self, blobs: list[bytes]) -> None:
+        n = int(self._lib.roce_blob_bytes())
+        if len(blobs) != self.world_size or any(len(b) != n for b in blobs):
+            raise RuntimeError(BLOB_STRUCT_ERR)
+        joined = b"".join(blobs)
+        buf = ctypes.create_string_buffer(joined, len(joined))
+        if self._lib.roce_connect(self._ctx, buf, len(joined)) != 0:
+            raise RuntimeError(f"RoCE queue-pair connect failed: {self.error()}")
+
+    def start(self) -> None:
+        if self._lib.roce_start(self._ctx) != 0:
+            raise RuntimeError(f"RoCE proxy thread failed to start: {self.error()}")
+
+    def failed(self) -> bool:
+        return bool(self._lib.roce_failed(self._ctx))
+
+    def error(self) -> str:
+        raw = self._lib.roce_error(self._ctx)
+        return raw.decode(errors="replace") if raw else ""
+
+    def stats(self) -> dict[str, int]:
+        return {
+            "ops_posted": int(self._lib.roce_stat(self._ctx, 0)),
+            "writes_completed": int(self._lib.roce_stat(self._ctx, 1)),
+            "last_seq": int(self._lib.roce_stat(self._ctx, 2)),
+        }
+
+    def peer_hca(self, peer: int) -> int:
+        return int(self._lib.roce_peer_hca(self._ctx, int(peer)))
+
+    def close(self) -> None:
+        ctx, self._ctx = self._ctx, None
+        if ctx:
+            self._lib.roce_destroy(ctx)
+
+    def __del__(self) -> None:  # pragma: no cover - defensive teardown
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+__all__ = ["Layout", "Proxy", "load"]

--- a/b12x/comm/roce/_roce_proxy.c
+++ b/b12x/comm/roce/_roce_proxy.c
@@ -1,0 +1,524 @@
+// RDMA proxy for the b12x RoCE one-shot all-reduce.
+//
+// One rank owns one pinned host region laid out as:
+//
+//   recv[src][slot]  (world * SLOTS * slot_bytes)  filled by peers' RDMA writes
+//   flag[src][slot]  (world * SLOTS * FLAG_STRIDE) sequence number written by
+//                                                  the peer after its payload
+//   send[slot]       (SLOTS * slot_bytes)          staged by the local GPU kernel
+//   ctrl             (FLAG_STRIDE)                 {u32 seq, u32 nbytes, u32 error,
+//                                                   u32 missing_peer} doorbell; the
+//                                                  last two are set by the kernel
+//                                                  when a wait times out
+//
+// The GPU kernel stages its input into send[seq & 1], publishes nbytes and seq
+// in ctrl, then spins on flag[peer][seq & 1] for every peer.  The proxy thread
+// below spins on ctrl.seq and, for every peer, posts one RDMA write of the
+// payload followed by one 4-byte RDMA write of seq on the same reliable QP, so
+// the flag cannot become visible before the payload.  Nothing on the receive
+// path involves the host.
+//
+// This file is compiled by b12x.comm.roce._proxy at first use with the host
+// gcc and libibverbs; it must stay plain C with no CUDA dependency.
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <infiniband/verbs.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ROCE_MAX_PEERS 16
+#define ROCE_MAX_HCAS 2
+#define ROCE_SLOTS 2
+#define ROCE_FLAG_STRIDE 128
+#define ROCE_PORT 1
+#define ROCE_SEND_DEPTH 256
+#define ROCE_ABI_VERSION 1
+
+typedef struct {
+    uint64_t region_addr;
+    uint32_t rkey[ROCE_MAX_HCAS];
+    uint16_t lid[ROCE_MAX_HCAS];
+    uint8_t gid[ROCE_MAX_HCAS][16];
+    uint32_t mtu[ROCE_MAX_HCAS];
+    uint32_t qp_num[ROCE_MAX_HCAS][ROCE_MAX_PEERS];
+} roce_blob_t;
+
+typedef struct {
+    struct ibv_context *ctx;
+    struct ibv_pd *pd;
+    struct ibv_mr *mr;
+    struct ibv_cq *cq;
+    struct ibv_qp *qp[ROCE_MAX_PEERS];
+    uint32_t outstanding[ROCE_MAX_PEERS];
+    union ibv_gid gid;
+    uint16_t lid;
+    enum ibv_mtu mtu;
+} roce_hca_t;
+
+typedef struct {
+    int world;
+    int rank;
+    int n_hca;
+    int gid_index;
+    roce_hca_t hca[ROCE_MAX_HCAS];
+    uint8_t *region;
+    size_t region_bytes;
+    size_t slot_bytes;
+    size_t recv_off;
+    size_t flag_off;
+    size_t send_off;
+    size_t ctrl_off;
+    uint64_t peer_addr[ROCE_MAX_PEERS];
+    uint32_t peer_rkey[ROCE_MAX_HCAS][ROCE_MAX_PEERS];
+    int peer_hca[ROCE_MAX_PEERS];
+    pthread_t thread;
+    atomic_int running;
+    atomic_int failed;
+    uint32_t last_seq;
+    uint64_t ops_posted;
+    uint64_t writes_completed;
+    char err[512];
+} roce_ctx_t;
+
+void roce_destroy(roce_ctx_t *c);
+
+static void set_err(roce_ctx_t *c, const char *what, int e) {
+    snprintf(c->err, sizeof(c->err), "%s: %s", what, e ? strerror(e) : "failed");
+}
+
+int roce_abi_version(void) { return ROCE_ABI_VERSION; }
+
+int roce_layout(int world, uint64_t slot_bytes, uint64_t *out) {
+    // out = {recv_off, flag_off, send_off, ctrl_off, total_bytes, flag_stride, slots}
+    if (world < 2 || world > ROCE_MAX_PEERS || slot_bytes == 0 || (slot_bytes % 4096) != 0) {
+        return -1;
+    }
+    uint64_t recv_off = 0;
+    uint64_t flag_off = recv_off + (uint64_t)world * ROCE_SLOTS * slot_bytes;
+    uint64_t send_off = flag_off + (uint64_t)world * ROCE_SLOTS * ROCE_FLAG_STRIDE;
+    uint64_t ctrl_off = send_off + (uint64_t)ROCE_SLOTS * slot_bytes;
+    uint64_t total = ctrl_off + ROCE_FLAG_STRIDE;
+    out[0] = recv_off;
+    out[1] = flag_off;
+    out[2] = send_off;
+    out[3] = ctrl_off;
+    out[4] = total;
+    out[5] = ROCE_FLAG_STRIDE;
+    out[6] = ROCE_SLOTS;
+    return 0;
+}
+
+uint64_t roce_blob_bytes(void) { return sizeof(roce_blob_t); }
+
+static int open_hca(roce_ctx_t *c, int h, const char *name) {
+    int num = 0;
+    struct ibv_device **list = ibv_get_device_list(&num);
+    if (list == NULL) {
+        set_err(c, "ibv_get_device_list", errno);
+        return -1;
+    }
+    struct ibv_device *dev = NULL;
+    for (int i = 0; i < num; i++) {
+        if (strcmp(ibv_get_device_name(list[i]), name) == 0) {
+            dev = list[i];
+            break;
+        }
+    }
+    if (dev == NULL) {
+        ibv_free_device_list(list);
+        snprintf(c->err, sizeof(c->err), "RDMA device %s not found", name);
+        return -1;
+    }
+    roce_hca_t *hca = &c->hca[h];
+    hca->ctx = ibv_open_device(dev);
+    ibv_free_device_list(list);
+    if (hca->ctx == NULL) {
+        set_err(c, "ibv_open_device", errno);
+        return -1;
+    }
+    struct ibv_port_attr port;
+    if (ibv_query_port(hca->ctx, ROCE_PORT, &port) != 0) {
+        set_err(c, "ibv_query_port", errno);
+        return -1;
+    }
+    if (port.state != IBV_PORT_ACTIVE) {
+        snprintf(c->err, sizeof(c->err), "RDMA device %s port %d is not active", name, ROCE_PORT);
+        return -1;
+    }
+    hca->lid = port.lid;
+    hca->mtu = port.active_mtu;
+    if (ibv_query_gid(hca->ctx, ROCE_PORT, c->gid_index, &hca->gid) != 0) {
+        set_err(c, "ibv_query_gid", errno);
+        return -1;
+    }
+    hca->pd = ibv_alloc_pd(hca->ctx);
+    if (hca->pd == NULL) {
+        set_err(c, "ibv_alloc_pd", errno);
+        return -1;
+    }
+    hca->mr = ibv_reg_mr(hca->pd, c->region, c->region_bytes,
+                         IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    if (hca->mr == NULL) {
+        set_err(c, "ibv_reg_mr(pinned region)", errno);
+        return -1;
+    }
+    hca->cq = ibv_create_cq(hca->ctx, ROCE_SEND_DEPTH * ROCE_MAX_PEERS, NULL, NULL, 0);
+    if (hca->cq == NULL) {
+        set_err(c, "ibv_create_cq", errno);
+        return -1;
+    }
+    for (int p = 0; p < c->world; p++) {
+        if (p == c->rank) {
+            continue;
+        }
+        struct ibv_qp_init_attr attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.send_cq = hca->cq;
+        attr.recv_cq = hca->cq;
+        attr.qp_type = IBV_QPT_RC;
+        attr.cap.max_send_wr = ROCE_SEND_DEPTH;
+        attr.cap.max_recv_wr = 1;
+        attr.cap.max_send_sge = 1;
+        attr.cap.max_recv_sge = 1;
+        attr.cap.max_inline_data = 16;
+        hca->qp[p] = ibv_create_qp(hca->pd, &attr);
+        if (hca->qp[p] == NULL) {
+            set_err(c, "ibv_create_qp", errno);
+            return -1;
+        }
+        struct ibv_qp_attr init;
+        memset(&init, 0, sizeof(init));
+        init.qp_state = IBV_QPS_INIT;
+        init.pkey_index = 0;
+        init.port_num = ROCE_PORT;
+        init.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
+        int rc = ibv_modify_qp(hca->qp[p], &init,
+                               IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+        if (rc != 0) {
+            set_err(c, "ibv_modify_qp(INIT)", rc);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+roce_ctx_t *roce_create(int world, int rank, const char *const *hca_names, int n_hca,
+                        int gid_index, void *region, uint64_t region_bytes,
+                        uint64_t slot_bytes, char *err, uint64_t err_len) {
+    uint64_t layout[7];
+    if (roce_layout(world, slot_bytes, layout) != 0 || layout[4] > region_bytes ||
+        rank < 0 || rank >= world || n_hca < 1 || n_hca > ROCE_MAX_HCAS) {
+        snprintf(err, err_len, "invalid roce runtime geometry");
+        return NULL;
+    }
+    roce_ctx_t *c = calloc(1, sizeof(*c));
+    if (c == NULL) {
+        snprintf(err, err_len, "out of memory");
+        return NULL;
+    }
+    c->world = world;
+    c->rank = rank;
+    c->n_hca = n_hca;
+    c->gid_index = gid_index;
+    c->region = region;
+    c->region_bytes = region_bytes;
+    c->slot_bytes = slot_bytes;
+    c->recv_off = layout[0];
+    c->flag_off = layout[1];
+    c->send_off = layout[2];
+    c->ctrl_off = layout[3];
+    for (int h = 0; h < n_hca; h++) {
+        if (open_hca(c, h, hca_names[h]) != 0) {
+            snprintf(err, err_len, "%s", c->err);
+            roce_destroy(c);
+            return NULL;
+        }
+    }
+    return c;
+}
+
+int roce_local_blob(roce_ctx_t *c, void *out, uint64_t out_len) {
+    if (out_len < sizeof(roce_blob_t)) {
+        return -1;
+    }
+    roce_blob_t blob;
+    memset(&blob, 0, sizeof(blob));
+    blob.region_addr = (uint64_t)(uintptr_t)c->region;
+    for (int h = 0; h < c->n_hca; h++) {
+        blob.rkey[h] = c->hca[h].mr->rkey;
+        blob.lid[h] = c->hca[h].lid;
+        blob.mtu[h] = (uint32_t)c->hca[h].mtu;
+        memcpy(blob.gid[h], c->hca[h].gid.raw, 16);
+        for (int p = 0; p < c->world; p++) {
+            blob.qp_num[h][p] = (p == c->rank) ? 0 : c->hca[h].qp[p]->qp_num;
+        }
+    }
+    memcpy(out, &blob, sizeof(blob));
+    return 0;
+}
+
+static int connect_qp(roce_ctx_t *c, int h, int p, const roce_blob_t *peer) {
+    roce_hca_t *hca = &c->hca[h];
+    struct ibv_qp_attr rtr;
+    memset(&rtr, 0, sizeof(rtr));
+    rtr.qp_state = IBV_QPS_RTR;
+    rtr.path_mtu = (enum ibv_mtu)(peer->mtu[h] < (uint32_t)hca->mtu ? peer->mtu[h] : (uint32_t)hca->mtu);
+    rtr.dest_qp_num = peer->qp_num[h][c->rank];
+    rtr.rq_psn = 0;
+    rtr.max_dest_rd_atomic = 1;
+    rtr.min_rnr_timer = 12;
+    rtr.ah_attr.is_global = 1;
+    rtr.ah_attr.dlid = peer->lid[h];
+    rtr.ah_attr.sl = 0;
+    rtr.ah_attr.src_path_bits = 0;
+    rtr.ah_attr.port_num = ROCE_PORT;
+    memcpy(rtr.ah_attr.grh.dgid.raw, peer->gid[h], 16);
+    rtr.ah_attr.grh.sgid_index = (uint8_t)c->gid_index;
+    rtr.ah_attr.grh.hop_limit = 64;
+    rtr.ah_attr.grh.traffic_class = 0;
+    rtr.ah_attr.grh.flow_label = 0;
+    int rc = ibv_modify_qp(hca->qp[p], &rtr,
+                           IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
+                               IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER);
+    if (rc != 0) {
+        set_err(c, "ibv_modify_qp(RTR)", rc);
+        return -1;
+    }
+    struct ibv_qp_attr rts;
+    memset(&rts, 0, sizeof(rts));
+    rts.qp_state = IBV_QPS_RTS;
+    rts.timeout = 14;
+    rts.retry_cnt = 7;
+    rts.rnr_retry = 7;
+    rts.sq_psn = 0;
+    rts.max_rd_atomic = 1;
+    rc = ibv_modify_qp(hca->qp[p], &rts,
+                       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+                           IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC);
+    if (rc != 0) {
+        set_err(c, "ibv_modify_qp(RTS)", rc);
+        return -1;
+    }
+    return 0;
+}
+
+int roce_connect(roce_ctx_t *c, const void *blobs, uint64_t blobs_len) {
+    if (blobs_len < sizeof(roce_blob_t) * (uint64_t)c->world) {
+        snprintf(c->err, sizeof(c->err), "peer blob buffer too small");
+        return -1;
+    }
+    const roce_blob_t *all = (const roce_blob_t *)blobs;
+    for (int p = 0; p < c->world; p++) {
+        if (p == c->rank) {
+            continue;
+        }
+        c->peer_addr[p] = all[p].region_addr;
+        // Spread rank pairs across the available HCAs; both ends compute the
+        // same value so the pair meets on one device.
+        c->peer_hca[p] = (c->rank + p) % c->n_hca;
+        for (int h = 0; h < c->n_hca; h++) {
+            c->peer_rkey[h][p] = all[p].rkey[h];
+            if (connect_qp(c, h, p, &all[p]) != 0) {
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+static int drain_cq(roce_ctx_t *c, int h) {
+    struct ibv_wc wc[32];
+    int n = ibv_poll_cq(c->hca[h].cq, 32, wc);
+    if (n < 0) {
+        set_err(c, "ibv_poll_cq", errno);
+        return -1;
+    }
+    for (int i = 0; i < n; i++) {
+        if (wc[i].status != IBV_WC_SUCCESS) {
+            snprintf(c->err, sizeof(c->err),
+                     "RDMA write to rank %u failed: %s (vendor_err 0x%x, seq %u)",
+                     (unsigned)wc[i].wr_id, ibv_wc_status_str(wc[i].status),
+                     wc[i].vendor_err, c->last_seq);
+            return -1;
+        }
+        c->hca[h].outstanding[wc[i].wr_id] -= 1;
+        c->writes_completed += 1;
+    }
+    return 0;
+}
+
+static int post_op(roce_ctx_t *c, uint32_t seq, uint32_t nbytes) {
+    uint32_t slot = seq & 1u;
+    uint8_t *send = c->region + c->send_off + (size_t)slot * c->slot_bytes;
+    uint32_t seq_copy = seq;
+    for (int p = 0; p < c->world; p++) {
+        if (p == c->rank) {
+            continue;
+        }
+        int h = c->peer_hca[p];
+        roce_hca_t *hca = &c->hca[h];
+        // Two work requests per op; keep the queue at most a quarter full so a
+        // provider that needs extra entries can never fail a post.
+        while (hca->outstanding[p] >= ROCE_SEND_DEPTH / 4) {
+            if (drain_cq(c, h) != 0) {
+                return -1;
+            }
+        }
+        uint64_t remote = c->peer_addr[p];
+        struct ibv_sge data_sge = {
+            .addr = (uint64_t)(uintptr_t)send,
+            .length = nbytes,
+            .lkey = hca->mr->lkey,
+        };
+        struct ibv_sge flag_sge = {
+            .addr = (uint64_t)(uintptr_t)&seq_copy,
+            .length = 4,
+            .lkey = 0,
+        };
+        struct ibv_send_wr flag_wr;
+        memset(&flag_wr, 0, sizeof(flag_wr));
+        flag_wr.wr_id = (uint64_t)p;
+        flag_wr.sg_list = &flag_sge;
+        flag_wr.num_sge = 1;
+        flag_wr.opcode = IBV_WR_RDMA_WRITE;
+        flag_wr.send_flags = IBV_SEND_SIGNALED | IBV_SEND_INLINE;
+        flag_wr.wr.rdma.remote_addr =
+            remote + c->flag_off + ((uint64_t)c->rank * ROCE_SLOTS + slot) * ROCE_FLAG_STRIDE;
+        flag_wr.wr.rdma.rkey = c->peer_rkey[h][p];
+        struct ibv_send_wr data_wr;
+        memset(&data_wr, 0, sizeof(data_wr));
+        data_wr.wr_id = (uint64_t)p;
+        data_wr.next = &flag_wr;
+        data_wr.sg_list = &data_sge;
+        data_wr.num_sge = 1;
+        data_wr.opcode = IBV_WR_RDMA_WRITE;
+        data_wr.send_flags = 0;
+        data_wr.wr.rdma.remote_addr =
+            remote + c->recv_off + ((uint64_t)c->rank * ROCE_SLOTS + slot) * c->slot_bytes;
+        data_wr.wr.rdma.rkey = c->peer_rkey[h][p];
+        struct ibv_send_wr *bad = NULL;
+        int rc = ibv_post_send(hca->qp[p], &data_wr, &bad);
+        if (rc != 0) {
+            set_err(c, "ibv_post_send", rc);
+            return -1;
+        }
+        hca->outstanding[p] += 1;
+    }
+    c->ops_posted += 1;
+    for (int h = 0; h < c->n_hca; h++) {
+        if (drain_cq(c, h) != 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void *proxy_main(void *arg) {
+    roce_ctx_t *c = (roce_ctx_t *)arg;
+    volatile uint32_t *ctrl = (volatile uint32_t *)(c->region + c->ctrl_off);
+    uint32_t idle = 0;
+    while (atomic_load_explicit(&c->running, memory_order_relaxed)) {
+        uint32_t seq = __atomic_load_n(&ctrl[0], __ATOMIC_ACQUIRE);
+        if (seq == c->last_seq) {
+            if (++idle >= 64) {
+                idle = 0;
+                for (int h = 0; h < c->n_hca; h++) {
+                    if (drain_cq(c, h) != 0) {
+                        atomic_store(&c->failed, 1);
+                        return NULL;
+                    }
+                }
+            }
+            continue;
+        }
+        idle = 0;
+        uint32_t nbytes = ctrl[1];
+        if (post_op(c, seq, nbytes) != 0) {
+            atomic_store(&c->failed, 1);
+            return NULL;
+        }
+        c->last_seq = seq;
+    }
+    return NULL;
+}
+
+int roce_start(roce_ctx_t *c) {
+    if (atomic_load(&c->running)) {
+        return 0;
+    }
+    volatile uint32_t *ctrl = (volatile uint32_t *)(c->region + c->ctrl_off);
+    c->last_seq = ctrl[0];
+    atomic_store(&c->failed, 0);
+    atomic_store(&c->running, 1);
+    int rc = pthread_create(&c->thread, NULL, proxy_main, c);
+    if (rc != 0) {
+        atomic_store(&c->running, 0);
+        set_err(c, "pthread_create", rc);
+        return -1;
+    }
+    return 0;
+}
+
+void roce_stop(roce_ctx_t *c) {
+    if (atomic_exchange(&c->running, 0)) {
+        pthread_join(c->thread, NULL);
+    }
+}
+
+int roce_failed(roce_ctx_t *c) { return atomic_load(&c->failed); }
+
+const char *roce_error(roce_ctx_t *c) { return c->err; }
+
+uint64_t roce_stat(roce_ctx_t *c, int which) {
+    switch (which) {
+    case 0:
+        return c->ops_posted;
+    case 1:
+        return c->writes_completed;
+    case 2:
+        return c->last_seq;
+    default:
+        return 0;
+    }
+}
+
+int roce_peer_hca(roce_ctx_t *c, int peer) {
+    if (peer < 0 || peer >= c->world) {
+        return -1;
+    }
+    return c->peer_hca[peer];
+}
+
+void roce_destroy(roce_ctx_t *c) {
+    if (c == NULL) {
+        return;
+    }
+    roce_stop(c);
+    for (int h = 0; h < ROCE_MAX_HCAS; h++) {
+        roce_hca_t *hca = &c->hca[h];
+        for (int p = 0; p < ROCE_MAX_PEERS; p++) {
+            if (hca->qp[p] != NULL) {
+                ibv_destroy_qp(hca->qp[p]);
+            }
+        }
+        if (hca->cq != NULL) {
+            ibv_destroy_cq(hca->cq);
+        }
+        if (hca->mr != NULL) {
+            ibv_dereg_mr(hca->mr);
+        }
+        if (hca->pd != NULL) {
+            ibv_dealloc_pd(hca->pd);
+        }
+        if (hca->ctx != NULL) {
+            ibv_close_device(hca->ctx);
+        }
+    }
+    free(c);
+}

--- a/b12x/comm/roce/api.py
+++ b/b12x/comm/roce/api.py
@@ -1,0 +1,23 @@
+"""Public surface for comm.roce (docs in the op ``__init__``)."""
+
+from __future__ import annotations
+
+from .roce_oneshot import (
+    DEFAULT_MAX_SIZE,
+    SUPPORTED_DTYPES,
+    SUPPORTED_WORLD_SIZES,
+    RoceOneshotAllReduce as AllReduce,
+    default_gid_index,
+    discover_hcas,
+    is_supported,
+)
+
+__all__ = [
+    "AllReduce",
+    "DEFAULT_MAX_SIZE",
+    "SUPPORTED_DTYPES",
+    "SUPPORTED_WORLD_SIZES",
+    "default_gid_index",
+    "discover_hcas",
+    "is_supported",
+]

--- a/b12x/comm/roce/api.py
+++ b/b12x/comm/roce/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .roce_oneshot import (
+    DEFAULT_MAX_GATHER_BYTES,
     DEFAULT_MAX_SIZE,
     SUPPORTED_DTYPES,
     SUPPORTED_WORLD_SIZES,
@@ -14,6 +15,7 @@ from .roce_oneshot import (
 
 __all__ = [
     "AllReduce",
+    "DEFAULT_MAX_GATHER_BYTES",
     "DEFAULT_MAX_SIZE",
     "SUPPORTED_DTYPES",
     "SUPPORTED_WORLD_SIZES",

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -1,4 +1,4 @@
-"""RoCE one-shot all-reduce and all-gather runtime for multi-node tensor parallelism.
+"""RoCEnante: one-shot RoCE all-reduce and all-gather runtime for multi-node tensor parallelism.
 
 Designed for DGX Spark clusters, whose integrated GPU can read pinned host
 memory in place and whose ConnectX-7 can RDMA-write into the same memory.
@@ -146,7 +146,7 @@ def _exchange(local: object, group: ProcessGroup) -> list[object]:
 class RoceOneshotAllReduce:
     """One-shot RDMA all-reduce over the DGX Spark 200 GbE fabric."""
 
-    algorithm = "roce_oneshot"
+    algorithm = "rocenante"
 
     def __init__(
         self,
@@ -249,7 +249,7 @@ class RoceOneshotAllReduce:
             raise RuntimeError("RoCE all-reduce connect failed: " + "; ".join(failures))
         if self.rank == 0:
             logger.info(
-                "RoCE one-shot all-reduce ready: world=%d hcas=%s gid_index=%d max_size=%d",
+                "RoCEnante ready: world=%d hcas=%s gid_index=%d max_size=%d",
                 self.world_size,
                 ",".join(self.hca_names),
                 self.gid_index,

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -1,0 +1,460 @@
+"""RoCE one-shot all-reduce runtime for multi-node tensor parallelism.
+
+Designed for DGX Spark clusters, whose integrated GPU can read pinned host
+memory in place and whose ConnectX-7 can RDMA-write into the same memory.
+Each rank owns one pinned region (see ``_roce_proxy.c``); every all-reduce is
+one kernel launch that stages the input, rings the proxy thread, waits for
+every peer's RDMA-written payload, and reduces in fixed rank order.
+
+Constraints of this first runtime:
+
+* one all-reduce in flight per runtime (single channel, one stream);
+* message sizes up to ``max_size`` bytes, a multiple of 16 bytes;
+* every rank of the exchange group must construct the runtime collectively.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from ._oneshot_cute import PACK_BYTES, get_launcher, is_launcher_prepared
+from ._proxy import Layout, Proxy
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+SUPPORTED_WORLD_SIZES = tuple(range(2, 17))
+DEFAULT_MAX_SIZE = 1024 * 1024
+DEFAULT_THREADS = 512
+DEFAULT_BLOCKS = 8
+DEFAULT_GID_INDEX = 3
+# Polls of a peer flag before the kernel gives up (each poll is a system-scope
+# load of host memory, roughly a microsecond): about 20 s.
+DEFAULT_SPIN_LIMIT = 20_000_000
+_SLOT_ALIGNMENT = 4096
+_DTYPE_NAMES = {
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.float32: "float32",
+}
+
+
+def _env_list(*names: str) -> tuple[str, ...]:
+    for name in names:
+        raw = os.getenv(name)
+        if raw:
+            items = []
+            for item in raw.split(","):
+                item = item.strip().lstrip("=^")
+                if item:
+                    items.append(item.split(":")[0])
+            if items:
+                return tuple(items)
+    return ()
+
+
+def _env_int(*names: str, default: int) -> int:
+    for name in names:
+        raw = os.getenv(name)
+        if raw:
+            return int(raw)
+    return default
+
+
+def default_gid_index() -> int:
+    """``B12X_ROCE_GID_INDEX``, else NCCL's ``NCCL_IB_GID_INDEX``, else 3."""
+
+    return _env_int("B12X_ROCE_GID_INDEX", "NCCL_IB_GID_INDEX", default=DEFAULT_GID_INDEX)
+
+
+def discover_hcas(gid_index: Optional[int] = None) -> tuple[str, ...]:
+    """Return the RDMA devices to use, at most two.
+
+    ``B12X_ROCE_HCA`` (or NCCL's ``NCCL_IB_HCA``) selects explicitly; otherwise
+    every active device with a populated GID at ``gid_index`` is used.
+    """
+
+    explicit = _env_list("B12X_ROCE_HCA", "NCCL_IB_HCA")
+    if explicit:
+        return explicit[:2]
+    gid_index = default_gid_index() if gid_index is None else int(gid_index)
+    found = []
+    root = Path("/sys/class/infiniband")
+    for dev in sorted(root.glob("*")):
+        state = dev / "ports" / "1" / "state"
+        gid = dev / "ports" / "1" / "gids" / str(gid_index)
+        try:
+            if "ACTIVE" not in state.read_text():
+                continue
+            if gid.read_text().strip().replace(":", "").strip("0") == "":
+                continue
+        except OSError:
+            continue
+        found.append(dev.name)
+    return tuple(found[:2])
+
+
+def is_supported(device: torch.device | int | str | None = None) -> bool:
+    """True on an integrated GPU with at least one active RDMA device.
+
+    The kernel reads pinned host memory in place, which needs an integrated
+    (unified-memory) GPU such as the DGX Spark GB10.
+    """
+
+    if not torch.cuda.is_available():
+        return False
+    index = torch.cuda.current_device() if device is None else torch.device(device).index
+    props = torch.cuda.get_device_properties(index if index is not None else 0)
+    if not getattr(props, "is_integrated", False):
+        return False
+    return len(discover_hcas()) > 0
+
+
+def _normalize_device(device: torch.device | int | str) -> torch.device:
+    if isinstance(device, int):
+        device = torch.device("cuda", device)
+    elif not isinstance(device, torch.device):
+        device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError("RoCE all-reduce requires a CUDA device")
+    if device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+def _exchange(local: object, group: ProcessGroup) -> list[object]:
+    gathered: list[object] = [None] * dist.get_world_size(group=group)
+    dist.all_gather_object(gathered, local, group=group)
+    return gathered
+
+
+class RoceOneshotAllReduce:
+    """One-shot RDMA all-reduce over the DGX Spark 200 GbE fabric."""
+
+    algorithm = "roce_oneshot"
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int = DEFAULT_MAX_SIZE,
+        hca_names: Optional[Sequence[str]] = None,
+        gid_index: Optional[int] = None,
+        threads: int = DEFAULT_THREADS,
+        blocks: int = DEFAULT_BLOCKS,
+    ) -> None:
+        self.device = _normalize_device(device)
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self._group = exchange_group
+        self._closed = False
+        self._proxy: Optional[Proxy] = None
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                f"unsupported RoCE all-reduce world size {self.world_size}; "
+                f"supported sizes are {SUPPORTED_WORLD_SIZES}"
+            )
+        if int(max_size) < PACK_BYTES:
+            raise ValueError("max_size must hold at least one 16-byte pack")
+        if int(threads) % 32 != 0 or int(threads) < 32 or int(threads) > 1024:
+            raise ValueError("threads must be a multiple of 32 between 32 and 1024")
+        if int(blocks) < 1:
+            raise ValueError("blocks must be positive")
+        self.max_size = int(max_size)
+        self._threads = int(threads)
+        self._blocks = int(blocks)
+        self.gid_index = default_gid_index() if gid_index is None else int(gid_index)
+        self.spin_limit = _env_int("B12X_ROCE_SPIN_LIMIT", default=DEFAULT_SPIN_LIMIT)
+        names = tuple(hca_names) if hca_names else discover_hcas(self.gid_index)
+        if not names:
+            raise RuntimeError("no active RDMA device found for the RoCE all-reduce")
+        self.hca_names = names[:2]
+
+        slot_bytes = _align_up(self.max_size, _SLOT_ALIGNMENT)
+        self._layout = Layout(self.world_size, slot_bytes)
+        self._slot_bytes = slot_bytes
+
+        with torch.cuda.device(self.device):
+            # Pinned, zero-initialised: flags and the control record start at 0
+            # and the first sequence number is 1.
+            self._region = torch.zeros(
+                self._layout.total_bytes, dtype=torch.uint8, pin_memory=True
+            )
+            self._counters = torch.zeros(4, dtype=torch.int32, device=self.device)
+        host_ptr = self._region.data_ptr()
+        device_ptr = self._device_pointer(host_ptr)
+        if device_ptr != host_ptr:
+            raise RuntimeError(
+                "RoCE all-reduce needs host pointers that are directly device "
+                "accessible (integrated GPU with unified addressing)"
+            )
+        self._recv_base = host_ptr + self._layout.recv_off
+        self._flag_base = host_ptr + self._layout.flag_off
+        self._send_base = host_ptr + self._layout.send_off
+        self._ctrl_base = host_ptr + self._layout.ctrl_off
+        # ctrl record: seq, nbytes, error seq, missing peer (kernel-written)
+        self._ctrl_words = self._region[
+            self._layout.ctrl_off : self._layout.ctrl_off + 16
+        ].view(torch.int32)
+        self._error_word = self._ctrl_words[2:3]
+        self._epoch_address = self._counters.data_ptr()
+
+        error: Optional[str] = None
+        try:
+            self._proxy = Proxy(
+                world_size=self.world_size,
+                rank=self.rank,
+                hca_names=self.hca_names,
+                gid_index=self.gid_index,
+                region_ptr=host_ptr,
+                region_bytes=self._layout.total_bytes,
+                slot_bytes=slot_bytes,
+            )
+            blob = self._proxy.local_blob()
+        except Exception as exc:  # noqa: BLE001 - reported collectively below
+            error = str(exc)
+            blob = b""
+        statuses = _exchange((error, blob), exchange_group)
+        failures = [f"rank {i}: {s[0]}" for i, s in enumerate(statuses) if s[0] is not None]
+        if failures:
+            self.close()
+            raise RuntimeError("RoCE all-reduce setup failed: " + "; ".join(failures))
+        try:
+            self._proxy.connect([s[1] for s in statuses])
+            self._proxy.start()
+        except Exception as exc:  # noqa: BLE001
+            error = str(exc)
+        verdicts = _exchange(error, exchange_group)
+        failures = [f"rank {i}: {v}" for i, v in enumerate(verdicts) if v is not None]
+        if failures:
+            self.close()
+            raise RuntimeError("RoCE all-reduce connect failed: " + "; ".join(failures))
+        if self.rank == 0:
+            logger.info(
+                "RoCE one-shot all-reduce ready: world=%d hcas=%s gid_index=%d max_size=%d",
+                self.world_size,
+                ",".join(self.hca_names),
+                self.gid_index,
+                self.max_size,
+            )
+
+    @staticmethod
+    def _device_pointer(host_ptr: int) -> int:
+        from cuda.bindings import runtime as cudart
+
+        err, ptr = cudart.cudaHostGetDevicePointer(host_ptr, 0)
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"cudaHostGetDevicePointer failed: {err}")
+        return int(ptr)
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int = DEFAULT_MAX_SIZE,
+        eager_buffer_bytes: Optional[int] = None,
+        **_ignored: Any,
+    ) -> "RoceOneshotAllReduce":
+        """Mirror ``comm.pcie.AllReduce.from_exchange_group``; PCIe-only knobs are ignored."""
+
+        capacity = max(int(max_size), int(eager_buffer_bytes or 0))
+        return cls(exchange_group=exchange_group, device=device, max_size=capacity)
+
+    @classmethod
+    def from_process_group(
+        cls,
+        *,
+        process_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int = DEFAULT_MAX_SIZE,
+        max_input_bytes: Optional[int] = None,
+        **_ignored: Any,
+    ) -> "RoceOneshotAllReduce":
+        capacity = max(int(max_size), int(max_input_bytes or 0))
+        return cls(exchange_group=process_group, device=device, max_size=capacity)
+
+    # -- policy -----------------------------------------------------------------
+
+    @property
+    def supports_all_peer_auxiliary(self) -> bool:
+        return False
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        if self._closed or self._proxy is None:
+            return False
+        if inp.dtype not in SUPPORTED_DTYPES or not inp.is_cuda:
+            return False
+        if inp.device != self.device or not inp.is_contiguous():
+            return False
+        nbytes = inp.numel() * inp.element_size()
+        return 0 < nbytes <= self.max_size and nbytes % PACK_BYTES == 0
+
+    # -- channels / streams (single channel runtime) ---------------------------
+
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        return None
+
+    def for_stream(self, stream: object = None, *, channel_id: Optional[str] = None):
+        return self
+
+    # -- compilation ------------------------------------------------------------
+
+    def _launcher_key(self, dtype: torch.dtype) -> tuple[object, ...]:
+        return (
+            _DTYPE_NAMES[dtype],
+            self.world_size,
+            self.rank,
+            self._threads,
+            self._layout.slots,
+            self._layout.flag_stride,
+            self.device.index,
+        )
+
+    def prepare(self, dtypes: Sequence[torch.dtype] = (torch.bfloat16,)) -> None:
+        """Compile launchers ahead of CUDA-graph capture."""
+
+        with torch.cuda.device(self.device):
+            for dtype in dtypes:
+                get_launcher(*self._launcher_key(dtype))
+
+    def prepare_graph_all_reduce(self, inp: torch.Tensor, *, stream: object = None) -> None:
+        self.prepare((inp.dtype,))
+
+    # -- execution ----------------------------------------------------------------
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: Optional[torch.Tensor] = None,
+        stream: object = None,
+        channel_id: Optional[str] = None,
+        peer_input_ptrs: Optional[Sequence[int]] = None,
+    ) -> torch.Tensor:
+        if not self.should_allreduce(inp):
+            raise ValueError("input is not eligible for the RoCE one-shot all-reduce")
+        if out is None:
+            out = torch.empty_like(inp)
+        elif out.shape != inp.shape or out.dtype != inp.dtype or not out.is_contiguous():
+            raise ValueError("out must be a contiguous tensor matching the input")
+        key = self._launcher_key(inp.dtype)
+        capturing = torch.cuda.is_current_stream_capturing()
+        if capturing and not is_launcher_prepared(*key):
+            raise RuntimeError(
+                "RoCE all-reduce launcher must be prepared before CUDA graph capture"
+            )
+        launcher = get_launcher(*key)
+        nbytes = inp.numel() * inp.element_size()
+        context = torch.cuda.stream(stream) if stream is not None else _nullcontext()
+        with torch.cuda.device(self.device), context:
+            launcher(
+                inp.data_ptr(),
+                out.data_ptr(),
+                nbytes // PACK_BYTES,
+                nbytes,
+                self._recv_base,
+                self._flag_base,
+                self._send_base,
+                self._ctrl_base,
+                self._slot_bytes,
+                self._epoch_address,
+                self.spin_limit,
+                self._blocks,
+            )
+        if not capturing:
+            self.check_health()
+        return out
+
+    def check_health(self) -> None:
+        """Raise if the proxy thread died or a kernel wait timed out.
+
+        Cheap (two host memory reads); call it after graph replays, which
+        cannot check inline.
+        """
+
+        if self._proxy is not None and self._proxy.failed():
+            raise RuntimeError(f"RoCE proxy failed: {self._proxy.error()}")
+        failed_seq = int(self._error_word.item())
+        if failed_seq != 0:
+            peer = int(self._ctrl_words[3].item())
+            raise RuntimeError(
+                f"RoCE all-reduce on rank {self.rank} timed out waiting for rank {peer} "
+                f"at sequence {failed_seq}; that rank's proxy or kernel is dead "
+                "(rank data is no longer trustworthy)"
+            )
+
+    @contextmanager
+    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
+        yield self
+
+    # -- diagnostics / lifecycle --------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        info: dict[str, Any] = {
+            "world_size": self.world_size,
+            "rank": self.rank,
+            "hcas": list(self.hca_names),
+            "max_size": self.max_size,
+            "slot_bytes": self._slot_bytes,
+            "epoch": int(self._counters[0].item()),
+            "error_seq": int(self._error_word.item()),
+            "error_peer": int(self._ctrl_words[3].item()),
+            "ctrl_seq": int(self._ctrl_words[0].item()),
+            "spin_limit": self.spin_limit,
+        }
+        if self._proxy is not None:
+            info.update(self._proxy.stats())
+            info["peer_hca"] = {
+                peer: self._proxy.peer_hca(peer)
+                for peer in range(self.world_size)
+                if peer != self.rank
+            }
+        return info
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._proxy is not None:
+            self._proxy.close()
+            self._proxy = None
+
+    def __del__(self) -> None:  # pragma: no cover - defensive teardown
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class _nullcontext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *exc):
+        return False
+
+
+__all__ = [
+    "DEFAULT_MAX_SIZE",
+    "SUPPORTED_DTYPES",
+    "SUPPORTED_WORLD_SIZES",
+    "RoceOneshotAllReduce",
+    "default_gid_index",
+    "discover_hcas",
+    "is_supported",
+]

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -1,4 +1,4 @@
-"""RoCE one-shot all-reduce runtime for multi-node tensor parallelism.
+"""RoCE one-shot all-reduce and all-gather runtime for multi-node tensor parallelism.
 
 Designed for DGX Spark clusters, whose integrated GPU can read pinned host
 memory in place and whose ConnectX-7 can RDMA-write into the same memory.
@@ -9,7 +9,8 @@ every peer's RDMA-written payload, and reduces in fixed rank order.
 Constraints of this first runtime:
 
 * one all-reduce in flight per runtime (single channel, one stream);
-* message sizes up to ``max_size`` bytes, a multiple of 16 bytes;
+* all-reduce messages up to ``max_size`` bytes and all-gather shards up to
+  ``max_gather_bytes``, both multiples of 16 bytes;
 * every rank of the exchange group must construct the runtime collectively.
 """
 
@@ -25,6 +26,7 @@ import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
+from . import _allgather_cute
 from ._oneshot_cute import PACK_BYTES, get_launcher, is_launcher_prepared
 from ._proxy import Layout, Proxy
 
@@ -32,7 +34,8 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 SUPPORTED_WORLD_SIZES = tuple(range(2, 17))
-DEFAULT_MAX_SIZE = 1024 * 1024
+DEFAULT_MAX_SIZE = 2 * 1024 * 1024
+DEFAULT_MAX_GATHER_BYTES = 16 * 1024 * 1024
 DEFAULT_THREADS = 512
 DEFAULT_BLOCKS = 8
 DEFAULT_GID_INDEX = 3
@@ -151,6 +154,7 @@ class RoceOneshotAllReduce:
         exchange_group: ProcessGroup,
         device: torch.device | int | str,
         max_size: int = DEFAULT_MAX_SIZE,
+        max_gather_bytes: int = DEFAULT_MAX_GATHER_BYTES,
         hca_names: Optional[Sequence[str]] = None,
         gid_index: Optional[int] = None,
         threads: int = DEFAULT_THREADS,
@@ -174,6 +178,7 @@ class RoceOneshotAllReduce:
         if int(blocks) < 1:
             raise ValueError("blocks must be positive")
         self.max_size = int(max_size)
+        self.max_gather_bytes = int(max_gather_bytes)
         self._threads = int(threads)
         self._blocks = int(blocks)
         self.gid_index = default_gid_index() if gid_index is None else int(gid_index)
@@ -183,7 +188,7 @@ class RoceOneshotAllReduce:
             raise RuntimeError("no active RDMA device found for the RoCE all-reduce")
         self.hca_names = names[:2]
 
-        slot_bytes = _align_up(self.max_size, _SLOT_ALIGNMENT)
+        slot_bytes = _align_up(max(self.max_size, self.max_gather_bytes), _SLOT_ALIGNMENT)
         self._layout = Layout(self.world_size, slot_bytes)
         self._slot_bytes = slot_bytes
 
@@ -268,12 +273,18 @@ class RoceOneshotAllReduce:
         device: torch.device | int | str,
         max_size: int = DEFAULT_MAX_SIZE,
         eager_buffer_bytes: Optional[int] = None,
+        max_gather_bytes: int = DEFAULT_MAX_GATHER_BYTES,
         **_ignored: Any,
     ) -> "RoceOneshotAllReduce":
         """Mirror ``comm.pcie.AllReduce.from_exchange_group``; PCIe-only knobs are ignored."""
 
         capacity = max(int(max_size), int(eager_buffer_bytes or 0))
-        return cls(exchange_group=exchange_group, device=device, max_size=capacity)
+        return cls(
+            exchange_group=exchange_group,
+            device=device,
+            max_size=capacity,
+            max_gather_bytes=max_gather_bytes,
+        )
 
     @classmethod
     def from_process_group(
@@ -325,12 +336,23 @@ class RoceOneshotAllReduce:
             self.device.index,
         )
 
+    def _gather_launcher_key(self) -> tuple[object, ...]:
+        return (
+            self.world_size,
+            self.rank,
+            self._threads,
+            self._layout.slots,
+            self._layout.flag_stride,
+            self.device.index,
+        )
+
     def prepare(self, dtypes: Sequence[torch.dtype] = (torch.bfloat16,)) -> None:
-        """Compile launchers ahead of CUDA-graph capture."""
+        """Compile the all-reduce launchers for ``dtypes`` and the all-gather launcher."""
 
         with torch.cuda.device(self.device):
             for dtype in dtypes:
                 get_launcher(*self._launcher_key(dtype))
+            _allgather_cute.get_launcher(*self._gather_launcher_key())
 
     def prepare_graph_all_reduce(self, inp: torch.Tensor, *, stream: object = None) -> None:
         self.prepare((inp.dtype,))
@@ -398,6 +420,90 @@ class RoceOneshotAllReduce:
                 "(rank data is no longer trustworthy)"
             )
 
+    # -- all-gather ---------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_dim(inp: torch.Tensor, dim: int) -> int:
+        if dim < 0:
+            dim += inp.dim()
+        return dim
+
+    def should_all_gather(self, inp: torch.Tensor, dim: int = -1) -> bool:
+        """Eligible: contiguous CUDA tensor, concat along dim 0 or the last dim."""
+
+        if self._closed or self._proxy is None or not inp.is_cuda or inp.dim() == 0:
+            return False
+        if inp.device != self.device or not inp.is_contiguous():
+            return False
+        if inp.dtype not in SUPPORTED_DTYPES:
+            return False
+        dim = self._normalize_dim(inp, dim)
+        if dim not in (0, inp.dim() - 1):
+            return False
+        nbytes = inp.numel() * inp.element_size()
+        if not (0 < nbytes <= self.max_gather_bytes) or nbytes % PACK_BYTES != 0:
+            return False
+        if dim == inp.dim() - 1 and (inp.shape[-1] * inp.element_size()) % PACK_BYTES != 0:
+            return False
+        return True
+
+    def all_gather(
+        self,
+        inp: torch.Tensor,
+        *,
+        dim: int = -1,
+        out: Optional[torch.Tensor] = None,
+        stream: object = None,
+    ) -> torch.Tensor:
+        """Concatenate every rank's ``inp`` along ``dim`` (0 or the last dim).
+
+        The kernel writes the concatenated layout directly, so a last-dim
+        gather needs no reshape or copy afterwards.
+        """
+
+        if not self.should_all_gather(inp, dim):
+            raise ValueError("input is not eligible for the RoCE all-gather")
+        dim = self._normalize_dim(inp, dim)
+        shape = list(inp.shape)
+        shape[dim] *= self.world_size
+        if out is None:
+            out = torch.empty(shape, dtype=inp.dtype, device=inp.device)
+        elif list(out.shape) != shape or out.dtype != inp.dtype or not out.is_contiguous():
+            raise ValueError("out must be a contiguous tensor of the gathered shape")
+        nbytes = inp.numel() * inp.element_size()
+        shard_packs = nbytes // PACK_BYTES
+        if dim == 0:
+            row_packs = shard_packs
+        else:
+            row_packs = (inp.shape[-1] * inp.element_size()) // PACK_BYTES
+        key = self._gather_launcher_key()
+        capturing = torch.cuda.is_current_stream_capturing()
+        if capturing and not _allgather_cute.is_launcher_prepared(*key):
+            raise RuntimeError(
+                "RoCE all-gather launcher must be prepared before CUDA graph capture"
+            )
+        launcher = _allgather_cute.get_launcher(*key)
+        context = torch.cuda.stream(stream) if stream is not None else _nullcontext()
+        with torch.cuda.device(self.device), context:
+            launcher(
+                inp.data_ptr(),
+                out.data_ptr(),
+                shard_packs,
+                nbytes,
+                row_packs,
+                self._recv_base,
+                self._flag_base,
+                self._send_base,
+                self._ctrl_base,
+                self._slot_bytes,
+                self._epoch_address,
+                self.spin_limit,
+                self._blocks,
+            )
+        if not capturing:
+            self.check_health()
+        return out
+
     @contextmanager
     def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
         yield self
@@ -410,6 +516,7 @@ class RoceOneshotAllReduce:
             "rank": self.rank,
             "hcas": list(self.hca_names),
             "max_size": self.max_size,
+            "max_gather_bytes": self.max_gather_bytes,
             "slot_bytes": self._slot_bytes,
             "epoch": int(self._counters[0].item()),
             "error_seq": int(self._error_word.item()),
@@ -450,6 +557,7 @@ class _nullcontext:
 
 
 __all__ = [
+    "DEFAULT_MAX_GATHER_BYTES",
     "DEFAULT_MAX_SIZE",
     "SUPPORTED_DTYPES",
     "SUPPORTED_WORLD_SIZES",

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -429,23 +429,30 @@ class RoceOneshotAllReduce:
         return dim
 
     def should_all_gather(self, inp: torch.Tensor, dim: int = -1) -> bool:
-        """Eligible: contiguous CUDA tensor, concat along dim 0 or the last dim."""
+        """Eligible: contiguous CUDA tensor of any dtype, concat along dim 0 or the last dim.
+
+        16-byte-aligned rows take the direct-layout kernel; anything else goes
+        through a padded contiguous gather plus a torch reshape, so shape never
+        forces a fallback to another backend.
+        """
 
         if self._closed or self._proxy is None or not inp.is_cuda or inp.dim() == 0:
             return False
         if inp.device != self.device or not inp.is_contiguous():
             return False
-        if inp.dtype not in SUPPORTED_DTYPES:
+        if inp.is_complex() or inp.is_sparse or inp.dtype == torch.bool:
             return False
         dim = self._normalize_dim(inp, dim)
         if dim not in (0, inp.dim() - 1):
             return False
         nbytes = inp.numel() * inp.element_size()
-        if not (0 < nbytes <= self.max_gather_bytes) or nbytes % PACK_BYTES != 0:
+        return 0 < nbytes <= self.max_gather_bytes
+
+    def _direct_gather_layout(self, inp: torch.Tensor, dim: int) -> bool:
+        nbytes = inp.numel() * inp.element_size()
+        if nbytes % PACK_BYTES != 0 or inp.data_ptr() % PACK_BYTES != 0:
             return False
-        if dim == inp.dim() - 1 and (inp.shape[-1] * inp.element_size()) % PACK_BYTES != 0:
-            return False
-        return True
+        return dim == 0 or (inp.shape[-1] * inp.element_size()) % PACK_BYTES == 0
 
     def all_gather(
         self,
@@ -457,8 +464,10 @@ class RoceOneshotAllReduce:
     ) -> torch.Tensor:
         """Concatenate every rank's ``inp`` along ``dim`` (0 or the last dim).
 
-        The kernel writes the concatenated layout directly, so a last-dim
-        gather needs no reshape or copy afterwards.
+        With 16-byte-aligned rows the kernel writes the concatenated layout
+        directly (no reshape or copy afterwards).  Otherwise the shards are
+        gathered contiguously with 16-byte padding and finished with a torch
+        reshape, which still keeps the collective on RDMA.
         """
 
         if not self.should_all_gather(inp, dim):
@@ -466,16 +475,42 @@ class RoceOneshotAllReduce:
         dim = self._normalize_dim(inp, dim)
         shape = list(inp.shape)
         shape[dim] *= self.world_size
-        if out is None:
-            out = torch.empty(shape, dtype=inp.dtype, device=inp.device)
-        elif list(out.shape) != shape or out.dtype != inp.dtype or not out.is_contiguous():
-            raise ValueError("out must be a contiguous tensor of the gathered shape")
-        nbytes = inp.numel() * inp.element_size()
-        shard_packs = nbytes // PACK_BYTES
-        if dim == 0:
-            row_packs = shard_packs
-        else:
-            row_packs = (inp.shape[-1] * inp.element_size()) // PACK_BYTES
+        context = torch.cuda.stream(stream) if stream is not None else _nullcontext()
+        with torch.cuda.device(self.device), context:
+            if self._direct_gather_layout(inp, dim):
+                if out is None:
+                    out = torch.empty(shape, dtype=inp.dtype, device=inp.device)
+                elif list(out.shape) != shape or out.dtype != inp.dtype or not out.is_contiguous():
+                    raise ValueError("out must be a contiguous tensor of the gathered shape")
+                nbytes = inp.numel() * inp.element_size()
+                row_packs = (
+                    nbytes // PACK_BYTES
+                    if dim == 0
+                    else (inp.shape[-1] * inp.element_size()) // PACK_BYTES
+                )
+                self._launch_gather(inp.data_ptr(), out.data_ptr(), nbytes, row_packs)
+                return out
+            # General path: pad each shard to a whole number of packs, gather
+            # contiguously, then let torch produce the requested layout.
+            nbytes = inp.numel() * inp.element_size()
+            padded = _align_up(nbytes, PACK_BYTES)
+            staged = torch.empty(padded, dtype=torch.uint8, device=inp.device)
+            staged[:nbytes].copy_(inp.reshape(-1).view(torch.uint8))
+            gathered = torch.empty(self.world_size * padded, dtype=torch.uint8, device=inp.device)
+            self._launch_gather(staged.data_ptr(), gathered.data_ptr(), padded, padded // PACK_BYTES)
+            stacked = (
+                gathered.view(self.world_size, padded)[:, :nbytes]
+                .reshape(-1)
+                .view(inp.dtype)
+                .reshape(self.world_size, *inp.shape)
+            )
+            result = stacked.movedim(0, dim).reshape(shape)
+            if out is None:
+                return result.contiguous()
+            out.copy_(result)
+            return out
+
+    def _launch_gather(self, input_address: int, output_address: int, nbytes: int, row_packs: int) -> None:
         key = self._gather_launcher_key()
         capturing = torch.cuda.is_current_stream_capturing()
         if capturing and not _allgather_cute.is_launcher_prepared(*key):
@@ -483,26 +518,23 @@ class RoceOneshotAllReduce:
                 "RoCE all-gather launcher must be prepared before CUDA graph capture"
             )
         launcher = _allgather_cute.get_launcher(*key)
-        context = torch.cuda.stream(stream) if stream is not None else _nullcontext()
-        with torch.cuda.device(self.device), context:
-            launcher(
-                inp.data_ptr(),
-                out.data_ptr(),
-                shard_packs,
-                nbytes,
-                row_packs,
-                self._recv_base,
-                self._flag_base,
-                self._send_base,
-                self._ctrl_base,
-                self._slot_bytes,
-                self._epoch_address,
-                self.spin_limit,
-                self._blocks,
-            )
+        launcher(
+            input_address,
+            output_address,
+            nbytes // PACK_BYTES,
+            nbytes,
+            row_packs,
+            self._recv_base,
+            self._flag_base,
+            self._send_base,
+            self._ctrl_base,
+            self._slot_bytes,
+            self._epoch_address,
+            self.spin_limit,
+            self._blocks,
+        )
         if not capturing:
             self.check_health()
-        return out
 
     @contextmanager
     def capture(self, stream: object = None, *, channel_id: Optional[str] = None):

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -16,6 +16,7 @@ Constraints of this first runtime:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from contextlib import contextmanager
@@ -574,10 +575,8 @@ class RoceOneshotAllReduce:
             self._proxy = None
 
     def __del__(self) -> None:  # pragma: no cover - defensive teardown
-        try:
+        with contextlib.suppress(Exception):
             self.close()
-        except Exception:
-            pass
 
 
 class _nullcontext:

--- a/benchmarks/benchmark_roce_oneshot.py
+++ b/benchmarks/benchmark_roce_oneshot.py
@@ -84,7 +84,8 @@ def main() -> None:
     ap.add_argument("--warmups", type=int, default=50)
     ap.add_argument("--samples", type=int, default=300)
     ap.add_argument("--graph-ops", type=int, default=20)
-    ap.add_argument("--max-size", type=int, default=1 << 20)
+    ap.add_argument("--max-size", type=int, default=2 << 20)
+    ap.add_argument("--gather-rows", default="6,16,96", help="rows of a [rows, 38720] bf16 logits shard to all-gather")
     ap.add_argument("--output", default="")
     args = ap.parse_args()
 
@@ -97,7 +98,7 @@ def main() -> None:
     from b12x.comm import roce
 
     runtime = roce.AllReduce.from_exchange_group(
-        exchange_group=dist.group.WORLD, device=device, max_size=args.max_size
+        exchange_group=dist.group.WORLD, device=device, max_size=args.max_size, max_gather_bytes=16 << 20
     )
     runtime.prepare((dtype,))
     sizes = [int(s) for s in args.sizes.split(",") if int(s) <= args.max_size]
@@ -145,6 +146,30 @@ def main() -> None:
                 f"  roce graph {row['roce_graph_us']:>8.1f} us  rel_err {row['rel_err']:.2e}",
                 flush=True,
             )
+    # all-gather of a logits shard [rows, 38720] along the last dim vs NCCL all_gather_into_tensor + copy
+    gather_rows = []
+    for rows in (int(r) for r in args.gather_rows.split(",")):
+        shard = torch.randn(rows, 38720, dtype=dtype, device=device)
+        if not runtime.should_all_gather(shard, -1):
+            continue
+        parts = [torch.empty_like(shard) for _ in range(world)]
+        dist.all_gather(parts, shard)
+        expected = torch.cat(parts, dim=-1)
+        got = runtime.all_gather(shard, dim=-1)
+        torch.cuda.synchronize()
+        exact = bool(torch.equal(got, expected))
+        stacked = torch.empty((world * rows, 38720), dtype=dtype, device=device)
+        def nccl_gather():
+            dist.all_gather_into_tensor(stacked, shard)
+            return stacked.reshape(world, rows, 38720).movedim(0, 1).reshape(rows, world * 38720)
+        nccl = _time_eager(nccl_gather, args.warmups, args.samples)
+        eager = _time_eager(lambda: runtime.all_gather(shard, dim=-1), args.warmups, args.samples)
+        graph = _time_graph(lambda: runtime.all_gather(shard, dim=-1, out=got), args.warmups, args.samples, args.graph_ops)
+        row = {"rows": rows, "shard_bytes": shard.numel() * shard.element_size(), "nccl_us": round(_median_of_max(nccl), 1),
+               "roce_eager_us": round(_median_of_max(eager), 1), "roce_graph_us": round(_median_of_max(graph), 1), "exact": exact}
+        gather_rows.append(row)
+        if rank == 0:
+            print(f"all-gather [{rows}, 38720]  nccl+copy {row['nccl_us']:>8.1f} us  roce eager {row['roce_eager_us']:>8.1f} us  roce graph {row['roce_graph_us']:>8.1f} us  exact={exact}", flush=True)
     stats = runtime.stats()
     if rank == 0:
         doc = {
@@ -156,6 +181,7 @@ def main() -> None:
             "hostname": os.uname().nodename,
             "runtime": stats,
             "rows": rows,
+            "all_gather": gather_rows,
         }
         if args.output:
             with open(args.output, "w") as f:

--- a/benchmarks/benchmark_roce_oneshot.py
+++ b/benchmarks/benchmark_roce_oneshot.py
@@ -1,0 +1,170 @@
+"""Latency of the RoCE one-shot all-reduce versus torch.distributed (NCCL).
+
+Launch with torchrun on every node (one GPU per node)::
+
+    torchrun --nnodes=4 --nproc-per-node=1 --node-rank=$RANK \\
+        --master-addr=$MASTER --master-port=29651 \\
+        benchmarks/benchmark_roce_oneshot.py --output roce.json
+
+Rank 0 prints a table and writes one JSON document with per-size medians of
+the slowest rank (CUDA-event timing around one call, graph replay timing for
+the captured variant), plus a correctness check against NCCL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+
+import torch
+import torch.distributed as dist
+
+
+def _median_of_max(values: list[float]) -> float:
+    t = torch.tensor([statistics.median(values)], device="cuda")
+    dist.all_reduce(t, op=dist.ReduceOp.MAX)
+    return float(t.item())
+
+
+def _time_eager(fn, warmups: int, samples: int) -> list[float]:
+    for _ in range(warmups):
+        fn()
+    torch.cuda.synchronize()
+    dist.barrier()
+    out = []
+    for _ in range(samples):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        out.append(start.elapsed_time(end) * 1000.0)
+    return out
+
+
+def _time_graph(fn, warmups: int, samples: int, per_graph: int) -> list[float]:
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(warmups):
+            fn()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        for _ in range(per_graph):
+            fn()
+    torch.cuda.synchronize()
+    dist.barrier()
+    for _ in range(warmups):
+        graph.replay()
+    torch.cuda.synchronize()
+    dist.barrier()
+    out = []
+    for _ in range(samples):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        graph.replay()
+        end.record()
+        end.synchronize()
+        out.append(start.elapsed_time(end) * 1000.0 / per_graph)
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sizes", default="8192,32768,49152,262144,786432,1048576")
+    ap.add_argument("--dtype", default="bfloat16")
+    ap.add_argument("--warmups", type=int, default=50)
+    ap.add_argument("--samples", type=int, default=300)
+    ap.add_argument("--graph-ops", type=int, default=20)
+    ap.add_argument("--max-size", type=int, default=1 << 20)
+    ap.add_argument("--output", default="")
+    args = ap.parse_args()
+
+    dist.init_process_group("nccl")
+    rank, world = dist.get_rank(), dist.get_world_size()
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    dtype = getattr(torch, args.dtype)
+
+    from b12x.comm import roce
+
+    runtime = roce.AllReduce.from_exchange_group(
+        exchange_group=dist.group.WORLD, device=device, max_size=args.max_size
+    )
+    runtime.prepare((dtype,))
+    sizes = [int(s) for s in args.sizes.split(",") if int(s) <= args.max_size]
+    def progress(msg: str) -> None:
+        if rank == 0:
+            print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+    progress(f"runtime ready: {runtime.stats()}")
+    rows = []
+    for nbytes in sizes:
+        progress(f"size {nbytes}: correctness")
+        numel = nbytes // torch.tensor([], dtype=dtype).element_size()
+        torch.manual_seed(rank + 17)
+        inp = torch.randn(numel, dtype=dtype, device=device)
+        out = torch.empty_like(inp)
+        expected = inp.clone()
+        dist.all_reduce(expected)
+        runtime.all_reduce(inp, out=out)
+        torch.cuda.synchronize()
+        err = (out.float() - expected.float()).abs().max().item()
+        scale = expected.float().abs().max().item() or 1.0
+        nccl_in = inp.clone()
+        progress(f"size {nbytes}: nccl timing")
+        nccl = _time_eager(lambda: dist.all_reduce(nccl_in), args.warmups, args.samples)
+        progress(f"size {nbytes}: roce eager timing")
+        eager = _time_eager(lambda: runtime.all_reduce(inp, out=out), args.warmups, args.samples)
+        runtime.check_health()
+        progress(f"size {nbytes}: roce graph timing")
+        graph = _time_graph(
+            lambda: runtime.all_reduce(inp, out=out), args.warmups, args.samples, args.graph_ops
+        )
+        runtime.check_health()
+        row = {
+            "bytes": nbytes,
+            "nccl_us": round(_median_of_max(nccl), 1),
+            "roce_eager_us": round(_median_of_max(eager), 1),
+            "roce_graph_us": round(_median_of_max(graph), 1),
+            "max_abs_err": err,
+            "rel_err": err / scale,
+        }
+        rows.append(row)
+        if rank == 0:
+            print(
+                f"{nbytes:>9} B  nccl {row['nccl_us']:>8.1f} us  roce eager {row['roce_eager_us']:>8.1f} us"
+                f"  roce graph {row['roce_graph_us']:>8.1f} us  rel_err {row['rel_err']:.2e}",
+                flush=True,
+            )
+    stats = runtime.stats()
+    if rank == 0:
+        doc = {
+            "schema": "b12x.comm.roce.oneshot.benchmark",
+            "version": 1,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "world_size": world,
+            "dtype": args.dtype,
+            "hostname": os.uname().nodename,
+            "runtime": stats,
+            "rows": rows,
+        }
+        if args.output:
+            with open(args.output, "w") as f:
+                json.dump(doc, f, indent=2)
+            print(f"wrote {args.output}")
+    dist.barrier()
+    runtime.close()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/rocenante.md
+++ b/docs/rocenante.md
@@ -1,0 +1,89 @@
+# RoCEnante: one-shot RoCE collectives for multi-node DGX Spark TP
+
+`b12x.comm.roce` (RoCEnante) is an all-reduce and all-gather runtime for tensor
+parallelism across DGX Spark nodes joined by their ConnectX-7 200 GbE ports, one
+GPU per node. It replaces NCCL on the decode path.
+
+## Why it works on GB10 without GPUDirect RDMA
+
+The GB10 is an integrated GPU with unified memory: pinned host memory is directly
+addressable by GPU kernels at full bandwidth, and the NIC can register it with a
+plain `ibv_reg_mr`. So peers RDMA-write into pinned slots that the local kernel
+reads in place. No dmabuf or `nvidia_peermem` support is needed (neither is
+available on the DGX Spark driver stack; NCCL therefore stays host-staged there).
+
+Each Spark's single cabled QSFP port is exposed as two PCIe Gen5 x4 functions
+(`rocep1s0f0`, `roceP2p1s0f0`). The runtime spreads rank pairs across both.
+
+## Protocol
+
+One pinned region per rank: `recv[src][slot]`, `flag[src][slot]`, `send[slot]`,
+and a control record. One kernel launch per collective:
+
+1. stage the input into `send[seq & 1]`;
+2. the last block to finish staging publishes `nbytes` and `seq` to the control
+   record, which a C proxy thread (`_roce_proxy.c`, libibverbs) polls; the proxy
+   posts one RDMA write of the payload and one 4-byte write of `seq` per peer on
+   the same reliable QP, so the flag cannot land before the payload;
+3. wait on `flag[peer][seq & 1] == seq` for every peer (bounded; a timeout
+   records the missing peer and the host raises instead of hanging);
+4. all-reduce: sum the local input and every peer slot in fixed rank order, so
+   all ranks produce bit-identical output; all-gather: strided copy that writes
+   the concatenated layout directly (dim 0 or last dim);
+5. the last block to finish advances a device-resident epoch, which makes `seq` a
+   runtime value and keeps CUDA-graph replay correct.
+
+Two slots suffice because a peer cannot start op k+2 before finishing op k+1,
+which needs our op k+1 data, which we only post after our op k kernel completed.
+Staging and tail arrivals use separate counters (a block with nothing to stage can
+pass the wait before a slower block has staged).
+
+## Interface
+
+`AllReduce.from_exchange_group(exchange_group=<gloo group>, device=..., max_size=,
+max_gather_bytes=)` mirrors `comm.pcie.AllReduce`: `should_allreduce`,
+`all_reduce`, `should_all_gather`, `all_gather(inp, dim=)`, `prepare(dtypes)`
+(compile before graph capture), `for_stream`, `capture`, `check_health`, `close`.
+Exchange setup over a CPU (gloo) group: using a torch NCCL group would create a
+torch NCCL communicator costing about 3.4 GB of unified memory per rank.
+
+Environment: `B12X_ROCE_HCA` (falls back to `NCCL_IB_HCA`), `B12X_ROCE_GID_INDEX`
+(falls back to `NCCL_IB_GID_INDEX`, default 3), `B12X_ROCE_SPIN_LIMIT`,
+`B12X_ROCE_CACHE_DIR` (where the proxy .so is built with the host C compiler).
+
+Constraints: 2 to 16 ranks, one collective in flight per runtime (single stream),
+integrated GPU with unified addressing, active RDMA devices.
+
+## Results (four DGX Spark, bf16, median of the slowest rank)
+
+| Collective | NCCL | RoCEnante, graph replay |
+|---|---|---|
+| all-reduce 48 KB (6-token decode step) | 59 us | 23 us |
+| all-reduce 1.5 MB (192-token batch) | 877 us | 277 us |
+| all-gather [6, 38720] logits shard | 331 us (incl. reshape copy) | 96 us |
+| all-gather [96, 38720] | 1491 us | 1493 us |
+
+Serving GLM-5.3-Flash (TP4, MTP5) with the vLLM shim: per-step decode latency
+lower in every cell of a 15-cell matrix (5 to 19%), c=16 throughput +15 to +23%,
+coding-peak c=1 +12.7%, prefill unchanged (its 64 MB all-reduces stay on NCCL).
+With both collectives routed, a decode-step profile shows zero NCCL kernels.
+
+## vLLM integration
+
+A thin adapter (`b12x_roce_all_reduce.py`, about 180 lines with the communicator
+hooks and env vars) dispatches eligible all-reduces and all-gathers to the
+runtime; enable with `VLLM_ENABLE_ROCE_ALLREDUCE=1`, bound with
+`VLLM_ROCE_ALLREDUCE_MAX_SIZE` (2MB) and `VLLM_ROCE_ALLGATHER_MAX_SIZE` (16MB).
+The backend appears as `B12X_ROCENANTE` in the communicator's dispatch list.
+
+## Tests and benchmark
+
+`tests/comm/test_roce_oneshot_gpu.py` (torchrun, 2+ nodes): NCCL parity,
+bit-identical ranks, dtype/shape eligibility, dim-0/last-dim/unaligned gathers,
+CUDA-graph replay mixing both collectives. `benchmarks/benchmark_roce_oneshot.py`
+times both collectives against NCCL.
+
+## Not yet
+
+Fused all-reduce + residual + RMSNorm (the PCIe runtime has it), all-to-all for
+expert parallelism, GPU-initiated posting (needs GDR support the platform lacks).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ include = ["b12x*"]
 
 [tool.setuptools.package-data]
 "b12x.policy._profiles" = ["data/*.json.gz"]
+"b12x.comm.roce" = ["*.c"]
 
 [tool.ruff.lint]
 select = ["E", "F", "B", "SIM"]

--- a/tests/comm/test_roce_oneshot_gpu.py
+++ b/tests/comm/test_roce_oneshot_gpu.py
@@ -1,0 +1,125 @@
+"""Correctness tests for the RoCE one-shot all-reduce.
+
+Run with torchrun on two or more nodes that share a RoCE fabric, for example
+from every node of a DGX Spark cluster::
+
+    NCCL_IB_HCA=rocep1s0f0,roceP2p1s0f0 NCCL_IB_GID_INDEX=3 \\
+    torchrun --nnodes=4 --nproc-per-node=1 --node-rank=$RANK \\
+        --master-addr=$MASTER --master-port=29650 \\
+        -m pytest -x tests/comm/test_roce_oneshot_gpu.py
+
+Without a torchrun environment the tests skip.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = pytest.mark.skipif(
+    "WORLD_SIZE" not in os.environ or int(os.environ.get("WORLD_SIZE", "1")) < 2,
+    reason="requires a torchrun launch with WORLD_SIZE >= 2",
+)
+
+
+@pytest.fixture(scope="module")
+def runtime():
+    from b12x.comm import roce
+
+    if not roce.is_supported():
+        pytest.skip("RoCE all-reduce needs an integrated GPU with an active RDMA device")
+    if not dist.is_initialized():
+        # A short timeout turns a rank that failed early into an error on every
+        # rank instead of a silent hang in the next collective.
+        dist.init_process_group("nccl", timeout=timedelta(seconds=60))
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    rt = roce.AllReduce.from_exchange_group(
+        exchange_group=dist.group.WORLD, device=device, max_size=1 << 20
+    )
+    rt.prepare((torch.bfloat16, torch.float32, torch.float16))
+    yield rt
+    rt.close()
+    dist.barrier()
+
+
+def _tolerance(dtype: torch.dtype, world: int) -> tuple[float, float]:
+    if dtype == torch.float32:
+        return 1e-5, 1e-5 * world
+    if dtype == torch.bfloat16:
+        return 1e-2, 2e-2 * world
+    return 2e-3, 4e-3 * world
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.float16])
+@pytest.mark.parametrize("numel_bytes", [16, 4096, 48 * 1024, 256 * 1024, 1 << 20])
+def test_matches_nccl_and_is_rank_identical(runtime, dtype, numel_bytes):
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    numel = numel_bytes // torch.tensor([], dtype=dtype).element_size()
+    for trial in range(4):
+        torch.manual_seed(1000 * trial + rank)
+        inp = torch.randn(numel, dtype=dtype, device=runtime.device)
+        expected = inp.clone()
+        dist.all_reduce(expected)
+        out = runtime.all_reduce(inp)
+        torch.cuda.synchronize()
+        rtol, atol = _tolerance(dtype, world)
+        if not torch.allclose(out, expected, rtol=rtol, atol=atol):
+            print(
+                f"[rank {rank} trial {trial} {dtype} {numel_bytes}B] MISMATCH stats={runtime.stats()}\n"
+                f"  inp={inp[:8].tolist()}\n  out={out[:8].tolist()}\n  exp={expected[:8].tolist()}",
+                flush=True,
+            )
+        torch.testing.assert_close(out, expected, rtol=rtol, atol=atol)
+        gathered = [torch.empty_like(out) for _ in range(world)]
+        dist.all_gather(gathered, out)
+        for peer_out in gathered:
+            assert torch.equal(peer_out, out), "ranks must produce bit-identical output"
+
+
+def test_rejects_ineligible_inputs(runtime):
+    huge = torch.zeros((runtime.max_size // 2) + 8, dtype=torch.bfloat16, device=runtime.device)
+    assert not runtime.should_allreduce(huge)
+    odd = torch.zeros(3, dtype=torch.bfloat16, device=runtime.device)
+    assert not runtime.should_allreduce(odd)
+    strided = torch.zeros(64, 8, dtype=torch.bfloat16, device=runtime.device)[:, ::2]
+    assert not runtime.should_allreduce(strided)
+    ok = torch.zeros(4096, dtype=torch.bfloat16, device=runtime.device)
+    assert runtime.should_allreduce(ok)
+
+
+def test_cuda_graph_replay(runtime):
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    static_in = torch.zeros(24 * 1024, dtype=torch.bfloat16, device=runtime.device)
+    static_out = torch.empty_like(static_in)
+    stream = torch.cuda.Stream(device=runtime.device)
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            runtime.all_reduce(static_in, out=static_out)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream), runtime.capture(stream=stream):
+        for _ in range(3):
+            runtime.all_reduce(static_in, out=static_out)
+            static_in.copy_(static_out)
+    torch.cuda.synchronize()
+    dist.barrier()
+    for replay in range(5):
+        torch.manual_seed(7 * replay + rank)
+        seed = torch.randn_like(static_in) * 0.01
+        static_in.copy_(seed)
+        expected = seed.clone()
+        for _ in range(3):
+            dist.all_reduce(expected)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(static_out, expected, rtol=2e-2, atol=2e-2 * world**3)

--- a/tests/comm/test_roce_oneshot_gpu.py
+++ b/tests/comm/test_roce_oneshot_gpu.py
@@ -39,7 +39,7 @@ def runtime():
     device = torch.device("cuda", 0)
     torch.cuda.set_device(device)
     rt = roce.AllReduce.from_exchange_group(
-        exchange_group=dist.group.WORLD, device=device, max_size=1 << 20
+        exchange_group=dist.group.WORLD, device=device, max_size=1 << 20, max_gather_bytes=4 << 20
     )
     rt.prepare((torch.bfloat16, torch.float32, torch.float16))
     yield rt
@@ -123,3 +123,70 @@ def test_cuda_graph_replay(runtime):
         graph.replay()
         torch.cuda.synchronize()
         torch.testing.assert_close(static_out, expected, rtol=2e-2, atol=2e-2 * world**3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "shape,dim",
+    [((6, 38720), -1), ((6, 38720), 1), ((16, 4096), 0), ((4096,), 0), ((2, 3, 1024), -1), ((96, 8192), 1)],
+)
+def test_all_gather_matches_torch(runtime, dtype, shape, dim):
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    for trial in range(3):
+        torch.manual_seed(500 * trial + rank)
+        inp = torch.randn(*shape, dtype=dtype, device=runtime.device)
+        assert runtime.should_all_gather(inp, dim)
+        gathered = [torch.empty_like(inp) for _ in range(world)]
+        dist.all_gather(gathered, inp)
+        expected = torch.cat(gathered, dim=dim)
+        out = runtime.all_gather(inp, dim=dim)
+        torch.cuda.synchronize()
+        assert out.shape == expected.shape
+        assert torch.equal(out, expected)
+
+
+def test_all_gather_rejects_ineligible(runtime):
+    x = torch.zeros(4, 8, 8, dtype=torch.bfloat16, device=runtime.device)
+    assert not runtime.should_all_gather(x, 1)  # middle dim
+    odd = torch.zeros(6, 5, dtype=torch.bfloat16, device=runtime.device)
+    assert not runtime.should_all_gather(odd, -1)  # rows not 16-byte multiples
+    huge = torch.zeros((runtime.max_gather_bytes // 2) + 8, dtype=torch.bfloat16, device=runtime.device)
+    assert not runtime.should_all_gather(huge, 0)
+
+
+def test_all_gather_graph_replay_mixed_with_all_reduce(runtime):
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    x = torch.zeros(6, 38720, dtype=torch.bfloat16, device=runtime.device)
+    h = torch.zeros(6 * 4096, dtype=torch.bfloat16, device=runtime.device)
+    gathered = torch.empty(6, 38720 * world, dtype=torch.bfloat16, device=runtime.device)
+    reduced = torch.empty_like(h)
+    stream = torch.cuda.Stream(device=runtime.device)
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        runtime.all_reduce(h, out=reduced)
+        runtime.all_gather(x, dim=-1, out=gathered)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream), runtime.capture(stream=stream):
+        runtime.all_reduce(h, out=reduced)
+        runtime.all_gather(x, dim=-1, out=gathered)
+        runtime.all_reduce(h, out=reduced)
+    torch.cuda.synchronize()
+    dist.barrier()
+    for replay in range(4):
+        torch.manual_seed(11 * replay + rank)
+        x.copy_(torch.randn_like(x))
+        h.copy_(torch.randn_like(h))
+        parts = [torch.empty_like(x) for _ in range(world)]
+        dist.all_gather(parts, x)
+        expected_gather = torch.cat(parts, dim=-1)
+        expected_reduce = h.clone()
+        dist.all_reduce(expected_reduce)
+        graph.replay()
+        torch.cuda.synchronize()
+        assert torch.equal(gathered, expected_gather)
+        torch.testing.assert_close(reduced, expected_reduce, rtol=2e-2, atol=2e-2 * world)

--- a/tests/comm/test_roce_oneshot_gpu.py
+++ b/tests/comm/test_roce_oneshot_gpu.py
@@ -125,17 +125,28 @@ def test_cuda_graph_replay(runtime):
         torch.testing.assert_close(static_out, expected, rtol=2e-2, atol=2e-2 * world**3)
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32, torch.int64, torch.int32])
 @pytest.mark.parametrize(
     "shape,dim",
-    [((6, 38720), -1), ((6, 38720), 1), ((16, 4096), 0), ((4096,), 0), ((2, 3, 1024), -1), ((96, 8192), 1)],
+    [
+        ((6, 38720), -1), ((6, 38720), 1), ((16, 4096), 0), ((4096,), 0), ((2, 3, 1024), -1),
+        ((96, 8192), 1), ((6, 8), -1),
+        # unaligned rows / sizes: padded contiguous path + torch reshape
+        ((6, 2), -1), ((5, 2), -1), ((7, 3), 0), ((6, 1), -1), ((3,), 0),
+    ],
 )
 def test_all_gather_matches_torch(runtime, dtype, shape, dim):
     world = dist.get_world_size()
     rank = dist.get_rank()
     for trial in range(3):
         torch.manual_seed(500 * trial + rank)
-        inp = torch.randn(*shape, dtype=dtype, device=runtime.device)
+        if dtype.is_floating_point:
+            inp = torch.randn(*shape, dtype=dtype, device=runtime.device)
+        else:
+            inp = torch.randint(-1000, 1000, shape, dtype=dtype, device=runtime.device)
+        if inp.numel() * inp.element_size() > runtime.max_gather_bytes:
+            assert not runtime.should_all_gather(inp, dim)
+            pytest.skip("shard exceeds the runtime's all-gather capacity")
         assert runtime.should_all_gather(inp, dim)
         gathered = [torch.empty_like(inp) for _ in range(world)]
         dist.all_gather(gathered, inp)
@@ -150,7 +161,8 @@ def test_all_gather_rejects_ineligible(runtime):
     x = torch.zeros(4, 8, 8, dtype=torch.bfloat16, device=runtime.device)
     assert not runtime.should_all_gather(x, 1)  # middle dim
     odd = torch.zeros(6, 5, dtype=torch.bfloat16, device=runtime.device)
-    assert not runtime.should_all_gather(odd, -1)  # rows not 16-byte multiples
+    assert runtime.should_all_gather(odd, -1)  # unaligned rows take the padded path
+    assert not runtime._direct_gather_layout(odd, 1)
     huge = torch.zeros((runtime.max_gather_bytes // 2) + 8, dtype=torch.bfloat16, device=runtime.device)
     assert not runtime.should_all_gather(huge, 0)
 


### PR DESCRIPTION
## Summary

Adds `b12x.comm.roce` (**RoCEnante**): a one-shot all-reduce and all-gather over RoCE for tensor parallelism across DGX Spark nodes (one GPU per node). With a thin vLLM shim (kept outside this repo) it takes NCCL entirely off the decode path for GLM-5.3-Flash TP4: a decode-step profile shows zero NCCL kernels.

Design and results: `docs/rocenante.md`.

## How it works

- GB10 is an integrated GPU with unified memory, so peers RDMA-write into ordinary pinned host memory (`ibv_reg_mr`) that the local kernel reads in place. No GPUDirect RDMA (dmabuf/peermem) needed; the Spark driver stack has neither, which is why NCCL stays host-staged there.
- One kernel launch per collective: stage → doorbell to a small C proxy thread (libibverbs, built at first use with the host C compiler) → wait on per-peer flags → reduce in fixed rank order (bit-identical output on every rank) or strided copy into the concatenated layout (no reshape/copy after a last-dim gather) → advance a device-resident epoch (CUDA-graph replay safe).
- Both ConnectX-7 PCIe functions are used; bounded waits report the missing peer instead of hanging.
- Same interface as `comm.pcie.AllReduce` plus `should_all_gather`/`all_gather`.

## Results (four DGX Spark, bf16, median of slowest rank)

| Collective | NCCL | RoCEnante (graph replay) |
|---|---|---|
| all-reduce 48 KB (6-token decode step) | 59 us | 23 us |
| all-reduce 1.5 MB (192-token batch) | 877 us | 277 us |
| all-gather [6, 38720] logits shard | 331 us incl. reshape copy | 96 us |

Serving GLM-5.3-Flash (TP4, MTP5, vLLM): per-step decode latency lower in all 15 cells of a concurrency × context matrix (5–19%), c=16 throughput +15–23%, coding-peak c=1 +12.7%, prefill unchanged (64 MB all-reduces stay on NCCL).

## Scope

- New package only: `b12x/comm/roce/` (+ one `package-data` line in `pyproject.toml` for the C source), `tests/comm/test_roce_oneshot_gpu.py`, `benchmarks/benchmark_roce_oneshot.py`, `docs/rocenante.md`, a README mention. Nothing under `comm/pcie` changed.
- Constraints: 2–16 ranks, one collective in flight per runtime, integrated GPU with unified addressing.
- Not included: fused all-reduce + RMSNorm, all-to-all (EP), GPU-initiated posting.

## Testing

- `tests/comm/test_roce_oneshot_gpu.py` under torchrun on 4 Sparks: 66 passed, 1 skipped (NCCL parity, bit-identical ranks, eligibility, dim-0/last-dim/unaligned gathers, graph replay mixing both collectives).
- `ruff check` clean on the new files.
- Deployed on the 4-Spark GLM-5.3-Flash test cluster; 8-iteration decode profile: 0 NCCL kernels/step, 102 RoCE all-reduces, 3 RoCE all-gathers.

## vLLM shim (separate)

`VLLM_ENABLE_ROCE_ALLREDUCE=1` with `VLLM_ROCE_ALLREDUCE_MAX_SIZE` (2MB) / `VLLM_ROCE_ALLGATHER_MAX_SIZE` (16MB); a ~180-line patch (adapter + communicator hooks + env vars) that dispatches eligible collectives to this runtime and lists the backend as `B12X_ROCENANTE`. Exchange setup must use the gloo group (a torch NCCL group costs ~3.4 GB per rank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UfbfZM16WWuuLNt5JMDGc
