### PR TITLE
perf(qwen3.8): trust scheduler-owned decode metadata

### DIFF
--- a/b12x/attention/qsa/_contract.py
+++ b/b12x/attention/qsa/_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
 
@@ -17,6 +18,7 @@ _SCORE_WORKSPACE_LIMIT_BYTES = 128 * 1024 * 1024
 _MIN_TOPK_WORKSPACE_BYTES = 1024 * 1024
 _STABLE_TOPK_BLOCK = 512
 _MAX_SCORE_CHUNK_GROUPS = 65536
+MetadataValidation = Literal["transactional", "trusted"]
 
 
 def _align_up(value: int, alignment: int = _ALIGN_BYTES) -> int:
@@ -200,6 +202,7 @@ class Caps:
     rms_norm_eps: float = 1e-6
     dtype: torch.dtype = torch.bfloat16
     kv_dtype: torch.dtype = torch.bfloat16
+    metadata_validation: MetadataValidation = "transactional"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "device", _canonical_device(self.device))
@@ -250,6 +253,11 @@ class Caps:
             raise TypeError("QSA query and selector-cache dtype must be torch.bfloat16")
         if self.kv_dtype not in (torch.bfloat16, torch.float8_e4m3fn):
             raise TypeError("QSA main KV cache dtype must be BF16 or FP8 E4M3FN")
+        if self.metadata_validation not in ("transactional", "trusted"):
+            raise ValueError(
+                "metadata_validation must be 'transactional' or 'trusted', got "
+                f"{self.metadata_validation!r}"
+            )
         if int(self.index_kv_heads) != 1:
             raise ValueError("QSA requires exactly one index KV head")
         if int(self.q_heads) % int(self.kv_heads):
