### PR TITLE
Guarantee KDA prefill pipeline forward progress

### DIFF
--- a/b12x/sequence/kda_prefill/_cute_kernels.py
+++ b/b12x/sequence/kda_prefill/_cute_kernels.py
@@ -2135,7 +2135,13 @@ def _side_resources(device: torch.device, windows: int) -> _SideResources:
                 "KDA prefill pipeline resources must be created by a warm run before CUDA graph capture"
             )
         if resources is None:
-            resources = _SideResources(stream=torch.cuda.Stream(device=device), events=[])
+            # Give the prepare stream higher priority so preparation for the
+            # following window can make progress while the persistent
+            # recurrence grid consumes the current window. The pipeline below
+            # makes each recurrence depend on its own completed prepare.
+            resources = _SideResources(
+                stream=torch.cuda.Stream(device=device, priority=-1), events=[]
+            )
             _SIDE[device.index] = resources
         current = torch.cuda.current_stream(device)
         while len(resources.events) < needed:
@@ -2150,9 +2156,9 @@ def run_prefill(
 ) -> None:
     """Launch the window pipeline: prologue, then prepare and recurrence per window.
 
-    Prepare launches run on a per-device side stream, recurrence launches on
-    the current stream. A window's recurrence overlaps its own prepare through
-    the ready flags; prepare of window ``w`` waits for the recurrence of window
+    Prepare launches run on a high-priority per-device side stream. Recurrence
+    for window ``w`` starts after prepare ``w`` completes, while prepare
+    ``w + 1`` may overlap recurrence ``w``. Prepare ``w`` waits for recurrence
     ``w - 2`` before reusing that workspace ring slot. Under stream capture the
     fork and join are recorded as graph dependencies.
     """
