### PR TITLE
feat(mla): support native NVFP4 DSV4 cache records

### DIFF
--- a/b12x/attention/_shared/mla/compressed_api.py
+++ b/b12x/attention/_shared/mla/compressed_api.py
@@ -24,6 +24,8 @@ from .compressed_reference import (
 
 
 _LN2 = math.log(2.0)
+_DSV4_FP8_RECORD_BYTES = COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
+_DSV4_NVFP4_RECORD_BYTES = 432
 
 
 def _should_use_sm121_single_pass_decode(
@@ -60,6 +62,7 @@ def compressed_sparse_mla_decode_forward(
     swa_topk_lengths: torch.Tensor | None = None,
     binding=None,
     sm_scale: float,
+    latent_scale: float = 1.0,
     swa_page_size: int = COMPRESSED_SPARSE_MLA_DSV4_PAGE_SIZE,
     indexed_k_cache: torch.Tensor | None = None,
     indexed_indices: torch.Tensor | None = None,
@@ -71,6 +74,7 @@ def compressed_sparse_mla_decode_forward(
     return_lse: bool = False,
     lse_scale: Literal["base2", "natural"] = "base2",
     backend: str | None = None,
+    cache_record_bytes: int = _DSV4_FP8_RECORD_BYTES,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Run compressed sparse MLA decode directly from compressed KV pages.
@@ -82,6 +86,12 @@ def compressed_sparse_mla_decode_forward(
 
     if lse_scale not in ("base2", "natural"):
         raise ValueError(f"lse_scale must be 'base2' or 'natural', got {lse_scale!r}")
+    cache_record_bytes = int(cache_record_bytes)
+    if cache_record_bytes not in (_DSV4_FP8_RECORD_BYTES, _DSV4_NVFP4_RECORD_BYTES):
+        raise ValueError(
+            "compressed DSV4 MLA cache_record_bytes must be 584 (FP8) or "
+            f"432 (NVFP4), got {cache_record_bytes}"
+        )
 
     if binding is None:
         raise TypeError("compressed_sparse_mla_decode_forward requires binding")
@@ -136,6 +146,7 @@ def compressed_sparse_mla_decode_forward(
         swa_k_cache,
         page_size=swa_page_size,
         name="swa_k_cache",
+        record_bytes=cache_record_bytes,
     )
 
     swa_indices_2d = _normalize_index_matrix(swa_indices, name="swa_indices")
@@ -181,6 +192,7 @@ def compressed_sparse_mla_decode_forward(
             indexed_k_cache,
             page_size=int(indexed_page_size),
             name="indexed_k_cache",
+            record_bytes=cache_record_bytes,
         )
         indexed_indices_2d = _normalize_index_matrix(
             indexed_indices, name="indexed_indices"
@@ -239,6 +251,7 @@ def compressed_sparse_mla_decode_forward(
             swa_topk_lengths=swa_topk_lengths,
             workspace=scratch,
             sm_scale=sm_scale,
+            latent_scale=latent_scale,
             swa_page_size=swa_page_size,
             indexed_k_cache=indexed_k_cache if has_indexed else None,
             indexed_indices=indexed_indices_2d,
@@ -247,10 +260,11 @@ def compressed_sparse_mla_decode_forward(
             attn_sink=attn_sink,
             return_lse=return_lse,
             lse_scale=lse_scale,
+            cache_record_bytes=cache_record_bytes,
             out=out,
         )
 
-    if _should_use_sm121_single_pass_decode(
+    if cache_record_bytes == _DSV4_FP8_RECORD_BYTES and _should_use_sm121_single_pass_decode(
         rows=rows,
         heads=heads,
         swa_width=int(swa_indices_2d.shape[1]),
@@ -265,6 +279,7 @@ def compressed_sparse_mla_decode_forward(
             swa_topk_lengths=swa_topk_lengths,
             workspace=scratch,
             sm_scale=sm_scale,
+            latent_scale=latent_scale,
             swa_page_size=swa_page_size,
             indexed_k_cache=indexed_k_cache if has_indexed else None,
             indexed_indices=indexed_indices_2d,
@@ -273,6 +288,7 @@ def compressed_sparse_mla_decode_forward(
             attn_sink=attn_sink,
             return_lse=return_lse,
             lse_scale=lse_scale,
+            cache_record_bytes=cache_record_bytes,
             out=out,
         )
 
@@ -285,6 +301,7 @@ def compressed_sparse_mla_decode_forward(
         swa_topk_lengths=swa_topk_lengths,
         workspace=scratch,
         sm_scale=sm_scale,
+        latent_scale=latent_scale,
         swa_page_size=swa_page_size,
         indexed_k_cache=indexed_k_cache if has_indexed else None,
         indexed_indices=indexed_indices_2d,
@@ -293,6 +310,12 @@ def compressed_sparse_mla_decode_forward(
         attn_sink=attn_sink,
         return_lse=return_lse,
         lse_scale=lse_scale,
+        scale_format_override=(
+            2 if cache_record_bytes == _DSV4_NVFP4_RECORD_BYTES else None
+        ),
+        fp8_rope_override=(
+            False if cache_record_bytes == _DSV4_NVFP4_RECORD_BYTES else None
+        ),
         out=out,
     )
 
@@ -322,6 +345,7 @@ def _run_sm120_compressed_prefill(
     swa_topk_lengths: torch.Tensor,
     workspace: object,
     sm_scale: float,
+    latent_scale: float,
     swa_page_size: int,
     indexed_k_cache: torch.Tensor | None,
     indexed_indices: torch.Tensor | None,
@@ -330,6 +354,7 @@ def _run_sm120_compressed_prefill(
     attn_sink: torch.Tensor | None,
     return_lse: bool,
     lse_scale: Literal["base2", "natural"],
+    cache_record_bytes: int,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Route a DSV4 prefill-like (extend/verify/draft_extend) compressed call to the
@@ -370,10 +395,15 @@ def _run_sm120_compressed_prefill(
         kv_cache=swa_k_cache,
         topk_indices=swa_indices_2d,
         sm_scale=float(sm_scale),
+        latent_scale=float(latent_scale),
         page_block_size=int(swa_page_size),
         topk_length=swa_topk_lengths,
         attn_sink=attn_sink,
         output=output,
+        scale_format=(
+            2 if cache_record_bytes == _DSV4_NVFP4_RECORD_BYTES else None
+        ),
+        fp8_rope=False if cache_record_bytes == _DSV4_NVFP4_RECORD_BYTES else None,
         **extra_kwargs,
     )
     if not return_lse:
@@ -526,12 +556,17 @@ def _validate_compressed_cache_layout(
     *,
     page_size: int,
     name: str,
+    record_bytes: int = _DSV4_FP8_RECORD_BYTES,
 ) -> None:
     page_size = int(page_size)
     if page_size <= 0:
         raise ValueError(f"{name} page_size must be positive, got {page_size}")
-    payload_nbytes = page_size * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
-    padded_page_nbytes = compressed_sparse_mla_page_nbytes(page_size)
+    payload_nbytes = page_size * int(record_bytes)
+    padded_page_nbytes = (
+        compressed_sparse_mla_page_nbytes(page_size)
+        if int(record_bytes) == _DSV4_FP8_RECORD_BYTES
+        else payload_nbytes
+    )
     page_nbytes = int(cache.shape[1])
     if page_nbytes not in (payload_nbytes, padded_page_nbytes):
         raise ValueError(

--- a/b12x/attention/_shared/mla/kernel.py
+++ b/b12x/attention/_shared/mla/kernel.py
@@ -58,6 +58,7 @@ from .decode_math import (
 from .io import io_issue_gather, io_issue_gather_packed, io_issue_packed_payload
 from .smem import get_unified_shared_storage_cls, make_smem_layout
 from .traits import (
+    ComputeMode,
     ModelType,
     ScaleFormat,
     infer_model_type,
@@ -1944,14 +1945,18 @@ def _cache_block_stride_bytes(
         COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN,
     )
 
-    if is_glm_model_type(model_type):
+    if record_bytes is not None:
+        expected = int(page_size) * int(record_bytes)
+    elif is_glm_model_type(model_type):
         # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
         # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
-        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
-        expected = int(page_size) * rec
+        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
     else:
         expected = int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
-    if is_glm_model_type(model_type) and cache.is_contiguous():
+    if (
+        cache.is_contiguous()
+        and int(expected) != int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
+    ):
         return expected
     # Use the tensor's physical page stride for padded views.
     if cache.ndim >= 2:
@@ -2018,10 +2023,13 @@ def _sparse_mla_decode_grid_flat_launch(
         and _env_glm_h8_native_enabled()
     )
     native_dsv4_h8 = bool(
-        int(model_type) == int(ModelType.DSV4) and int(valid_hpb) == 8
+        int(model_type) == int(ModelType.DSV4)
+        and int(scale_format) == int(ScaleFormat.UE8M0_BYTE)
+        and int(valid_hpb) == 8
     )
     native_dsv4_h16 = bool(
         int(model_type) == int(ModelType.DSV4)
+        and int(scale_format) == int(ScaleFormat.UE8M0_BYTE)
         and int(valid_hpb) == 16
         and int(head_block_offset) == 0
         and (int(topk) + _CAND_WINDOW - 1) // _CAND_WINDOW
@@ -2502,6 +2510,11 @@ def run_unified_decode(
     )
     if scale_format_override is not None:
         scale_format = int(scale_format_override)
+    if (
+        int(model_type) == int(ModelType.DSV4)
+        and int(scale_format) == int(ScaleFormat.NVFP4_E4M3)
+    ):
+        compute_mode = ComputeMode.BF16
     if scale_format == ScaleFormat.NVFP4_E4M3 and fp8_rope_override is None:
         record_bytes = int(swa_k_cache.shape[-1])
         if record_bytes not in (368, 432):
@@ -2563,6 +2576,7 @@ def run_unified_decode(
 
     h16_allowed = bool(
         int(model_type) == int(ModelType.DSV4)
+        and int(scale_format) == int(ScaleFormat.UE8M0_BYTE)
         and heads % 16 == 0
         and num_main_chunks + num_extra_chunks <= _DSV4_H8_MAX_CHUNKS
     )
@@ -2587,6 +2601,7 @@ def run_unified_decode(
         native_dsv4_h16 = bool(h16_allowed and h16_mode)
     native_dsv4_h8 = bool(
         int(model_type) == int(ModelType.DSV4)
+        and int(scale_format) == int(ScaleFormat.UE8M0_BYTE)
         and heads % 8 == 0
         and num_main_chunks + num_extra_chunks <= _DSV4_H8_MAX_CHUNKS
         and not native_dsv4_h16

--- a/b12x/attention/_shared/mla/prefill.py
+++ b/b12x/attention/_shared/mla/prefill.py
@@ -54,14 +54,18 @@ def _cache_block_stride_bytes(
         COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN,
     )
 
-    if is_glm_model_type(model_type):
+    if record_bytes is not None:
+        expected = int(page_size) * int(record_bytes)
+    elif is_glm_model_type(model_type):
         # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
         # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
-        rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
-        expected = int(page_size) * rec
+        expected = int(page_size) * _GLM_KV_GMEM_STRIDE
     else:
         expected = int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
-    if is_glm_model_type(model_type) and cache.is_contiguous():
+    if (
+        cache.is_contiguous()
+        and int(expected) != int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
+    ):
         return expected
     # The runtime page stride is part of the packed/padded cache contract.
     if cache.ndim >= 2:
@@ -209,8 +213,11 @@ def run_unified_prefill(
         scale_format = inferred_scale_format
     else:
         scale_format = int(scale_format)
-        if model_type == ModelType.GLM_NSA and scale_format == ScaleFormat.NVFP4_E4M3:
-            # NVFP4 GLM-family prefill runs the BF16-QK MG arm (native E2M1
+        if (
+            model_type in (ModelType.DSV4, ModelType.GLM_NSA)
+            and scale_format == ScaleFormat.NVFP4_E4M3
+        ):
+            # Native NVFP4 prefill runs the BF16-QK MG arm (E2M1/E4M3
             # dequant + BF16 MMA); FP8 compute would misread the 432B record.
             compute_mode = ComputeMode.BF16
         elif scale_format != inferred_scale_format:
@@ -402,20 +409,21 @@ def run_unified_prefill(
             model_type=model_type,
             scale_format=ScaleFormat.ARBITRARY_FP32,
         )
-    # ── NVFP4 (E2M1 + E4M3 group-16, GLM-family) MG gate ───────────────────────
-    # Same MG head-group structure as GLM; the math arms are the BF16-QK path
+    # ── NVFP4 (E2M1 + E4M3 group-16) MG gate ──────────────────────────────────
+    # DSV4 and GLM share the BF16-QK math arm while retaining their own query
+    # geometry and value/RoPE traits.
     # with native in-register E2M1/E4M3 dequant (the same math as the validated
     # NVFP4 decode). topk==128 additionally routes here (BF16-QK shape).
     _mg_nvfp4 = (
         _mg_enabled
         and not has_extra
-        and model_type == ModelType.GLM_NSA
+        and model_type in (ModelType.DSV4, ModelType.GLM_NSA)
         and scale_format == ScaleFormat.NVFP4_E4M3
     )
     if _mg_nvfp4 and topk in (128, 512, 1024, 2048):
         return _run_partitioned_mg(
             compute_mode=ComputeMode.BF16,
-            model_type=ModelType.GLM_NSA,
+            model_type=model_type,
             scale_format=ScaleFormat.NVFP4_E4M3,
         )
     _mg_base = (

--- a/b12x/attention/_shared/mla/prefill.py
+++ b/b12x/attention/_shared/mla/prefill.py
@@ -482,6 +482,6 @@ def run_unified_prefill(
         "DSV4 dual-cache topk==128 with heads%8==0 and pbs_extra in {2, 64}; "
         "GLM_NSA topk in {512, 1024, 2048}; GLM_NEXT topk in "
         "{512, 1024, 2048, 2051, 2112}; "
-        "NVFP4 (GLM-family, scale_format=2) topk in {128, 512, 1024, 2048}. "
+        "NVFP4 (DSV4/GLM_NSA, scale_format=2) topk in {128, 512, 1024, 2048}. "
         "No decode-reuse fallback."
     )

--- a/b12x/attention/_shared/mla/prefill_mg.py
+++ b/b12x/attention/_shared/mla/prefill_mg.py
@@ -208,14 +208,18 @@ def _cache_block_stride_bytes(
         COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN,
     )
 
-    if is_glm:
+    if record_bytes is not None:
+        expected = int(page_size) * int(record_bytes)
+    elif is_glm:
         # GLM-family per-token contiguous record: 656B (ARBITRARY_FP32) or
         # 432B (NVFP4_E4M3). ``record_bytes`` comes from traits.kv_gmem_stride.
-        rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
-        expected = int(page_size) * rec
+        expected = int(page_size) * _GLM_IO_STRIDE
     else:
         expected = int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
-    if is_glm and cache.is_contiguous():
+    if (
+        cache.is_contiguous()
+        and int(expected) != int(page_size) * COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN
+    ):
         return expected
     # Use the tensor's physical page stride for padded views.
     if cache.ndim >= 2:
@@ -2357,10 +2361,10 @@ class UnifiedPrefillMGKernel:
             t.model_type in (ModelType.GLM_NSA, ModelType.GLM_NEXT)
         )
         has_rope = cutlass.const_expr(t.d_rope > 0)
-        # NVFP4 (E2M1 + E4M3 group-16) GLM-family arm: BF16-QK with native
-        # in-register dequant, BF16 P.V staged in the dead W_FP8 region, and
-        # the 432B/288B record geometry. is_glm stays true for NVFP4 so the
-        # shared GLM staging (io gather / kv_sc absence / q_rope alias) applies.
+        # NVFP4 (E2M1 + E4M3 group-16) uses BF16-QK with native in-register
+        # dequant, BF16 P.V staged in the dead W_FP8 region, and the
+        # 432B/288B record geometry. DSV4 keeps its 448+64 query/value traits;
+        # the shared inline-scale gather is selected by ``is_nvfp4`` below.
         is_nvfp4 = cutlass.const_expr(t.scale_format == ScaleFormat.NVFP4_E4M3)
         q_head_dim = cutlass.const_expr(t.d_nope + t.d_rope)
         # Compile-time head-group count: 1 (heads==16) or 2 (heads % 32 == 0). All
@@ -2378,7 +2382,9 @@ class UnifiedPrefillMGKernel:
         # NVFP4 per-token latent-scale mode, which stages one fp32 per
         # candidate.  DSV4 stages XV-RoPE weights into the W_FP8 region after
         # XV-NoPE consumes it.
-        if cutlass.const_expr(is_glm and not t.latent_scale_per_token):
+        if cutlass.const_expr(
+            not t.has_extra_cache and not t.latent_scale_per_token
+        ):
             kv_sc_addr = Int32(0)
         else:
             kv_sc_addr = shared_ptr_to_u32(st.kv_sc.data_ptr())
@@ -2532,7 +2538,7 @@ class UnifiedPrefillMGKernel:
                 g_end0 = Int32(_CAND_WINDOW)
                 if g_end0 > section_len:
                     g_end0 = section_len
-                if cutlass.const_expr(is_glm):
+                if cutlass.const_expr(is_glm or is_nvfp4):
                     io_issue_gather_glm_mg(
                         kv_cache_u8,
                         topk_row,
@@ -2633,7 +2639,7 @@ class UnifiedPrefillMGKernel:
                         g_end = g_start + Int32(_CAND_WINDOW)
                         if g_end > section_len:
                             g_end = section_len
-                        if cutlass.const_expr(is_glm):
+                        if cutlass.const_expr(is_glm or is_nvfp4):
                             io_issue_gather_glm_mg(
                                 kv_cache_u8,
                                 topk_row,
@@ -4135,6 +4141,11 @@ def run_unified_prefill_mg(
     if scale_format is None:
         scale_format = ScaleFormat.ARBITRARY_FP32 if is_glm else ScaleFormat.UE8M0_BYTE
     scale_format = int(scale_format)
+    if (
+        model_type == ModelType.DSV4
+        and scale_format == ScaleFormat.NVFP4_E4M3
+    ):
+        compute_mode = ComputeMode.BF16
     expected_qdim = {
         ModelType.DSV4: _DSV4_HEAD_DIM,
         ModelType.GLM_NSA: _GLM_HEAD_DIM,

--- a/b12x/attention/_shared/mla/smem.py
+++ b/b12x/attention/_shared/mla/smem.py
@@ -558,6 +558,7 @@ def _run_module_asserts() -> None:
 
     dsv4 = _assert_model(ModelType.DSV4, ComputeMode.FP8, ScaleFormat.UE8M0_BYTE)
     _assert_model(ModelType.DSV4, ComputeMode.BF16, ScaleFormat.UE8M0_BYTE)
+    _assert_model(ModelType.DSV4, ComputeMode.BF16, ScaleFormat.NVFP4_E4M3)
     glm = _assert_model(ModelType.GLM_NSA, ComputeMode.FP8, ScaleFormat.ARBITRARY_FP32)
     _assert_model(ModelType.GLM_NSA, ComputeMode.BF16, ScaleFormat.ARBITRARY_FP32)
     _assert_model(ModelType.GLM_NSA, ComputeMode.BF16, ScaleFormat.NVFP4_E4M3)

--- a/b12x/attention/_shared/mla/traits.py
+++ b/b12x/attention/_shared/mla/traits.py
@@ -155,7 +155,10 @@ def make_unified_traits(
                 block_threads=288,
                 math_threads=256,
                 bulk_tx_bytes=26624,
-                v_has_rope=True,
+                # The eight FP4 V chunks already cover all 512 latent values,
+                # including the rotated 64-wide tail.  ``kv_rope`` remains for
+                # QK-RoPE, but must not contribute a second XV tail.
+                v_has_rope=False,
                 has_extra_cache=False,
                 fp8_rope=False,
                 rope_gmem_offset=304,

--- a/b12x/attention/_shared/mla/traits.py
+++ b/b12x/attention/_shared/mla/traits.py
@@ -120,9 +120,52 @@ def make_unified_traits(
         )
 
     if model_type == ModelType.DSV4:
+        if scale_format == ScaleFormat.NVFP4_E4M3:
+            if fp8_rope is True:
+                raise ValueError(
+                    "DSV4 NVFP4 uses the 432-byte BF16-RoPE record; "
+                    "fp8_rope=True is unsupported"
+                )
+            if latent_scale_per_token:
+                raise ValueError(
+                    "DSV4 NVFP4 does not define a per-token latent scale"
+                )
+            # DeepSeek-V4 retains its 448 NoPE + 64 RoPE query contract while
+            # changing only the cache encoding.  The writer packs all 512 latent
+            # values as E2M1, stores 32 E4M3 group-16 scales, and keeps the
+            # rotated 64-wide RoPE tail in BF16 at byte offset 304.  The final
+            # four packed/scaled groups are the duplicated RoPE tail; QK consumes
+            # the first 448 NoPE values and XV consumes the full 512-value latent.
+            return UnifiedMLATraits(
+                model_type=ModelType.DSV4,
+                compute_mode=ComputeMode.BF16,
+                scale_format=ScaleFormat.NVFP4_E4M3,
+                d_nope=448,
+                d_rope=64,
+                d_v=512,
+                quant_tile=64,
+                num_scales=7,
+                n_v_chunks=8,
+                nt_per_warp_xv=1,
+                kv_gmem_stride=432,
+                kv_smem_stride=288,
+                q_nope_stride=456,
+                bi=64,
+                hpb=16,
+                block_threads=288,
+                math_threads=256,
+                bulk_tx_bytes=26624,
+                v_has_rope=True,
+                has_extra_cache=False,
+                fp8_rope=False,
+                rope_gmem_offset=304,
+                rope_payload_bytes=128,
+                rope_scale_offset=-1,
+            )
         if scale_format != ScaleFormat.UE8M0_BYTE:
             raise ValueError(
-                "DSV4 requires ScaleFormat.UE8M0_BYTE (footer); "
+                "DSV4 requires ScaleFormat.UE8M0_BYTE (footer) or "
+                "ScaleFormat.NVFP4_E4M3 (432-byte native record); "
                 f"got scale_format={scale_format!r}"
             )
         # DSV4 column of verified_traits.md (UE8M0_BYTE, V_HAS_ROPE=true).

--- a/tests/attention/test_compressed_sparse_mla.py
+++ b/tests/attention/test_compressed_sparse_mla.py
@@ -116,7 +116,7 @@ def test_dsv4_nvfp4_traits_keep_the_dsv4_query_contract() -> None:
     assert (native.d_nope, native.d_rope, native.d_v) == (448, 64, 512)
     assert native.kv_gmem_stride == 432
     assert native.rope_gmem_offset == 304
-    assert native.v_has_rope is True
+    assert native.v_has_rope is False
     assert native.has_extra_cache is False
 
 

--- a/tests/attention/test_compressed_sparse_mla.py
+++ b/tests/attention/test_compressed_sparse_mla.py
@@ -19,6 +19,12 @@ from b12x.attention._shared.mla.prefill import (
 from b12x.attention._shared.mla.prefill_mg import (
     _cache_block_stride_bytes as _prefill_mg_cache_block_stride_bytes,
 )
+from b12x.attention._shared.mla.traits import (
+    ComputeMode,
+    ModelType,
+    ScaleFormat,
+    make_unified_traits,
+)
 from b12x.attention._shared.mla.compressed_reference import (
     COMPRESSED_SPARSE_MLA_BYTES_PER_TOKEN,
     COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE,
@@ -85,6 +91,33 @@ def test_compressed_sparse_mla_layout_accepts_compact_nvfp4_pages(
         name="cache",
         record_bytes=432,
     )
+
+
+def test_compressed_sparse_mla_layout_rejects_short_nvfp4_page() -> None:
+    page_size = 64
+    with pytest.raises(ValueError, match="contiguous payload"):
+        _validate_compressed_cache_layout(
+            torch.empty((2, page_size * 432 - 1), dtype=torch.uint8),
+            page_size=page_size,
+            name="cache",
+            record_bytes=432,
+        )
+
+
+def test_dsv4_nvfp4_traits_keep_the_dsv4_query_contract() -> None:
+    native = make_unified_traits(
+        ModelType.DSV4,
+        ComputeMode.FP8,
+        ScaleFormat.NVFP4_E4M3,
+        fp8_rope=False,
+    )
+
+    assert native.compute_mode == ComputeMode.BF16
+    assert (native.d_nope, native.d_rope, native.d_v) == (448, 64, 512)
+    assert native.kv_gmem_stride == 432
+    assert native.rope_gmem_offset == 304
+    assert native.v_has_rope is True
+    assert native.has_extra_cache is False
 
 
 def test_compressed_sparse_mla_exposes_native_nvfp4_contract() -> None:

--- a/tests/attention/test_compressed_sparse_mla.py
+++ b/tests/attention/test_compressed_sparse_mla.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import math
 from collections.abc import Callable
 
@@ -72,6 +73,25 @@ def test_compressed_sparse_mla_layout_rejects_short_page() -> None:
             page_size=COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE,
             name="cache",
         )
+
+
+@pytest.mark.parametrize("page_size", [16, 64, 256])
+def test_compressed_sparse_mla_layout_accepts_compact_nvfp4_pages(
+    page_size: int,
+) -> None:
+    _validate_compressed_cache_layout(
+        torch.empty((2, page_size * 432), dtype=torch.uint8),
+        page_size=page_size,
+        name="cache",
+        record_bytes=432,
+    )
+
+
+def test_compressed_sparse_mla_exposes_native_nvfp4_contract() -> None:
+    signature = inspect.signature(compressed_sparse_mla_decode_forward)
+
+    assert signature.parameters["cache_record_bytes"].default == 584
+    assert signature.parameters["latent_scale"].default == 1.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add an explicit native DeepSeek V4 NVFP4 cache-record layout to the compressed sparse MLA API.
- Preserve the existing FP8 record path while allowing the caller to provide the native record width and latent scale.
- Cover the layout selection and decode paths with unit tests.

## Testing
- `pytest -q tests/attention/test_compressed_sparse_mla.py` (16 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds native DeepSeek V4 NVFP4 cache-record support to `compressed_sparse_mla_decode_forward`.

- Supports FP8 records (`584` bytes) and NVFP4 records (`432` bytes).
- Adds `cache_record_bytes` and `latent_scale` parameters while preserving FP8 defaults.
- Validates record sizes and computes cache-page widths for each layout.
- Routes DSV4 NVFP4 records through BF16 compute with `scale_format=2`.
- Disables FP8 RoPE and avoids duplicate native NVFP4 RoPE output.
- Adds DSV4 NVFP4 traits, SM120 decode support, and prefill dispatch paths.
- Preserves existing FP8 decode and prefill behavior.
- Updates the unsupported-shape message to identify DSV4/GLM_NSA NVFP4 support.
- Adds tests for NVFP4 page validation and DSV4 trait contracts.

Validation: `pytest -q tests/attention/test_compressed_sparse_mla.py` — 16 passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->