### PR TITLE
fix(moe): refresh FC1 fragment aliases after sub-128 FC2

### DIFF
--- a/b12x/moe/_shared/kernels/dynamic.py
+++ b/b12x/moe/_shared/kernels/dynamic.py
@@ -1001,15 +1001,14 @@ class MoEDynamicKernelBackend:
         # element per byte, so the same 128-byte row is sf_vec_size*4 elements.
         tile_k = sf_vec_size * 4 if self.is_w6a8 else sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
-        # Scale-factor tiles are 128-row atoms in hardware.  The native NVFP4
-        # payload itself does not need to inherit that 128-row capacity: route
-        # compaction already makes every task's tile_m rows contiguous.  Keep
-        # only the live payload rows in sA while retaining the complete SFA
-        # atom below.  At decode M16 this removes 14 KiB from a two-stage CTA
-        # without changing the scale-factor or MMA contracts.
+        # Scale-factor tiles are 128-row atoms in hardware.  Native NVFP4
+        # consumes only the compact route tile in sA while retaining the
+        # complete SFA atom below.  Swapped FC1 addresses multiple row slices
+        # through the established 128-row sA contract and retains that
+        # capacity.
         a_tile_m = (
             mma_tiler_mn[0]
-            if self.quant_recipe == "nvfp4"
+            if self.quant_recipe == "nvfp4" and not self.swap_ab
             else max(128, mma_tiler_mn[0])
         )
         self.sa_tile_shape_mk = (a_tile_m, tile_k)

--- a/b12x/moe/_shared/kernels/dynamic.py
+++ b/b12x/moe/_shared/kernels/dynamic.py
@@ -984,17 +984,35 @@ class MoEDynamicKernelBackend:
         self.separate_w13_halves = bool(separate_w13_halves) and self.is_gated
         if self.separate_w13_halves and self.swap_ab:
             raise ValueError("separate_w13_halves and swap_ab are mutually exclusive")
+        self.w4a4_fc1_fused = bool(
+            quant_recipe == "nvfp4"
+            and self.is_gated
+            and not self.swap_ab
+            and not self.separate_w13_halves
+            and mma_tiler_mn[0] <= 32
+        )
+        # FC1 swap produce-tile width (intermediate cols per swapped MMA tile).
+        # 32: for any 32-aligned n the gate-half base n%128 in {0,32,64,96}, so
+        # offset+32 <= 128 always fits one 128-row SF atom; and tile_m=32 keeps
+        # the base atom_shape (2,2,1)/4-warps, so FC1 and FC2 share warp count.
         self._fc1_int_tile = 32
         # FP4 packs two elements per byte, so its K-tile is sf_vec_size*8 with
         # a 64-byte SW atom; the FP6/FP8 byte-container path carries one
         # element per byte, so the same 128-byte row is sf_vec_size*4 elements.
         tile_k = sf_vec_size * 4 if self.is_w6a8 else sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