@@ -1436,6 +1444,7 @@ def _qsa_decode_impl(
     partial_output_offset_bytes: int,
     partial_lse_offset_bytes: int,
     work_metadata_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     """Launch the complete decode transaction inside one dispatcher boundary."""
     rows = int(query.shape[0])
@@ -1621,67 +1630,71 @@ def _qsa_decode_impl(
         launch_topk_groups,
         launch_commit_raw_ring,
         launch_validate_completed_groups,
+        launch_clear_state_errors,
         launch_validate_rows,
         launch_validate_page_tables,
         launch_validate_shared_pool_ownership,
     )
 
-    launch_validate_rows(
-        request_ids=request_ids,
-        query_positions=query_positions,
-        rope_positions=rope_positions,
-        sequence_lengths=sequence_lengths,
-        query_start_loc=query_start_loc,
-        num_accepted_tokens=num_accepted_tokens,
-        is_prefilling=is_prefilling,
-        raw_state_slot_ids=raw_state_slot_ids,
-        raw_interval_start_positions=raw_interval_start_positions,
-        request_errors=request_errors,
-        state_errors=state_errors,
-        rope_position_rows=int(rope_cos.shape[0]),
-        caps=caps,
-    )
-    launch_validate_page_tables(
-        request_ids=request_ids,
-        sequence_lengths=sequence_lengths,
-        main_block_table=main_block_table,
-        compressed_block_table=compressed_block_table,
-        raw_state_slot_ids=raw_state_slot_ids,
-        state_errors=state_errors,
-        num_main_pages=int(main_k_cache.shape[0]),
-        num_compressed_pages=int(compressed_k_cache.shape[0]),
-        shared_compressed_raw_pool=shared_compressed_raw_pool,
-        caps=caps,
-    )
-    if shared_compressed_raw_pool:
-        launch_validate_shared_pool_ownership(
+    if validate_metadata:
+        launch_validate_rows(
+            request_ids=request_ids,
+            query_positions=query_positions,
+            rope_positions=rope_positions,
+            sequence_lengths=sequence_lengths,
+            query_start_loc=query_start_loc,
+            num_accepted_tokens=num_accepted_tokens,
+            is_prefilling=is_prefilling,
+            raw_state_slot_ids=raw_state_slot_ids,
+            raw_interval_start_positions=raw_interval_start_positions,
+            request_errors=request_errors,
+            state_errors=state_errors,
+            rope_position_rows=int(rope_cos.shape[0]),
+            caps=caps,
+        )
+        launch_validate_page_tables(
             request_ids=request_ids,
             sequence_lengths=sequence_lengths,
+            main_block_table=main_block_table,
             compressed_block_table=compressed_block_table,
             raw_state_slot_ids=raw_state_slot_ids,
             state_errors=state_errors,
-            occupancy=shared_page_occupancy,
+            num_main_pages=int(main_k_cache.shape[0]),
             num_compressed_pages=int(compressed_k_cache.shape[0]),
+            shared_compressed_raw_pool=shared_compressed_raw_pool,
             caps=caps,
         )
-    launch_validate_completed_groups(
-        query_positions=query_positions,
-        rope_positions=rope_positions,
-        request_ids=request_ids,
-        query_start_loc=query_start_loc,
-        raw_state_slot_ids=raw_state_slot_ids,
-        raw_logical_positions=raw_logical_positions,
-        raw_rope_positions=raw_rope_positions,
-        state_errors=state_errors,
-        rope_position_rows=int(rope_cos.shape[0]),
-        caps=caps,
-    )
-    launch_propagate_request_errors(
-        request_ids=request_ids,
-        request_errors=request_errors,
-        state_errors=state_errors,
-        caps=caps,
-    )
+        if shared_compressed_raw_pool:
+            launch_validate_shared_pool_ownership(
+                request_ids=request_ids,
+                sequence_lengths=sequence_lengths,
+                compressed_block_table=compressed_block_table,
+                raw_state_slot_ids=raw_state_slot_ids,
+                state_errors=state_errors,
+                occupancy=shared_page_occupancy,
+                num_compressed_pages=int(compressed_k_cache.shape[0]),
+                caps=caps,
+            )
+        launch_validate_completed_groups(
+            query_positions=query_positions,
+            rope_positions=rope_positions,
+            request_ids=request_ids,
+            query_start_loc=query_start_loc,
+            raw_state_slot_ids=raw_state_slot_ids,
+            raw_logical_positions=raw_logical_positions,
+            raw_rope_positions=raw_rope_positions,
+            state_errors=state_errors,
+            rope_position_rows=int(rope_cos.shape[0]),
+            caps=caps,
+        )
+        launch_propagate_request_errors(
+            request_ids=request_ids,
+            request_errors=request_errors,
+            state_errors=state_errors,
+            caps=caps,
+        )
+    else:
+        launch_clear_state_errors(state_errors)
     # Completion consumes the old ring before the current suffix can wrap it.
     launch_compress_completed_groups(
         raw_index_key=raw_index_key,
@@ -1857,7 +1870,8 @@ def _qsa_decode_impl(
             block_n=block_n,
             splits=splits,
         )
-        launch_poison_failed_rows(output=active_output, state_errors=chunk_errors)
+        if validate_metadata:
+            launch_poison_failed_rows(output=active_output, state_errors=chunk_errors)
 
 
 _QSA_MUTATED_ARGUMENTS = (
@@ -1935,6 +1949,7 @@ def _qsa_decode_op(
     partial_output_offset_bytes: int,
     partial_lse_offset_bytes: int,
     work_metadata_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     _require_mutation_alias_contract(
         mutable=(
@@ -2019,6 +2034,7 @@ def _qsa_decode_op(
         partial_output_offset_bytes,
         partial_lse_offset_bytes,
         work_metadata_offset_bytes,
+        validate_metadata,
     )
 
 
@@ -2082,6 +2098,7 @@ def _qsa_decode_fake(
     partial_output_offset_bytes: int,
     partial_lse_offset_bytes: int,
     work_metadata_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     return None
 
@@ -2211,6 +2228,7 @@ def _qsa_decode_shared_op(
     partial_output_offset_bytes: int,
     partial_lse_offset_bytes: int,
     work_metadata_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     _require_mutation_alias_contract(
         mutable=(
@@ -2303,6 +2321,7 @@ def _qsa_decode_shared_op(
         partial_output_offset_bytes,
         partial_lse_offset_bytes,
         work_metadata_offset_bytes,
+        validate_metadata,
     )
 
 
@@ -2364,6 +2383,7 @@ def _qsa_decode_shared_fake(
     partial_output_offset_bytes: int,
     partial_lse_offset_bytes: int,
     work_metadata_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     return None
 
@@ -2568,6 +2588,7 @@ def run(
             int(layout.partial_output_offset_bytes),
             int(layout.partial_lse_offset_bytes),
             int(layout.work_metadata_offset_bytes),
+            caps.metadata_validation == "transactional",
         )
         return binding.output[:rows]
     _qsa_decode_op(
@@ -2629,6 +2650,7 @@ def run(
         int(layout.partial_output_offset_bytes),
         int(layout.partial_lse_offset_bytes),
         int(layout.work_metadata_offset_bytes),
+        caps.metadata_validation == "transactional",
     )
     return binding.output[:rows]
 

--- a/b12x/attention/qsa/_kernels.py
+++ b/b12x/attention/qsa/_kernels.py
@@ -10,6 +10,12 @@ import triton.language as tl
 
 
 @triton.jit
+def _clear_state_errors_kernel(state_errors, rows, BLOCK: tl.constexpr):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    tl.store(state_errors + offsets, 0, mask=offsets < rows)
+
+
+@triton.jit
 def _round_fp32_to_bf16(value):
     """Round FP32 to BF16 and widen without permitting arithmetic fusion."""
     bits = value.to(tl.uint32, bitcast=True)
@@ -1391,6 +1397,18 @@ def launch_validate_rows(
     )
 
 
+def launch_clear_state_errors(state_errors: torch.Tensor) -> None:
+    """Initialize status rows when the caller guarantees valid metadata."""
+    rows = int(state_errors.shape[0])
+    block = min(256, triton.next_power_of_2(rows))
+    _clear_state_errors_kernel[(triton.cdiv(rows, block),)](
+        state_errors,
+        rows,
+        BLOCK=block,
+        num_warps=1,
+    )
+
+
 def launch_validate_page_tables(
     *,
     request_ids: torch.Tensor,
@@ -1938,6 +1956,7 @@ def launch_poison_failed_rows(
 
 
 __all__ = [
+    "launch_clear_state_errors",
     "launch_validate_rows",
     "launch_validate_page_tables",
     "launch_validate_shared_pool_ownership",

--- a/b12x/sequence/gdn_decode/__init__.py
+++ b/b12x/sequence/gdn_decode/__init__.py
@@ -11,9 +11,10 @@ outside this package.
 raw gate while preserving the same state, transaction, and serving lifecycle.
 KDA bindings accept live tensor capacities within the plan, so serving runtimes
 can bind projection, metadata, and output tensors directly without staging.
-``Caps.kda_metadata_validation="trusted"`` disables device-side validation when
-the runtime already guarantees packed-request geometry, unique active state
-ownership, and in-range state indices.
+``Caps.kda_metadata_validation="trusted"`` and
+``Caps.qwen_metadata_validation="trusted"`` disable device-side validation for
+their respective recurrence when the runtime already guarantees packed-request
+geometry, unique active state ownership, and in-range state indices.
 
 The recurrent-state pool uses the optimized physical layout
 ``[slot, value_head, value_dim, key_dim]``. This is the transpose of the

--- a/b12x/sequence/gdn_decode/_cute_kernels.py
+++ b/b12x/sequence/gdn_decode/_cute_kernels.py
@@ -401,6 +401,7 @@ class _PackedRecurrentQwenKernel:
         qk_l2norm: bool,
         null_state_index: int | None,
         state_type: type[cutlass.Numeric],
+        validate_metadata: bool,
     ) -> None:
         self.max_seqs = int(max_seqs)
         self.state_index_columns = int(state_index_columns)
@@ -424,6 +425,7 @@ class _PackedRecurrentQwenKernel:
             0 if null_state_index is None else int(null_state_index)
         )
         self.state_type = state_type
+        self.validate_metadata = bool(validate_metadata)
 
     @cute.jit
     def __call__(
@@ -1076,10 +1078,10 @@ class _PackedRecurrentQwenKernel:
         lane, _, _ = cute.arch.thread_idx()
         work_block = Int32(work_block)
 
-        # CuTe kernels cannot use dynamic early returns. Nesting the work under
-        # the validation flag preserves the transaction boundary: nonzero
-        # error_code launches perform no state or output access.
-        if error_code[Int32(0)].to(Int32) == Int32(0):
+        error = Int32(0)
+        if cutlass.const_expr(self.validate_metadata):
+            error = error_code[Int32(0)].to(Int32)
+        if error == Int32(0):
             live_seqs = num_seqs[Int32(0)].to(Int32)
             bounded_seqs = cutlass.max(
                 Int32(0), cutlass.min(live_seqs, Int32(self.max_seqs))
@@ -1301,6 +1303,7 @@ def _binding_key(binding: Binding) -> tuple[object, ...]:
         binding.state_indices.dtype,
         binding.A_log.dtype,
         binding.dt_bias.dtype,
+        caps.qwen_metadata_validation,
     )
 
 
@@ -1323,6 +1326,7 @@ def _compile(binding: Binding) -> tuple[tuple[object, ...], Callable[[Binding, f
         qk_l2norm=caps.qk_l2norm,
         null_state_index=caps.null_state_index,
         state_type=state_type,
+        validate_metadata=caps.qwen_metadata_validation == "transactional",
     )
     raise_if_kernel_resolution_frozen(
         "cute.compile",

--- a/b12x/sequence/gdn_decode/_impl.py
+++ b/b12x/sequence/gdn_decode/_impl.py
@@ -26,6 +26,7 @@ from ._policy import GDN_POLICY, GdnQuery
 
 GateActivation = Literal["silu", "sigmoid"]
 KdaMetadataValidation = Literal["transactional", "trusted"]
+QwenMetadataValidation = Literal["transactional", "trusted"]
 
 
 def _canonical_device(device: torch.device | str) -> torch.device:
@@ -65,6 +66,7 @@ class Caps:
     qk_l2norm: bool = True
     null_state_index: int | None = None
     kda_metadata_validation: KdaMetadataValidation = "transactional"
+    qwen_metadata_validation: QwenMetadataValidation = "transactional"
 
     def __post_init__(self) -> None:
         device = _canonical_device(self.device)
@@ -113,6 +115,11 @@ class Caps:
             raise ValueError(
                 "kda_metadata_validation must be 'transactional' or 'trusted', got "
                 f"{self.kda_metadata_validation!r}"
+            )
+        if self.qwen_metadata_validation not in ("transactional", "trusted"):
+            raise ValueError(
+                "qwen_metadata_validation must be 'transactional' or 'trusted', got "
+                f"{self.qwen_metadata_validation!r}"
             )
         null_state_index = self.null_state_index
         if null_state_index is not None:
@@ -883,7 +890,7 @@ def run(
         duplicate_table_size=binding.plan.duplicate_table_size,
         recurrent_num_warps=binding.plan.recurrent_num_warps,
         norm_num_warps=binding.plan.norm_num_warps,
-        validate_metadata=True,
+        validate_metadata=caps.qwen_metadata_validation == "transactional",
     )
     return binding.output
 

--- a/b12x/sequence/gdn_decode/_kernels.py
+++ b/b12x/sequence/gdn_decode/_kernels.py
@@ -434,6 +434,7 @@ def _make_qwen_binding(
     qk_l2norm: bool,
     null_state_index: int | None,
     duplicate_table_size: int,
+    validate_metadata: bool,
 ):
     from ._impl import Binding, Caps, _materialize_plan
 
@@ -452,6 +453,7 @@ def _make_qwen_binding(
         gate_activation="sigmoid" if sigmoid_gate else "silu",
         qk_l2norm=qk_l2norm,
         null_state_index=null_state_index,
+        qwen_metadata_validation=("transactional" if validate_metadata else "trusted"),
     )
     launch_plan = _materialize_plan(caps, policy_resolution=None)
     if launch_plan.duplicate_table_size != duplicate_table_size:
@@ -609,6 +611,7 @@ def _launch_gdn_decode(
             qk_l2norm=qk_l2norm,
             null_state_index=(null_state_index if has_null_state_index else None),
             duplicate_table_size=duplicate_table_size,
+            validate_metadata=validate_metadata,
         )
         from ._cute_kernels import run_packed_recurrent_qwen
 

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -735,6 +735,67 @@ def test_qsa_prefill_capacity_uses_full_row_workspace() -> None:
     assert prefill.max_split_row_product == 4096 * 16
 
 
+def test_qsa_caps_reject_unknown_metadata_validation() -> None:
+    with pytest.raises(ValueError, match="metadata_validation"):
+        _caps(metadata_validation="unchecked")
+
+
+def test_qsa_trusted_metadata_matches_transactional_decode_under_graph_replay() -> None:
+    device = require_sm120()
+    common = dict(
+        max_batch=1,
+        max_raw_state_slots=1,
+        max_q_rows=1,
+        q_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
+        index_rotary_dim=64,
+    )
+    transactional = _allocate_binding(_caps(device, **common))
+    trusted = _allocate_binding(_caps(device, metadata_validation="trusted", **common))
+    for binding in (transactional, trusted):
+        binding.main_block_table[0, 0] = 0
+        binding.main_k_cache.zero_()
+        binding.main_v_cache.zero_()
+        binding.compressed_k_cache.zero_()
+        binding.index_q_norm_weight.zero_()
+        binding.index_k_norm_weight.zero_()
+    transactional_inputs = _dynamic_inputs(transactional, positions=(0,))
+    trusted_inputs = _dynamic_inputs(trusted, positions=(0,))
+    trusted.state_errors.fill_(73)
+
+    expected = qsa.run(transactional, **transactional_inputs).clone()
+    expected_selected = transactional.selected_positions.clone()
+    qsa.run(trusted, **trusted_inputs)
+
+    def reset_trusted_state() -> None:
+        trusted.compressed_k_cache.zero_()
+        trusted.raw_k_ring.zero_()
+        trusted.raw_logical_positions.fill_(-1)
+        trusted.raw_rope_positions.fill_(-1)
+        trusted.raw_interval_start_positions.fill_(-1)
+        trusted.output.zero_()
+        trusted.selected_positions.zero_()
+        trusted.state_errors.fill_(73)
+
+    reset_trusted_state()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = qsa.run(trusted, **trusted_inputs)
+
+    reset_trusted_state()
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.equal(trusted.selected_positions, expected_selected)
+    assert trusted.state_errors.item() == 0
+
+
 @pytest.mark.parametrize("rows", [1, 16, 32, 257, 513])
 def test_qsa_scaled_topk_scratch_executes_fixed_capacity_rows(rows: int) -> None:
     device = require_sm120()

--- a/tests/sequence/test_gdn_decode.py
+++ b/tests/sequence/test_gdn_decode.py
@@ -42,6 +42,7 @@ def _make_case(
     dt_bias_dtype: torch.dtype = torch.float32,
     norm_dtype: torch.dtype = torch.bfloat16,
     qk_l2norm: bool = True,
+    metadata_validation: str = "transactional",
 ) -> tuple[gdn.Binding, dict[str, torch.Tensor]]:
     live_seqs = len(query_lengths)
     columns = 4 if columns is None else columns
@@ -62,6 +63,7 @@ def _make_case(
         state_dtype=state_dtype,
         gate_activation=activation,
         qk_l2norm=qk_l2norm,
+        qwen_metadata_validation=metadata_validation,
     )
     plan = gdn.plan(caps)
     (scratch_spec,) = plan.scratch_specs()
@@ -350,6 +352,46 @@ def test_public_qwen38_cute_path_is_graph_safe_without_replay_allocation() -> No
     )
     assert binding.error_code.item() == 0
     torch.testing.assert_close(binding.output, expected, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(
+        binding.recurrent_state, expected_state, rtol=1e-5, atol=2e-5
+    )
+
+
+def test_public_qwen38_cuda_graph_replays_with_trusted_metadata() -> None:
+    device = require_sm120()
+    binding, _ = _make_case(
+        device=device,
+        query_lengths=(4, 2, 1, 3),
+        max_tokens=16,
+        max_seqs=4,
+        columns=4,
+        state_slots=17,
+        key_heads=16,
+        value_heads=48,
+        activation="sigmoid",
+        state_dtype=torch.float32,
+        metadata_validation="trusted",
+    )
+    initial_state = binding.recurrent_state.clone()
+    expected_state = initial_state.clone()
+    expected = _reference(binding, expected_state)
+
+    binding.error_code.fill_(11)
+    gdn.run(binding)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = gdn.run(binding)
+
+    binding.recurrent_state.copy_(initial_state)
+    binding.output.fill_(float("nan"))
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    assert captured.data_ptr() == binding.output.data_ptr()
+    assert binding.error_code.item() == 11
+    torch.testing.assert_close(captured, expected, rtol=1e-2, atol=2e-2)
     torch.testing.assert_close(
         binding.recurrent_state, expected_state, rtol=1e-5, atol=2e-5
     )
@@ -1148,4 +1190,14 @@ def test_caps_accept_divisible_head_ratios_and_reject_invalid_capacity() -> None
             key_heads=1,
             value_heads=1,
             state_index_columns=1,
+        )
+    with pytest.raises(ValueError, match="qwen_metadata_validation"):
+        gdn.Caps(
+            device=device,
+            max_tokens=1,
+            max_seqs=1,
+            max_state_slots=1,
+            key_heads=1,
+            value_heads=3,
+            qwen_metadata_validation="unchecked",
         )


### PR DESCRIPTION
## Purpose

Status: **qualified** on NVIDIA RTX PRO 6000 Blackwell Workstation Edition.

Qwen3.8 decode metadata is produced by a scheduler that owns packed request
boundaries, cache page tables, and exclusive recurrent-state slots. This change
adds opt-in trusted metadata specializations so that integration can avoid
revalidating those invariants in every recurrent GDN and QSA layer.

The public B12X defaults remain transactional. Callers that do not explicitly
select trusted validation retain device-side validation and failed-row
poisoning.

## Resulting behavior

- `gdn_decode.Caps.qwen_metadata_validation="trusted"` compiles a Qwen
  recurrence that does not read stale error storage or launch the validation
  transaction. The validation mode is part of the static kernel key.
- `qsa.Caps.metadata_validation="trusted"` replaces the QSA validation and
  failed-row poison chain with one status-buffer initialization required by
  downstream kernels.
- Caller-owned scratch, stable addresses, and allocation-free CUDA graph replay
  are unchanged.
- Unknown validation modes fail during plan construction.

Trusted mode is valid only when the caller guarantees in-range page tables,
packed request geometry, unique active state ownership, and in-range state
indices.

## Performance evidence

The matched test used TP1 Qwen3.8-Flash-Next-NVFP4, MTP with three speculative
tokens, C1 greedy decode, 30-second samples, stock clocks, and the same physical
GPU 10. The runtime used the R18 B12X integration stack because B12X master does
not contain all pending production MoE optimizations used by that image.

| Mode | Target verifier steps/s |
|---|---:|
| Transactional validation, median of 2 | 61.491 |
| Trusted validation, median of 3 | 62.360 |

The verifier gain is **1.41%**. Output tok/s is intentionally not used for the
comparison because MTP acceptance varied between samples.

A rank-0 Torch trace measured 160.5 microseconds of redundant GDN validation
and 118.8 microseconds of redundant QSA validation per target step. Trusted QSA
retains a 9.1-microsecond status clear, for a net removal of approximately 270.2
microseconds per target step. The trusted trace contains none of the removed GDN
or QSA validation kernels.

## Validation

The following focused SM120 tests passed (`6 passed`):

```text
pytest -q \
  tests/sequence/test_gdn_decode.py::test_public_qwen38_cute_path_is_graph_safe_without_replay_allocation \
  tests/sequence/test_gdn_decode.py::test_public_qwen38_cuda_graph_replays_with_trusted_metadata \
  tests/sequence/test_gdn_decode.py::test_caps_accept_divisible_head_ratios_and_reject_invalid_capacity \
  tests/attention/test_qsa_contract.py::test_qsa_caps_reject_unknown_metadata_validation \
  tests/attention/test_qsa_contract.py::test_qsa_trusted_metadata_matches_transactional_decode_under_graph_replay \
  tests/attention/test_qsa_contract.py::test_qsa_production_page_boundary_after_speculative_rollback_graph_replay
```

The tests cover transactional behavior, trusted-mode parity, stale status,
production page-boundary rollback, CUDA graph replay, stable allocation, and
plan validation. Ruff and `git diff --check` pass.

The composed vLLM server also passed a six-sample 32,161-token prefill and four
deterministic post-prefill requests with the expected answers `36`, `Paris`,
`OK`, and `Jupiter`.

## Duplicate-work check

No open local-inference-lab/b12x pull request or issue matches the Qwen GDN and
QSA trusted-validation contract.

AI assistance was used to inspect traces, implement the specialization, and
prepare tests. The submitter reviewed the resulting diff and executed the
validation listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds opt-in `"trusted"` metadata validation for Qwen GDN recurrence and QSA decode paths.
- Preserves `"transactional"` behavior by default, including device validation and failed-row poisoning.
- Trusted Qwen GDN mode skips redundant validation and includes the mode in the static kernel key.
- Trusted QSA mode clears state errors and omits output poisoning.
- Rejects unknown validation modes during plan construction.
- Preserves caller-owned scratch buffers, stable addresses, and allocation-free CUDA Graph replay.
- Adds coverage for invalid modes, transactional behavior, QSA parity, stale-status handling, and trusted CUDA Graph replay.
- Focused SM120 tests, formatting checks, and composed vLLM server validation passed.
- The reported target verifier benchmark improved from 61.491 to 62.360 steps/s, a 1.41% increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->