### PR TITLE
perf(qsa): execute large prefill without split scratch

### DIFF
--- a/b12x/attention/qsa/__init__.py
+++ b/b12x/attention/qsa/__init__.py
@@ -1,9 +1,12 @@
 """Grouped-selector sparse GQA for the Qwen3.8-Flash-Next QSA contract.
 
-QSA keeps exact, original-token BF16 GQA K/V and uses a second compressed
-BF16 key cache only to select groups of logical token positions.  The public
-lifecycle is ``Caps -> plan -> bind -> run``.  Planning owns split and scratch
-policy; binding validates tensors and creates references without allocating.
+QSA keeps exact, original-token BF16 or globally scaled FP8 E4M3 GQA K/V and
+uses a second compressed BF16 key cache only to select groups of logical token
+positions. The public lifecycle is ``Caps -> plan -> bind -> prewarm -> run``.
+Planning owns split and scratch policy; binding validates tensors and creates
+references without allocating. ``prewarm`` compiles large-prefill sparse GQA
+without reading or mutating cache state and may be omitted when first-use JIT
+latency is acceptable.
 
 ``run`` executes the decode transaction behind one opaque mutating dispatcher
 boundary and never dispatches the slow functions in
@@ -71,6 +74,7 @@ META = OpMeta(
         "cache_requirements",
         "plan",
         "bind",
+        "prewarm",
         "run",
         "is_supported",
     ),
@@ -89,12 +93,11 @@ META = OpMeta(
     test_path="tests/attention/test_qsa_contract.py",
     since="1.3.0",
     notes=(
-        "The Qwen sparse-GQA layout uses CuTeDSL for every row count "
-        "and fails closed when its CuTe contract is not satisfied. No "
-        "alternate sparse-GQA implementation is dispatched. Triton is used "
-        "only for auxiliary selection and cache-maintenance stages in the "
-        "Qwen pipeline. Main K/V cache writes are unsupported. Page- and "
-        "state-slot-scaled addressing uses signed 64-bit arithmetic."
+        "The Qwen sparse-GQA layout uses split CuTeDSL kernels for at most "
+        "64 query rows and a direct paged Triton kernel for larger prefill "
+        "batches. Unsupported geometry fails closed. Main K/V cache writes "
+        "are unsupported. Page- and state-slot-scaled addressing uses signed "
+        "64-bit arithmetic."
     ),
 )
 
@@ -110,6 +113,7 @@ if TYPE_CHECKING:
         cache_requirements,
         is_supported,
         plan,
+        prewarm,
         run,
     )
 

--- a/b12x/attention/qsa/_contract.py
+++ b/b12x/attention/qsa/_contract.py
@@ -516,6 +516,7 @@ class _KernelCaps:
 def _target_splits(caps: Caps, rows: int) -> tuple[int, int]:
     from ._sparse_gqa_cute_config import (
         BLOCK_N as QWEN_CUTE_BLOCK_N,
+        MAX_SPLIT_ROWS as QWEN_CUTE_MAX_SPLIT_ROWS,
         NUM_SPLITS as QWEN_CUTE_NUM_SPLITS,
         is_qwen_geometry,
     )
@@ -529,7 +530,15 @@ def _target_splits(caps: Caps, rows: int) -> tuple[int, int]:
         splits=QWEN_CUTE_NUM_SPLITS,
     ):
         rows = int(rows)
-        splits = 64 if rows == 1 else 32 if rows <= 4 else 16
+        splits = (
+            64
+            if rows == 1
+            else 32
+            if rows <= 4
+            else 16
+            if rows <= QWEN_CUTE_MAX_SPLIT_ROWS
+            else 1
+        )
         return QWEN_CUTE_BLOCK_N, splits
     raise NotImplementedError(
         "QSA requires the CuTe Qwen sparse-GQA geometry: q_heads divisible by "
@@ -571,8 +580,11 @@ def _scratch_layout(
         * torch.bfloat16.itemsize
     )
     score_nbytes = workspace_q_rows * score_workspace_width * torch.float32.itemsize
+    from ._sparse_gqa_cute_config import MAX_SPLIT_ROWS
+
     max_split_row_product = max(
-        rows * _target_splits(caps, rows)[1] for rows in range(1, workspace_q_rows + 1)
+        rows * _target_splits(caps, rows)[1]
+        for rows in range(1, min(workspace_q_rows, MAX_SPLIT_ROWS) + 1)
     )
     partial_output_nbytes = (
         max_split_row_product
@@ -1833,12 +1845,15 @@ def _qsa_decode_impl(
         )
 
         block_n, splits = _target_splits(caps, chunk_rows)
-        split_output = partial_output_storage[: chunk_rows * splits].view(
-            chunk_rows, splits, q_heads, head_dim
-        )
-        split_lse = partial_lse_storage[: chunk_rows * splits].view(
-            chunk_rows, splits, q_heads
-        )
+        split_output = None
+        split_lse = None
+        if splits > 1:
+            split_output = partial_output_storage[: chunk_rows * splits].view(
+                chunk_rows, splits, q_heads, head_dim
+            )
+            split_lse = partial_lse_storage[: chunk_rows * splits].view(
+                chunk_rows, splits, q_heads
+            )
         active_output = output[row_slice]
         launch_sparse_paged_gqa(
             query=query[row_slice],
@@ -2633,6 +2648,70 @@ def run(
     return binding.output[:rows]
 
 
+def prewarm(binding: Binding, *, rows: int | None = None) -> None:
+    """Compile a bound QSA transaction without mutating persistent state.
+
+    Every synthetic row has an invalid request ID and position. The launch
+    therefore compiles the plan's exact row capacity, cache-table stride,
+    selector workspace, and sparse-GQA specialization while all cache accesses
+    and persistent selector-state writes remain masked. Scratch, output, and
+    selected-position buffers are transient and have unspecified contents
+    after this call.
+    """
+    if not isinstance(binding, Binding):
+        raise TypeError("binding must be a qsa.Binding")
+
+    caps = binding.plan.caps
+    rows = int(caps.max_q_rows if rows is None else rows)
+    if not 0 < rows <= int(caps.max_q_rows):
+        raise ValueError("prewarm rows must be within the planned QSA capacity")
+    device = caps.device
+    query = torch.empty(
+        (rows, int(caps.q_heads), int(caps.head_dim)),
+        dtype=caps.dtype,
+        device=device,
+    )
+    index_query = torch.empty(
+        (rows, int(caps.index_heads), int(caps.index_head_dim)),
+        dtype=caps.dtype,
+        device=device,
+    )
+    raw_index_key = torch.empty(
+        (rows, int(caps.index_head_dim)), dtype=caps.dtype, device=device
+    )
+    request_ids = torch.full((rows,), -1, dtype=torch.int32, device=device)
+    query_positions = torch.full((rows,), -1, dtype=torch.int64, device=device)
+    rope_positions = torch.full(
+        (rows, int(caps.position_axes)),
+        -1,
+        dtype=torch.int64,
+        device=device,
+    )
+    sequence_lengths = torch.zeros(
+        int(caps.max_batch), dtype=torch.int32, device=device
+    )
+    query_start_loc = torch.zeros(
+        int(caps.max_batch) + 1, dtype=torch.int32, device=device
+    )
+    num_accepted_tokens = torch.ones(
+        int(caps.max_batch), dtype=torch.int32, device=device
+    )
+    is_prefilling = torch.ones(int(caps.max_batch), dtype=torch.bool, device=device)
+    run(
+        binding,
+        query=query,
+        index_query=index_query,
+        raw_index_key=raw_index_key,
+        request_ids=request_ids,
+        query_positions=query_positions,
+        rope_positions=rope_positions,
+        sequence_lengths=sequence_lengths,
+        query_start_loc=query_start_loc,
+        num_accepted_tokens=num_accepted_tokens,
+        is_prefilling=is_prefilling,
+    )
+
+
 def is_supported(device: torch.device | str | None = None) -> bool:
     """Return whether the mandatory CuTe QSA dependencies are available."""
     from ..._lib.gating import has_cutlass_dsl, has_triton
@@ -2649,6 +2728,7 @@ __all__ = [
     "cache_requirements",
     "plan",
     "bind",
+    "prewarm",
     "run",
     "is_supported",
 ]

--- a/b12x/attention/qsa/_sparse_gqa.py
+++ b/b12x/attention/qsa/_sparse_gqa.py
@@ -1,10 +1,11 @@
-"""CuTeDSL indexed sparse paged causal GQA for Qwen3.8 Flash Next.
+"""Indexed sparse paged causal GQA for Qwen3.8 Flash Next.
 
 This private stage reads BF16 or globally scaled FP8 E4M3 main-cache K/V at
-caller-selected logical token positions. It never writes either cache. The
-supported Qwen geometry always launches the CuTe split and merge kernels;
-every other geometry, layout, or device fails instead of selecting an alternate
-implementation.
+caller-selected logical token positions. It never writes either cache. Small
+batches use split CuTe kernels to expose enough parallel work. Large prefill
+batches use one Triton program per query-row and KV-head pair and write output
+directly, avoiding FP32 split tensors and a merge launch. Every unsupported
+geometry, layout, or device fails closed.
 """
 
 from __future__ import annotations