-        # Scale-factor tiles are 128-row atoms in hardware. For sub-128 MMA
-        # tiles (e.g. tile_m=64) one SF atom backs several MMA tiles, so the
-        # TMA atom + smem are built at max(128, tile) and the kernel offsets
-        # into the shared block by `*_tiles_per_block` (mirrors dense.py).
-        self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
+        # Scale-factor tiles are 128-row atoms in hardware.  The native NVFP4
+        # payload itself does not need to inherit that 128-row capacity: route
+        # compaction already makes every task's tile_m rows contiguous.  Keep
+        # only the live payload rows in sA while retaining the complete SFA
+        # atom below.  At decode M16 this removes 14 KiB from a two-stage CTA
+        # without changing the scale-factor or MMA contracts.
+        a_tile_m = (
+            mma_tiler_mn[0]
+            if self.quant_recipe == "nvfp4"
+            else max(128, mma_tiler_mn[0])
+        )
+        self.sa_tile_shape_mk = (a_tile_m, tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
         self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
@@ -2772,11 +2790,16 @@ class MoEDynamicKernelBackend:
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
+        up_tx_count = (
+            phase2_tma_copy_bytes
+            if self.w4a4_fc1_fused
+            else tma_copy_bytes
+        )
         up_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
             producer_group=prod_group,
             consumer_group=cons_group,
-            tx_count=tma_copy_bytes,
+            tx_count=up_tx_count,
             barrier_storage=storage.up_pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
@@ -2798,6 +2821,10 @@ class MoEDynamicKernelBackend:
         cute.arch.sync_threads()
 
         sA = storage.sA.get_tensor(a_smem_staged.outer, swizzle=a_smem_staged.inner)
+        # Raw base is also used by compact native-NVFP4 requant stores.  Keep
+        # it outside the W6A8-only branch so staged control flow sees a stable
+        # value in every specialization.
+        sa_base_addr = shared_ptr_to_u32(storage.sA.data_ptr())
         sB = storage.sB.get_tensor(b_smem_staged.outer, swizzle=b_smem_staged.inner)
         sB_up = storage.sB_up.get_tensor(
             b_smem_staged.outer, swizzle=b_smem_staged.inner
@@ -2819,7 +2846,6 @@ class MoEDynamicKernelBackend:
             # Raw sA base for the FC2 requant byte-container store (the
             # swizzled Float8 A stage; upstream nvfp4 writes through the
             # recast tensor, whose swizzle-free view only fits the FP4 math).
-            sa_base_addr = shared_ptr_to_u32(storage.sA.data_ptr())
         sSFA = storage.sSFA.get_tensor(sfa_smem_staged)
         sSFB = storage.sSFB.get_tensor(sfb_smem_staged)
         sSFB_up = storage.sSFB_up.get_tensor(sfb_smem_staged)
@@ -4282,6 +4308,9 @@ class MoEDynamicKernelBackend:
         tCrSFB = self._dense_cls._partition_fragment_SFB(
             self, sSFB[None, None, 0], thr_mma, tidx
         )
+        if cutlass.const_expr(self.w4a4_fc1_fused):
+            tCrB_up_fused = cute.make_fragment_like(tCrB)
+            tCrSFB_up_fused = cute.make_fragment_like(tCrSFB)
 
         tCsC_for_shape = thr_mma.partition_C(sC[None, None, 0])
         epi_m_scale = self.tile_shape_mnk[0] // self.epi_tile[0]
@@ -4361,6 +4390,8 @@ class MoEDynamicKernelBackend:
         csB = thr_ld_B.partition_S(sB)
         csB_up = thr_ld_B.partition_S(sB_up)
         crB = thr_ld_B.retile(tCrB)
+        if cutlass.const_expr(self.w4a4_fc1_fused):
+            crB_up_fused = thr_ld_B.retile(tCrB_up_fused)
 
         thr_ld_SFA = smem_copy_SFA.get_slice(tidx)
         thr_ld_SFB = smem_copy_SFB.get_slice(tidx)
@@ -4370,6 +4401,15 @@ class MoEDynamicKernelBackend:
         else:
             csSFA = thr_ld_SFA.partition_S(sSFA_part)
             crSFA = thr_ld_SFA.retile(tCrSFA)
+        # Keep the generic fragments as defaults for non-fused specializations.
+        # The fused W4A4 specialization replaces these aliases below with a
+        # single-live-slot fragment.  Defining them before any staged control
+        # flow also makes the specialization valid when full graph capture
+        # compiles both fused and non-fused token-capacity variants.
+        tCrA_fc1_cur = tCrA
+        crA_fc1_cur = crA
+        tCrSFA_fc1_cur = tCrSFA
+        crSFA_fc1_cur = crSFA
         csSFB = thr_ld_SFB.partition_S(sSFB)
         csSFB_up = thr_ld_SFB.partition_S(sSFB_up)
         # The W4A8 mainloop decodes its B scale bytes directly and never uses
@@ -4380,6 +4420,16 @@ class MoEDynamicKernelBackend:
             crSFB = tCrSFB
         else:
             crSFB = thr_ld_SFB.retile(tCrSFB)
+            if cutlass.const_expr(self.w4a4_fc1_fused):
+                crSFB_up_fused = thr_ld_SFB.retile(tCrSFB_up_fused)
+                # Retile requires the complete MMA fragment shape, but only
+                # slot zero is live. Each source K block is rebound into this
+                # slot after the preceding MMA consumes it, avoiding an
+                # addressable two-block A fragment in thread-local memory.
+                tCrA_fc1_cur = cute.make_fragment_like(tCrA)
+                crA_fc1_cur = thr_ld_A.retile(tCrA_fc1_cur)
+                tCrSFA_fc1_cur = cute.make_fragment_like(tCrSFA)
+                crSFA_fc1_cur = thr_ld_SFA.retile(tCrSFA_fc1_cur)
 
         if cutlass.const_expr(self.swap_ab):
             # Swapped FC1 (dense.py swap_ab pattern): the gate/up weight (sB /
@@ -4808,32 +4858,39 @@ class MoEDynamicKernelBackend:
                 # 128-row atom. (FC2 re-slices at offset 0 before phase B, since
                 # its intermediate SF is quant-written to the atom's first half.)
                 if cutlass.const_expr(
-                    (not self.is_w4a8) and self.sfa_tiles_per_block > 1
+                    (not self.is_w4a8)
+                    and (
+                        self.sa_tiles_per_block > 1
+                        or self.sfa_tiles_per_block > 1
+                    )
                 ):
                     _fc1_off = task_m_tile_idx % Int32(self.sfa_tiles_per_block)
-                    _sA_il = cute.local_tile(
-                        sA,
-                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
-                        (_fc1_off, 0, None),
-                    )
-                    tCrA = tiled_mma.make_fragment_A(
-                        thr_mma.partition_A(_sA_il)[None, None, None, 0]
-                    )
-                    csA = thr_ld_A.partition_S(_sA_il)
-                    crA = thr_ld_A.retile(tCrA)
-                    _sSFA_il = cute.local_tile(
-                        sSFA,
-                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
-                        (_fc1_off, 0, None),
-                    )
-                    tCrSFA = self._dense_cls._partition_fragment_SFA(
-                        self,
-                        _sSFA_il[None, None, 0],
-                        thr_mma,
-                        tidx,
-                    )
-                    csSFA = thr_ld_SFA.partition_S(_sSFA_il)
-                    crSFA = thr_ld_SFA.retile(tCrSFA)
+                    if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                        _sA_il = cute.local_tile(
+                            sA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (_fc1_off, 0, None),
+                        )
+                        tCrA = tiled_mma.make_fragment_A(
+                            thr_mma.partition_A(_sA_il)[None, None, None, 0]
+                        )
+                        csA = thr_ld_A.partition_S(_sA_il)
+                        crA = thr_ld_A.retile(tCrA)
+                    if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                        _sSFA_il = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (_fc1_off, 0, None),
+                        )
+                        if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                            tCrSFA = self._dense_cls._partition_fragment_SFA(
+                                self,
+                                _sSFA_il[None, None, 0],
+                                thr_mma,
+                                tidx,
+                            )
+                        csSFA = thr_ld_SFA.partition_S(_sSFA_il)
+                        crSFA = thr_ld_SFA.retile(tCrSFA)
 
                 _is_m_major = self.c_layout.is_m_major_c()
                 copy_atom_r2s = cute.make_copy_atom(
@@ -4888,29 +4945,35 @@ class MoEDynamicKernelBackend:
                     if cutlass.const_expr(
                         self.deterministic_output
                         and (not self.is_w4a8)
-                        and self.sfa_tiles_per_block > 1
+                        and (
+                            self.sa_tiles_per_block > 1
+                            or self.sfa_tiles_per_block > 1
+                        )
                     ):
                         _fc1_off = task_m_tile_idx % Int32(self.sfa_tiles_per_block)
-                        _sA_il = cute.local_tile(
-                            sA,
-                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
-                            (_fc1_off, 0, None),
-                        )
-                        tCrA = tiled_mma.make_fragment_A(
-                            thr_mma.partition_A(_sA_il)[None, None, None, 0]
-                        )
-                        csA = thr_ld_A.partition_S(_sA_il)
-                        crA = thr_ld_A.retile(tCrA)
-                        _sSFA_il = cute.local_tile(
-                            sSFA,
-                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
-                            (_fc1_off, 0, None),
-                        )
-                        tCrSFA = self._dense_cls._partition_fragment_SFA(
-                            self, _sSFA_il[None, None, 0], thr_mma, tidx
-                        )
-                        csSFA = thr_ld_SFA.partition_S(_sSFA_il)
-                        crSFA = thr_ld_SFA.retile(tCrSFA)
+                        if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                            _sA_il = cute.local_tile(
+                                sA,
+                                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                                (_fc1_off, 0, None),
+                            )
+                            tCrA = tiled_mma.make_fragment_A(
+                                thr_mma.partition_A(_sA_il)[None, None, None, 0]
+                            )
+                            csA = thr_ld_A.partition_S(_sA_il)
+                            crA = thr_ld_A.retile(tCrA)
+                        if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                            _sSFA_il = cute.local_tile(
+                                sSFA,
+                                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                                (_fc1_off, 0, None),
+                            )
+                            if cutlass.const_expr(self.sa_tiles_per_block > 1):
+                                tCrSFA = self._dense_cls._partition_fragment_SFA(
+                                    self, _sSFA_il[None, None, 0], thr_mma, tidx
+                                )
+                            csSFA = thr_ld_SFA.partition_S(_sSFA_il)
+                            crSFA = thr_ld_SFA.retile(tCrSFA)
 
                     # ============================================================
                     # PHASE A: FC1 for this slice (gate/only pass, plus up for silu)
@@ -5195,16 +5258,46 @@ class MoEDynamicKernelBackend:
                                     values, block_max, _qgs
                                 )
                             packed_base = _sfb << Int32(3)
-                            dst_pcol = row & Int32(63)
-                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                            row_high = row >> Int32(6)
                             for byte_idx in cutlass.range_constexpr(8):
                                 src_pcol = packed_base + Int32(byte_idx)
-                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                                dst_flat = dst_row * packed_cols + dst_pcol
-                                sA_u8[dst_flat] = Uint8(
-                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                byte_val = Uint8(
+                                    (packed64 >> Uint64(byte_idx * 8))
+                                    & Uint64(0xFF)
                                 )
+                                if cutlass.const_expr(self.sa_tile_shape_mk[0] < 128):
+                                    # Compact M16/M32/M64 A uses the same
+                                    # byte-domain S<2,4,3> layout produced by
+                                    # the TMA descriptor: 64-byte logical rows
+                                    # with the 16-byte chunk XOR-swizzled by
+                                    # (row >> 1) & 3.  The old 128-major store
+                                    # below transposes K bytes across 128 rows
+                                    # and therefore writes outside this compact
+                                    # allocation.
+                                    src_chunk = src_pcol >> Int32(4)
+                                    src_in_chunk = src_pcol & Int32(15)
+                                    dst_chunk = src_chunk ^ (
+                                        (row >> Int32(1)) & Int32(3)
+                                    )
+                                    dst_flat = (
+                                        row * packed_cols
+                                        + (dst_chunk << Int32(4))
+                                        + src_in_chunk
+                                    )
+                                    # dst_flat is already the physical byte
+                                    # address.  Indexing the recast tensor here
+                                    # would apply its FP4 swizzle a second time.
+                                    st_shared_u8(sa_base_addr + dst_flat, byte_val)
+                                else:
+                                    dst_pcol = row & Int32(63)
+                                    xor_bits = (
+                                        (dst_pcol >> Int32(1)) & Int32(0x3)
+                                    ) << Int32(4)
+                                    row_high = row >> Int32(6)
+                                    dst_row = (
+                                        (src_pcol ^ xor_bits) << Int32(1)
+                                    ) + row_high
+                                    dst_flat = dst_row * packed_cols + dst_pcol
+                                    sA_u8[dst_flat] = byte_val
                             outer_m_idx = row % Int32(32)
                             inner_m_idx = row // Int32(32)
                             inner_k_idx = _sfb % Int32(4)
@@ -6346,10 +6439,21 @@ class MoEDynamicKernelBackend:
                         # Gate GEMM (inlined to avoid @cute.jit pass-by-value for acc)
                         fz_crSFA = cute.filter_zeros(crSFA)
                         fz_crSFB = cute.filter_zeros(crSFB)
+                        fz_crSFA_fc1_cur = fz_crSFA
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            fz_crSFA_fc1_cur = cute.filter_zeros(crSFA_fc1_cur)
+                            fz_crSFB_up = cute.filter_zeros(crSFB_up_fused)
+                            up_acc.fill(0.0)
                         gate_acc.fill(0.0)
                         cons_state.reset_count()
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            up_cons_state.reset_count()
                         peek = ml_pipeline.consumer_try_wait(cons_state)
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            up_peek = up_pipeline.consumer_try_wait(up_cons_state)
                         ml_pipeline.consumer_wait(cons_state, peek)
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            up_pipeline.consumer_wait(up_cons_state, up_peek)
                         if cutlass.const_expr(self.is_w6a8):
                             # Expand the TMA-staged 3:4-packed FP6 B tile in
                             # place into the swizzled byte-container sB stage
@@ -6369,20 +6473,58 @@ class MoEDynamicKernelBackend:
                         csB_p = csB[None, None, None, cons_state.index]
                         csSFA_p = csSFA[None, None, None, cons_state.index]
                         csSFB_p = csSFB[None, None, None, cons_state.index]
-                        cute.copy(smem_copy_A, csA_p[None, None, 0], crA[None, None, 0])
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            csB_up_p = csB_up[
+                                None, None, None, up_cons_state.index
+                            ]
+                            csSFB_up_p = csSFB_up[
+                                None, None, None, up_cons_state.index
+                            ]
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, 0],
+                                crA_fc1_cur[None, None, 0],
+                            )
+                        else:
+                            cute.copy(
+                                smem_copy_A,
+                                csA_p[None, None, 0],
+                                crA[None, None, 0],
+                            )
                         cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
                         fz_csSFA_p = cute.filter_zeros(csSFA_p)
                         fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, 0],