@@ -2169,19 +2175,30 @@ def run_prefill(
         prepared = resources.events[:launched]
         consumed = resources.events[launched : 2 * launched]
         run_prologue(binding, windows=launched)
-        # Enqueue window by window so every event is recorded before a stream
-        # waits on it (a wait binds to the event's most recent record).
         fork.record(main)
         side.wait_event(fork)
-        for window in range(launched):
+
+        def enqueue_prepare(window: int) -> None:
+            """Prepare one window after its ring slot is no longer in use."""
             with torch.cuda.stream(side):
                 if window >= 2:
                     side.wait_event(consumed[window - 2])
-                run_prepare(binding, lower_bound=lower_bound, scale=scale, eps=eps, window=window)
+                run_prepare(
+                    binding,
+                    lower_bound=lower_bound,
+                    scale=scale,
+                    eps=eps,
+                    window=window,
+                )
                 prepared[window].record(side)
+
+        enqueue_prepare(0)
+        for window in range(launched):
+            main.wait_event(prepared[window])
             run_recurrence(binding, window=window)
             consumed[window].record(main)
-        main.wait_event(prepared[launched - 1])
+            if window + 1 < launched:
+                enqueue_prepare(window + 1)
 
 
 def prewarm_binding(binding: Binding) -> None:

--- a/docs/evidence/kda_prefill/20260903-glm53-nvfp4-vllm-e2e.json
+++ b/docs/evidence/kda_prefill/20260903-glm53-nvfp4-vllm-e2e.json
@@ -1,0 +1,144 @@
+{
+  "schema": "b12x.kda_prefill.vllm_serving_evidence.v1",
+  "status": "qualified_explicit_backend_not_automatic",
+  "operation": "GLM-5.3 gated-delta-network prefill through vLLM's production B12X integration",
+  "production_path": "vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py -> b12x.sequence.kda_prefill",
+  "source": {
+    "vllm": {
+      "revision": "e2eaf734cb997cbfbf6c4fcfb6d69f8ee4f8eb23",
+      "tree": "cb8efe698c04d21e73a25568ac120b701ec805c4",
+      "clean_worktree": true
+    },
+    "b12x": {
+      "revision": "ca8052c7f4692c3241858c9bdace3053764be22d",
+      "tree": "08bff16624bd0c37f5902a454270888ad42a62d7",
+      "clean_worktree": true
+    }
+  },
+  "model": {
+    "repository": "local-inference-lab/GLM-5.3-Flash-NVFP4",
+    "revision": "378ca54585c46542bad1f3cb3ed0d73ae51cdb62"
+  },
+  "hardware": {
+    "gpus": [
+      {
+        "physical_index": 4,
+        "uuid": "GPU-8800cf0c-1ba5-7136-d796-2a91f9e9586e",
+        "pci_bus_id": "00000000:43:00.0"
+      },
+      {
+        "physical_index": 5,
+        "uuid": "GPU-4a0aa20b-8e36-2e05-4efb-8befbf1181d4",
+        "pci_bus_id": "00000000:44:00.0"
+      },
+      {
+        "physical_index": 6,
+        "uuid": "GPU-1a0323f7-8113-a1e1-c68b-f23fecf77171",
+        "pci_bus_id": "00000000:63:00.0"
+      },
+      {
+        "physical_index": 7,
+        "uuid": "GPU-0027fc86-3322-ce2a-856c-f49eb61eb63e",
+        "pci_bus_id": "00000000:64:00.0"
+      }
+    ],
+    "model": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+    "power_limit_watts": 600,
+    "pcie_generation": 5,
+    "pcie_width": 16,
+    "clock_mode": "stock automatic clocks; no graphics or memory offset"
+  },
+  "serving_configuration": {
+    "tensor_parallelism": 4,
+    "decode_context_parallelism": [1, 4],
+    "dcp4_prefill_mode": "full-CKV gather",
+    "max_num_batched_tokens": 4096,
+    "max_num_sequences": 32,
+    "target_cache_page_tokens": 2048,
+    "kv_cache_dtype": "fp8_ds_mla",
+    "cuda_graph_mode": "full and piecewise",
+    "nccl_channels": 16,
+    "nccl_buffer_bytes": 2097152,
+    "kv_cache_memory_bytes_per_rank": 30064771072,
+    "backend_selector": "--kda-prefill-backend flashkda|b12x"
+  },
+  "commands": {
+    "server": "GLM53_KDA_PREFILL_BACKEND=<flashkda|b12x> DCP=<1|4> TP=4 MAX_NUM_BATCHED_TOKENS=4096 GLM53_TARGET_BLOCK_SIZE=2048 CUDAGRAPH_MODE=FULL_AND_PIECEWISE NCCL_MIN_NCHANNELS=16 NCCL_MAX_NCHANNELS=16 NCCL_BUFFSIZE=2097152 launch_glm53_b12x_kda_prefill_ab.sh <flashkda|b12x> <dcp1|dcp4>",
+    "measurement": "BENCH_PORT=5051 BENCH_MODEL=GLM-5.3-Flash-NVFP4 measure_32k_prefill_case.sh <result-directory> 3 30",
+    "measurement_expansion": "llm_decode_bench.py --host 127.0.0.1 --port 5051 --model GLM-5.3-Flash-NVFP4 --standalone-prefill --prefill-only --prefill-contexts 32k --prefill-duration 30 --max-tokens 1 --display-mode plain --no-hw-monitor --no-resume --output <result-file>",
+    "measurement_tool_version": "llm-decode-bench 0.4.29"
+  },
+  "method": {
+    "prompt": "one independently generated cold prompt targeting 32K tokens per sample",
+    "output_tokens": 1,
+    "metric": "client prompt tokens divided by time to first token",
+    "warmup": "one 30-second standalone cold-prefill run per arm",
+    "measured_runs": 3,
+    "duration_seconds_per_run": 30,
+    "requests_per_run": 12,
+    "summary_statistic": "median throughput across the three measured runs",
+    "direction": "higher throughput is better"
+  },
+  "correctness": {
+    "measured_requests": "all requests completed with valid token accounting and the server remained healthy",
+    "vllm_integration": "four GLM-5.3 tests passed, including mixed decode/prefill dispatch and B12X-versus-Triton numerical parity",
+    "b12x_operation": "fifteen selected GPU tests passed after adding the three-window ring-reuse test; eager execution and CUDA graph replay match the oracle, preserve state, retain fixed workspace capacity and stable addresses, and allocate zero bytes during replay",
+    "server_lifecycle": "tensor-parallel server startup, kernel warmup, full graph capture, and piecewise graph capture completed for decode-context parallelism of one and four"
+  },
+  "cases": [
+    {
+      "backend": "b12x",
+      "decode_context_parallelism": 1,
+      "samples": [
+        {"prompt_tokens": 32321, "ttft_seconds": 2.162, "tokens_per_second": 14952},
+        {"prompt_tokens": 32320, "ttft_seconds": 2.169, "tokens_per_second": 14899},
+        {"prompt_tokens": 32321, "ttft_seconds": 2.172, "tokens_per_second": 14883}
+      ],
+      "median_tokens_per_second": 14899
+    },
+    {
+      "backend": "flashkda",
+      "decode_context_parallelism": 1,
+      "samples": [
+        {"prompt_tokens": 32320, "ttft_seconds": 2.168, "tokens_per_second": 14909},
+        {"prompt_tokens": 32322, "ttft_seconds": 2.169, "tokens_per_second": 14900},
+        {"prompt_tokens": 32321, "ttft_seconds": 2.175, "tokens_per_second": 14863}
+      ],
+      "median_tokens_per_second": 14900
+    },
+    {
+      "backend": "b12x",
+      "decode_context_parallelism": 4,
+      "samples": [
+        {"prompt_tokens": 32321, "ttft_seconds": 2.457, "tokens_per_second": 13154},
+        {"prompt_tokens": 32321, "ttft_seconds": 2.466, "tokens_per_second": 13106},
+        {"prompt_tokens": 32320, "ttft_seconds": 2.474, "tokens_per_second": 13063}
+      ],
+      "median_tokens_per_second": 13106
+    },
+    {
+      "backend": "flashkda",
+      "decode_context_parallelism": 4,
+      "samples": [
+        {"prompt_tokens": 32320, "ttft_seconds": 2.436, "tokens_per_second": 13267},
+        {"prompt_tokens": 32321, "ttft_seconds": 2.441, "tokens_per_second": 13242},
+        {"prompt_tokens": 32321, "ttft_seconds": 2.443, "tokens_per_second": 13232}
+      ],
+      "median_tokens_per_second": 13242
+    }
+  ],
+  "comparisons": [
+    {
+      "decode_context_parallelism": 1,
+      "b12x_over_flashkda_ratio": 0.999933,
+      "b12x_percent_difference": -0.01,
+      "conclusion": "equivalent within run noise"
+    },
+    {
+      "decode_context_parallelism": 4,
+      "b12x_over_flashkda_ratio": 0.98973,
+      "b12x_percent_difference": -1.03,
+      "conclusion": "FlashKDA is faster and remains the automatic selection"
+    }
+  ]
+}

--- a/docs/evidence/kda_prefill/README.md
+++ b/docs/evidence/kda_prefill/README.md
@@ -4,6 +4,28 @@ Measurements that back the `sequence.kda_prefill` performance claims. Each JSON
 file records the device, the commit of the checkout that produced it, and raw
 samples; the tables below summarize them.
 
+## 20260903-glm53-nvfp4-vllm-e2e.json
+
+End-to-end GLM-5.3 NVFP4 serving qualification for the production B12X KDA
+prefill integration. The comparison holds model, vLLM and B12X source trees,
+four RTX PRO 6000 Blackwell GPUs, tensor parallelism, scheduler budget, cache
+geometry, collectives, and CUDA graph mode constant. Tensor parallelism is four;
+decode-context parallelism is one or four. The four-way decode-context-parallel
+case uses full cross-rank KV-cache gathering during prefill.
+
+| Decode-context parallelism | B12X KDA tok/s | FlashKDA tok/s | B12X difference |
+|---:|---:|---:|---:|
+| 1 | 14,899 | 14,900 | -0.01% |
+| 4 | 13,106 | 13,242 | -1.03% |
+
+B12X and FlashKDA are equivalent within run noise when decode-context
+parallelism is one. FlashKDA is 1.03% faster with four-way decode-context
+parallelism, so FlashKDA remains the automatic selection and B12X is qualified
+as an explicit backend. The JSON receipt records source trees, clean-worktree
+state, physical GPU identities, operating mode, exact launch and measurement
+commands, correctness results, raw run measurements, medians, and directed
+comparison ratios.
+
 ## 20260903-rtx-pro-6000-flashkda-triton-baselines.json
 
 Baseline for the vLLM KDA prefill backends that b12x must beat, measured on an

--- a/tests/sequence/test_kda_prefill.py
+++ b/tests/sequence/test_kda_prefill.py
@@ -689,6 +689,62 @@ def test_op_cuda_graph_replay_is_allocation_free_with_poison() -> None:
     assert torch.isnan(binding.output[inputs["num_tokens"] :].float()).all()
 
 
+def test_op_three_window_ring_reuse_is_capture_safe() -> None:
+    """Three populated windows preserve results and fixed storage on replay."""
+    from ..conftest import require_b12x
+    from b12x.policy import PolicyContext, PolicyMode
+    from b12x.policy.components import KDA_PREFILL
+    from b12x.sequence.kda_prefill import KdaPrefillConfig
+
+    device = require_b12x()
+    inputs = make_inputs(lengths=[160], heads=2, seed=74, device=device, state_slots=4)
+    policy = PolicyContext.for_device(device, mode=PolicyMode.HEURISTIC_ONLY).with_override(
+        KDA_PREFILL,
+        KdaPrefillConfig(v_split=64, k_split=1, stages=3, window_tiles=4),
+    )
+    binding, tensors = make_binding(inputs, max_tokens=160, max_seqs=1, policy=policy)
+
+    assert binding.plan.window_tiles == 4
+    assert binding.plan.launched_windows(inputs["num_tokens"], inputs["num_seqs"]) == 3
+    scratch_capacity = binding.scratch.numel()
+    addresses = (
+        tensors["recurrent_state"].data_ptr(),
+        binding.output.data_ptr(),
+        binding.scratch.data_ptr(),
+        binding.ws.data_ptr(),
+    )
+
+    _run(binding, inputs)
+    torch.cuda.synchronize(device)
+    assert binding.error_code.item() == 0
+    _assert_op_matches_oracle(binding, tensors, inputs)
+
+    tensors["recurrent_state"].copy_(inputs["pool"])
+    binding.output.zero_()
+    binding.scratch.zero_()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _run(binding, inputs)
+
+    tensors["recurrent_state"].copy_(inputs["pool"])
+    binding.output.fill_(float("nan"))
+    binding.scratch.fill_(0xFF)
+    allocated_before = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    assert torch.cuda.memory_allocated(device) == allocated_before
+    assert binding.scratch.numel() == scratch_capacity
+    assert addresses == (
+        tensors["recurrent_state"].data_ptr(),
+        binding.output.data_ptr(),
+        binding.scratch.data_ptr(),
+        binding.ws.data_ptr(),
+    )
+    assert binding.error_code.item() == 0
+    _assert_op_matches_oracle(binding, tensors, inputs)
+
+
 def test_op_cuda_graph_replay_uses_device_metadata() -> None:
     from ..conftest import require_b12x
 


### PR DESCRIPTION
## Resulting behavior

B12X gated-delta-network attention (KDA) prefill guarantees that preparation
for a tile window completes before the persistent recurrence grid for that
window starts. Preparation for the following window may overlap recurrence for
the preceding window. The two-slot workspace ring is reused only after its
consumer finishes.

The preparation stream uses high priority so preparation for the following
window can make progress while recurrence occupies the device.

## Technical reason

The recurrence kernel polls readiness flags written by the preparation kernel.
Launching the persistent recurrence grid without an explicit same-window
dependency can let recurrence occupy every schedulable cooperative thread array
(CTA), preventing its producer from running. The resulting circular wait can
stall vLLM warmup or CUDA graph capture at full GPU utilization.

CUDA events now encode the producer dependency and the two-window ring reuse
dependency. CUDA graph capture records the same dependencies used by eager
execution.

## Compatibility

The public KDA prefill operation, plan, binding, capacity, and workspace layout
are unchanged. The change affects only stream priority and launch ordering.

## Validation

- Fifteen selected B12X KDA prefill GPU tests passed on an NVIDIA RTX PRO 6000
  Blackwell GPU. A deterministic test uses three populated tile windows to
  exercise ring-slot reuse after window zero is consumed. Eager execution and
  CUDA graph replay match the numerical oracle, preserve recurrent state, keep
  workspace capacity and buffer addresses fixed, and allocate zero bytes during
  replay.
- The vLLM GLM-5.3 serving warmup shape completed with error code zero.
- Server startup and full and piecewise CUDA graph capture completed with tensor
  parallelism of four and decode-context parallelism of one and four.
- Matched cold 32K-token prefill medians at a 4,096-token scheduler budget were
  14,899 tok/s for B12X and 14,900 tok/s for FlashKDA with decode-context
  parallelism of one. With decode-context parallelism of four and full
  cross-rank KV-cache gathering, the medians were 13,106 tok/s for B12X and
  13,242 tok/s for FlashKDA. FlashKDA therefore remains the automatic selection;
  B12X is qualified as an explicit backend.

The [serving qualification receipt](https://github.com/voipmonitor/b12x/blob/6bacce5de2e23dfcec774f38b5aa7a5dec23d25c/docs/evidence/kda_prefill/20260903-glm53-nvfp4-vllm-e2e.json)
records both source trees, clean-worktree state, physical GPU identities, stock
clock mode, exact commands, raw run measurements, correctness results, medians,
and directed comparison ratios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- KDA prefill preparation now runs on a high-priority stream.
- Each recurrence waits for its window preparation to complete before execution.
- Preparation for the next window overlaps recurrence for the current window.
- CUDA events enforce preparation and two-slot workspace reuse dependencies during eager execution and CUDA graph capture.
- Public interfaces and workspace layouts remain unchanged.
- Added three-window eager and CUDA graph coverage for output, recurrent state, fixed workspace capacity, stable buffer addresses, and allocation-free replay.
- Added GLM-5.3 NVFP4 serving evidence comparing B12X with FlashKDA at decode-context parallelism 1 and 4. B12X is qualified as an explicit backend, while FlashKDA remains the automatic selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->