### PR TITLE
perf(ple): trust scheduler-owned metadata

### DIFF
--- a/b12x/sequence/ple/STATE.md
+++ b/b12x/sequence/ple/STATE.md
@@ -51,14 +51,20 @@ A `state_slot_ids[r]` value of `-1` is a dummy sink for CUDA-graph padding. Its
 tokens produce zero output and no state mutation. Other negative values and
 values at or above `max_state_slots` are invalid.
 
-`run_decode`, `run_prefill`, and `run_mixed` reset and then populate
-`binding.error_code`, a one-element device `int32` scratch view. A nonzero code
-means the entire launch wrote zero output and did not mutate state. The masks
-are `1` for capacity metadata, `2` for packed-query boundaries, `4` for decode
-query length, `8` for accepted-token count, and `16` for state-slot ID. Serving
-integrations must inspect this value after stream or graph completion and treat
-any nonzero value as fatal.
-The additional mask `32` reports duplicate nonnegative live state-slot IDs.
+The default `metadata_validation="transactional"` mode makes `run_decode`,
+`run_prefill`, and `run_mixed` reset and populate `binding.error_code`, a
+one-element device `int32` scratch view. A nonzero code means the entire launch
+wrote zero output and did not mutate state. The masks are `1` for capacity
+metadata, `2` for packed-query boundaries, `4` for decode query length, `8` for
+accepted-token count, `16` for state-slot ID, and `32` for duplicate
+nonnegative live state-slot IDs. Transactional integrations must inspect this
+value after stream or graph completion and treat any nonzero value as fatal.
+
+The opt-in `metadata_validation="trusted"` mode performs neither the validation
+transaction nor any access to `binding.error_code`. The caller must guarantee
+the same capacity, packed-query, decode-length, accepted-token, state-slot
+range, and state-slot exclusivity invariants before launch. The error-code
+contents are not meaningful in trusted mode.
 
 Norm weights bind as flat `[streams * hidden_size]` tensors. A checkpoint
 depthwise-convolution weight shaped