-                            fz_crSFA[None, None, 0],
-                        )
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            fz_csSFB_up_p = cute.filter_zeros(csSFB_up_p)
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, 0],
+                                fz_crSFA_fc1_cur[None, None, 0],
+                            )
+                        else:
+                            cute.copy(
+                                smem_copy_SFA,
+                                fz_csSFA_p[None, None, 0],
+                                fz_crSFA[None, None, 0],
+                            )
                         cute.copy(
                             smem_copy_SFB,
                             fz_csSFB_p[None, None, 0],
                             fz_crSFB[None, None, 0],
                         )
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            cute.copy(
+                                smem_copy_B,
+                                csB_up_p[None, None, 0],
+                                crB_up_fused[None, None, 0],
+                            )
+                            cute.copy(
+                                smem_copy_SFB,
+                                fz_csSFB_up_p[None, None, 0],
+                                fz_crSFB_up[None, None, 0],
+                            )
                         for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):
                             for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                                 k_next = (
@@ -6393,14 +6535,36 @@ class MoEDynamicKernelBackend:
                                 if k_block_idx == num_k_blocks - 1:
                                     ml_pipeline.consumer_release(cons_state)
                                     cons_state.advance()
+                                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                                        up_pipeline.consumer_release(up_cons_state)
+                                        up_cons_state.advance()
                                     peek = ml_pipeline.consumer_try_wait(cons_state)
+                                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                                        up_peek = up_pipeline.consumer_try_wait(
+                                            up_cons_state
+                                        )
                                     csA_p = csA[None, None, None, cons_state.index]
                                     csB_p = csB[None, None, None, cons_state.index]
                                     csSFA_p = csSFA[None, None, None, cons_state.index]
                                     csSFB_p = csSFB[None, None, None, cons_state.index]
+                                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                                        csB_up_p = csB_up[
+                                            None, None, None, up_cons_state.index
+                                        ]
+                                        csSFB_up_p = csSFB_up[
+                                            None, None, None, up_cons_state.index
+                                        ]
                                     fz_csSFA_p = cute.filter_zeros(csSFA_p)
                                     fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                                        fz_csSFB_up_p = cute.filter_zeros(
+                                            csSFB_up_p
+                                        )
                                     ml_pipeline.consumer_wait(cons_state, peek)
+                                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                                        up_pipeline.consumer_wait(
+                                            up_cons_state, up_peek
+                                        )
                                     if cutlass.const_expr(self.is_w6a8):
                                         # The stage just became full (packed
                                         # bytes only); expand before this
@@ -6435,7 +6599,9 @@ class MoEDynamicKernelBackend:
                                         else:
                                             mma_atom.set(
                                                 WarpField.SFA,
-                                                tCrSFA[None, _mt, k_block_idx].iterator,
+                                                tCrSFA_fc1_cur[
+                                                    None, _mt, 0
+                                                ].iterator,
                                             )
                                             mma_atom.set(
                                                 WarpField.SFB,
@@ -6444,20 +6610,50 @@ class MoEDynamicKernelBackend:
                                             cute.gemm(
                                                 mma_atom,
                                                 gate_acc[None, _mt, _nt],
-                                                tCrA[None, _mt, k_block_idx],
+                                                tCrA_fc1_cur[None, _mt, 0],
                                                 tCrB[None, _nt, k_block_idx],
                                                 gate_acc[None, _mt, _nt],
                                             )
+                                            if cutlass.const_expr(
+                                                self.w4a4_fc1_fused
+                                            ):
+                                                mma_atom.set(
+                                                    WarpField.SFA,
+                                                    tCrSFA_fc1_cur[
+                                                        None, _mt, 0
+                                                    ].iterator,
+                                                )
+                                                mma_atom.set(
+                                                    WarpField.SFB,
+                                                    tCrSFB_up_fused[
+                                                        None, _nt, k_block_idx
+                                                    ].iterator,
+                                                )
+                                                cute.gemm(
+                                                    mma_atom,
+                                                    up_acc[None, _mt, _nt],
+                                                    tCrA_fc1_cur[None, _mt, 0],
+                                                    tCrB_up_fused[
+                                                        None, _nt, k_block_idx
+                                                    ],
+                                                    up_acc[None, _mt, _nt],
+                                                )
                                 cute.copy(
                                     smem_copy_A,
                                     csA_p[None, None, k_next],
-                                    crA[None, None, k_next],
+                                    crA_fc1_cur[None, None, 0],
                                 )
                                 cute.copy(
                                     smem_copy_B,
                                     csB_p[None, None, k_next],
                                     crB[None, None, k_next],
                                 )
+                                if cutlass.const_expr(self.w4a4_fc1_fused):
+                                    cute.copy(
+                                        smem_copy_B,
+                                        csB_up_p[None, None, k_next],
+                                        crB_up_fused[None, None, k_next],
+                                    )
                                 fz_csSFA_cur = cute.filter_zeros(
                                     csSFA[None, None, None, cons_state.index]
                                 )
@@ -6467,13 +6663,19 @@ class MoEDynamicKernelBackend:
                                 cute.copy(
                                     smem_copy_SFA,
                                     fz_csSFA_cur[None, None, k_next],
-                                    fz_crSFA[None, None, k_next],
+                                    fz_crSFA_fc1_cur[None, None, 0],
                                 )
                                 cute.copy(
                                     smem_copy_SFB,
                                     fz_csSFB_cur[None, None, k_next],
                                     fz_crSFB[None, None, k_next],
                                 )
+                                if cutlass.const_expr(self.w4a4_fc1_fused):
+                                    cute.copy(
+                                        smem_copy_SFB,
+                                        fz_csSFB_up_p[None, None, k_next],
+                                        fz_crSFB_up[None, None, k_next],
+                                    )
                         for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                             k_next = (
                                 0
@@ -6483,27 +6685,32 @@ class MoEDynamicKernelBackend:
                             if k_block_idx == num_k_blocks - 1:
                                 ml_pipeline.consumer_release(cons_state)
                                 cons_state.advance()
+                                if cutlass.const_expr(self.w4a4_fc1_fused):
+                                    up_pipeline.consumer_release(up_cons_state)
+                                    up_cons_state.advance()
                             if k_next > 0 and fc1_k_tile_cnt > Int32(0):
-                                cute.copy(
-                                    smem_copy_A,
-                                    csA_p[None, None, k_next],
-                                    crA[None, None, k_next],
-                                )
                                 cute.copy(
                                     smem_copy_B,
                                     csB_p[None, None, k_next],
                                     crB[None, None, k_next],
                                 )
-                                cute.copy(
-                                    smem_copy_SFA,
-                                    fz_csSFA_p[None, None, k_next],
-                                    fz_crSFA[None, None, k_next],
-                                )
+                                if cutlass.const_expr(self.w4a4_fc1_fused):
+                                    cute.copy(
+                                        smem_copy_B,
+                                        csB_up_p[None, None, k_next],
+                                        crB_up_fused[None, None, k_next],
+                                    )
                                 cute.copy(
                                     smem_copy_SFB,
                                     fz_csSFB_p[None, None, k_next],
                                     fz_crSFB[None, None, k_next],
                                 )
+                                if cutlass.const_expr(self.w4a4_fc1_fused):
+                                    cute.copy(
+                                        smem_copy_SFB,
+                                        fz_csSFB_up_p[None, None, k_next],
+                                        fz_crSFB_up[None, None, k_next],
+                                    )
                             for _mt in cutlass.range_constexpr(fc1_m_tiles):
                                 for _nt in cutlass.range_constexpr(fc1_n_tiles):
                                     if cutlass.const_expr(self.is_w6a8):
@@ -6523,7 +6730,7 @@ class MoEDynamicKernelBackend:
                                     else:
                                         mma_atom.set(
                                             WarpField.SFA,
-                                            tCrSFA[None, _mt, k_block_idx].iterator,
+                                            tCrSFA_fc1_cur[None, _mt, 0].iterator,
                                         )
                                         mma_atom.set(
                                             WarpField.SFB,
@@ -6532,15 +6739,50 @@ class MoEDynamicKernelBackend:
                                         cute.gemm(
                                             mma_atom,
                                             gate_acc[None, _mt, _nt],
-                                            tCrA[None, _mt, k_block_idx],
+                                            tCrA_fc1_cur[None, _mt, 0],
                                             tCrB[None, _nt, k_block_idx],
                                             gate_acc[None, _mt, _nt],
                                         )
+                                        if cutlass.const_expr(
+                                            self.w4a4_fc1_fused
+                                        ):
+                                            mma_atom.set(
+                                                WarpField.SFA,
+                                                tCrSFA_fc1_cur[
+                                                    None, _mt, 0
+                                                ].iterator,
+                                            )
+                                            mma_atom.set(
+                                                WarpField.SFB,
+                                                tCrSFB_up_fused[
+                                                    None, _nt, k_block_idx
+                                                ].iterator,
+                                            )
+                                            cute.gemm(
+                                                mma_atom,
+                                                up_acc[None, _mt, _nt],
+                                                tCrA_fc1_cur[None, _mt, 0],
+                                                tCrB_up_fused[
+                                                    None, _nt, k_block_idx
+                                                ],
+                                                up_acc[None, _mt, _nt],
+                                            )
+                            if k_next > 0 and fc1_k_tile_cnt > Int32(0):
+                                cute.copy(
+                                    smem_copy_A,
+                                    csA_p[None, None, k_next],
+                                    crA_fc1_cur[None, None, 0],
+                                )
+                                cute.copy(
+                                    smem_copy_SFA,
+                                    fz_csSFA_p[None, None, k_next],
+                                    fz_crSFA_fc1_cur[None, None, 0],
+                                )
                         # Signal FC1 gate/only completion before producer warps
                         # reuse the shared A/gate buffers for the next pass.
                         self.pass_gate_barrier.arrive_unaligned()
 
-                        if self.is_gated:
+                        if self.is_gated and not self.w4a4_fc1_fused:
                             # Up GEMM (inlined, same pattern)
                             up_acc.fill(0.0)
                             up_cons_state.reset_count()
@@ -6973,22 +7215,41 @@ class MoEDynamicKernelBackend:
                                             values, block_max, quant_gs_value
                                         )
                                     packed_base = sf_block << Int32(3)
-                                    dst_pcol = row & Int32(63)
-                                    xor_bits = (
-                                        (dst_pcol >> Int32(1)) & Int32(0x3)
-                                    ) << Int32(4)
-                                    row_high = row >> Int32(6)
                                     for byte_idx in cutlass.range_constexpr(8):
                                         src_pcol = packed_base + Int32(byte_idx)
-                                        dst_row = (
-                                            (src_pcol ^ xor_bits) << Int32(1)
-                                        ) + row_high
-                                        dst_flat = dst_row * packed_cols + dst_pcol
                                         byte_val = Uint8(
                                             (packed64 >> Uint64(byte_idx * 8))
                                             & Uint64(0xFF)
                                         )
-                                        sA_u8[dst_flat] = byte_val
+                                        if cutlass.const_expr(
+                                            self.sa_tile_shape_mk[0] < 128
+                                        ):
+                                            src_chunk = src_pcol >> Int32(4)
+                                            src_in_chunk = src_pcol & Int32(15)
+                                            dst_chunk = src_chunk ^ (
+                                                (row >> Int32(1)) & Int32(3)
+                                            )
+                                            dst_flat = (
+                                                row * packed_cols
+                                                + (dst_chunk << Int32(4))
+                                                + src_in_chunk
+                                            )
+                                            st_shared_u8(
+                                                sa_base_addr + dst_flat, byte_val
+                                            )
+                                        else:
+                                            dst_pcol = row & Int32(63)
+                                            xor_bits = (
+                                                (dst_pcol >> Int32(1)) & Int32(0x3)
+                                            ) << Int32(4)
+                                            row_high = row >> Int32(6)
+                                            dst_row = (
+                                                (src_pcol ^ xor_bits) << Int32(1)
+                                            ) + row_high
+                                            dst_flat = (
+                                                dst_row * packed_cols + dst_pcol
+                                            )
+                                            sA_u8[dst_flat] = byte_val
 
                                 outer_m_idx = row % Int32(32)
                                 inner_m_idx = row // Int32(32)
@@ -8798,6 +9059,8 @@ class MoEDynamicKernelBackend:
                         gate_tBsB = tBsB_w13
                         gate_tBsSFB = tBsSFB_w13
                     prod_state.reset_count()
+                    if cutlass.const_expr(self.w4a4_fc1_fused):
+                        up_prod_state.reset_count()
                     for k_tile in range(
                         0, fc1_k_tile_cnt if not self.is_w4a8 else 0, 1, unroll=4
                     ):
@@ -8854,6 +9117,26 @@ class MoEDynamicKernelBackend:
                             )
                         ml_pipeline.producer_commit(prod_state)
                         prod_state.advance()
+                        if cutlass.const_expr(self.w4a4_fc1_fused):
+                            up_pipeline.producer_acquire(up_prod_state)
+                            cute.copy(
+                                tma_b_w13,
+                                tBgB_w13_up_nk[(None, k_tile)],
+                                tBsB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfb_w13,
+                                tBgSFB_w13_up_nk[(None, k_tile)],
+                                tBsSFB_w13_up[(None, up_prod_state.index)],
+                                tma_bar_ptr=up_pipeline.producer_get_barrier(
+                                    up_prod_state
+                                ),
+                            )
+                            up_pipeline.producer_commit(up_prod_state)
+                            up_prod_state.advance()
 
                     # Pair with the MMA warps' FC1 completion arrival before
                     # generic shared-buffer reuse.  Small NVFP4 completed this
@@ -8867,7 +9150,7 @@ class MoEDynamicKernelBackend:
                     else:
                         self.pass_gate_barrier.wait_unaligned()
 
-                    if self.is_gated:
+                    if self.is_gated and not self.w4a4_fc1_fused:
                         # ---- FC1 up pass ----
                         up_prod_state.reset_count()
                         for k_tile in range(

--- a/b12x/moe/_shared/kernels/dynamic.py
+++ b/b12x/moe/_shared/kernels/dynamic.py
@@ -6436,6 +6436,17 @@ class MoEDynamicKernelBackend:
 
                     if cutlass.const_expr((not self.swap_ab) and (not self.is_w4a8)):
                         # Gate GEMM (inlined to avoid @cute.jit pass-by-value for acc)
+                        if cutlass.const_expr(not self.w4a4_fc1_fused):
+                            # Sub-128 FC2 re-partitions A/SFA for its intermediate
+                            # at offset zero. Refresh the generic FC1 aliases on
+                            # every task/slice so the gate MMA consumes the same
+                            # fragments that the restored routed-input copies
+                            # write. The fused path owns separate single-slot
+                            # fragments and must retain those allocations.
+                            tCrA_fc1_cur = tCrA
+                            crA_fc1_cur = crA
+                            tCrSFA_fc1_cur = tCrSFA
+                            crSFA_fc1_cur = crSFA
                         fz_crSFA = cute.filter_zeros(crSFA)
                         fz_crSFB = cute.filter_zeros(crSFB)
                         fz_crSFA_fc1_cur = fz_crSFA

--- a/tests/moe/test_dynamic_fc1_fragment_rebind.py
+++ b/tests/moe/test_dynamic_fc1_fragment_rebind.py
@@ -1,0 +1,126 @@
+"""FC1 must not consume stale fragment aliases after a prior task's FC2.
+
+The normal tiny corpus has fewer work items than resident CTAs, so each CTA
+can exit after one task. Force one resident CTA to exercise repeated tasks
+without changing the production route/compute implementation.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from b12x.moe import fused_moe
+from b12x.policy import MOE_DECODE, get_auto_policy
+from tests._reference.helpers import prepare_tp_moe_fp4_experts, require_b12x
+from tests.moe.test_cute_migration_moe_standard_corpus import (
+    _BoundCase,
+    _make_inputs,
+    _make_nvfp4_weights,
+    _nvfp4_oracle,
+    _reset_dispatch_environment,
+    _run_live_graph_check,
+)
+
+
+@pytest.mark.parametrize("work_source", ["persistent_grid", "materialized_queue"])
+@pytest.mark.parametrize(
+    ("tile_m", "deterministic"),
+    [(16, False), (32, False), (64, False), (128, False), (64, True)],
+)
+def test_dynamic_fc1_fragments_follow_current_task(
+    monkeypatch: pytest.MonkeyPatch,
+    work_source: str,
+    tile_m: int,
+    deterministic: bool,
+) -> None:
+    device = require_b12x()
+    _reset_dispatch_environment(monkeypatch)
+    monkeypatch.setenv("B12X_DYNAMIC_MAX_ACTIVE_CLUSTERS", "1")
+    monkeypatch.setenv("B12X_DYNAMIC_WORK_SOURCE", work_source)
+    monkeypatch.setenv("B12X_DYNAMIC_DETERMINISTIC_OUTPUT", str(int(deterministic)))
+    # Two intermediate slices also exercise the inner grouped-slice loop in
+    # deterministic mode, not just transitions between unrelated tasks.
+    intermediate_size = 256 if deterministic else 128
+    weights = _make_nvfp4_weights(device, seed=201, intermediate_size=intermediate_size)
+    initial = _make_inputs(device, m=128, seed=202, route_shift=0)
+    changed = _make_inputs(device, m=128, seed=203, route_shift=2)
+    initial_reference = _nvfp4_oracle(
+        weights, initial, intermediate_size=intermediate_size
+    )
+    changed_reference = _nvfp4_oracle(
+        weights, changed, intermediate_size=intermediate_size
+    )
+    experts = prepare_tp_moe_fp4_experts(
+        a=initial.a,
+        a1_gscale=weights.a1_scale,
+        w1_fp4=weights.w1_fp4,
+        w1_blockscale=weights.w1_scale,
+        w1_alphas=weights.w1_alpha,
+        a2_gscale=weights.a2_scale,
+        w2_fp4=weights.w2_fp4,
+        w2_blockscale=weights.w2_scale,
+        w2_alphas=weights.w2_alpha,
+        quant_mode="nvfp4",
+        source_format="modelopt_nvfp4",
+    )
+    policy = get_auto_policy(initial.a.device).with_override(
+        MOE_DECODE,
+        fused_moe.MoeDecodeConfig(
+            backend="dynamic",
+            route_planner="internal",
+            max_active_clusters=None,
+            dynamic_tile_m=tile_m,
+            dynamic_route_mode="grouped",
+        ),
+    )
+    plan = fused_moe.plan(
+        fused_moe.Caps(
+            max_tokens=128,
+            num_topk=2,
+            device=initial.a.device,
+            weight_plan=experts.plan,
+            quant_mode="nvfp4",
+            core_token_counts=(128,),
+            frozen=True,
+            policy_context=policy,
+            deterministic_output=deterministic,
+        )
+    )
+    scratch = tuple(
+        torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+        for spec in plan.scratch_specs()
+    )
+    output = torch.empty_like(initial.a)
+    binding = fused_moe.bind(
+        plan,
+        scratch=scratch,
+        a=initial.a,
+        experts=experts,
+        topk_ids=initial.topk_ids,
+        topk_weights=initial.topk_weights,
+        output=output,
+        input_scales_static=True,
+        # The inherited Torch oracle models precise quantization. Native
+        # fast-math coverage is retained separately on real GLM weights.
+        fast_math=False,
+    )
+    case = _BoundCase(weights, experts, plan, scratch, binding)
+    assert case.binding.implementation == "dynamic"
+    assert case.scratch_plan.launch_plan.execution.tile_m == tile_m
+    assert (
+        case.scratch_plan.launch_plan.policy_resolution.config.dynamic_tile_m == tile_m
+    )
+    assert case.scratch_plan.launch_plan.deterministic_output == deterministic
+    _run_live_graph_check(
+        case,
+        initial=initial,
+        changed=changed,
+        initial_reference=initial_reference,
+        changed_reference=changed_reference,
+        context=f"fc1-rebind-m{tile_m}-{work_source}-det{deterministic}",
+        min_cos=0.999,
+        max_normalized_rmse=0.03,
+        replay_count=3,
+        assert_no_replay_allocations=True,
+    )


### PR DESCRIPTION
**Targets `master`; depends on #268. Ready for review/testing, with exact-head GPU validation pending.**

## Why this matters

The MoE kernel reuses temporary workspace between its two calculation stages.
On the affected path, the next task could still read stale input/scale
references left by the previous stage.

This refreshes those references before the next FC1 calculation: **11 runtime
lines**, without changing the math, quantization, planner or tolerances.

## How we proved it

We forced the real GPU kernel to process successive tasks, then compared its
outputs with a reference calculation:

| Prior R25 evidence | Before | After |
|---|---:|---:|
| M64 repeated-task correctness check | Failed | Passed |
| Real layer-3 M64/M128 cosine agreement¹ | 0.93044 | 0.999969 |

¹ Higher is better; not a claim of bit-identical tensors.

**13 GPU tests passed** on the corrected R25 source, including changed-input
graph replay, poisoned scratch and stable-allocation checks. The bug was
reproduced before applying the fix; we did not loosen the pass threshold.

[Raw failure/pass logs, source hashes, real-layer comparisons and full configuration](https://gist.github.com/MadeBy561/90b728c7b6b329895719a1e812d36534).

## Scope and remaining limits

Current `master` does not yet contain the affected native-FC1 implementation.
This branch therefore carries **only #268's two unchanged prerequisite
commits, followed by this fix/test commit**. No other release-stack changes
are included. Merge #268 first and rebase, or fold this correction into it.

Our 4K serving plan uses M128, so this M64 bug is **not established as the
cause of our model-quality complaints**. No serving speed gain is claimed.

One layer-44 atomic-sum comparison still misses its strict error limit
(0.078125 vs 0.05); deterministic reduction matched exactly. That failed
check remains disclosed, not relabeled a pass.

**Pending:** exact-head GPU tests and full-model quality/performance.
The added test passes Ruff check/format; diff checks pass. Production was
untouched.

<details>
<summary>Technical reproduction, hardware and attribution</summary>

Base: `master` at `613cfd9`; fix commit `033a0f6`.
Prerequisites: #268's `0d741e1` / `24a93aa`, cherry-picked without changes
as `874559a` / `c3cfce0` (patch IDs verified).
The fix and test are unchanged from the R25/R26 submission; this narrower
master-based runtime is not byte-identical to the tested release stack.
Current runtime SHA256:
`65aea85dd9001b07f14adfd0b0dc1acf2bc2ce33d90fc54dd72e5ea374f460ea`.

Refresh non-fused FC1 A/SFA aliases after sub-128 FC2 repartitioning;
retain fused M16/M32 allocations. This is distinct from #268's swapped-
scratch correction. Open-PR checks found no equivalent fix.

Rig: **GLM-5.3-Flash-NVFP4 TP4 shard; 4× RTX PRO 6000 Blackwell Max-Q,
300 W/card, +6000 memory OC, zero core OC**. Kernel probes used GPU0;
serving configuration was TP4/DCP1, Marlin MTP3.

```bash
.venv/bin/python -m pytest -q -p no:cacheprovider --confcutdir=tests \
  tests/moe/test_dynamic_fc1_fragment_rebind.py
```

Also rerun the standard-MoE corpus, including dynamic-prefill oracle cases.
Companions: [vLLM #652](https://github.com/local-inference-lab/vllm/pull/652)
and [vLLM #653](https://github.com/local-inference-lab/vllm/pull/653).

AI assistance: OpenAI Codex under MadeBy561's direction. Human line-by-line
review remains pending.

</details>