@@ -14,6 +15,7 @@ import math
 import torch
 
 from ._sparse_gqa_cute_config import (
+    MAX_SPLIT_ROWS as _MAX_SPLIT_ROWS,
     is_candidate as _cute_is_candidate,
     is_qwen_geometry as _is_qwen_geometry,
 )
@@ -222,6 +224,22 @@ def launch_sparse_paged_gqa(
             f"head_dim={int(query.shape[2])}, page_size={int(key_cache.shape[1])}, "
             f"selection_width={int(selected_positions.shape[1])}, "
             f"block_n={int(block_n)}, splits={int(splits)}"
+        )
+    if rows > _MAX_SPLIT_ROWS:
+        from ._sparse_gqa_triton import launch_sparse_paged_gqa_prefill
+
+        return launch_sparse_paged_gqa_prefill(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            block_table=block_table,
+            request_ids=request_ids,
+            selected_positions=selected_positions,
+            query_positions=query_positions,
+            output=output,
+            softmax_scale=softmax_scale,
         )
     assert partial_output is not None and partial_lse is not None
     if not _cute_is_candidate(

--- a/b12x/attention/qsa/_sparse_gqa_cute_config.py
+++ b/b12x/attention/qsa/_sparse_gqa_cute_config.py
@@ -8,6 +8,7 @@ HEAD_DIM = 256
 SELECTION_WIDTH = 2051
 BLOCK_N = 16
 NUM_SPLITS = 64
+MAX_SPLIT_ROWS = 64
 
 
 def _is_page_token_head_layout(tensor: torch.Tensor) -> bool:
@@ -142,6 +143,7 @@ def is_candidate(
 __all__ = [
     "BLOCK_N",
     "HEAD_DIM",
+    "MAX_SPLIT_ROWS",
     "NUM_SPLITS",
     "SELECTION_WIDTH",
     "is_candidate",

--- a/b12x/attention/qsa/_sparse_gqa_triton.py
+++ b/b12x/attention/qsa/_sparse_gqa_triton.py
@@ -1,0 +1,223 @@
+"""Triton sparse paged GQA for large Qwen prefill batches.
+
+The kernel assigns one program to each query-row and KV-head pair. Large
+prefill batches therefore provide enough independent work without splitting
+one attention row across intermediate FP32 tensors. Logical token positions
+are translated through the caller's page table, so the kernel reads the
+existing QSA cache without a contiguous-cache gather.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sparse_paged_gqa_prefill(
+    query,
+    key_cache,
+    value_cache,
+    k_descale,
+    v_descale,
+    block_table,
+    request_ids,
+    selected_positions,
+    query_positions,
+    output,
+    rows,
+    num_cache_pages,
+    num_requests,
+    table_width,
+    softmax_scale,
+    QUERY_STRIDE_ROW: tl.constexpr,
+    QUERY_STRIDE_HEAD: tl.constexpr,
+    KEY_STRIDE_PAGE: tl.constexpr,
+    KEY_STRIDE_TOKEN: tl.constexpr,
+    KEY_STRIDE_HEAD: tl.constexpr,
+    VALUE_STRIDE_PAGE: tl.constexpr,
+    VALUE_STRIDE_TOKEN: tl.constexpr,
+    VALUE_STRIDE_HEAD: tl.constexpr,
+    TABLE_STRIDE_ROW: tl.constexpr,
+    SELECTED_STRIDE_ROW: tl.constexpr,
+    OUTPUT_STRIDE_ROW: tl.constexpr,
+    OUTPUT_STRIDE_HEAD: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    HEADS_PER_KV: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    SELECTION_WIDTH: tl.constexpr,
+    FP8_CACHE: tl.constexpr,
+):
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    if row >= rows:
+        return
+
+    request_id = tl.load(request_ids + row).to(tl.int64)
+    query_position = tl.load(query_positions + row).to(tl.int64)
+    row_is_valid = (request_id >= 0) & (request_id < num_requests)
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    first_head = kv_head * HEADS_PER_KV
+    query_values = tl.load(
+        query
+        + row * QUERY_STRIDE_ROW
+        + (first_head + head_offsets[:, None]) * QUERY_STRIDE_HEAD
+        + dim_offsets[None, :],
+        mask=(head_offsets < HEADS_PER_KV)[:, None],
+        other=0.0,
+    )
+    key_scale = tl.load(k_descale) if FP8_CACHE else 1.0
+    value_scale = tl.load(v_descale) if FP8_CACHE else 1.0
+    query_values = (query_values * softmax_scale * key_scale * 1.4426950408889634).to(
+        query_values.dtype
+    )
+
+    maximum = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    normalizer = tl.zeros([BLOCK_M], tl.float32)
+    accumulator = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    selection_offsets = tl.arange(0, BLOCK_N)
+    visible_selection = tl.minimum(SELECTION_WIDTH, query_position + 1)
+    selection_limit = ((visible_selection + BLOCK_N - 1) // BLOCK_N) * BLOCK_N
+
+    for start in range(0, selection_limit, BLOCK_N):
+        selection_index = start + selection_offsets
+        logical_position = tl.load(
+            selected_positions + row * SELECTED_STRIDE_ROW + selection_index,
+            mask=selection_index < SELECTION_WIDTH,
+            other=-1,
+        ).to(tl.int64)
+        logical_page = logical_position // PAGE_SIZE
+        page_offset = logical_position - logical_page * PAGE_SIZE
+        position_is_valid = (
+            row_is_valid
+            & (logical_position >= 0)
+            & (logical_position <= query_position)
+            & (logical_page >= 0)
+            & (logical_page < table_width)
+        )
+        physical_page = tl.load(
+            block_table + request_id * TABLE_STRIDE_ROW + logical_page,
+            mask=position_is_valid,
+            other=-1,
+        ).to(tl.int64)
+        position_is_valid &= (physical_page >= 0) & (physical_page < num_cache_pages)
+
+        keys = tl.load(
+            key_cache
+            + physical_page[None, :] * KEY_STRIDE_PAGE
+            + page_offset[None, :] * KEY_STRIDE_TOKEN
+            + kv_head * KEY_STRIDE_HEAD
+            + dim_offsets[:, None],
+            mask=position_is_valid[None, :],
+            other=0.0,
+        ).to(query_values.dtype)
+        values = tl.load(
+            value_cache
+            + physical_page[:, None] * VALUE_STRIDE_PAGE
+            + page_offset[:, None] * VALUE_STRIDE_TOKEN
+            + kv_head * VALUE_STRIDE_HEAD
+            + dim_offsets[None, :],
+            mask=position_is_valid[:, None],
+            other=0.0,
+        ).to(query_values.dtype)
+        if FP8_CACHE:
+            values = (values * value_scale).to(query_values.dtype)
+
+        scores = tl.where(
+            position_is_valid[None, :],
+            tl.dot(query_values, keys),
+            -float("inf"),
+        )
+        next_maximum = tl.maximum(maximum, tl.max(scores, axis=1))
+        alpha = tl.exp2(maximum - next_maximum)
+        probabilities = tl.exp2(scores - next_maximum[:, None])
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        maximum = next_maximum
+
+    normalized = accumulator / normalizer[:, None]
+    normalized = tl.where(normalizer[:, None] > 0.0, normalized, 0.0)
+    tl.store(
+        output
+        + row * OUTPUT_STRIDE_ROW
+        + (first_head + head_offsets[:, None]) * OUTPUT_STRIDE_HEAD
+        + dim_offsets[None, :],
+        normalized,
+        mask=(head_offsets < HEADS_PER_KV)[:, None],
+    )
+
+
+def launch_sparse_paged_gqa_prefill(
+    *,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    k_descale: torch.Tensor | None,
+    v_descale: torch.Tensor | None,
+    block_table: torch.Tensor,
+    request_ids: torch.Tensor,
+    selected_positions: torch.Tensor,
+    query_positions: torch.Tensor,
+    output: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run the large-row sparse GQA kernel into caller-owned output storage."""
+    rows, query_heads, head_dim = map(int, query.shape)
+    kv_heads = int(key_cache.shape[2])
+    heads_per_kv = query_heads // kv_heads
+    block_m = max(16, triton.next_power_of_2(heads_per_kv))
+    fp8_cache = key_cache.dtype == torch.float8_e4m3fn
+    if fp8_cache and (k_descale is None or v_descale is None):
+        raise ValueError("FP8 QSA caches require K/V descale tensors")
+    scale_pointer = query if k_descale is None else k_descale
+    value_scale_pointer = query if v_descale is None else v_descale
+    _sparse_paged_gqa_prefill[(rows, kv_heads)](
+        query,
+        key_cache,
+        value_cache,
+        scale_pointer,
+        value_scale_pointer,
+        block_table,
+        request_ids,
+        selected_positions,
+        query_positions,
+        output,
+        rows,
+        int(key_cache.shape[0]),
+        int(block_table.shape[0]),
+        int(block_table.shape[1]),
+        float(softmax_scale),
+        QUERY_STRIDE_ROW=int(query.stride(0)),
+        QUERY_STRIDE_HEAD=int(query.stride(1)),
+        KEY_STRIDE_PAGE=int(key_cache.stride(0)),
+        KEY_STRIDE_TOKEN=int(key_cache.stride(1)),
+        KEY_STRIDE_HEAD=int(key_cache.stride(2)),
+        VALUE_STRIDE_PAGE=int(value_cache.stride(0)),
+        VALUE_STRIDE_TOKEN=int(value_cache.stride(1)),
+        VALUE_STRIDE_HEAD=int(value_cache.stride(2)),
+        TABLE_STRIDE_ROW=int(block_table.stride(0)),
+        SELECTED_STRIDE_ROW=int(selected_positions.stride(0)),
+        OUTPUT_STRIDE_ROW=int(output.stride(0)),
+        OUTPUT_STRIDE_HEAD=int(output.stride(1)),
+        PAGE_SIZE=int(key_cache.shape[1]),
+        HEADS_PER_KV=heads_per_kv,
+        BLOCK_M=block_m,
+        BLOCK_N=16,
+        HEAD_DIM=head_dim,
+        SELECTION_WIDTH=int(selected_positions.shape[1]),
+        FP8_CACHE=fp8_cache,
+        num_warps=2,
+        num_stages=1,
+    )
+    return output[:rows]
+
+
+__all__ = ["launch_sparse_paged_gqa_prefill"]

--- a/b12x/attention/qsa/api.py
+++ b/b12x/attention/qsa/api.py
@@ -11,6 +11,7 @@ from ._contract import (
     cache_requirements,
     is_supported,
     plan,
+    prewarm,
     run,
 )
 from ._policy import QsaConfig, QsaQuery
@@ -25,6 +26,7 @@ __all__ = [
     "cache_requirements",
     "plan",
     "bind",
+    "prewarm",
     "run",
     "is_supported",
 ]

--- a/tests/attention/test_benchmark_qsa.py
+++ b/tests/attention/test_benchmark_qsa.py
@@ -292,7 +292,7 @@ def test_benchmark_calls_only_the_public_qsa_lifecycle() -> None:
     )
 
 
-def test_sparse_gqa_has_no_triton_alternate() -> None:
+def test_sparse_gqa_implementation_modules_are_imported_lazily() -> None:
     repository = Path(benchmark_qsa.__file__).resolve().parents[1]
     source = textwrap.dedent(
         """
@@ -302,12 +302,15 @@ def test_sparse_gqa_has_no_triton_alternate() -> None:
         from b12x.attention.qsa import _sparse_gqa
 
         cute_module = "b12x.attention.qsa._sparse_gqa_cute"
+        triton_module = "b12x.attention.qsa._sparse_gqa_triton"
         assert cute_module not in sys.modules
+        assert triton_module not in sys.modules
         source = inspect.getsource(_sparse_gqa).lower()
-        assert "triton" not in source
         assert "_cute_is_candidate" in source
+        assert "launch_sparse_paged_gqa_prefill" in source
         assert "notimplementederror" in source
         assert cute_module not in sys.modules
+        assert triton_module not in sys.modules
         """
     )
 

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -522,6 +522,52 @@ def test_qsa_plan_is_one_caller_owned_scratch_buffer() -> None:
     assert planned.caps.max_groups == 16
 
 
+def test_qsa_large_prefill_prewarm_preserves_bound_state() -> None:
+    device = require_sm120()
+    caps = qsa.Caps(
+        device=device,
+        max_batch=1,
+        max_raw_state_slots=1,
+        max_q_rows=65,
+        max_seq_len=64,
+        num_main_cache_pages=4,
+        num_compressed_cache_pages=4,
+        main_page_size=16,
+        compressed_page_size=4,
+        q_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        index_heads=4,
+        index_kv_heads=1,
+        index_head_dim=128,
+        index_rotary_dim=64,
+        compress_ratio=4,
+        budget=2048,
+    )
+    binding = _allocate_binding(caps)
+    tracked = (
+        binding.main_k_cache,
+        binding.main_v_cache,
+        binding.main_block_table,
+        binding.compressed_k_cache,
+        binding.compressed_block_table,
+        binding.raw_k_ring,
+        binding.raw_logical_positions,
+        binding.raw_rope_positions,
+        binding.raw_interval_start_positions,
+        binding.raw_state_slot_ids,
+    )
+    for tensor in tracked:
+        tensor.zero_()
+    before = tuple(tensor.clone() for tensor in tracked)
+
+    qsa.prewarm(binding)
+    torch.cuda.synchronize(device)
+
+    for actual, expected in zip(tracked, before, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
 def test_qsa_cache_requirements_are_pure_and_describe_shared_page_layout() -> None:
     requirements = qsa.cache_requirements(
         main_page_size=64,
@@ -731,8 +777,8 @@ def test_qsa_prefill_capacity_uses_full_row_workspace() -> None:
 
     assert decode.workspace_q_rows == 128
     assert prefill.workspace_q_rows == 4096
-    assert decode.max_split_row_product == 128 * 16
-    assert prefill.max_split_row_product == 4096 * 16
+    assert decode.max_split_row_product == 64 * 16
+    assert prefill.max_split_row_product == 64 * 16
 
 
 @pytest.mark.parametrize("rows", [1, 16, 32, 257, 513])

--- a/tests/attention/test_qsa_sparse_gqa.py
+++ b/tests/attention/test_qsa_sparse_gqa.py
@@ -269,9 +269,7 @@ def test_cute_candidate_accepts_all_qwen_rows_for_interleaved_blh_cache_views(
                 ),
                 torch.float32,
             ),
-            partial_lse=_CandidateTensor(
-                (rows, splits, q_heads), torch.float32
-            ),
+            partial_lse=_CandidateTensor((rows, splits, q_heads), torch.float32),
             block_n=cute_config.BLOCK_N,
             splits=splits,
         )
@@ -279,7 +277,7 @@ def test_cute_candidate_accepts_all_qwen_rows_for_interleaved_blh_cache_views(
     )
 
 
-def test_qwen_split_policy_does_not_route_large_rows_to_triton() -> None:
+def test_qwen_split_policy_uses_unsplit_large_rows() -> None:
     caps = SimpleNamespace(
         q_heads=12,
         kv_heads=1,
@@ -291,6 +289,8 @@ def test_qwen_split_policy_does_not_route_large_rows_to_triton() -> None:
     assert _target_splits(caps, 1) == (16, 64)
     assert _target_splits(caps, 4) == (16, 32)
     assert _target_splits(caps, 32) == (16, 16)
+    assert _target_splits(caps, 64) == (16, 16)
+    assert _target_splits(caps, 65) == (16, 1)
 
     with pytest.raises(NotImplementedError, match="requires the CuTe Qwen"):
         _target_splits(
@@ -395,10 +395,10 @@ def test_non_qwen_geometry_has_no_sparse_gqa_fallback(
         "splits",
         "layout",
     ),
-        [
-            (1, 24, 2, 256, 16, 2051, 16, 64, "contiguous"),
-            (1, 8, 2, 256, 16, 2051, 16, 64, "contiguous"),
-            (1, 6, 1, 256, 16, 2051, 16, 64, "interleaved_page"),
+    [
+        (1, 24, 2, 256, 16, 2051, 16, 64, "contiguous"),
+        (1, 8, 2, 256, 16, 2051, 16, 64, "contiguous"),
+        (1, 6, 1, 256, 16, 2051, 16, 64, "interleaved_page"),
         (5, 12, 1, 256, 16, 2051, 16, 64, "interleaved_page"),
     ],
 )
@@ -511,6 +511,175 @@ def test_sparse_gqa_matches_gathered_dense_reference(
         softmax_scale,
     )
     torch.testing.assert_close(actual, expected, rtol=0.0, atol=2e-2)
+
+
+@pytest.mark.parametrize("page_size", [16, 3008])
+@pytest.mark.parametrize(
+    "kv_dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8_e4m3"],
+)
+def test_large_prefill_sparse_gqa_addresses_paged_cache(
+    page_size: int,
+    kv_dtype: torch.dtype,
+) -> None:
+    device = require_sm120()
+    rows, q_heads, kv_heads, head_dim = 65, 24, 2, 256
+    pages, batches = 4, 2
+    storage = torch.randn(
+        (pages, 2, page_size, kv_heads, head_dim),
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(kv_dtype)
+    key_cache, value_cache = storage.unbind(1)
+    block_table = torch.tensor([[2, 0], [1, 3]], dtype=torch.int32, device=device)
+    request_ids = torch.arange(rows, dtype=torch.int64, device=device) % batches
+    request_ids[-1] = -1
+    query_positions = torch.zeros(rows, dtype=torch.int64, device=device)
+    selected_positions = torch.full((rows, 2051), -1, dtype=torch.int32, device=device)
+    selected_positions[:, 0] = 0
+    query = torch.randn((rows, q_heads, head_dim), dtype=torch.bfloat16, device=device)
+    output = torch.full_like(query, float("nan"))
+    k_descale = None
+    v_descale = None
+    value_scale = 1.0
+    if kv_dtype == torch.float8_e4m3fn:
+        k_descale = torch.tensor([0.125], dtype=torch.float32, device=device)
+        v_descale = torch.tensor([0.125], dtype=torch.float32, device=device)
+        value_scale = float(v_descale)
+
+    actual = launch_sparse_paged_gqa(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        block_table=block_table,
+        request_ids=request_ids,
+        selected_positions=selected_positions,
+        query_positions=query_positions,
+        output=output,
+        partial_output=None,
+        partial_lse=None,
+        softmax_scale=1.0 / math.sqrt(head_dim),
+        block_n=16,
+        splits=1,
+    )
+
+    expected = torch.zeros_like(query)
+    heads_per_kv = q_heads // kv_heads
+    for row in range(rows - 1):
+        request = int(request_ids[row])
+        physical_page = int(block_table[request, 0])
+        expected[row].copy_(
+            (value_cache[physical_page, 0].float() * value_scale)
+            .repeat_interleave(heads_per_kv, dim=0)
+            .to(torch.bfloat16)
+        )
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=2e-3)
+
+
+@pytest.mark.parametrize(
+    "kv_dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8_e4m3"],
+)
+def test_large_prefill_sparse_gqa_matches_cute_for_full_selection(
+    kv_dtype: torch.dtype,
+) -> None:
+    from b12x.attention.qsa._sparse_gqa_cute import (
+        launch_sparse_gqa_merge,
+        launch_sparse_gqa_split,
+    )
+    from b12x.attention.qsa._sparse_gqa_triton import (
+        launch_sparse_paged_gqa_prefill,
+    )
+
+    device = require_sm120()
+    rows, q_heads, kv_heads, head_dim = 65, 24, 2, 256
+    page_size, pages, selection_width = 3008, 4, 2051
+    generator = torch.Generator(device="cpu").manual_seed(93865)
+    source = torch.randn(
+        (pages, 2, page_size, kv_heads, head_dim),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cpu",
+    ).to(device)
+    k_descale = None
+    v_descale = None
+    if kv_dtype == torch.float8_e4m3fn:
+        k_descale = torch.tensor([0.125], dtype=torch.float32, device=device)
+        v_descale = torch.tensor([0.125], dtype=torch.float32, device=device)
+        storage = torch.empty_like(source, dtype=kv_dtype)
+        storage[:, 0].copy_((source[:, 0].float() / k_descale).to(kv_dtype))
+        storage[:, 1].copy_((source[:, 1].float() / v_descale).to(kv_dtype))
+    else:
+        storage = source
+    key_cache, value_cache = storage.unbind(1)
+    block_table = torch.arange(pages, dtype=torch.int32, device=device).view(1, -1)
+    request_ids = torch.zeros(rows, dtype=torch.int64, device=device)
+    query_positions = torch.full(
+        (rows,), pages * page_size - 1, dtype=torch.int64, device=device
+    )
+    selected = torch.randperm(
+        pages * page_size, generator=generator, dtype=torch.int64
+    )[:selection_width]
+    selected_positions = (
+        selected.to(device=device, dtype=torch.int32)
+        .view(1, -1)
+        .expand(rows, -1)
+        .contiguous()
+    )
+    query = torch.randn(
+        (rows, q_heads, head_dim),
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cpu",
+    ).to(device)
+    triton_output = torch.empty_like(query)
+    cute_output = torch.empty_like(query)
+    split_output = torch.empty(
+        (rows, 16, q_heads, head_dim), dtype=torch.float32, device=device
+    )
+    split_lse = torch.empty((rows, 16, q_heads), dtype=torch.float32, device=device)
+    scale = 1.0 / math.sqrt(head_dim)
+
+    launch_sparse_paged_gqa_prefill(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        block_table=block_table,
+        request_ids=request_ids,
+        selected_positions=selected_positions,
+        query_positions=query_positions,
+        output=triton_output,
+        softmax_scale=scale,
+    )
+    launch_sparse_gqa_split(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        block_table=block_table,
+        request_ids=request_ids,
+        selected_positions=selected_positions,
+        query_positions=query_positions,
+        partial_output=split_output,
+        partial_lse=split_lse,
+        softmax_scale=scale,
+        splits=16,
+    )
+    launch_sparse_gqa_merge(
+        partial_output=split_output,
+        partial_lse=split_lse,
+        output=cute_output,
+        rows=rows,
+        splits=16,
+    )
+    torch.testing.assert_close(triton_output, cute_output, rtol=0.0, atol=3e-2)
 
 
 def test_sparse_gqa_matches_reference_for_1504_token_pages() -> None:


### PR DESCRIPTION
## Purpose

Execute Qwen3.8-Flash-Next QSA prefill without allocating split-attention scratch proportional to the prefill row count.

## Behavior

- QSA batches of at most 64 query rows retain the existing split CuTe implementation. This preserves the qualified decode path.
- Larger batches use a B12X-owned Triton sparse paged-GQA kernel. The kernel reads BF16 or globally scaled FP8 E4M3 K/V through the existing page table and writes directly into caller-owned output storage.
- Split-attention scratch is bounded by the 64-row CuTe envelope instead of the maximum prefill batch.
- `qsa.prewarm(binding, rows=...)` compiles an exact large-prefill specialization with invalid request IDs, so it cannot read or mutate persistent cache state.
- Unsupported model geometry continues to fail closed.

## Compatibility

The public QSA lifecycle gains the optional `prewarm` operation. Existing callers that use `Caps -> plan -> bind -> run` remain valid. The large-row kernel supports the Qwen production geometry and both supported main-cache dtypes; other geometry is rejected by the existing contract.

## Validation

Status: **qualified** for Qwen3.8-Flash-Next TP1 with MTP3 on one NVIDIA RTX PRO 6000 Blackwell GPU.

Focused B12X validation passed 10 tests covering:

- BF16 and FP8 paged addressing with page sizes 16 and 3008;
- numerical parity with the CuTe implementation;
- prewarm preservation of persistent selector state and cache data;
- split policy, bounded scratch capacity, and lazy imports.

The companion vLLM QSA-plan change was tested end to end with model revision `b797d2e1160b9596b2570e56c1d3590faa09d4ed`, FP8 KV cache, `max_num_batched_tokens=6019`, `max_num_seqs=4`, and a 32,768-token prompt. One JIT warmup request was excluded and five measured requests were used.

| Stack | Median wall prefill | Median engine prefill |
|---|---:|---:|
| vLLM `c085b910ebd` + B12X `1a7e3ec2` | 6,978 tok/s | 7,014 tok/s |
| companion vLLM branch + this branch | 16,593 tok/s | 16,788 tok/s |

The combined result is +137.8% wall throughput and +139.4% engine throughput on the same GPU and launch configuration.

## Dependency

[vLLM #633](https://github.com/local-inference-lab/vllm/pull/633) calls `qsa.prewarm` and selects bounded context plans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- QSA prefill uses the CuTe split implementation for up to 64 query rows.
- Larger prefills use a Triton sparse paged-GQA kernel with BF16 and globally scaled FP8 K/V support.
- Split-attention scratch allocation remains bounded to the 64-row geometry.
- Added `qsa.prewarm(binding, rows=...)` to compile large-prefill specializations without reading or modifying persistent cache state.
- Unsupported model geometries continue to fail closed.
- Existing `Caps -> plan -> bind -> run` callers remain compatible.

## Validation

- Verified paged-cache addressing, BF16 and FP8 numerical parity, full-selection parity with CuTe, split policy, bounded scratch capacity, prewarm state preservation, and lazy implementation imports.
- Qwen3.8-Flash-Next TP1 validation measured median throughput increases of 137.8% in wall time and 139.4% in engine time against the baseline stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->