--- a/b12x/sequence/ple/__init__.py
+++ b/b12x/sequence/ple/__init__.py
@@ -21,6 +21,7 @@ META = OpMeta(
     group="sequence",
     api_style="planned",
     entry_points=(
+        "MetadataValidation",
         "Caps",
         "Plan",
         "Binding",
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from .api import (  # noqa: F401
         Binding,
         Caps,
+        MetadataValidation,
         Plan,
         PleConfig,
         PleQuery,

--- a/b12x/sequence/ple/_contracts.py
+++ b/b12x/sequence/ple/_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
 
@@ -18,6 +19,8 @@ from b12x._lib.scratch_layout import (
 from b12x.policy import PolicyContext, get_auto_policy
 
 from ._policy import PLE_POLICY, PleQuery
+
+MetadataValidation = Literal["transactional", "trusted"]
 
 
 def _canonical_device(device: torch.device | str) -> torch.device:
@@ -123,7 +126,12 @@ def _require_mutation_alias_contract(
 
 @dataclass(frozen=True, kw_only=True)
 class LayerCaps:
-    """Capacity contract for the stateful PLE residual contribution."""
+    """Capacity contract for the stateful PLE residual contribution.
+
+    ``metadata_validation="trusted"`` removes device validation and requires
+    the caller to guarantee packed boundaries, decode lengths, accepted-token
+    counts, and exclusive ownership of every nonnegative state slot.
+    """
 
     device: torch.device | str
     mode: str
@@ -136,6 +144,7 @@ class LayerCaps:
     kernel_size: int
     dilation: int
     dtype: torch.dtype = torch.bfloat16
+    metadata_validation: MetadataValidation = "transactional"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "device", _canonical_device(self.device))
@@ -168,6 +177,11 @@ class LayerCaps:
         if self.dtype != torch.bfloat16:
             raise TypeError(
                 f"PLE layer currently requires torch.bfloat16, got {self.dtype}"
+            )
+        if self.metadata_validation not in ("transactional", "trusted"):
+            raise ValueError(
+                "metadata_validation must be 'transactional' or 'trusted', got "
+                f"{self.metadata_validation!r}"
             )
 
     @property
@@ -540,6 +554,7 @@ def run_mixed(binding: LayerBinding, *, eps: float) -> torch.Tensor:
 
 
 __all__ = [
+    "MetadataValidation",
     "LayerCaps",
     "LayerPlan",
     "LayerBinding",

--- a/b12x/sequence/ple/_kernels.py
+++ b/b12x/sequence/ple/_kernels.py
@@ -142,11 +142,15 @@ def _request_ids_kernel(
     request_ids_ptr,
     error_code_ptr,
     MAX_TOKENS: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     token = tl.program_id(0)
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
     num_seqs = tl.load(num_seqs_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    else:
+        valid_metadata = tl.full((), True, tl.int1)
     live = (token < num_tokens) & valid_metadata
 
     low = tl.zeros((), tl.int32)
@@ -180,13 +184,17 @@ def _prepare_history_kernel(
     DECODE: tl.constexpr,
     MIXED: tl.constexpr,
     BLOCK_C: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     request = tl.program_id(0)
     channel_block = tl.program_id(1)
     channels = channel_block * BLOCK_C + tl.arange(0, BLOCK_C)
     channel_mask = channels < CHANNELS
     num_seqs = tl.load(num_seqs_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    else:
+        valid_metadata = tl.full((), True, tl.int1)
     request_live = (request < num_seqs) & valid_metadata
     slot = tl.load(state_slot_ids_ptr + request, mask=request_live, other=-1).to(
         tl.int64
@@ -253,13 +261,17 @@ def _gated_u_norm_kernel(
     HIDDEN_SIZE: tl.constexpr,
     CHANNELS: tl.constexpr,
     BLOCK_H: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     token = tl.program_id(0)
     stream = tl.program_id(1)
     columns = tl.arange(0, BLOCK_H)
     column_mask = columns < HIDDEN_SIZE
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    else:
+        valid_metadata = tl.full((), True, tl.int1)
     token_live = (token < num_tokens) & valid_metadata
     request = tl.load(request_ids_ptr + token).to(tl.int32)
     slot = tl.load(
@@ -342,13 +354,17 @@ def _dilated_conv_kernel(
     KERNEL_SIZE: tl.constexpr,
     DILATION: tl.constexpr,
     BLOCK_C: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     token = tl.program_id(0)
     channel_block = tl.program_id(1)
     channels = channel_block * BLOCK_C + tl.arange(0, BLOCK_C)
     channel_mask = channels < CHANNELS
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    else:
+        valid_metadata = tl.full((), True, tl.int1)
     token_live = (token < num_tokens) & valid_metadata
     request = tl.load(request_ids_ptr + token).to(tl.int32)
     slot = tl.load(
@@ -432,13 +448,17 @@ def _update_state_kernel(
     DECODE: tl.constexpr,
     MIXED: tl.constexpr,
     BLOCK_C: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     request = tl.program_id(0)
     channel_block = tl.program_id(1)
     channels = channel_block * BLOCK_C + tl.arange(0, BLOCK_C)
     channel_mask = channels < CHANNELS
     num_seqs = tl.load(num_seqs_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    else:
+        valid_metadata = tl.full((), True, tl.int1)
     request_live = (request < num_seqs) & valid_metadata
     slot = tl.load(state_slot_ids_ptr + request, mask=request_live, other=-1).to(
         tl.int64
@@ -568,6 +588,7 @@ def _launch_layer_pipeline(
     dilation: int,
     decode: bool,
     mixed: bool,
+    validate_metadata: bool,
 ) -> None:
     """Launch the allocation-free PLE pipeline on the current CUDA stream."""
     channels = streams * hidden_size
@@ -575,25 +596,26 @@ def _launch_layer_pipeline(
     state_capacity = state_length + max_speculative_tokens
     state_strides = tuple(int(stride) for stride in conv_state.stride())
     channel_grid = triton.cdiv(channels, _CHANNEL_BLOCK)
-    _reset_error_kernel[(1,)](error_code, num_warps=1)
-    request_block = 128
-    _validate_metadata_kernel[(max_seqs, triton.cdiv(max_seqs, request_block))](
-        query_start_loc,
-        state_slot_ids,
-        num_accepted_tokens,
-        request_is_prefill,
-        num_seqs,
-        num_tokens,
-        error_code,
-        MAX_TOKENS=max_tokens,
-        MAX_SEQS=max_seqs,
-        MAX_STATE_SLOTS=max_state_slots,
-        MAX_SPECULATIVE=max_speculative_tokens,
-        DECODE=decode,
-        MIXED=mixed,
-        BLOCK_R=request_block,
-        num_warps=1,
-    )
+    if validate_metadata:
+        _reset_error_kernel[(1,)](error_code, num_warps=1)
+        request_block = 128
+        _validate_metadata_kernel[(max_seqs, triton.cdiv(max_seqs, request_block))](
+            query_start_loc,
+            state_slot_ids,
+            num_accepted_tokens,
+            request_is_prefill,
+            num_seqs,
+            num_tokens,
+            error_code,
+            MAX_TOKENS=max_tokens,
+            MAX_SEQS=max_seqs,
+            MAX_STATE_SLOTS=max_state_slots,
+            MAX_SPECULATIVE=max_speculative_tokens,
+            DECODE=decode,
+            MIXED=mixed,
+            BLOCK_R=request_block,
+            num_warps=1,
+        )
     _request_ids_kernel[(max_tokens,)](
         query_start_loc,
         num_seqs,
@@ -601,6 +623,7 @@ def _launch_layer_pipeline(
         request_ids,
         error_code,
         MAX_TOKENS=max_tokens,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=1,
     )
     _prepare_history_kernel[(max_seqs, channel_grid)](
@@ -622,6 +645,7 @@ def _launch_layer_pipeline(
         DECODE=decode,
         MIXED=mixed,
         BLOCK_C=_CHANNEL_BLOCK,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=4,
     )
     block_h = max(16, triton.next_power_of_2(hidden_size))
@@ -644,6 +668,7 @@ def _launch_layer_pipeline(
         HIDDEN_SIZE=hidden_size,
         CHANNELS=channels,
         BLOCK_H=block_h,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=reduction_warps,
     )
     _dilated_conv_kernel[(max_tokens, channel_grid)](
@@ -661,6 +686,7 @@ def _launch_layer_pipeline(
         KERNEL_SIZE=kernel_size,
         DILATION=dilation,
         BLOCK_C=_CHANNEL_BLOCK,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=4,
     )
     _update_state_kernel[(max_seqs, channel_grid)](
@@ -682,6 +708,7 @@ def _launch_layer_pipeline(
         DECODE=decode,
         MIXED=mixed,
         BLOCK_C=_CHANNEL_BLOCK,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=4,
     )
 
@@ -727,6 +754,7 @@ def _layer_pipeline_op(
     kernel_size: int,
     dilation: int,
     decode: bool,
+    validate_metadata: bool,
 ) -> None:
     _launch_layer_pipeline(
         residual,
@@ -760,6 +788,7 @@ def _layer_pipeline_op(
         dilation,
         decode,
         False,
+        validate_metadata,
     )
 
 
@@ -794,13 +823,14 @@ def _layer_pipeline_fake(
     kernel_size: int,
     dilation: int,
     decode: bool,
+    validate_metadata: bool,
 ) -> None:
     del residual, key, value, k_norm_weight, q_norm_weight, u_norm_weight
     del conv_weight, query_start_loc, state_slot_ids, state_is_fresh
     del num_accepted_tokens, num_seqs, num_tokens, conv_state, out
     del normalized_u, gathered_state, request_ids, error_code, eps
     del max_tokens, max_seqs, max_state_slots, max_speculative_tokens
-    del streams, hidden_size, kernel_size, dilation, decode
+    del streams, hidden_size, kernel_size, dilation, decode, validate_metadata
 
 
 @torch.library.custom_op(
@@ -844,6 +874,7 @@ def _layer_mixed_pipeline_op(
     hidden_size: int,
     kernel_size: int,
     dilation: int,
+    validate_metadata: bool,
 ) -> None:
     _launch_layer_pipeline(
         residual,
@@ -877,6 +908,7 @@ def _layer_mixed_pipeline_op(
         dilation,
         False,
         True,
+        validate_metadata,
     )
 
 
@@ -911,13 +943,14 @@ def _layer_mixed_pipeline_fake(
     hidden_size: int,
     kernel_size: int,
     dilation: int,
+    validate_metadata: bool,
 ) -> None:
     del residual, key, value, k_norm_weight, q_norm_weight, u_norm_weight
     del conv_weight, query_start_loc, state_slot_ids, state_is_fresh
     del num_accepted_tokens, request_is_prefill, num_seqs, num_tokens
     del conv_state, out, normalized_u, gathered_state, request_ids, error_code, eps
     del max_tokens, max_seqs, max_state_slots, max_speculative_tokens
-    del streams, hidden_size, kernel_size, dilation
+    del streams, hidden_size, kernel_size, dilation, validate_metadata
 
 
 def run_layer_kernels(binding: LayerBinding, *, eps: float, decode: bool) -> None:
@@ -953,6 +986,7 @@ def run_layer_kernels(binding: LayerBinding, *, eps: float, decode: bool) -> Non
         caps.kernel_size,
         caps.dilation,
         decode,
+        caps.metadata_validation == "transactional",
     )
 
 
@@ -991,6 +1025,7 @@ def run_layer_mixed_kernels(binding: LayerBinding, *, eps: float) -> None:
         caps.hidden_size,
         caps.kernel_size,
         caps.dilation,
+        caps.metadata_validation == "transactional",
     )
 
 

--- a/b12x/sequence/ple/api.py
+++ b/b12x/sequence/ple/api.py
@@ -7,6 +7,7 @@ from ._contracts import (
     LayerBinding as Binding,
     LayerCaps as Caps,
     LayerPlan as Plan,
+    MetadataValidation,
     bind_layer as bind,
     plan_layer as plan,
     run_decode,
@@ -22,6 +23,7 @@ def is_supported(device=None) -> bool:
 
 
 __all__ = [
+    "MetadataValidation",
     "Caps",
     "Plan",
     "Binding",

--- a/b12x/sequence/ple_embedding/__init__.py
+++ b/b12x/sequence/ple_embedding/__init__.py
@@ -25,6 +25,7 @@ META = OpMeta(
     group="sequence",
     api_style="planned",
     entry_points=(
+        "MetadataValidation",
         "QuantMode",
         "TableMemory",
         "TableStorage",
@@ -67,6 +68,7 @@ if TYPE_CHECKING:
     from .api import (  # noqa: F401
         Binding,
         Caps,
+        MetadataValidation,
         Plan,
         PleEmbeddingConfig,
         PleEmbeddingQuery,

--- a/b12x/sequence/ple_embedding/_contracts.py
+++ b/b12x/sequence/ple_embedding/_contracts.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 _SIGNED_INT64_MAX = (1 << 63) - 1
 QuantMode = Literal["bf16", "fp8_e4m3_per_tensor", "nvfp4_group16"]
 TableMemory = Literal["device", "mapped_host"]
+MetadataValidation = Literal["transactional", "trusted"]
 _BF16_MODE: QuantMode = "bf16"
 _FP8_QUANT_MODE: QuantMode = "fp8_e4m3_per_tensor"
 _NVFP4_QUANT_MODE: QuantMode = "nvfp4_group16"
@@ -114,7 +115,9 @@ class Caps:
     ``scale_dtype`` is validated against the selected storage format.
     ``table_memory="mapped_host"`` places row payloads and row-associated
     scales in CUDA-mapped, write-combined host memory while scalar scales stay
-    device-resident.
+    device-resident. ``metadata_validation="trusted"`` removes device
+    validation and requires the caller to guarantee every packed-hash metadata
+    invariant.
     """
 
     device: torch.device | str
@@ -134,6 +137,7 @@ class Caps:
     table_memory: TableMemory = "device"
     scale_dtype: torch.dtype | None = None
     output_dtype: torch.dtype = torch.bfloat16
+    metadata_validation: MetadataValidation = "transactional"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "device", _canonical_device(self.device))
@@ -222,6 +226,11 @@ class Caps:
         if self.output_dtype != torch.bfloat16:
             raise TypeError(
                 f"PLE embedding output must use torch.bfloat16, got {self.output_dtype}"
+            )
+        if self.metadata_validation not in ("transactional", "trusted"):
+            raise ValueError(
+                "metadata_validation must be 'transactional' or 'trusted', got "
+                f"{self.metadata_validation!r}"
             )
 
     @property
@@ -372,6 +381,7 @@ def plan(
             dense_layer_ordinal=caps.dense_layer_ordinal,
             base_table_size=caps.base_table_size,
             table_alignment=caps.table_alignment,
+            metadata_validation=caps.metadata_validation,
         ),
         prime_sizes=prime_sizes,
         table_offsets=table_offsets,
@@ -612,6 +622,7 @@ def run(binding: Binding) -> torch.Tensor:
 
 
 __all__ = [
+    "MetadataValidation",
     "QuantMode",
     "TableMemory",
     "Caps",

--- a/b12x/sequence/ple_embedding/_kernels.py
+++ b/b12x/sequence/ple_embedding/_kernels.py
@@ -81,9 +81,7 @@ def _bf16_lookup_kernel(
     columns = tl.program_id(2) * BLOCK_D + tl.arange(0, BLOCK_D)
     column_mask = columns < HEAD_DIM
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
-    token_live = (
-        (token < num_tokens) & (num_tokens >= 0) & (num_tokens <= MAX_TOKENS)
-    )
+    token_live = (token < num_tokens) & (num_tokens >= 0) & (num_tokens <= MAX_TOKENS)
     id_offset = token.to(tl.int64) * HEAD_COUNT + head.to(tl.int64)
     embedding_id = tl.load(ids_ptr + id_offset, mask=token_live, other=-1).to(tl.int64)
     local = (
@@ -190,9 +188,7 @@ def _nvfp4_lookup_kernel(
     columns = tl.program_id(2) * BLOCK_D + tl.arange(0, BLOCK_D)
     column_mask = columns < HEAD_DIM
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
-    token_live = (
-        (token < num_tokens) & (num_tokens >= 0) & (num_tokens <= MAX_TOKENS)
-    )
+    token_live = (token < num_tokens) & (num_tokens >= 0) & (num_tokens <= MAX_TOKENS)
     id_offset = token.to(tl.int64) * HEAD_COUNT + head.to(tl.int64)
     embedding_id = tl.load(ids_ptr + id_offset, mask=token_live, other=-1).to(tl.int64)
     local = (
@@ -546,6 +542,7 @@ def _launch_hash(
     heads_per_order: int,
     max_seqs: int,
     max_tokens: int,
+    validate_metadata: bool,
 ) -> None:
     _launch_hash_pipeline(
         token_ids,
@@ -565,6 +562,7 @@ def _launch_hash(
         heads_per_order,
         max_seqs,
         max_tokens,
+        validate_metadata,
     )
 
 
@@ -599,6 +597,7 @@ def _bf16_pipeline_op(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     ids, request_ids, error_code = _pipeline_scratch_views(
         scratch,
@@ -626,6 +625,7 @@ def _bf16_pipeline_op(
         heads_per_order,
         max_seqs,
         max_tokens,
+        validate_metadata,
     )
     _launch_bf16_lookup(
         weight,
@@ -670,6 +670,7 @@ def _bf16_pipeline_fake(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     del weight, token_ids, query_start_loc, committed_history
     del num_seqs, num_tokens, multipliers, prime_sizes, table_offsets
@@ -677,6 +678,7 @@ def _bf16_pipeline_fake(
     del max_seqs, max_tokens, head_count, head_dim, embedding_dim
     del table_vocab_size, shard_start, shard_end
     del ids_offset_bytes, request_ids_offset_bytes, error_code_offset_bytes
+    del validate_metadata
 
 
 @torch.library.custom_op(
@@ -711,6 +713,7 @@ def _fp8_pipeline_op(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     ids, request_ids, error_code = _pipeline_scratch_views(
         scratch,
@@ -738,6 +741,7 @@ def _fp8_pipeline_op(
         heads_per_order,
         max_seqs,
         max_tokens,
+        validate_metadata,
     )
     _launch_fp8_lookup(
         weight,
@@ -784,6 +788,7 @@ def _fp8_pipeline_fake(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     del weight, weight_scale, token_ids, query_start_loc, committed_history
     del num_seqs, num_tokens, multipliers, prime_sizes, table_offsets
@@ -791,6 +796,7 @@ def _fp8_pipeline_fake(
     del max_seqs, max_tokens, head_count, head_dim, embedding_dim
     del table_vocab_size, shard_start, shard_end
     del ids_offset_bytes, request_ids_offset_bytes, error_code_offset_bytes
+    del validate_metadata
 
 
 @torch.library.custom_op(
@@ -826,6 +832,7 @@ def _nvfp4_pipeline_op(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     ids, request_ids, error_code = _pipeline_scratch_views(
         scratch,
@@ -853,6 +860,7 @@ def _nvfp4_pipeline_op(
         heads_per_order,
         max_seqs,
         max_tokens,
+        validate_metadata,
     )
     _launch_nvfp4_lookup(
         weight,
@@ -901,6 +909,7 @@ def _nvfp4_pipeline_fake(
     ids_offset_bytes: int,
     request_ids_offset_bytes: int,
     error_code_offset_bytes: int,
+    validate_metadata: bool,
 ) -> None:
     del weight, weight_scale, weight_scale_2
     del token_ids, query_start_loc, committed_history
@@ -909,6 +918,7 @@ def _nvfp4_pipeline_fake(
     del max_seqs, max_tokens, head_count, head_dim, embedding_dim
     del table_vocab_size, shard_start, shard_end
     del ids_offset_bytes, request_ids_offset_bytes, error_code_offset_bytes
+    del validate_metadata
 
 
 def run_pipeline(binding: Binding) -> None:
@@ -943,6 +953,7 @@ def run_pipeline(binding: Binding) -> None:
         + plan._hash_plan.layout.request_ids_offset_bytes,
         plan._layout.hash_scratch_offset_bytes
         + plan._hash_plan.layout.error_code_offset_bytes,
+        caps.metadata_validation == "transactional",
     )
     if caps.quant_mode == "bf16":
         torch.ops.b12x.ple_embedding_bf16_pipeline(binding.weight, *hash_args)

--- a/b12x/sequence/ple_embedding/api.py
+++ b/b12x/sequence/ple_embedding/api.py
@@ -7,6 +7,7 @@ from . import META
 from ._contracts import (
     Binding,
     Caps,
+    MetadataValidation,
     Plan,
     QuantMode,
     TableMemory,
@@ -24,6 +25,7 @@ def is_supported(device=None) -> bool:
 
 
 __all__ = [
+    "MetadataValidation",
     "QuantMode",
     "TableMemory",
     "TableStorage",

--- a/b12x/sequence/ple_hash/__init__.py
+++ b/b12x/sequence/ple_hash/__init__.py
@@ -20,6 +20,7 @@ META = OpMeta(
     group="sequence",
     api_style="planned",
     entry_points=(
+        "MetadataValidation",
         "Caps",
         "Plan",
         "Binding",
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from .api import (  # noqa: F401
         Binding,
         Caps,
+        MetadataValidation,
         Plan,
         PleHashConfig,
         PleHashQuery,

--- a/b12x/sequence/ple_hash/_contracts.py
+++ b/b12x/sequence/ple_hash/_contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 import torch
 
@@ -20,6 +21,7 @@ from ._policy import PLE_HASH_POLICY, PleHashQuery
 from .reference import is_prime_64, ple_multipliers, ple_table_geometry
 
 _SIGNED_INT64_MAX = (1 << 63) - 1
+MetadataValidation = Literal["transactional", "trusted"]
 
 
 def _canonical_device(device: torch.device | str) -> torch.device:
@@ -93,6 +95,8 @@ class Caps:
     ``max_tokens`` and ``max_seqs`` are serving capacities and therefore part
     of the compile/cache identity. ``dense_layer_ordinal`` is the zero-based
     ordinal among PLE-enabled layers, not the decoder layer index.
+    ``metadata_validation="trusted"`` removes device validation and requires
+    the caller to guarantee all packed-metadata invariants.
     """
 
     device: torch.device | str
@@ -105,6 +109,7 @@ class Caps:
     dense_layer_ordinal: int
     base_table_size: int
     table_alignment: int = 128
+    metadata_validation: MetadataValidation = "transactional"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "device", _canonical_device(self.device))
@@ -133,6 +138,11 @@ class Caps:
                 f"eos_token_id must be in [0, {self.vocab_size}), got {eos_token_id}"
             )
         object.__setattr__(self, "eos_token_id", eos_token_id)
+        if self.metadata_validation not in ("transactional", "trusted"):
+            raise ValueError(
+                "metadata_validation must be 'transactional' or 'trusted', got "
+                f"{self.metadata_validation!r}"
+            )
 
     @property
     def head_count(self) -> int:
@@ -432,4 +442,12 @@ def run(binding: Binding) -> torch.Tensor:
     return binding.out
 
 
-__all__ = ["Caps", "Plan", "Binding", "plan", "bind", "run"]
+__all__ = [
+    "MetadataValidation",
+    "Caps",
+    "Plan",
+    "Binding",
+    "plan",
+    "bind",
+    "run",
+]

--- a/b12x/sequence/ple_hash/_kernels.py
+++ b/b12x/sequence/ple_hash/_kernels.py
@@ -100,11 +100,14 @@ def _request_ids_kernel(
     request_ids_ptr,
     error_code_ptr,
     MAX_TOKENS: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     token = tl.program_id(0)
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
     num_seqs = tl.load(num_seqs_ptr).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    valid_metadata = tl.full((), True, tl.int1)
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
     live = (token < num_tokens) & valid_metadata
 
     low = tl.zeros((), tl.int32)
@@ -165,12 +168,15 @@ def _hash_ids_kernel(
     MAX_ORDER: tl.constexpr,
     HEADS_PER_ORDER: tl.constexpr,
     HEAD_COUNT: tl.constexpr,
+    VALIDATE_METADATA: tl.constexpr,
 ):
     token = tl.program_id(0)
     head = tl.program_id(1)
     num_tokens = tl.load(num_tokens_ptr).to(tl.int32)
     request = tl.load(request_ids_ptr + token).to(tl.int32)
-    valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
+    valid_metadata = tl.full((), True, tl.int1)
+    if VALIDATE_METADATA:
+        valid_metadata = tl.load(error_code_ptr).to(tl.int32) == 0
     live = (token < num_tokens) & (request >= 0) & valid_metadata
     query_start = tl.load(query_start_loc_ptr + request, mask=live, other=0).to(
         tl.int32
@@ -247,23 +253,25 @@ def _launch_hash_pipeline(
     heads_per_order: int,
     max_seqs: int,
     max_tokens: int,
+    validate_metadata: bool,
 ) -> None:
     """Launch fixed-capacity request mapping and hash kernels."""
     head_count = (max_order - 1) * heads_per_order
-    _reset_error_kernel[(1,)](error_code, num_warps=1)
-    _validate_metadata_kernel[(max(max_tokens, max_seqs),)](
-        token_ids,
-        query_start_loc,
-        committed_history,
-        num_seqs,
-        num_tokens,
-        error_code,
-        VOCAB_SIZE=vocab_size,
-        MAX_ORDER=max_order,
-        MAX_SEQS=max_seqs,
-        MAX_TOKENS=max_tokens,
-        num_warps=1,
-    )
+    if validate_metadata:
+        _reset_error_kernel[(1,)](error_code, num_warps=1)
+        _validate_metadata_kernel[(max(max_tokens, max_seqs),)](
+            token_ids,
+            query_start_loc,
+            committed_history,
+            num_seqs,
+            num_tokens,
+            error_code,
+            VOCAB_SIZE=vocab_size,
+            MAX_ORDER=max_order,
+            MAX_SEQS=max_seqs,
+            MAX_TOKENS=max_tokens,
+            num_warps=1,
+        )
     _request_ids_kernel[(max_tokens,)](
         query_start_loc,
         num_seqs,
@@ -271,6 +279,7 @@ def _launch_hash_pipeline(
         request_ids,
         error_code,
         MAX_TOKENS=max_tokens,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=1,
     )
     _hash_ids_kernel[(max_tokens, head_count)](
@@ -289,6 +298,7 @@ def _launch_hash_pipeline(
         MAX_ORDER=max_order,
         HEADS_PER_ORDER=heads_per_order,
         HEAD_COUNT=head_count,
+        VALIDATE_METADATA=validate_metadata,
         num_warps=1,
     )
 
@@ -315,6 +325,7 @@ def _hash_pipeline_op(
     heads_per_order: int,
     max_seqs: int,
     max_tokens: int,
+    validate_metadata: bool,
 ) -> None:
     _launch_hash_pipeline(
         token_ids,
@@ -334,6 +345,7 @@ def _hash_pipeline_op(
         heads_per_order,
         max_seqs,
         max_tokens,
+        validate_metadata,
     )
 
 
@@ -356,10 +368,12 @@ def _hash_pipeline_fake(
     heads_per_order: int,
     max_seqs: int,
     max_tokens: int,
+    validate_metadata: bool,
 ) -> None:
     del token_ids, query_start_loc, committed_history, num_seqs, num_tokens
     del multipliers, prime_sizes, table_offsets, out, request_ids, error_code
     del eos_token_id, vocab_size, max_order, heads_per_order, max_seqs, max_tokens
+    del validate_metadata
 
 
 def run_hash_kernel(binding: Binding) -> None:
@@ -383,6 +397,7 @@ def run_hash_kernel(binding: Binding) -> None:
         caps.heads_per_order,
         caps.max_seqs,
         caps.max_tokens,
+        caps.metadata_validation == "transactional",
     )
 
 

--- a/b12x/sequence/ple_hash/api.py
+++ b/b12x/sequence/ple_hash/api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ..._lib.gating import default_is_supported
-from ._contracts import Binding, Caps, Plan, bind, plan, run
+from ._contracts import Binding, Caps, MetadataValidation, Plan, bind, plan, run
 from ._policy import PleHashConfig, PleHashQuery
 
 
@@ -13,6 +13,7 @@ def is_supported(device=None) -> bool:
 
 
 __all__ = [
+    "MetadataValidation",
     "Caps",
     "Plan",
     "Binding",

--- a/tests/sequence/test_ple.py
+++ b/tests/sequence/test_ple.py
@@ -75,6 +75,36 @@ def test_ple_hash_geometry_is_distinct_deterministic_and_aligned() -> None:
     assert minimum_offsets.tolist() == [0, 2, 5, 10]
 
 
+def test_ple_caps_reject_unknown_metadata_validation() -> None:
+    with pytest.raises(ValueError, match="metadata_validation"):
+        ple_hash.Caps(
+            device="cpu",
+            max_tokens=1,
+            max_seqs=1,
+            vocab_size=100,
+            eos_token_id=99,
+            max_order=2,
+            heads_per_order=1,
+            dense_layer_ordinal=0,
+            base_table_size=101,
+            metadata_validation="unchecked",
+        )
+    with pytest.raises(ValueError, match="metadata_validation"):
+        ple.Caps(
+            device="cpu",
+            mode="decode",
+            max_tokens=1,
+            max_seqs=1,
+            max_state_slots=1,
+            max_speculative_tokens=0,
+            streams=1,
+            hidden_size=16,
+            kernel_size=2,
+            dilation=1,
+            metadata_validation="unchecked",
+        )
+
+
 def test_ple_hash_plan_rejects_cumulative_table_extent_beyond_int64() -> None:
     caps = ple_hash.Caps(
         device="cpu",
@@ -360,6 +390,7 @@ def _bind_cuda_layer(
     max_speculative_tokens: int,
     dilation: int,
     request_is_prefill: torch.Tensor | None = None,
+    metadata_validation: str = "transactional",
 ):
     max_tokens, streams, hidden = residual.shape
     max_seqs = int(state_slot_ids.numel())
@@ -375,6 +406,7 @@ def _bind_cuda_layer(
             hidden_size=hidden,
             kernel_size=conv_weight.shape[-1],
             dilation=dilation,
+            metadata_validation=metadata_validation,
         )
     )
     out = torch.full_like(residual, 91)
@@ -1088,6 +1120,71 @@ def test_ple_hash_cuda_graph_replay_is_allocation_free() -> None:
     assert captured_out.data_ptr() == output_address == binding.out.data_ptr()
     assert allocated_after_replay == allocated_before_replay
     torch.testing.assert_close(captured_out, expected, rtol=0, atol=0)
+
+
+@torch.inference_mode()
+def test_ple_hash_trusted_metadata_ignores_stale_error_under_graph_replay() -> None:
+    device = require_b12x()
+    caps = ple_hash.Caps(
+        device=device,
+        max_tokens=4,
+        max_seqs=2,
+        vocab_size=100,
+        eos_token_id=99,
+        max_order=3,
+        heads_per_order=2,
+        dense_layer_ordinal=0,
+        base_table_size=101,
+        metadata_validation="trusted",
+    )
+    plan = ple_hash.plan(caps)
+    token_ids = torch.tensor([1, 2, 0, 0], dtype=torch.int64, device=device)
+    query_start_loc = torch.tensor([0, 2, 2], dtype=torch.int32, device=device)
+    committed_history = torch.tensor(
+        [[99, 99], [99, 99]], dtype=torch.int64, device=device
+    )
+    binding = ple_hash.bind(
+        plan,
+        scratch=_scratch(plan),
+        token_ids=token_ids,
+        query_start_loc=query_start_loc,
+        committed_history=committed_history,
+        num_seqs=torch.tensor([1], dtype=torch.int32, device=device),
+        num_tokens=torch.tensor([2], dtype=torch.int32, device=device),
+        out=torch.empty(
+            (caps.max_tokens, caps.head_count), dtype=torch.int64, device=device
+        ),
+    )
+    binding.error_code.fill_(73)
+    ple_hash.run(binding)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = ple_hash.run(binding)
+
+    token_ids.copy_(torch.tensor([3, 4, 5, 0], dtype=torch.int64, device=device))
+    query_start_loc.copy_(torch.tensor([0, 1, 3], dtype=torch.int32, device=device))
+    binding.num_seqs.fill_(2)
+    binding.num_tokens.fill_(3)
+    binding.out.fill_(91)
+    binding.error_code.fill_(73)
+    expected = ple_hash_packed_reference(
+        token_ids[:3],
+        query_start_loc,
+        committed_history,
+        eos_token_id=caps.eos_token_id,
+        multipliers=plan.multipliers,
+        prime_sizes=plan.prime_sizes,
+        table_offsets=plan.table_offsets,
+        heads_per_order=caps.heads_per_order,
+    )
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    assert binding.error_code.item() == 73
+    torch.testing.assert_close(captured[:3], expected, rtol=0, atol=0)
+    assert bool((captured[3:] == -1).all().item())
 
 
 @torch.inference_mode()
@@ -1901,6 +1998,88 @@ def test_ple_dummy_slots_replay_under_cuda_graph_without_state_mutation() -> Non
     assert bool((binding.out == 0).all().item())
     torch.testing.assert_close(conv_state, state_before, rtol=0, atol=0)
     assert allocated_after_replay == allocated_before_replay
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("mode", ["decode", "mixed"])
+def test_ple_trusted_metadata_matches_transactional_graph_replay(mode: str) -> None:
+    device = require_b12x()
+    tokens, streams, hidden = 4, 2, 32
+    kernel_size, dilation, max_speculative = 4, 3, 4
+    residual, key, value, weights, generator = _cuda_projected_inputs(
+        tokens, streams, hidden, device=device, seed=1219
+    )
+    conv_weight = torch.randn(
+        (streams * hidden, kernel_size),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device=device,
+    ).contiguous()
+    state_length = dilation * (kernel_size - 1)
+    initial_state = torch.randn(
+        (1, streams * hidden, state_length + max_speculative),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    def make_binding(metadata_validation: str):
+        return _bind_cuda_layer(
+            mode=mode,
+            residual=residual.clone(),
+            key=key.clone(),
+            value=value.clone(),
+            weights=[weight.clone() for weight in weights],
+            conv_weight=conv_weight.clone(),
+            query_start_loc=torch.tensor([0, tokens], dtype=torch.int32, device=device),
+            state_slot_ids=torch.tensor([0], dtype=torch.int64, device=device),
+            state_is_fresh=torch.tensor([False], dtype=torch.bool, device=device),
+            num_accepted_tokens=torch.tensor([2], dtype=torch.int32, device=device),
+            num_seqs=1,
+            num_tokens=tokens,
+            conv_state=initial_state.clone(),
+            max_speculative_tokens=max_speculative,
+            dilation=dilation,
+            request_is_prefill=(
+                torch.tensor([False], dtype=torch.bool, device=device)
+                if mode == "mixed"
+                else None
+            ),
+            metadata_validation=metadata_validation,
+        )[1]
+
+    def run(binding):
+        if mode == "mixed":
+            return ple.run_mixed(binding, eps=1e-6)
+        return ple.run_decode(binding, eps=1e-6)
+
+    transactional = make_binding("transactional")
+    run(transactional)
+    torch.cuda.synchronize(device)
+    expected_out = transactional.out.clone()
+    expected_state = transactional.conv_state.clone()
+
+    trusted = make_binding("trusted")
+    trusted.error_code.fill_(73)
+    run(trusted)
+    trusted.conv_state.copy_(initial_state)
+    trusted.out.fill_(91)
+    trusted.error_code.fill_(73)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run(trusted)
+
+    trusted.conv_state.copy_(initial_state)
+    trusted.out.fill_(91)
+    trusted.error_code.fill_(73)
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    assert trusted.error_code.item() == 73
+    torch.testing.assert_close(captured, expected_out, rtol=0, atol=0)
+    torch.testing.assert_close(trusted.conv_state, expected_state, rtol=0, atol=0)
 
 
 @torch.inference_mode()

--- a/tests/sequence/test_ple_embedding.py
+++ b/tests/sequence/test_ple_embedding.py
@@ -28,6 +28,7 @@ def _small_plan(
     tp_size: int = 2,
     max_tokens: int = 5,
     quant_mode: str = "fp8_e4m3_per_tensor",
+    metadata_validation: str = "transactional",
 ) -> ple_embedding.Plan:
     prime_sizes, table_offsets, multipliers = _small_geometry()
     return ple_embedding.plan(
@@ -46,6 +47,7 @@ def _small_plan(
             tp_rank=tp_rank,
             table_alignment=8,
             quant_mode=quant_mode,
+            metadata_validation=metadata_validation,
         ),
         prime_sizes=prime_sizes,
         table_offsets=table_offsets,
@@ -279,6 +281,8 @@ def test_caps_and_plan_reject_unsupported_storage_contracts() -> None:
         ple_embedding.Caps(**{**common, "quant_mode": "int8"})
     with pytest.raises(ValueError, match="table_memory"):
         ple_embedding.Caps(**{**common, "table_memory": "managed"})
+    with pytest.raises(ValueError, match="metadata_validation"):
+        ple_embedding.Caps(**{**common, "metadata_validation": "unchecked"})
     with pytest.raises(ValueError, match="requires a CUDA device"):
         ple_embedding.Caps(**{**common, "table_memory": "mapped_host"})
     with pytest.raises(TypeError, match="BF16.*scale_dtype must be None"):
@@ -697,6 +701,43 @@ def test_cuda_graph_replay_uses_bound_storage_without_allocating(
     assert captured.data_ptr() == output_address == binding.out.data_ptr()
     assert binding.scratch.data_ptr() == scratch_address
     assert allocated_after == allocated_before
+    torch.testing.assert_close(captured, expected, rtol=0, atol=0)
+
+
+@torch.inference_mode()
+def test_cuda_trusted_metadata_ignores_stale_error_under_graph_replay() -> None:
+    device = require_b12x()
+    plan = _small_plan(
+        device,
+        quant_mode="nvfp4_group16",
+        metadata_validation="trusted",
+    )
+    binding = _bind_small(plan)
+    binding.error_code.fill_(73)
+    ple_embedding.run(binding)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = ple_embedding.run(binding)
+    output_address = captured.data_ptr()
+    scratch_address = binding.scratch.data_ptr()
+
+    binding.token_ids[:2].copy_(torch.tensor([8, 9], dtype=torch.int64, device=device))
+    binding.query_start_loc.copy_(
+        torch.tensor([0, 2, 0], dtype=torch.int32, device=device)
+    )
+    binding.num_seqs.fill_(1)
+    binding.num_tokens.fill_(2)
+    binding.out.fill_(37)
+    binding.error_code.fill_(73)
+    expected = _reference(binding)
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    assert captured.data_ptr() == output_address == binding.out.data_ptr()
+    assert binding.scratch.data_ptr() == scratch_address
+    assert binding.error_code.item() == 73
     torch.testing.assert_close(captured, expected, rtol=0, atol=0)
 
 


### PR DESCRIPTION
## Purpose

PLE hashing, fused embedding lookup, and recurrent-state execution validate
device-resident request metadata before every transaction. Integrations whose
scheduler already guarantees packed bounds and exclusive cache-slot ownership
can select `metadata_validation="trusted"` to omit that redundant work.

The public default remains `transactional`, which resets the error status,
validates metadata, and fails closed. The trusted mode also specializes
downstream kernels so they neither read nor write stale error storage. Fused
PLE embedding propagates the selected contract to its internal hash plan.

The trusted contract requires the caller to guarantee:

- packed query offsets remain within the planned token capacity;
- live request counts remain within the planned sequence capacity;
- state-slot IDs are valid and exclusively owned for the transaction; and
- speculative acceptance metadata satisfies the PLE mode contract.

## Correctness and graph-safety validation

The CUDA test suite ran on an NVIDIA RTX PRO 6000 Blackwell Workstation Edition:

```text
python -m pytest -q tests/sequence/test_ple.py tests/sequence/test_ple_embedding.py
85 passed

python -m pytest -q tests/test_registry.py
9 passed
```

The coverage includes exact hash and embedding results, decode and mixed-state
parity, invalid-mode rejection, transactional fail-closed behavior, stale error
storage, dynamic CUDA graph replay, stable allocation, and custom-op export.

## Serving validation

The serving comparison used `Qwen3.8-Flash-Next-NVFP4`, TP1, MTP3, FP8 KV
cache, B12X GDN decode, B12X NVFP4 MoE, full-and-piecewise CUDA graphs, 4,096
maximum batched tokens, stock GPU clocks, and the same physical RTX PRO 6000
Blackwell Workstation Edition.

| Measurement | Transactional PLE | Trusted PLE | Result |
| --- | ---: | ---: | ---: |
| C1 verifier steps/s, median | 62.36 (5 runs) | 63.87 (3 runs) | +2.43% |
| 32K prefill tok/s | 6,483 | 6,458 | -0.39% |

Output tokens/s is not used as the decode comparison because MTP acceptance
varied by generated text. Each decode sample used a 10-second warmup followed
by a 30-second measurement; verifier steps/s normalizes that acceptance.

A rank-0 Torch trace captured four target iterations. Transactional PLE
executed eight metadata-validation kernels and eight error-reset kernels,
using 67.391 microseconds of CUDA kernel time. Trusted PLE executed none of
those kernels and the trace contained exactly 16 fewer CUDA kernel events.

Short deterministic serving probes returned the expected answers `36`,
`Paris`, `OK`, and `Jupiter`, with no repeated-token corruption.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds opt-in `metadata_validation="trusted"` mode to PLE hash, fused embedding lookup, and recurrent-state execution.

- Keeps `transactional` as the default. It resets `binding.error_code`, validates device-resident metadata, and fails closed.
- Skips validation and error-reset kernels in `trusted` mode. Downstream kernels assume valid metadata and ignore stale error storage.
- Propagates the selected mode from fused PLE embedding to its internal hash plan.
- Exposes `MetadataValidation` through the PLE, PLE hash, and PLE embedding APIs.
- Requires trusted callers to guarantee valid packed query offsets, live request counts, unique owned state slots, and valid speculative acceptance metadata.
- Rejects unsupported mode values with `ValueError`.

## Compatibility

Existing callers retain transactional behavior. Trusted mode is opt-in and requires the caller to uphold the metadata contract.

## Validation

CUDA and registry tests pass. Trusted-mode CUDA graph replay tests verify stale error handling, unchanged addresses, no allocation, and output/state equivalence with transactional mode. Serving measurements show 2.43% higher verifier steps/s, 0.39% lower 32K prefill throughput, and 16 fewer kernel events for trusted PLE. Deterministic serving probes produce expected answers without repeated-token corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->