### PR TITLE
comm.roce: size the all-gather grid like the all-reduce

### DIFF
--- a/b12x/comm/roce/_allgather_cute.py
+++ b/b12x/comm/roce/_allgather_cute.py
@@ -11,6 +11,11 @@ replaced by a strided copy that writes the concatenated output directly:
 
 The local shard is copied from the input; peer shards are read in place from
 the NIC-written slots with system-scope loads.
+
+Launch grid and message size are runtime scalars.  The host picks a
+power-of-two grid from the shard size and hands the kernel that grid's own
+staging and tail counters, so small gathers do not pay for the full grid and
+gathers may interleave with reductions of any size inside one CUDA graph.
 """
 
 from __future__ import annotations
@@ -169,11 +174,13 @@ class _RoceAllGatherLaunch:
                     words[3],
                 )
                 stage_index += stride
-            fence_sc_sys()
             cute.arch.sync_threads()
 
-            # 2. the last block to finish staging rings the proxy doorbell
+            # 2. the last block to finish staging rings the proxy doorbell.  One
+            # system fence per block after the barrier (cumulative over the
+            # staging stores the barrier ordered) replaces one per thread.
             if Int32(tidx) == Int32(0):
+                fence_sc_sys()
                 prior = atomic_add_relaxed_gpu_u32(stage_counter_ptr, Uint32(1))
                 if (prior + Uint32(1)) % Uint32(gdim) == Uint32(0):
                     st_relaxed_sys_u32(ctrl_base + Int64(4), Uint32(nbytes))
@@ -325,7 +332,7 @@ def get_launcher(
         1,
         1,
         current_cuda_stream(),
-        compile_spec=KernelCompileSpec.from_key("comm.roce.allgather", 3, cache_key),
+        compile_spec=KernelCompileSpec.from_key("comm.roce.allgather", 4, cache_key),
     )
 
     def run(

--- a/b12x/comm/roce/roce_oneshot.py
+++ b/b12x/comm/roce/roce_oneshot.py
@@ -826,7 +826,12 @@ class RoceOneshotAllReduce:
                 "RoCE all-gather launcher must be prepared before CUDA graph capture"
             )
         launcher = _allgather_cute.get_launcher(*key)
-        stage_counter, tail_counter = self._counter_addresses(self._blocks)
+        # Same size-aware geometry as the all-reduce: a small shard (top-k
+        # values and ids, MTP logits) launches a few blocks instead of the
+        # full grid, and each power-of-two grid has its own arrival counters
+        # so gathers and reductions of any size may interleave in one graph.
+        grid_blocks = _grid_blocks(nbytes // PACK_BYTES, self._threads, self._blocks)
+        stage_counter, tail_counter = self._counter_addresses(grid_blocks)
         launcher(
             input_address,
             output_address,
@@ -843,7 +848,7 @@ class RoceOneshotAllReduce:
             tail_counter,
             self._poison_address,
             self.spin_limit,
-            self._blocks,
+            grid_blocks,
         )
         if not capturing:
             self.check_health()

--- a/tests/comm/test_roce_oneshot_gpu.py
+++ b/tests/comm/test_roce_oneshot_gpu.py
@@ -584,6 +584,78 @@ def test_all_gather_rejects_ineligible(runtime):
             )
 
 
+def test_all_gather_graph_replay_with_alternating_grid_sizes(runtime):
+    """Tiny (top-k) and large (logits) gathers may alternate in one graph.
+
+    The gather grid follows the shard size like the all-reduce grid, and each
+    power-of-two grid owns its arrival counters, so a one-block gather may sit
+    between full-grid gathers and reductions without sharing arrivals.
+    """
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    topk = torch.zeros(8, 64, dtype=torch.float32, device=runtime.device)
+    logits = torch.zeros(8, 38720, dtype=torch.bfloat16, device=runtime.device)
+    h = torch.zeros(8 * 4096, dtype=torch.bfloat16, device=runtime.device)
+    topk_out = torch.empty(8, 64 * world, dtype=torch.float32, device=runtime.device)
+    logits_out = torch.empty(
+        8, 38720 * world, dtype=torch.bfloat16, device=runtime.device
+    )
+    reduced = torch.empty_like(h)
+    from b12x.comm.roce import roce_oneshot
+
+    small_grid = roce_oneshot._grid_blocks(
+        topk.numel() * topk.element_size() // roce_oneshot.PACK_BYTES,
+        runtime._threads,
+        runtime._blocks,
+    )
+    large_grid = roce_oneshot._grid_blocks(
+        logits.numel() * logits.element_size() // roce_oneshot.PACK_BYTES,
+        runtime._threads,
+        runtime._blocks,
+    )
+    assert small_grid == 1
+    assert large_grid > small_grid
+    stream = torch.cuda.Stream(device=runtime.device)
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        runtime.all_gather(topk, dim=-1, out=topk_out)
+        runtime.all_gather(logits, dim=-1, out=logits_out)
+        runtime.all_reduce(h, out=reduced)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream), runtime.capture(stream=stream):
+        runtime.all_gather(topk, dim=-1, out=topk_out)
+        runtime.all_gather(logits, dim=-1, out=logits_out)
+        runtime.all_gather(topk, dim=-1, out=topk_out)
+        runtime.all_reduce(h, out=reduced)
+        runtime.all_gather(topk, dim=-1, out=topk_out)
+    torch.cuda.synchronize()
+    dist.barrier()
+    for replay in range(24):
+        torch.manual_seed(31 * replay + rank)
+        topk.copy_(torch.randn_like(topk))
+        logits.copy_(torch.randn_like(logits))
+        h.copy_(torch.randn_like(h))
+        parts = [torch.empty_like(topk) for _ in range(world)]
+        dist.all_gather(parts, topk)
+        expected_topk = torch.cat(parts, dim=-1)
+        parts = [torch.empty_like(logits) for _ in range(world)]
+        dist.all_gather(parts, logits)
+        expected_logits = torch.cat(parts, dim=-1)
+        expected_reduce = h.clone()
+        dist.all_reduce(expected_reduce)
+        graph.replay()
+        torch.cuda.synchronize()
+        runtime.check_health()
+        assert torch.equal(topk_out, expected_topk)
+        assert torch.equal(logits_out, expected_logits)
+        torch.testing.assert_close(
+            reduced, expected_reduce, rtol=2e-2, atol=2e-2 * world
+        )
+
+
 def test_all_gather_graph_replay_mixed_with_all_reduce(runtime):
     """A captured graph mixing both collectives replays correctly."""
     world = dist.get_world_size()


### PR DESCRIPTION
## TL;DR

The all-gather always launched the full grid; the all-reduce has picked its grid from the message size since the DSV4 optimization (1a7e3ec). Small gathers therefore paid for eight blocks of staging, a system fence per thread, and a full-grid arrival on both counters.

Sizing the gather grid the same way makes small shards **~28% faster in graph mode** and leaves large shards untouched:

| shard | before | after | |
|---|---|---|---|
| 128 B (1x32 fp32) | 14.5 us | **10.5 us** | -28% |
| 1 KB (8x32) | 14.9 us | **10.9 us** | -27% |
| 4 KB (32x32) | 16.1 us | **11.5 us** | -29% |
| 8 KB (64x32) | 17.1 us | **12.5 us** | -27% |
| 464 KB (6x38720 bf16 logits) | 88.9 us | 89.5 us | parity |
| 1.2 MB (16x38720 bf16 logits) | 207.6 us | 207.7 us | parity |

Graph-captured, cross-rank median-of-slowest, TP4 over the RoCE fabric. Eager gathers improve ~6% at the same sizes. On the smallest shard the NCCL-graph-over-RoCEnante-graph ratio goes 2.2x -> 2.8x.

## What changed

- `_launch_gather` picks its grid with `_grid_blocks(nbytes // PACK_BYTES, threads, blocks)`, the same helper the all-reduce uses, and passes it as the runtime `grid_x` scalar the launcher already accepted.
- It takes that grid's own staging and tail counters via `_counter_addresses(grid_blocks)` instead of always using the top counter class, so gathers and reductions of any size may interleave inside one CUDA graph without sharing arrivals. This is the invariant 1a7e3ec established for the all-reduce; the gather was still on the old shared-counter assumption.
- The staging fence moves from one `fence_sc_sys()` per thread to one per block, after the barrier that already orders the staging stores, mirroring the all-reduce kernel.
- Kernel cache version bumped 3 -> 4.

## Why this shape matters now

vLLM's vocab-parallel top-k gathers a shard of `[batch, 2k]`, which for the GLM-5.3 DFlash candidate selector (`selector_top_k=16`) is 128 bytes per rank, and it runs on every draft step inside the decode graph. That is the far-left column of the table. Nothing in the large-message path changes.

## Tests

- New `test_all_gather_graph_replay_with_alternating_grid_sizes`: captures a graph that alternates a one-block gather with full-grid gathers and an all-reduce, replays it 24 times, and checks the gathers bit-exact against NCCL and the reduction within tolerance. It also asserts the small shard actually resolves to a one-block grid, so the test would fail if the geometry silently reverted.
- Full `tests/comm/test_roce_oneshot_gpu.py` under torchrun on a 4-node DGX Spark cluster (GB10, dual-rail ConnectX-7 RoCE): **74 passed, 1 skipped on all four ranks**.
- `benchmarks/benchmark_roce_oneshot.py` correctness gates run before and after timing on every row (all-gather is required to be bit-exact against NCCL); the numbers above come from those receipts.

## Risk

The launcher already took `grid_x` as a runtime scalar and the counter file already reserved a stage/tail pair per power-of-two grid class, so this is a host-side selection change plus a fence move; no new device state. The one behavioral assumption is that `_grid_blocks` returns a power of two within `blocks`, which `_counter_addresses` requires and which it enforces by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

RoCE all-gather now selects its launch grid from shard size through `_grid_blocks`. Small shards use fewer blocks, while large shards retain full-grid behavior. Staging and tail counters use the selected grid.

Each block now issues one system fence after the staging barrier instead of one fence per thread. The all-gather compile specification cache version is now 4.

This reduces overhead for 128 B–8 KB shards without changing large-shard behavior. Graph replay coverage verifies alternating one-block gathers, full-grid gathers, and all-reduces. The RoCE test suite passed 74 tests with one skip on all four ranks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->