### PR TITLE
feat(comm): nine-rank PCIe collectives, push two-shot BF16 all-reduce and compact QSRT extents for Kimi-K3 TP9

### DIFF
--- a/b12x/comm/pcie/_island9_cute.py
+++ b/b12x/comm/pcie/_island9_cute.py
@@ -1,0 +1,574 @@
+"""CuTeDSL push-based nine-rank island all-reduce (two PCIe islands + one root rank).
+
+Topology contract: ranks 0-3 share one PCIe switch cluster (island 0), ranks
+4-7 share another (island 1), and rank 8 sits on the CPU root complex, so every
+link to rank 8 crosses the root and every island-0 <-> island-1 transfer
+crosses the two-tier cascade. Rank ``island * 4 + lane`` owns quarter ``lane``
+of the vector; rank 8 owns nothing and contributes through island 0.
+
+Three phases, every remote transfer a posted write into a peer's inbox:
+
+1. Each rank scatters its input quarters into the owners' stage inboxes
+   (island ranks to their three island peers, rank 8 to the four island-0
+   owners). An owner reduces its quarter in fp32 in ascending source rank
+   order: island 0 owners over ranks 0, 1, 2, 3, 8; island 1 owners over
+   ranks 4, 5, 6, 7. The fp32 partial stays in fp32 (no intermediate
+   rounding) and is pushed to the same-lane owner of the other island.
+2. Both owners of a quarter add the island partials (island 0 first) and
+   round once to bf16: the same value on both ranks.
+3. Owners push their final quarter to their island peers (island 0 owners
+   also to rank 8); every rank assembles the output from local memory.
+
+Per-block arrival flags with generation counters double-buffer the inboxes,
+so the kernel is CUDA-graph replayable without host involvement.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Sequence
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils
+from cutlass import Float32, Int32, Int64, Uint32
+
+from b12x._lib.compiler import KernelCompileSpec
+from b12x._lib.compiler import compile as b12x_compile
+from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+from b12x._lib.utils import (
+    cuda_stream_from_int_or_current,
+    cuda_stream_to_int,
+    current_cuda_stream,
+    make_ptr,
+)
+
+from ._island_rs_cute import (
+    _atomic_add_global_u32,
+    _fence_sc_sys,
+    _load_acquire_sys_u32,
+    _nanosleep,
+    _store_release_sys_u32,
+    pack_f32x2_to_bf16x2,
+    unpack_bf16x2,
+)
+
+WORLD_SIZE = 9
+ISLAND_SIZE = 4
+ROOT_RANK = 8
+# Stage inbox source slots: island lanes 0-3, rank 8 in slot 4.
+_ROOT_SLOT = 4
+_STAGE_SLOTS = 5
+_FLAG_SLOTS = 8
+MAX_BLOCKS = 32
+_FLAG_LINE = 128
+_FLAG_REGION_BYTES = MAX_BLOCKS * _FLAG_SLOTS * _FLAG_LINE
+_P1_ARRIVED = 256
+_P2_ARRIVED = _P1_ARRIVED + _FLAG_REGION_BYTES
+_P3_ARRIVED = _P2_ARRIVED + _FLAG_REGION_BYTES
+HEADER_BYTES = _P3_ARRIVED + _FLAG_REGION_BYTES
+
+
+def island_of(rank: int) -> int:
+    """Island index of an island rank (rank 8 has none)."""
+    if not 0 <= rank < ROOT_RANK:
+        raise ValueError(f"rank {rank} is not an island rank")
+    return rank // ISLAND_SIZE
+
+
+def lane_of(rank: int) -> int:
+    if not 0 <= rank < ROOT_RANK:
+        raise ValueError(f"rank {rank} is not an island rank")
+    return rank % ISLAND_SIZE
+
+
+def island9_peers(rank: int) -> tuple[int, ...]:
+    """Ranks whose slabs this rank maps (inbox destinations and flag targets)."""
+    if not 0 <= rank < WORLD_SIZE:
+        raise ValueError(f"invalid rank {rank} for TP{WORLD_SIZE}")
+    if rank == ROOT_RANK:
+        return tuple(range(ISLAND_SIZE))
+    island, lane = divmod(rank, ISLAND_SIZE)
+    peers = {island * ISLAND_SIZE + p for p in range(ISLAND_SIZE)} - {rank}
+    peers.add((1 - island) * ISLAND_SIZE + lane)
+    if island == 0:
+        peers.add(ROOT_RANK)
+    return tuple(sorted(peers))
+
+
+@cute.jit
+def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
+    observed = _load_acquire_sys_u32(address)
+    while observed < generation:
+        if cutlass.const_expr(cycles > 0):
+            _nanosleep(Uint32(cycles))
+        observed = _load_acquire_sys_u32(address)
+
+
+@cute.jit
+def _flag_address(base: Int64, region: int, block: Int32, slot: int) -> Int64:
+    return (
+        base
+        + Int64(region)
+        + (Int64(block) * Int64(_FLAG_SLOTS) + Int64(slot)) * Int64(_FLAG_LINE)
+    )
+
+
+@cute.jit
+def _word_ptr(address: Int64):
+    """Uint32 (bf16x2) view of a 4-byte aligned global address."""
+    return cute.recast_ptr(
+        cute.make_ptr(
+            cutlass.BFloat16,
+            address,
+            cute.AddressSpace.gmem,
+            assumed_align=16,
+        ).align(4),
+        dtype=Uint32,
+    )
+
+
+@cute.jit
+def _float_ptr(address: Int64):
+    """Float32 view of a 4-byte aligned global address."""
+    return cute.make_ptr(
+        cutlass.Float32,
+        address,
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    ).align(4)
+
+
+class _Island9Launch:
+    """Rank-specialized launcher; the role and every peer index fold at compile time."""
+
+    def __init__(
+        self,
+        rank: int,
+        *,
+        threads: int = 256,
+        wait_nanosleep_cycles: int = 24,
+    ) -> None:
+        if not 0 <= rank < WORLD_SIZE:
+            raise ValueError(f"invalid rank {rank} for world size {WORLD_SIZE}")
+        if not 32 <= threads <= 1024 or threads % 32:
+            raise ValueError("threads must be a multiple of 32 in [32, 1024]")
+        self._rank = int(rank)
+        self._threads = int(threads)
+        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
+        self._is_root = self._rank == ROOT_RANK
+        self._island = 0 if self._is_root else self._rank // ISLAND_SIZE
+        self._lane = -1 if self._is_root else self._rank % ISLAND_SIZE
+        self._partner = (
+            -1 if self._is_root else (1 - self._island) * ISLAND_SIZE + self._lane
+        )
+        self._my_slot = _ROOT_SLOT if self._is_root else self._lane
+
+    @cute.jit
+    def __call__(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_self_offset: Int64,
+        part_inbox_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+        blocks: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            slab0,
+            slab1,
+            slab2,
+            slab3,
+            slab4,
+            slab5,
+            slab6,
+            slab7,
+            slab8,
+            input_ptr,
+            output_ptr,
+            stage_offset,
+            part_self_offset,
+            part_inbox_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+        ).launch(
+            grid=(blocks, 1, 1),
+            block=[self._threads, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        slab0: cute.Pointer,
+        slab1: cute.Pointer,
+        slab2: cute.Pointer,
+        slab3: cute.Pointer,
+        slab4: cute.Pointer,
+        slab5: cute.Pointer,
+        slab6: cute.Pointer,
+        slab7: cute.Pointer,
+        slab8: cute.Pointer,
+        input_ptr: cute.Pointer,
+        output_ptr: cute.Pointer,
+        stage_offset: Int64,
+        part_self_offset: Int64,
+        part_inbox_offset: Int64,
+        final_offset: Int64,
+        quarter_capacity: Int64,
+        elements: Int64,
+    ) -> None:
+        slabs = (slab0, slab1, slab2, slab3, slab4, slab5, slab6, slab7, slab8)
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        self_base = Int64(slabs[self._rank].toint())
+
+        allocator = cutlass.utils.SmemAllocator()
+        shared_generation = allocator.allocate_tensor(
+            element_type=cutlass.Uint32,
+            layout=cute.make_layout((1,)),
+            byte_alignment=4,
+        )
+        if tidx == Int32(0):
+            shared_generation[0] = _atomic_add_global_u32(
+                self_base + Int64(bidx) * Int64(4), Uint32(1)
+            ) + Uint32(1)
+        cute.arch.barrier()
+        generation = Uint32(shared_generation[0])
+        # Double-buffered inboxes: odd generations use the second slot set.
+        if generation % Uint32(2) != Uint32(0):
+            stage_offset += quarter_capacity * Int64(_STAGE_SLOTS * 4)
+            part_self_offset += quarter_capacity * Int64(8)
+            part_inbox_offset += quarter_capacity * Int64(8)
+            final_offset += quarter_capacity * Int64(ISLAND_SIZE * 4)
+
+        # Everything below counts bf16x2 words; callers guarantee an even
+        # element count.
+        pairs = elements // Int64(2)
+        quarter = (pairs + Int64(ISLAND_SIZE - 1)) // Int64(ISLAND_SIZE)
+        stride = Int64(gdim) * Int64(self._threads)
+        start = Int64(bidx) * Int64(self._threads) + Int64(tidx)
+
+        input_words = cute.recast_ptr(input_ptr.align(4), dtype=Uint32)
+        output_words = cute.recast_ptr(output_ptr.align(4), dtype=Uint32)
+
+        # ---- Phase 1: scatter my quarters into the owners' stage inboxes. ----
+        my_slot = self._my_slot
+        for lane in cutlass.range_constexpr(ISLAND_SIZE):
+            if cutlass.const_expr(self._is_root or lane != self._lane):
+                owner = self._island * ISLAND_SIZE + lane
+                begin = Int64(lane) * quarter
+                stop = begin + quarter
+                if stop > pairs:
+                    stop = pairs
+                inbox = _word_ptr(
+                    Int64(slabs[owner].toint())
+                    + stage_offset
+                    + Int64(my_slot) * quarter_capacity * Int64(4)
+                )
+                index = start
+                while index < stop - begin:
+                    inbox[index] = input_words[begin + index]
+                    index += stride
+        cute.arch.barrier()
+        if tidx == Int32(0):
+            _fence_sc_sys()
+            for lane in cutlass.range_constexpr(ISLAND_SIZE):
+                if cutlass.const_expr(self._is_root or lane != self._lane):
+                    owner = self._island * ISLAND_SIZE + lane
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[owner].toint()), _P1_ARRIVED, bidx, my_slot
+                        ),
+                        generation,
+                    )
+
+        if cutlass.const_expr(not self._is_root):
+            # ---- Phase 1 (owner): wait for the island contributions, reduce
+            # my quarter in fp32 in ascending source rank order. ----
+            if tidx == Int32(0):
+                for slot in cutlass.range_constexpr(ISLAND_SIZE):
+                    if cutlass.const_expr(slot != self._lane):
+                        _wait_for(
+                            _flag_address(self_base, _P1_ARRIVED, bidx, slot),
+                            generation,
+                            self._wait_nanosleep_cycles,
+                        )
+                if cutlass.const_expr(self._island == 0):
+                    _wait_for(
+                        _flag_address(self_base, _P1_ARRIVED, bidx, _ROOT_SLOT),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+            cute.arch.barrier()
+
+            mine_begin = Int64(self._lane) * quarter
+            mine_stop = mine_begin + quarter
+            if mine_stop > pairs:
+                mine_stop = pairs
+            mine_length = mine_stop - mine_begin
+
+            part_self = _float_ptr(self_base + part_self_offset)
+            partner_inbox = _float_ptr(
+                Int64(slabs[self._partner].toint()) + part_inbox_offset
+            )
+            index = start
+            while index < mine_length:
+                total_lo = Float32(0.0)
+                total_hi = Float32(0.0)
+                for slot in cutlass.range_constexpr(ISLAND_SIZE):
+                    if cutlass.const_expr(slot == self._lane):
+                        lo, hi = unpack_bf16x2(input_words[mine_begin + index])
+                    else:
+                        stage = _word_ptr(
+                            self_base
+                            + stage_offset
+                            + Int64(slot) * quarter_capacity * Int64(4)
+                        )
+                        lo, hi = unpack_bf16x2(stage[index])
+                    total_lo += lo
+                    total_hi += hi
+                if cutlass.const_expr(self._island == 0):
+                    stage = _word_ptr(
+                        self_base
+                        + stage_offset
+                        + Int64(_ROOT_SLOT) * quarter_capacity * Int64(4)
+                    )
+                    lo, hi = unpack_bf16x2(stage[index])
+                    total_lo += lo
+                    total_hi += hi
+                part_self[index * Int64(2)] = total_lo
+                part_self[index * Int64(2) + Int64(1)] = total_hi
+                partner_inbox[index * Int64(2)] = total_lo
+                partner_inbox[index * Int64(2) + Int64(1)] = total_hi
+                index += stride
+            cute.arch.barrier()
+            if tidx == Int32(0):
+                _fence_sc_sys()
+                _store_release_sys_u32(
+                    _flag_address(
+                        Int64(slabs[self._partner].toint()), _P2_ARRIVED, bidx, 0
+                    ),
+                    generation,
+                )
+                _wait_for(
+                    _flag_address(self_base, _P2_ARRIVED, bidx, 0),
+                    generation,
+                    self._wait_nanosleep_cycles,
+                )
+            cute.arch.barrier()
+
+            # ---- Phase 2: island 0 partial + island 1 partial, one rounding.
+            # The same operand order on both owners gives identical bits. ----
+            part_inbox = _float_ptr(self_base + part_inbox_offset)
+            index = start
+            while index < mine_length:
+                self_lo = part_self[index * Int64(2)]
+                self_hi = part_self[index * Int64(2) + Int64(1)]
+                other_lo = part_inbox[index * Int64(2)]
+                other_hi = part_inbox[index * Int64(2) + Int64(1)]
+                if cutlass.const_expr(self._island == 0):
+                    total_lo = self_lo + other_lo
+                    total_hi = self_hi + other_hi
+                else:
+                    total_lo = other_lo + self_lo
+                    total_hi = other_hi + self_hi
+                value = pack_f32x2_to_bf16x2(total_lo, total_hi)
+                output_words[mine_begin + index] = value
+                for lane in cutlass.range_constexpr(ISLAND_SIZE):
+                    if cutlass.const_expr(lane != self._lane):
+                        peer = self._island * ISLAND_SIZE + lane
+                        peer_final = _word_ptr(
+                            Int64(slabs[peer].toint())
+                            + final_offset
+                            + Int64(self._lane) * quarter_capacity * Int64(4)
+                        )
+                        peer_final[index] = value
+                if cutlass.const_expr(self._island == 0):
+                    root_final = _word_ptr(
+                        Int64(slabs[ROOT_RANK].toint())
+                        + final_offset
+                        + Int64(self._lane) * quarter_capacity * Int64(4)
+                    )
+                    root_final[index] = value
+                index += stride
+            cute.arch.barrier()
+            if tidx == Int32(0):
+                _fence_sc_sys()
+                for lane in cutlass.range_constexpr(ISLAND_SIZE):
+                    if cutlass.const_expr(lane != self._lane):
+                        peer = self._island * ISLAND_SIZE + lane
+                        _store_release_sys_u32(
+                            _flag_address(
+                                Int64(slabs[peer].toint()),
+                                _P3_ARRIVED,
+                                bidx,
+                                self._lane,
+                            ),
+                            generation,
+                        )
+                if cutlass.const_expr(self._island == 0):
+                    _store_release_sys_u32(
+                        _flag_address(
+                            Int64(slabs[ROOT_RANK].toint()),
+                            _P3_ARRIVED,
+                            bidx,
+                            self._lane,
+                        ),
+                        generation,
+                    )
+
+        # ---- Phase 3: assemble the quarters I do not own from my final inbox. ----
+        if tidx == Int32(0):
+            for lane in cutlass.range_constexpr(ISLAND_SIZE):
+                if cutlass.const_expr(self._is_root or lane != self._lane):
+                    _wait_for(
+                        _flag_address(self_base, _P3_ARRIVED, bidx, lane),
+                        generation,
+                        self._wait_nanosleep_cycles,
+                    )
+        cute.arch.barrier()
+        for lane in cutlass.range_constexpr(ISLAND_SIZE):
+            if cutlass.const_expr(self._is_root or lane != self._lane):
+                final_inbox = _word_ptr(
+                    self_base + final_offset + Int64(lane) * quarter_capacity * Int64(4)
+                )
+                begin = Int64(lane) * quarter
+                stop = begin + quarter
+                if stop > pairs:
+                    stop = pairs
+                index = start
+                while index < stop - begin:
+                    output_words[begin + index] = final_inbox[index]
+                    index += stride
+
+
+@functools.lru_cache(maxsize=None)
+def get_island9_launcher(
+    rank: int,
+    device_index: int,
+    *,
+    threads: int = 256,
+    wait_nanosleep_cycles: int = 24,
+) -> Callable[..., None]:
+    """Return the rank-specialized nine-rank island all-reduce launcher."""
+
+    del device_index  # retained in the process-local cache key
+    launch = _Island9Launch(
+        rank,
+        threads=threads,
+        wait_nanosleep_cycles=wait_nanosleep_cycles,
+    )
+    cache_key = (int(rank), int(threads), int(wait_nanosleep_cycles))
+    raise_if_kernel_resolution_frozen(
+        "cute.compile", target=launch, cache_key=cache_key
+    )
+    slab_placeholder = make_ptr(
+        cutlass.Uint8,
+        256,
+        cute.AddressSpace.gmem,
+        assumed_align=256,
+    )
+    raw = b12x_compile(
+        launch,
+        *(slab_placeholder for _ in range(WORLD_SIZE)),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key(
+            "comm.pcie.island9.bf16",
+            1,
+            cache_key,
+            labels=("rank", "threads", "wait_nanosleep_cycles"),
+        ),
+    )
+
+    def run(
+        slab_addresses: Sequence[int],
+        input_address: int,
+        output_address: int,
+        stage_offset: int,
+        part_self_offset: int,
+        part_inbox_offset: int,
+        final_offset: int,
+        quarter_capacity: int,
+        elements: int,
+        blocks: int,
+        stream: object = None,
+    ) -> None:
+        if len(slab_addresses) != WORLD_SIZE:
+            raise ValueError(
+                f"expected {WORLD_SIZE} slab addresses, got {len(slab_addresses)}"
+            )
+        if not 1 <= int(blocks) <= MAX_BLOCKS:
+            raise ValueError(f"blocks must be in [1, {MAX_BLOCKS}], got {blocks}")
+        raw(
+            *(
+                make_ptr(
+                    cutlass.Uint8,
+                    int(address),
+                    cute.AddressSpace.gmem,
+                    assumed_align=256,
+                )
+                for address in slab_addresses
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                input_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            make_ptr(
+                cutlass.BFloat16,
+                output_address,
+                cute.AddressSpace.gmem,
+                assumed_align=2,
+            ),
+            stage_offset,
+            part_self_offset,
+            part_inbox_offset,
+            final_offset,
+            quarter_capacity,
+            elements,
+            blocks,
+            cuda_stream_from_int_or_current(cuda_stream_to_int(stream)),
+        )
+
+    return run
+
+
+__all__ = [
+    "HEADER_BYTES",
+    "ISLAND_SIZE",
+    "MAX_BLOCKS",
+    "ROOT_RANK",
+    "WORLD_SIZE",
+    "get_island9_launcher",
+    "island9_peers",
+    "island_of",
+    "lane_of",
+]

--- a/b12x/comm/pcie/_oneshot_cute.py
+++ b/b12x/comm/pcie/_oneshot_cute.py
@@ -265,7 +265,12 @@ class _OneshotLaunch(_PackedMath):
         while index < size_packs:
             accumulator = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
             for peer_index in cutlass.range_constexpr(self._world_size):
-                peer_rank = (self._rank + peer_index) % self._world_size
+                if cutlass.const_expr(self._world_size == 9):
+                    # Independent rank-local reductions must return identical
+                    # bits even when inputs have widely separated exponents.
+                    peer_rank = peer_index
+                else:
+                    peer_rank = (self._rank + peer_index) % self._world_size
                 peer_base = Int64(peer_ptrs[peer_rank])
                 self._load_accumulate(
                     accumulator,
@@ -643,25 +648,33 @@ class _FusedOneshotLaunch(_PackedMath):
                     False,
                 )
         elif cutlass.const_expr(self._mode == "stage_push"):
-            self._load_accumulate(
-                accumulator,
-                input_base + index * Int64(16),
-                True,
-            )
             local_stage = Int64(peer_ptrs[self._rank])
-            initialized = True
-            for source_rank in cutlass.range_constexpr(self._world_size):
-                if cutlass.const_expr(source_rank != self._rank):
-                    self._load_accumulate(
-                        accumulator,
-                        local_stage
-                        + (Int64(source_rank) * shard_packs + index) * Int64(16),
-                        not initialized,
-                    )
-                    initialized = True
+            if cutlass.const_expr(self._world_size == 9):
+                for source_rank in cutlass.range_constexpr(self._world_size):
+                    source = local_stage + (
+                        Int64(source_rank) * shard_packs + index
+                    ) * Int64(16)
+                    if cutlass.const_expr(source_rank == self._rank):
+                        source = input_base + index * Int64(16)
+                    self._load_accumulate(accumulator, source, source_rank == 0)
+            else:
+                self._load_accumulate(accumulator, input_base + index * Int64(16), True)
+                for source_rank in cutlass.range_constexpr(self._world_size):
+                    if cutlass.const_expr(source_rank != self._rank):
+                        self._load_accumulate(
+                            accumulator,
+                            local_stage
+                            + (Int64(source_rank) * shard_packs + index) * Int64(16),
+                            False,
+                        )
         else:
             for peer_index in cutlass.range_constexpr(self._world_size):
-                peer_rank = (self._rank + peer_index) % self._world_size
+                if cutlass.const_expr(self._world_size == 9):
+                    # Independent rank-local reductions must return identical
+                    # bits even when inputs have widely separated exponents.
+                    peer_rank = peer_index
+                else:
+                    peer_rank = (self._rank + peer_index) % self._world_size
                 self._load_accumulate(
                     accumulator,
                     Int64(peer_ptrs[peer_rank]) + index * Int64(16),
@@ -1052,7 +1065,7 @@ def get_oneshot_launcher(
         1,
         1,
         current_cuda_stream(),
-        compile_spec=KernelCompileSpec.from_key("comm.pcie.oneshot", 1, cache_key),
+        compile_spec=KernelCompileSpec.from_key("comm.pcie.oneshot", 2, cache_key),
     )
 
     def run(
@@ -1223,7 +1236,7 @@ def get_fused_oneshot_launcher(
         1,
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
-            "comm.pcie.oneshot_fused_rmsnorm", 1, cache_key
+            "comm.pcie.oneshot_fused_rmsnorm", 2, cache_key
         ),
     )
 

--- a/b12x/comm/pcie/_twoshot_bf16_cute.py
+++ b/b12x/comm/pcie/_twoshot_bf16_cute.py
@@ -666,6 +666,12 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
     barrier, every rank pulls the other ranks' reduced shards into the output.
     PCIe read volume per rank is 2P*(world - 1)/world, which is 1.5P for world
     size 4; synchronization uses two barriers.
+
+    Shards are contiguous pack ranges. ``rows_per_rank`` rows of ``row_elems``
+    form the base shard; ``remainder_packs`` (below the world size) extra packs
+    are handed one each to the lowest ranks, so a payload whose pack count is
+    not a multiple of the world size is reduced in place without wire padding.
+    Rank ``k`` owns packs ``[k*base + min(k, r), (k+1)*base + min(k+1, r))``.
     """
 
     def __init__(
@@ -714,6 +720,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         reduced_offset: Int64,
         slot_bytes: Int64,
         rows_per_rank: Int32,
+        remainder_packs: Int32,
         grid_x: Int32,
         stream: cuda.CUstream,
     ) -> None:
@@ -742,6 +749,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
             reduced_offset,
             slot_bytes,
             rows_per_rank,
+            remainder_packs,
         ).launch(
             grid=(grid_x, 1, 1),
             block=[self._threads, 1, 1],
@@ -787,6 +795,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         reduced_offset: Int64,
         slot_bytes: Int64,
         rows_per_rank: Int32,
+        remainder_packs: Int32,
     ) -> None:
         staging = (
             staging0,
@@ -815,8 +824,17 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         gdim, _, _ = cute.arch.grid_dim()
         local_rank = rank
         packs_per_row = Int32(self._row_elems // _PACK_ELEMS)
-        shard_packs = Int64(rows_per_rank) * Int64(packs_per_row)
-        full_packs = shard_packs * Int64(self._world_size)
+        base_packs = Int64(rows_per_rank) * Int64(packs_per_row)
+        remainder = Int64(remainder_packs)
+        full_packs = base_packs * Int64(self._world_size) + remainder
+        # Balanced contiguous partition: ranks below the remainder own one
+        # extra pack. The local shard bounds are runtime scalars.
+        shard_base = Int64(local_rank) * base_packs + Int64(
+            cutlass.min(local_rank, remainder_packs)
+        )
+        shard_packs = base_packs
+        if local_rank < remainder_packs:
+            shard_packs = base_packs + Int64(1)
         threads = Int64(self._threads)
         grid_threads = Int64(gdim) * threads
         flat = Int64(bidx) * threads + Int64(tidx)
@@ -855,7 +873,6 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         self._barrier(signals, local_rank)
 
         # Pull and reduce this rank's shard from every staged peer payload.
-        shard_base = Int64(local_rank) * shard_packs
         index = flat
         while index < shard_packs:
             accumulator = cute.make_rmem_tensor((_PACK_ELEMS,), cutlass.Float32)
@@ -894,9 +911,15 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
                 + staging_slot_offset
                 + reduced_offset
             )
-            destination = output_address + Int64(source_rank) * shard_packs * Int64(16)
+            peer_shard_base = Int64(source_rank) * base_packs + Int64(
+                cutlass.min(source_rank, remainder_packs)
+            )
+            peer_shard_packs = base_packs
+            if source_rank < remainder_packs:
+                peer_shard_packs = base_packs + Int64(1)
+            destination = output_address + peer_shard_base * Int64(16)
             index = flat
-            while index < shard_packs:
+            while index < peer_shard_packs:
                 words = ld_global_v4_u32(peer_reduced + index * Int64(16))
                 st_global_v4_u32(
                     destination + index * Int64(16),
@@ -989,6 +1012,7 @@ def get_twoshot_bf16_allreduce_launcher(
         1,
         1,
         1,
+        0,
         1,
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
@@ -1007,10 +1031,13 @@ def get_twoshot_bf16_allreduce_launcher(
         reduced_offset: int,
         slot_bytes: int,
         rows_per_rank: int,
+        remainder_packs: int,
         grid_x: int,
     ) -> None:
         if len(staging_addresses) != 9 or len(signal_addresses) != 9:
             raise ValueError("two-shot scalar pointer ABI requires nine peer slots")
+        if not 0 <= int(remainder_packs) < world_size:
+            raise ValueError("remainder_packs must be below the world size")
         raw_args = (
             make_ptr(
                 cutlass.Uint32,
@@ -1046,6 +1073,7 @@ def get_twoshot_bf16_allreduce_launcher(
             reduced_offset,
             slot_bytes,
             rows_per_rank,
+            remainder_packs,
             grid_x,
             current_cuda_stream(),
         )

--- a/b12x/comm/pcie/_twoshot_bf16_cute.py
+++ b/b12x/comm/pcie/_twoshot_bf16_cute.py
@@ -931,6 +931,285 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
                 index += grid_threads
 
 
+class _TwoShotPushAllReduceLaunch(_TwoShotPullAllReduceLaunch):
+    """Single-launch lossless bf16 all-reduce built on posted PCIe WRITES.
+
+    Phase one pushes this rank's contribution to every peer's shard into that
+    peer's staged payload region (rank-staggered destinations). After the
+    first barrier every rank reduces its own shard from local memory only, in
+    the same fixed order as the pull kernel (self, then ``(rank + i) % world``),
+    writes the bf16 result to the output and pushes it into every peer's
+    reduced region. After the second barrier the peers' reduced shards are
+    copied from local memory into the output. Remote traffic is posted writes
+    only; the shard partition matches the pull kernel, so outputs are
+    bit-identical between the two kernels.
+    """
+
+    @cute.jit
+    def __call__(
+        self,
+        payload: cute.Pointer,
+        staging0: cute.Pointer,
+        staging1: cute.Pointer,
+        staging2: cute.Pointer,
+        staging3: cute.Pointer,
+        staging4: cute.Pointer,
+        staging5: cute.Pointer,
+        staging6: cute.Pointer,
+        staging7: cute.Pointer,
+        staging8: cute.Pointer,
+        signal0: cute.Pointer,
+        signal1: cute.Pointer,
+        signal2: cute.Pointer,
+        signal3: cute.Pointer,
+        signal4: cute.Pointer,
+        signal5: cute.Pointer,
+        signal6: cute.Pointer,
+        signal7: cute.Pointer,
+        signal8: cute.Pointer,
+        output: cute.Pointer,
+        rank: Int32,
+        pack_stride: Int64,
+        reduced_offset: Int64,
+        slot_bytes: Int64,
+        rows_per_rank: Int32,
+        remainder_packs: Int32,
+        grid_x: Int32,
+        stream: cuda.CUstream,
+    ) -> None:
+        self.kernel(
+            payload,
+            staging0,
+            staging1,
+            staging2,
+            staging3,
+            staging4,
+            staging5,
+            staging6,
+            staging7,
+            staging8,
+            signal0,
+            signal1,
+            signal2,
+            signal3,
+            signal4,
+            signal5,
+            signal6,
+            signal7,
+            signal8,
+            output,
+            rank,
+            pack_stride,
+            reduced_offset,
+            slot_bytes,
+            rows_per_rank,
+            remainder_packs,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=[self._threads, 1, 1],
+            max_number_threads=(512, 1, 1),
+            min_blocks_per_mp=1,
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        payload: cute.Pointer,
+        staging0: cute.Pointer,
+        staging1: cute.Pointer,
+        staging2: cute.Pointer,
+        staging3: cute.Pointer,
+        staging4: cute.Pointer,
+        staging5: cute.Pointer,
+        staging6: cute.Pointer,
+        staging7: cute.Pointer,
+        staging8: cute.Pointer,
+        signal0: cute.Pointer,
+        signal1: cute.Pointer,
+        signal2: cute.Pointer,
+        signal3: cute.Pointer,
+        signal4: cute.Pointer,
+        signal5: cute.Pointer,
+        signal6: cute.Pointer,
+        signal7: cute.Pointer,
+        signal8: cute.Pointer,
+        output: cute.Pointer,
+        rank: Int32,
+        pack_stride: Int64,
+        reduced_offset: Int64,
+        slot_bytes: Int64,
+        rows_per_rank: Int32,
+        remainder_packs: Int32,
+    ) -> None:
+        staging = (
+            staging0,
+            staging1,
+            staging2,
+            staging3,
+            staging4,
+            staging5,
+            staging6,
+            staging7,
+            staging8,
+        )
+        signals = (
+            signal0,
+            signal1,
+            signal2,
+            signal3,
+            signal4,
+            signal5,
+            signal6,
+            signal7,
+            signal8,
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdim, _, _ = cute.arch.grid_dim()
+        local_rank = rank
+        packs_per_row = Int32(self._row_elems // _PACK_ELEMS)
+        base_packs = Int64(rows_per_rank) * Int64(packs_per_row)
+        shard_base = Int64(local_rank) * base_packs + Int64(
+            cutlass.min(local_rank, remainder_packs)
+        )
+        shard_packs = base_packs
+        if local_rank < remainder_packs:
+            shard_packs = base_packs + Int64(1)
+        threads = Int64(self._threads)
+        grid_threads = Int64(gdim) * threads
+        flat = Int64(bidx) * threads + Int64(tidx)
+
+        payload_address = Int64(payload.toint())
+        output_address = Int64(output.toint())
+        staging_slot_offset = Int64(0)
+        self_signal = self._select_address(signals, local_rank)
+        if cutlass.const_expr(self._device_slot_selection):
+            generation = ld_relaxed_gpu_u32(self_signal + Int64(_GRAPH_EPOCH_OFFSET))
+            staging_slot_offset = (
+                Int64((generation + Uint32(self._slot_bias)) % Uint32(2)) * slot_bytes
+            )
+            cute.arch.barrier()
+            if Int32(tidx) == Int32(self._threads - 1):
+                graph_epoch_arrive_serialized(
+                    self_signal + Int64(_GRAPH_EPOCH_OFFSET),
+                    self_signal + Int64(_GRAPH_BLOCKS_ARRIVED_OFFSET),
+                    Uint32(gdim),
+                )
+        self_base = self._select_address(staging, local_rank) + staging_slot_offset
+
+        # Phase one: push this rank's contribution to each peer's shard into
+        # the peer's payload region, at this rank's source slot.
+        peer_index = Int32(1)
+        while peer_index < Int32(self._world_size):
+            destination = (local_rank + peer_index) % Int32(self._world_size)
+            destination_shard_base = Int64(destination) * base_packs + Int64(
+                cutlass.min(destination, remainder_packs)
+            )
+            destination_shard_packs = base_packs
+            if destination < remainder_packs:
+                destination_shard_packs = base_packs + Int64(1)
+            destination_slot = (
+                self._select_address(staging, destination)
+                + staging_slot_offset
+                + Int64(local_rank) * pack_stride * Int64(16)
+            )
+            index = flat
+            while index < destination_shard_packs:
+                words = ld_global_nc_v4_u32(
+                    payload_address + (destination_shard_base + index) * Int64(16)
+                )
+                _st_generic_v4_u32(
+                    destination_slot + index * Int64(16),
+                    words[0],
+                    words[1],
+                    words[2],
+                    words[3],
+                )
+                index += grid_threads
+            peer_index += Int32(1)
+
+        self._barrier(signals, local_rank)
+
+        # Phase two: reduce this rank's shard from local memory, publish the
+        # result to the output and to every peer's reduced region.
+        index = flat
+        while index < shard_packs:
+            accumulator = cute.make_rmem_tensor((_PACK_ELEMS,), cutlass.Float32)
+            for lane in cutlass.range_constexpr(_PACK_ELEMS):
+                accumulator[lane] = Float32(0.0)
+            local_words = ld_global_nc_v4_u32(
+                payload_address + (shard_base + index) * Int64(16)
+            )
+            peer_words = []
+            for peer_index in cutlass.range_constexpr(1, self._world_size):
+                source_rank = (local_rank + Int32(peer_index)) % Int32(self._world_size)
+                staged_pack = (
+                    self_base
+                    + Int64(source_rank) * pack_stride * Int64(16)
+                    + index * Int64(16)
+                )
+                peer_words.append(_ld_generic_v4_u32(staged_pack))
+            self._accumulate_words(accumulator, local_words)
+            for peer_index in cutlass.range_constexpr(self._world_size - 1):
+                self._accumulate_words(accumulator, peer_words[peer_index])
+            self._store_pack(
+                output_address + (shard_base + index) * Int64(16), accumulator
+            )
+            reduced_words = (
+                pack_f32x2_to_bf16x2(accumulator[0], accumulator[1]),
+                pack_f32x2_to_bf16x2(accumulator[2], accumulator[3]),
+                pack_f32x2_to_bf16x2(accumulator[4], accumulator[5]),
+                pack_f32x2_to_bf16x2(accumulator[6], accumulator[7]),
+            )
+            for peer_index in cutlass.range_constexpr(1, self._world_size):
+                destination = (local_rank + Int32(peer_index)) % Int32(self._world_size)
+                destination_reduced = (
+                    self._select_address(staging, destination)
+                    + staging_slot_offset
+                    + reduced_offset
+                    + Int64(local_rank) * pack_stride * Int64(16)
+                )
+                _st_generic_v4_u32(
+                    destination_reduced + index * Int64(16),
+                    reduced_words[0],
+                    reduced_words[1],
+                    reduced_words[2],
+                    reduced_words[3],
+                )
+            index += grid_threads
+
+        self._barrier(signals, local_rank)
+
+        # Phase three: copy the peers' reduced shards from local memory.
+        for peer_index in cutlass.range_constexpr(1, self._world_size):
+            source_rank = (local_rank + Int32(peer_index)) % Int32(self._world_size)
+            source_reduced = (
+                self_base
+                + reduced_offset
+                + Int64(source_rank) * pack_stride * Int64(16)
+            )
+            source_shard_base = Int64(source_rank) * base_packs + Int64(
+                cutlass.min(source_rank, remainder_packs)
+            )
+            source_shard_packs = base_packs
+            if source_rank < remainder_packs:
+                source_shard_packs = base_packs + Int64(1)
+            destination = output_address + source_shard_base * Int64(16)
+            index = flat
+            while index < source_shard_packs:
+                words = _ld_generic_v4_u32(source_reduced + index * Int64(16))
+                st_global_v4_u32(
+                    destination + index * Int64(16),
+                    words[0],
+                    words[1],
+                    words[2],
+                    words[3],
+                )
+                index += grid_threads
+
+
 @functools.cache
 def get_twoshot_bf16_allreduce_launcher(
     world_size: int,
@@ -940,10 +1219,18 @@ def get_twoshot_bf16_allreduce_launcher(
     threads: int,
     row_elems: int,
     device_index: int,
+    mode: str = "pull",
 ) -> Callable[..., None]:
-    """Compile the single-launch pull-based bf16 all-reduce specialization."""
+    """Compile the single-launch bf16 all-reduce specialization.
+
+    ``mode`` selects the remote-read (``"pull"``) or posted-write (``"push"``)
+    kernel; both use the same shard partition and reduction order.
+    """
+    if mode not in ("pull", "push"):
+        raise ValueError(f"invalid all-reduce mode {mode!r}")
+    operation = f"all_reduce_{mode}"
     process_key = _bf16_process_key(
-        "all_reduce_pull",
+        operation,
         world_size,
         rank,
         device_slot_selection,
@@ -965,7 +1252,10 @@ def get_twoshot_bf16_allreduce_launcher(
     if row_elems <= 0 or row_elems % _PACK_ELEMS != 0:
         raise ValueError("row_elems must be a positive multiple of 8")
     slot_bias = int(slot_bias) & 1
-    launch = _TwoShotPullAllReduceLaunch(
+    launch_cls = (
+        _TwoShotPushAllReduceLaunch if mode == "push" else _TwoShotPullAllReduceLaunch
+    )
+    launch = launch_cls(
         world_size,
         rank,
         device_slot_selection,
@@ -975,7 +1265,7 @@ def get_twoshot_bf16_allreduce_launcher(
     )
     cache_key = (
         "bf16",
-        "all_reduce_pull",
+        operation,
         int(world_size),
         int(rank),
         bool(device_slot_selection),
@@ -986,6 +1276,9 @@ def get_twoshot_bf16_allreduce_launcher(
     raise_if_kernel_resolution_frozen(
         "cute.compile", target=launch, cache_key=cache_key
     )
+    # The push kernel takes the per-source pack stride ahead of the reduced
+    # region offset; the pull kernel does not need it.
+    scalar_samples = (0, 1, 1, 1, 1, 0, 1) if mode == "push" else (0, 1, 1, 1, 0, 1)
     raw = b12x_compile(
         launch,
         make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
@@ -1008,15 +1301,10 @@ def get_twoshot_bf16_allreduce_launcher(
             for _ in range(9)
         ),
         make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
-        0,
-        1,
-        1,
-        1,
-        0,
-        1,
+        *scalar_samples,
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
-            "comm.pcie.twoshot_bf16.all_reduce_pull",
+            f"comm.pcie.twoshot_bf16.{operation}",
             2,
             cache_key,
         ),
@@ -1033,11 +1321,20 @@ def get_twoshot_bf16_allreduce_launcher(
         rows_per_rank: int,
         remainder_packs: int,
         grid_x: int,
+        pack_stride: int = 0,
     ) -> None:
         if len(staging_addresses) != 9 or len(signal_addresses) != 9:
             raise ValueError("two-shot scalar pointer ABI requires nine peer slots")
         if not 0 <= int(remainder_packs) < world_size:
             raise ValueError("remainder_packs must be below the world size")
+        if mode == "push":
+            if pack_stride <= 0:
+                raise ValueError("the push all-reduce needs a positive pack_stride")
+            scalars = (rank, pack_stride, reduced_offset, slot_bytes,
+                       rows_per_rank, remainder_packs, grid_x)
+        else:
+            scalars = (rank, reduced_offset, slot_bytes, rows_per_rank,
+                       remainder_packs, grid_x)
         raw_args = (
             make_ptr(
                 cutlass.Uint32,
@@ -1069,12 +1366,7 @@ def get_twoshot_bf16_allreduce_launcher(
                 cute.AddressSpace.gmem,
                 assumed_align=16,
             ),
-            rank,
-            reduced_offset,
-            slot_bytes,
-            rows_per_rank,
-            remainder_packs,
-            grid_x,
+            *scalars,
             current_cuda_stream(),
         )
         raw(*raw_args)
@@ -1091,10 +1383,11 @@ def is_twoshot_bf16_allreduce_launcher_prepared(
     threads: int,
     row_elems: int,
     device_index: int,
+    mode: str = "pull",
 ) -> bool:
     return (
         _bf16_process_key(
-            "all_reduce_pull",
+            f"all_reduce_{mode}",
             world_size,
             rank,
             device_slot_selection,

--- a/b12x/comm/pcie/_twoshot_bf16_cute.py
+++ b/b12x/comm/pcie/_twoshot_bf16_cute.py
@@ -50,7 +50,9 @@ from ._twoshot_cute import (
 
 _PREPARED_BF16_LAUNCHERS: set[tuple[object, ...]] = set()
 _PACK_ELEMS = 8  # bf16 values per 16-byte pack
-_SUPPORTED_WORLD_SIZE = 4
+# Topologies with retained qualification evidence: TP4 (GLM-5.3 DCP4) and the
+# Kimi-K3 TP8 / TP9 PCIe rings (docs/evidence, tests/comm/test_pcie_tp9_physical.py).
+_SUPPORTED_WORLD_SIZES = (2, 4, 8, 9)
 
 
 class _TwoShotBf16Launch:
@@ -86,6 +88,7 @@ class _TwoShotBf16Launch:
         staging5: cute.Pointer,
         staging6: cute.Pointer,
         staging7: cute.Pointer,
+        staging8: cute.Pointer,
         signal0: cute.Pointer,
         signal1: cute.Pointer,
         signal2: cute.Pointer,
@@ -94,6 +97,7 @@ class _TwoShotBf16Launch:
         signal5: cute.Pointer,
         signal6: cute.Pointer,
         signal7: cute.Pointer,
+        signal8: cute.Pointer,
         output: cute.Pointer,
         rank: Int32,
         pack_stride: Int64,
@@ -112,6 +116,7 @@ class _TwoShotBf16Launch:
             staging5,
             staging6,
             staging7,
+            staging8,
             signal0,
             signal1,
             signal2,
@@ -120,6 +125,7 @@ class _TwoShotBf16Launch:
             signal5,
             signal6,
             signal7,
+            signal8,
             output,
             rank,
             pack_stride,
@@ -163,9 +169,12 @@ class _TwoShotBf16Launch:
                     address = Int64(pointers[5].toint())
             else:
                 address = Int64(pointers[6].toint())
-                if cutlass.const_expr(self._world_size == 8):
+                if cutlass.const_expr(self._world_size >= 8):
                     if index == Int32(7):
                         address = Int64(pointers[7].toint())
+        if cutlass.const_expr(self._world_size == 9):
+            if index == Int32(8):
+                address = Int64(pointers[8].toint())
         return address
 
     @cute.jit
@@ -269,6 +278,7 @@ class _TwoShotBf16Launch:
         staging5: cute.Pointer,
         staging6: cute.Pointer,
         staging7: cute.Pointer,
+        staging8: cute.Pointer,
         signal0: cute.Pointer,
         signal1: cute.Pointer,
         signal2: cute.Pointer,
@@ -277,6 +287,7 @@ class _TwoShotBf16Launch:
         signal5: cute.Pointer,
         signal6: cute.Pointer,
         signal7: cute.Pointer,
+        signal8: cute.Pointer,
         output: cute.Pointer,
         rank: Int32,
         pack_stride: Int64,
@@ -292,6 +303,7 @@ class _TwoShotBf16Launch:
             staging5,
             staging6,
             staging7,
+            staging8,
         )
         signals = (
             signal0,
@@ -302,6 +314,7 @@ class _TwoShotBf16Launch:
             signal5,
             signal6,
             signal7,
+            signal8,
         )
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
@@ -515,10 +528,10 @@ def get_twoshot_bf16_launcher(
         device_index,
     )
     del device_index  # part of the process-local cache key
-    if world_size != _SUPPORTED_WORLD_SIZE:
+    if world_size not in _SUPPORTED_WORLD_SIZES:
         raise ValueError(
-            "single-rounding BF16 two-shot launchers require world size 4, "
-            f"got {world_size}"
+            "single-rounding BF16 two-shot launchers require a world size in "
+            f"{_SUPPORTED_WORLD_SIZES}, got {world_size}"
         )
     if rank < 0 or rank >= world_size:
         raise ValueError(f"rank {rank} is outside world size {world_size}")
@@ -559,7 +572,7 @@ def get_twoshot_bf16_launcher(
                 cute.AddressSpace.gmem,
                 assumed_align=16,
             )
-            for _ in range(8)
+            for _ in range(9)
         ),
         *(
             make_ptr(
@@ -568,7 +581,7 @@ def get_twoshot_bf16_launcher(
                 cute.AddressSpace.gmem,
                 assumed_align=4,
             )
-            for _ in range(8)
+            for _ in range(9)
         ),
         make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
         0,
@@ -579,7 +592,7 @@ def get_twoshot_bf16_launcher(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             f"comm.pcie.twoshot_bf16.{operation}",
-            1,
+            2,
             cache_key,
         ),
     )
@@ -595,8 +608,8 @@ def get_twoshot_bf16_launcher(
         rows_per_rank: int,
         grid_x: int,
     ) -> None:
-        if len(staging_addresses) != 8 or len(signal_addresses) != 8:
-            raise ValueError("two-shot scalar pointer ABI requires eight peers")
+        if len(staging_addresses) != 9 or len(signal_addresses) != 9:
+            raise ValueError("two-shot scalar pointer ABI requires nine peer slots")
         raw_args = (
             make_ptr(
                 cutlass.Uint32,
@@ -686,6 +699,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         staging5: cute.Pointer,
         staging6: cute.Pointer,
         staging7: cute.Pointer,
+        staging8: cute.Pointer,
         signal0: cute.Pointer,
         signal1: cute.Pointer,
         signal2: cute.Pointer,
@@ -694,6 +708,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         signal5: cute.Pointer,
         signal6: cute.Pointer,
         signal7: cute.Pointer,
+        signal8: cute.Pointer,
         output: cute.Pointer,
         rank: Int32,
         reduced_offset: Int64,
@@ -712,6 +727,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
             staging5,
             staging6,
             staging7,
+            staging8,
             signal0,
             signal1,
             signal2,
@@ -720,6 +736,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
             signal5,
             signal6,
             signal7,
+            signal8,
             output,
             rank,
             reduced_offset,
@@ -755,6 +772,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         staging5: cute.Pointer,
         staging6: cute.Pointer,
         staging7: cute.Pointer,
+        staging8: cute.Pointer,
         signal0: cute.Pointer,
         signal1: cute.Pointer,
         signal2: cute.Pointer,
@@ -763,6 +781,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
         signal5: cute.Pointer,
         signal6: cute.Pointer,
         signal7: cute.Pointer,
+        signal8: cute.Pointer,
         output: cute.Pointer,
         rank: Int32,
         reduced_offset: Int64,
@@ -778,6 +797,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
             staging5,
             staging6,
             staging7,
+            staging8,
         )
         signals = (
             signal0,
@@ -788,6 +808,7 @@ class _TwoShotPullAllReduceLaunch(_TwoShotBf16Launch):
             signal5,
             signal6,
             signal7,
+            signal8,
         )
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
@@ -909,10 +930,10 @@ def get_twoshot_bf16_allreduce_launcher(
         device_index,
     )
     del device_index
-    if world_size != _SUPPORTED_WORLD_SIZE:
+    if world_size not in _SUPPORTED_WORLD_SIZES:
         raise ValueError(
-            "single-rounding BF16 two-shot launchers require world size 4, "
-            f"got {world_size}"
+            "single-rounding BF16 two-shot launchers require a world size in "
+            f"{_SUPPORTED_WORLD_SIZES}, got {world_size}"
         )
     if rank < 0 or rank >= world_size:
         raise ValueError(f"rank {rank} is outside world size {world_size}")
@@ -952,7 +973,7 @@ def get_twoshot_bf16_allreduce_launcher(
                 cute.AddressSpace.gmem,
                 assumed_align=16,
             )
-            for _ in range(8)
+            for _ in range(9)
         ),
         *(
             make_ptr(
@@ -961,7 +982,7 @@ def get_twoshot_bf16_allreduce_launcher(
                 cute.AddressSpace.gmem,
                 assumed_align=4,
             )
-            for _ in range(8)
+            for _ in range(9)
         ),
         make_ptr(cutlass.Uint32, 16, cute.AddressSpace.gmem, assumed_align=16),
         0,
@@ -972,7 +993,7 @@ def get_twoshot_bf16_allreduce_launcher(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "comm.pcie.twoshot_bf16.all_reduce_pull",
-            1,
+            2,
             cache_key,
         ),
     )
@@ -988,8 +1009,8 @@ def get_twoshot_bf16_allreduce_launcher(
         rows_per_rank: int,
         grid_x: int,
     ) -> None:
-        if len(staging_addresses) != 8 or len(signal_addresses) != 8:
-            raise ValueError("two-shot scalar pointer ABI requires eight peers")
+        if len(staging_addresses) != 9 or len(signal_addresses) != 9:
+            raise ValueError("two-shot scalar pointer ABI requires nine peer slots")
         raw_args = (
             make_ptr(
                 cutlass.Uint32,

--- a/b12x/comm/pcie/pcie_allreduce.py
+++ b/b12x/comm/pcie/pcie_allreduce.py
@@ -73,7 +73,9 @@ def recommended_max_bytes(world_size: int, *, default: int = DEFAULT_MAX_SIZE) -
     return default
 
 
-MAX_DIRECT_WORLD_SIZE = 8
+# Nine ranks use at most eight peer mappings per CUDA context. Larger groups
+# use the bounded-degree hierarchy instead of an all-peer pointer table.
+MAX_DIRECT_WORLD_SIZE = 9
 DIRECT_WORLD_SIZES = tuple(
     world_size
     for world_size in ONESHOT_WORLD_SIZES
@@ -96,7 +98,7 @@ def _algorithm_for_world_size(world_size: int) -> str:
 class PCIeAllReduce:
     """Select a peer-safe all-reduce implementation from the world size.
 
-    Worlds through TP8 use the low-latency all-peer oneshot runtime. TP12 and
+    Worlds through TP9 use the low-latency all-peer oneshot runtime. TP12 and
     TP16 use bounded-degree four-GPU islands so no CUDA context maps more than
     six peers. Other worlds fail closed instead of exceeding the CUDA peer
     connection limit.

--- a/b12x/comm/pcie/pcie_dcp_a2a.py
+++ b/b12x/comm/pcie/pcie_dcp_a2a.py
@@ -36,7 +36,7 @@ from .pcie_oneshot import (
 )
 
 
-SUPPORTED_WORLD_SIZES = (2, 4, 8, 16)
+SUPPORTED_WORLD_SIZES = (2, 4, 8, 9, 16)
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 SUPPORTED_GATHER_DTYPES = (*SUPPORTED_DTYPES, torch.float8_e4m3fn)
 SUPPORTED_PAIR_DTYPES = (*SUPPORTED_GATHER_DTYPES, torch.float32)
@@ -66,7 +66,11 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         return False
     batch, heads, head_dim = (int(value) for value in tensor.shape)
     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
-    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+    packed_token_major = (
+        stride_batch >= heads * head_dim
+        and stride_batch % 8 == 0
+        and stride_head == head_dim
+    )
     capacity_strided_head_major = (
         stride_batch == head_dim
         and stride_head >= batch * head_dim

--- a/b12x/comm/pcie/pcie_dma.py
+++ b/b12x/comm/pcie/pcie_dma.py
@@ -33,7 +33,7 @@ SUPPORTED_DTYPES = {
     torch.float16: 1,
     torch.float32: 2,
 }
-SUPPORTED_WORLD_SIZES = (2, 4, 6, 8, 10)
+SUPPORTED_WORLD_SIZES = (2, 4, 6, 8, 9, 10)
 FLAG_STRIDE = 128
 FLAG_SLOTS = 256
 MAX_PIECES = 8

--- a/b12x/comm/pcie/pcie_dma.py
+++ b/b12x/comm/pcie/pcie_dma.py
@@ -172,6 +172,16 @@ class PCIeDmaAllReduce:
         if self.device.type != "cuda":
             raise ValueError("PCIe ring allreduce requires a CUDA device")
         self.max_bytes = int(max_bytes)
+        self._wire_input = None
+        self._wire_output = None
+        if self.world_size == 9:
+            # Eight-element shards keep vector accesses aligned for every
+            # supported dtype. Wire tails do not change the model tensors.
+            wire_bytes = _align_up(self.max_bytes, self.world_size * 8 * 4)
+            self._wire_input = torch.empty(
+                wire_bytes, dtype=torch.uint8, device=self.device
+            )
+            self._wire_output = torch.empty_like(self._wire_input)
         self._kernels = _load_kernels()
         self._ipc = CudaRTLibrary()
         self._ipc.cudaSetDevice(self.device.index or 0)
@@ -329,7 +339,8 @@ class PCIeDmaAllReduce:
         if inp.dtype not in SUPPORTED_DTYPES:
             return False
         numel = inp.numel()
-        if numel <= 0 or numel % (self.world_size * 8) != 0:
+        alignment = 8 if self.world_size == 9 else self.world_size * 8
+        if numel <= 0 or numel % alignment != 0:
             return False
         size_bytes = numel * inp.element_size()
         if size_bytes < self.min_bytes:
@@ -363,6 +374,24 @@ class PCIeDmaAllReduce:
             raise ValueError(
                 "output must match input shape/dtype/device and be contiguous"
             )
+        if self.world_size == 9 and inp.numel() % (self.world_size * 8):
+            numel = inp.numel()
+            wire_numel = _align_up(numel, self.world_size * 8)
+            wire_bytes = wire_numel * inp.element_size()
+            assert self._wire_input is not None and self._wire_output is not None
+            wire_in = self._wire_input[:wire_bytes].view(inp.dtype)
+            wire_out = self._wire_output[:wire_bytes].view(inp.dtype)
+            wire_in[:numel].copy_(inp.view(-1))
+            wire_in[numel:].zero_()
+            self._all_reduce_aligned(wire_in, wire_out)
+            out.view(-1).copy_(wire_out[:numel])
+            return out
+        return self._all_reduce_aligned(inp, out)
+
+    def _all_reduce_aligned(
+        self, inp: torch.Tensor, out: torch.Tensor
+    ) -> torch.Tensor:
+        """Reduce equal, eight-element-aligned shards into the supplied output."""
         kernels = self._kernels
         world = self.world_size
         rank = self.rank

--- a/b12x/comm/pcie/pcie_island9.py
+++ b/b12x/comm/pcie/pcie_island9.py
@@ -1,0 +1,299 @@
+"""Push-based nine-rank island all-reduce runtime (two PCIe islands + root rank).
+
+Serves the mid-size bf16 all-reduce class (a few KB to a few hundred KB) on
+the nine-GPU PCIe topology where ranks 0-3 and 4-7 sit behind two switch
+clusters and rank 8 on the CPU root complex. Rank ``island * 4 + lane`` owns
+quarter ``lane`` of the vector; rank 8 contributes through island 0. Every
+remote transfer is a posted write into a peer inbox, each rank maps at most
+five peers, and the reduction accumulates in fp32 with one bf16 rounding
+(island partials stay in fp32).
+
+The public surface mirrors :class:`PCIeTwoShotBF16` where vLLM's PCIe
+crossover dispatcher needs it: ``accepts``, ``all_reduce(inp, out=)``,
+``prepare_graph``, ``capture``, ``close``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from contextlib import contextmanager
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from ._island9_cute import (
+    HEADER_BYTES,
+    ISLAND_SIZE,
+    MAX_BLOCKS,
+    WORLD_SIZE,
+    get_island9_launcher,
+    island9_peers,
+)
+from ._cuda_ipc import CudaRTLibrary
+from .pcie_oneshot import (
+    PCIeOneshotAllReduce,
+    _finish_collective_runtime_setup,
+    _is_current_stream_capturing,
+    _normalize_device,
+)
+
+SUPPORTED_WORLD_SIZES = (WORLD_SIZE,)
+SUPPORTED_BLOCKS = (1, 2, 4, 8, 16, 32)
+_ALIGNMENT = 256
+
+
+def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
+    return (int(value) + alignment - 1) // alignment * alignment
+
+
+def _threads_from_env() -> int:
+    raw = os.getenv("B12X_PCIE_ISLAND9_THREADS", "256")
+    threads = int(raw)
+    if not 32 <= threads <= 1024 or threads % 32:
+        raise ValueError(
+            "B12X_PCIE_ISLAND9_THREADS must be a multiple of 32 in [32, 1024]"
+        )
+    return threads
+
+
+def _wait_nanosleep_cycles_from_env() -> int:
+    cycles = int(os.getenv("B12X_PCIE_ISLAND9_NANOSLEEP_CYCLES", "24"))
+    if not 0 <= cycles <= 1024:
+        raise ValueError("B12X_PCIE_ISLAND9_NANOSLEEP_CYCLES must be in [0, 1024]")
+    return cycles
+
+
+def _pick_blocks(elements: int) -> int:
+    """Launch geometry by element count: one warp-row of blocks per ~4 KB."""
+    if elements <= 8192:
+        return 8
+    if elements <= 65536:
+        return 16
+    return 32
+
+
+class PCIeIsland9AllReduce:
+    """Equal-quarter bf16 all-reduce for TP9 on two PCIe islands plus a root rank."""
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_elements: int,
+        blocks: Optional[int] = None,
+    ) -> None:
+        self.group = exchange_group
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.device = _normalize_device(device)
+        if self.world_size not in SUPPORTED_WORLD_SIZES:
+            raise ValueError(f"island9 all-reduce requires TP9, got TP{self.world_size}")
+        if self.device.type != "cuda":
+            raise ValueError("island9 all-reduce requires a CUDA device")
+        if blocks is not None and blocks not in SUPPORTED_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        if max_elements <= 0 or max_elements % 2:
+            raise ValueError("max_elements must be a positive even count")
+
+        self.max_elements = int(max_elements)
+        self.blocks = None if blocks is None else int(blocks)
+        self.threads = _threads_from_env()
+        self.wait_nanosleep_cycles = _wait_nanosleep_cycles_from_env()
+        self.all_reduce_mode = "push"
+
+        max_pairs = self.max_elements // 2
+        # Quarter stride in bf16x2 words; every inbox has two generation slots.
+        self.quarter_capacity = _align_up((max_pairs + ISLAND_SIZE - 1) // ISLAND_SIZE, 8)
+        quarter_bytes = self.quarter_capacity * 4
+        stage_bytes = 5 * quarter_bytes  # four island lanes + rank 8
+        part_bytes = 2 * quarter_bytes  # fp32 pairs
+        final_bytes = ISLAND_SIZE * quarter_bytes
+        self.stage_offset = _align_up(HEADER_BYTES)
+        self.part_self_offset = _align_up(self.stage_offset + 2 * stage_bytes)
+        self.part_inbox_offset = _align_up(self.part_self_offset + 2 * part_bytes)
+        self.final_offset = _align_up(self.part_inbox_offset + 2 * part_bytes)
+        self.slab_bytes = _align_up(self.final_offset + 2 * final_bytes)
+
+        self._ipc = CudaRTLibrary()
+        self._ipc.cudaSetDevice(self.device.index or 0)
+        self._slab_ptrs: tuple[int, ...] = ()
+        self._local_ptr = 0
+        self._remote_ptrs: list[int] = []
+        self._closed = False
+        self._launcher = None
+        self._mapped_peers = island9_peers(self.rank)
+        self._capture_depth = 0
+
+        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
+            exchange_group,
+            self.slab_bytes,
+            zero_fill=True,
+            ipc=self._ipc,
+            peer_ranks=self._mapped_peers,
+        )
+        self._local_ptr = shared.local_ptr
+        self._remote_ptrs = list(shared.remote_ptrs)
+        self._slab_ptrs = shared.peer_ptrs
+
+        init_error: BaseException | None = None
+        try:
+            with torch.cuda.device(self.device):
+                self._launcher = get_island9_launcher(
+                    self.rank,
+                    self.device.index or 0,
+                    threads=self.threads,
+                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
+                )
+        except Exception as exc:
+            init_error = exc
+
+        def detach_shared_ownership() -> None:
+            self._slab_ptrs = ()
+            self._remote_ptrs.clear()
+            self._local_ptr = 0
+
+        _finish_collective_runtime_setup(
+            owner="PCIe island9 all-reduce",
+            exchange_group=exchange_group,
+            ipc=self._ipc,
+            shared=shared,
+            local_error=init_error,
+            detach_shared_ownership=detach_shared_ownership,
+        )
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_rows: int,
+        row_elems: int,
+    ) -> "PCIeIsland9AllReduce":
+        """Construct with the two-shot runtime's capacity vocabulary."""
+        elements = int(max_rows) * int(row_elems)
+        return cls(
+            exchange_group=exchange_group,
+            device=device,
+            max_elements=elements - (elements % 2),
+        )
+
+    @property
+    def mapped_peers(self) -> tuple[int, ...]:
+        return self._mapped_peers
+
+    def accepts(self, inp: torch.Tensor) -> bool:
+        return (
+            not self._closed
+            and inp.device == self.device
+            and inp.dtype == torch.bfloat16
+            and inp.is_contiguous()
+            and 0 < inp.numel() <= self.max_elements
+            and inp.numel() % 2 == 0
+            and inp.data_ptr() % 4 == 0
+        )
+
+    should_allreduce = accepts
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        out: Optional[torch.Tensor] = None,
+        *,
+        blocks: Optional[int] = None,
+        stream: object = None,
+        channel_id: Optional[str] = None,
+        threads: Optional[int] = None,
+        block_limit: Optional[int] = None,
+    ) -> torch.Tensor:
+        del channel_id, threads, block_limit
+        if not self.accepts(inp):
+            raise ValueError(
+                "input does not satisfy island9 all-reduce requirements "
+                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
+            )
+        if out is None:
+            if _is_current_stream_capturing(self.device):
+                raise RuntimeError(
+                    "PCIeIsland9AllReduce.all_reduce CUDA graph capture requires "
+                    "a caller-owned preallocated output"
+                )
+            out = torch.empty_like(inp)
+        if (
+            out.dtype != inp.dtype
+            or out.device != inp.device
+            or out.shape != inp.shape
+            or not out.is_contiguous()
+            or out.data_ptr() % 4 != 0
+        ):
+            raise ValueError("output must match input and be 4-byte aligned")
+        if blocks is not None:
+            selected = int(blocks)
+        elif self.blocks is not None:
+            selected = self.blocks
+        else:
+            selected = _pick_blocks(inp.numel())
+        if selected not in SUPPORTED_BLOCKS or selected > MAX_BLOCKS:
+            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
+        with torch.cuda.device(self.device):
+            self._launcher(
+                self._slab_ptrs,
+                inp.data_ptr(),
+                out.data_ptr(),
+                self.stage_offset,
+                self.part_self_offset,
+                self.part_inbox_offset,
+                self.final_offset,
+                self.quarter_capacity,
+                inp.numel(),
+                selected,
+                stream,
+            )
+        return out
+
+    def prepare_graph(self, **kwargs: object) -> None:
+        """The launcher is resolved at construction; nothing to stage before capture."""
+        del kwargs
+        if self._closed:
+            raise RuntimeError("PCIeIsland9AllReduce is closed")
+
+    @contextmanager
+    def capture(self, **kwargs: object):
+        del kwargs
+        self.prepare_graph()
+        self._capture_depth += 1
+        try:
+            yield self
+        finally:
+            self._capture_depth -= 1
+
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        del channel_ids
+
+    def for_stream(self, stream: object = None, *, channel_id: Optional[str] = None):
+        del stream, channel_id
+        return self
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+        dist.barrier(group=self.group)
+        self._slab_ptrs = ()
+        for ptr in self._remote_ptrs:
+            self._ipc.cudaIpcCloseMemHandle(ptr)
+        self._remote_ptrs.clear()
+        dist.barrier(group=self.group)
+        if self._local_ptr:
+            self._ipc.cudaFree(self._local_ptr)
+            self._local_ptr = 0
+        dist.barrier(group=self.group)
+
+
+__all__ = ["PCIeIsland9AllReduce", "SUPPORTED_BLOCKS", "SUPPORTED_WORLD_SIZES"]

--- a/b12x/comm/pcie/pcie_oneshot.py
+++ b/b12x/comm/pcie/pcie_oneshot.py
@@ -21,7 +21,7 @@ from ._cuda_ipc import CudaRTLibrary
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_WORLD_SIZES = (2, 4, 6, 8, 10)
+SUPPORTED_WORLD_SIZES = (2, 4, 6, 8, 9, 10)
 SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 DEFAULT_MAX_SIZE = 8 * 1024 * 1024
 DEFAULT_RANK_DATA_BYTES = 8 * 1024 * 1024

--- a/b12x/comm/pcie/pcie_twoshot_bf16.py
+++ b/b12x/comm/pcie/pcie_twoshot_bf16.py
@@ -88,10 +88,13 @@ def _make_layout(max_rows: int, row_elems: int, world_size: int) -> _TwoShotBf16
     packs_per_row = row_elems // _PACK_ELEMS
     pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
     payload_bytes = world_size * pack_stride * 16
-    # The pull all-reduce keeps one reduced shard (pack_stride packs) per slot
-    # after the full staged payload.
+    # After the staged payload each slot keeps a reduced region with one
+    # shard per source rank: the pull all-reduce publishes its own shard in
+    # the first entry, the push all-reduce receives every peer's shard.
     reduced_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
-    slot_bytes = _align_up(reduced_offset + pack_stride * 16, IPC_SLAB_ALIGNMENT)
+    slot_bytes = _align_up(
+        reduced_offset + world_size * pack_stride * 16, IPC_SLAB_ALIGNMENT
+    )
     signal_bytes = _align_up(_SIGNAL_BYTES, IPC_SLAB_ALIGNMENT)
     return _TwoShotBf16Layout(
         signal_bytes=signal_bytes,
@@ -191,6 +194,9 @@ class PCIeTwoShotBF16:
             )
             self._wire_output = torch.empty_like(self._wire_input)
         self._closed_ipc_import_indices: set[tuple[int, int]] = set()
+        # "pull": remote reads (the original single-launch kernel);
+        # "push": posted remote writes. Same partition and reduction order.
+        self.all_reduce_mode = "pull"
         return self
 
     @classmethod
@@ -420,6 +426,7 @@ class PCIeTwoShotBF16:
                     threads,
                     self.row_elems,
                     device_index,
+                    self.all_reduce_mode,
                 )
 
     @contextmanager
@@ -507,6 +514,7 @@ class PCIeTwoShotBF16:
                     threads,
                     self.row_elems,
                     device_index,
+                    self.all_reduce_mode,
                 )
             else:
                 prepared = is_twoshot_bf16_launcher_prepared(
@@ -678,6 +686,7 @@ class PCIeTwoShotBF16:
                 threads,
                 self.row_elems,
                 device_index,
+                self.all_reduce_mode,
             )
             launcher(
                 payload.data_ptr(),
@@ -690,6 +699,7 @@ class PCIeTwoShotBF16:
                 rows_per_rank,
                 remainder_packs,
                 blocks,
+                pack_stride=self._pack_stride,
             )
 
     def all_reduce(
@@ -700,7 +710,11 @@ class PCIeTwoShotBF16:
         threads: int = 512,
         block_limit: int = 64,
     ) -> torch.Tensor:
-        """FP32-accumulating BF16 all-reduce with one BF16 rounding."""
+        """FP32-accumulating BF16 all-reduce with one BF16 rounding.
+
+        ``all_reduce_mode`` selects remote reads (``pull``) or posted remote
+        writes (``push``); both give bit-identical results.
+        """
         if not self.accepts(inp):
             raise ValueError("input not accepted by PCIeTwoShotBF16.all_reduce")
         logical_numel = inp.numel()

--- a/b12x/comm/pcie/pcie_twoshot_bf16.py
+++ b/b12x/comm/pcie/pcie_twoshot_bf16.py
@@ -49,11 +49,21 @@ from .pcie_twoshot import (
     TWOSHOT_REQUIRED_SMS,
     _MAX_BLOCKS,
     _SIGNAL_BYTES,
-    _pad_scalar_peer_ptrs,
 )
 
+SUPPORTED_WORLD_SIZES = (2, 4, 8, 9)
 _PACK_ELEMS = 8
 SUPPORTED_WORLD_SIZES = (4,)
+
+
+def _pad_scalar_peer_ptrs(pointers, *, rank, world_size):
+    """Retain every peer in the nine-slot BF16 launch ABI."""
+    live = tuple(int(pointer) for pointer in pointers)
+    if world_size not in SUPPORTED_WORLD_SIZES or len(live) != world_size:
+        raise ValueError("invalid BF16 two-shot peer set")
+    if not 0 <= rank < world_size:
+        raise ValueError("BF16 two-shot rank is outside its peer set")
+    return live + (live[rank],) * (9 - world_size)
 
 
 @dataclass(frozen=True)
@@ -146,11 +156,13 @@ class PCIeTwoShotBF16:
         self._staging_ptrs = tuple(
             tuple(int(pointer) for pointer in slot) for slot in staging_ptrs
         )
-        if len(self._signal_ptrs) != 8 or (
+        if len(self._signal_ptrs) != 9 or (
             len(self._staging_ptrs) != 2
-            or any(len(slot) != 8 for slot in self._staging_ptrs)
+            or any(len(slot) != 9 for slot in self._staging_ptrs)
         ):
-            raise ValueError("two-shot scalar pointer ABI requires 8 peers and 2 slots")
+            raise ValueError(
+                "two-shot scalar pointer ABI requires 9 peer slots and 2 slots"
+            )
         self._owned_buffers = list(owned_buffers)
         self._ipc = ipc
         self.max_rows = max_rows

--- a/b12x/comm/pcie/pcie_twoshot_bf16.py
+++ b/b12x/comm/pcie/pcie_twoshot_bf16.py
@@ -178,6 +178,15 @@ class PCIeTwoShotBF16:
         self._ipc_imports_closed = False
         self._ipc_exports_freed = False
         self._coordinated_close_complete = False
+        self._wire_input = None
+        self._wire_output = None
+        if world_size == 9:
+            # Model widths need not divide nine. These fixed owners keep wire
+            # padding allocation-free during eager launches and graph replay.
+            self._wire_input = torch.empty(
+                (max_rows, row_elems), dtype=torch.bfloat16, device=self.device
+            )
+            self._wire_output = torch.empty_like(self._wire_input)
         self._closed_ipc_import_indices: set[tuple[int, int]] = set()
         return self
 
@@ -344,9 +353,12 @@ class PCIeTwoShotBF16:
         if inp.device != self.device:
             return False
         numel = inp.numel()
-        if numel == 0 or numel % (self.row_elems * self.world_size) != 0:
+        if numel == 0 or numel % _PACK_ELEMS != 0:
             return False
-        return numel // self.row_elems <= self.max_rows
+        alignment = self.row_elems * self.world_size
+        if self.world_size == 9:
+            return _align_up(numel, alignment) <= self.max_rows * self.row_elems
+        return numel % alignment == 0 and numel // self.row_elems <= self.max_rows
 
     # ---- graph plumbing ---------------------------------------------------
 
@@ -664,8 +676,9 @@ class PCIeTwoShotBF16:
         """FP32-accumulating BF16 all-reduce with one BF16 rounding."""
         if not self.accepts(inp):
             raise ValueError("input not accepted by PCIeTwoShotBF16.all_reduce")
-        rows = inp.numel() // self.row_elems
-        payload = inp.view(rows, self.row_elems)
+        logical_numel = inp.numel()
+        wire_numel = _align_up(logical_numel, self.row_elems * self.world_size)
+        rows = wire_numel // self.row_elems
         with _device_guard(self.device):
             if out is None:
                 if _is_current_stream_capturing(self.device):
@@ -680,7 +693,16 @@ class PCIeTwoShotBF16:
                 name="output",
             )
             _require_disjoint(out, inp, source_name="input")
-            out_view = out.view(rows, self.row_elems)
+            padded = wire_numel != logical_numel
+            if padded:
+                assert self._wire_input is not None and self._wire_output is not None
+                payload = self._wire_input[:rows]
+                payload.view(-1)[:logical_numel].copy_(inp.view(-1))
+                payload.view(-1)[logical_numel:].zero_()
+                out_view = self._wire_output[:rows]
+            else:
+                payload = inp.view(rows, self.row_elems)
+                out_view = out.view(rows, self.row_elems)
             self._launch_pull_all_reduce(
                 payload,
                 out_view,
@@ -688,6 +710,8 @@ class PCIeTwoShotBF16:
                 threads=threads,
                 block_limit=block_limit,
             )
+            if padded:
+                out.view(-1).copy_(out_view.view(-1)[:logical_numel])
         return out
 
     # ---- teardown (mirrors pcie_twoshot) -----------------------------------

--- a/b12x/comm/pcie/pcie_twoshot_bf16.py
+++ b/b12x/comm/pcie/pcie_twoshot_bf16.py
@@ -180,9 +180,12 @@ class PCIeTwoShotBF16:
         self._coordinated_close_complete = False
         self._wire_input = None
         self._wire_output = None
-        if world_size == 9:
-            # Model widths need not divide nine. These fixed owners keep wire
-            # padding allocation-free during eager launches and graph replay.
+        if world_size == 9 and row_elems != _PACK_ELEMS:
+            # Multi-pack rows cannot be split at pack granularity, so payloads
+            # whose row count does not divide nine are padded on the wire.
+            # These fixed owners keep that padding allocation-free during
+            # eager launches and graph replay. Single-pack rows use the
+            # balanced pack partition of the pull all-reduce instead.
             self._wire_input = torch.empty(
                 (max_rows, row_elems), dtype=torch.bfloat16, device=self.device
             )
@@ -355,10 +358,26 @@ class PCIeTwoShotBF16:
         numel = inp.numel()
         if numel == 0 or numel % _PACK_ELEMS != 0:
             return False
+        if self._balanced_partition:
+            # Pack-granular shards: the largest shard must fit the per-rank
+            # reduced region, and the whole payload the staged payload region.
+            packs = numel // _PACK_ELEMS
+            largest_shard = -(-packs // self.world_size)
+            return largest_shard <= self._pack_stride
         alignment = self.row_elems * self.world_size
         if self.world_size == 9:
             return _align_up(numel, alignment) <= self.max_rows * self.row_elems
         return numel % alignment == 0 and numel // self.row_elems <= self.max_rows
+
+    @property
+    def _balanced_partition(self) -> bool:
+        """True when ``all_reduce`` splits payloads at pack granularity.
+
+        Single-pack rows let the pull all-reduce hand each rank a contiguous
+        pack range whose lengths differ by at most one, so no payload needs
+        wire padding. Wider rows keep the row-aligned equal shards.
+        """
+        return self.row_elems == _PACK_ELEMS
 
     # ---- graph plumbing ---------------------------------------------------
 
@@ -448,11 +467,16 @@ class PCIeTwoShotBF16:
         rows_per_rank: int,
         threads: int,
         block_limit: int,
+        remainder_packs: int = 0,
     ) -> tuple[int, int, int]:
         threads = int(threads)
         if threads <= 0 or threads > 512 or threads % 32 != 0:
             raise ValueError("threads must be a warp-aligned value in [32, 512]")
+        if not 0 <= int(remainder_packs) < self.world_size:
+            raise ValueError("remainder_packs must be below the world size")
         shard_packs = rows_per_rank * (self.row_elems // _PACK_ELEMS)
+        if remainder_packs:
+            shard_packs += 1
         if shard_packs > self._pack_stride:
             raise ValueError("pcie_twoshot_bf16 staging capacity exceeded")
         if block_limit <= 0 or block_limit > _MAX_BLOCKS:
@@ -636,12 +660,14 @@ class PCIeTwoShotBF16:
         rows_per_rank: int,
         threads: int,
         block_limit: int,
+        remainder_packs: int = 0,
     ) -> None:
         blocks, slot, device_index = self._resolve_launch_parameters(
             "all_reduce",
             rows_per_rank=rows_per_rank,
             threads=threads,
             block_limit=block_limit,
+            remainder_packs=remainder_packs,
         )
         with torch.cuda.device(self.device):
             launcher = get_twoshot_bf16_allreduce_launcher(
@@ -662,6 +688,7 @@ class PCIeTwoShotBF16:
                 self._reduced_offset,
                 self._slot_bytes,
                 rows_per_rank,
+                remainder_packs,
                 blocks,
             )
 
@@ -677,8 +704,6 @@ class PCIeTwoShotBF16:
         if not self.accepts(inp):
             raise ValueError("input not accepted by PCIeTwoShotBF16.all_reduce")
         logical_numel = inp.numel()
-        wire_numel = _align_up(logical_numel, self.row_elems * self.world_size)
-        rows = wire_numel // self.row_elems
         with _device_guard(self.device):
             if out is None:
                 if _is_current_stream_capturing(self.device):
@@ -693,6 +718,19 @@ class PCIeTwoShotBF16:
                 name="output",
             )
             _require_disjoint(out, inp, source_name="input")
+            if self._balanced_partition:
+                packs = logical_numel // _PACK_ELEMS
+                self._launch_pull_all_reduce(
+                    inp.view(-1),
+                    out.view(-1),
+                    rows_per_rank=packs // self.world_size,
+                    remainder_packs=packs % self.world_size,
+                    threads=threads,
+                    block_limit=block_limit,
+                )
+                return out
+            wire_numel = _align_up(logical_numel, self.row_elems * self.world_size)
+            rows = wire_numel // self.row_elems
             padded = wire_numel != logical_numel
             if padded:
                 assert self._wire_input is not None and self._wire_output is not None

--- a/b12x/comm/pcie/pcie_twoshot_bf16.py
+++ b/b12x/comm/pcie/pcie_twoshot_bf16.py
@@ -51,9 +51,11 @@ from .pcie_twoshot import (
     _SIGNAL_BYTES,
 )
 
+# Topologies with retained qualification evidence: TP4 (GLM-5.3 DCP4,
+# docs/evidence/pcie_twoshot_bf16_sm120.md) and the Kimi-K3 TP8/TP9 PCIe rings
+# (tests/comm/test_pcie_tp9_physical.py, nine RTX PRO 6000).
 SUPPORTED_WORLD_SIZES = (2, 4, 8, 9)
 _PACK_ELEMS = 8
-SUPPORTED_WORLD_SIZES = (4,)
 
 
 def _pad_scalar_peer_ptrs(pointers, *, rank, world_size):
@@ -78,7 +80,7 @@ class _TwoShotBf16Layout:
 def _make_layout(max_rows: int, row_elems: int, world_size: int) -> _TwoShotBf16Layout:
     if world_size not in SUPPORTED_WORLD_SIZES:
         raise ValueError(
-            f"PCIeTwoShotBF16 supports only world size 4, got {world_size}"
+            f"PCIeTwoShotBF16 supports world sizes {SUPPORTED_WORLD_SIZES}, got {world_size}"
         )
     if max_rows <= 0 or max_rows % world_size != 0:
         raise ValueError("max_rows must be positive and divisible by world size")
@@ -127,7 +129,7 @@ def _require_disjoint(
 
 
 class PCIeTwoShotBF16:
-    """Serialized single-rounding BF16 collective runtime for world size 4."""
+    """Serialized single-rounding BF16 collective runtime (world sizes 2/4/8/9)."""
 
     def __init__(self, *args, **kwargs) -> None:
         raise RuntimeError("use PCIeTwoShotBF16.from_exchange_group()")
@@ -217,7 +219,7 @@ class PCIeTwoShotBF16:
             normalized_row_elems = int(row_elems)
             if world_size not in SUPPORTED_WORLD_SIZES:
                 raise ValueError(
-                    f"PCIeTwoShotBF16 supports only world size 4, got {world_size}"
+                    f"PCIeTwoShotBF16 supports world sizes {SUPPORTED_WORLD_SIZES}, got {world_size}"
                 )
             if device_obj.type != "cuda":
                 raise ValueError("PCIe twoshot requires a CUDA device")
@@ -367,9 +369,16 @@ class PCIeTwoShotBF16:
         if self._balanced_partition:
             # Pack-granular shards: the largest shard must fit the per-rank
             # reduced region, and the whole payload the staged payload region.
+            # The region size follows the layout of the configured capacity
+            # (a runtime built without a slab derives it the same way).
+            pack_stride = getattr(self, "_pack_stride", None)
+            if pack_stride is None:
+                pack_stride = _make_layout(
+                    self.max_rows, self.row_elems, self.world_size
+                ).pack_stride
             packs = numel // _PACK_ELEMS
             largest_shard = -(-packs // self.world_size)
-            return largest_shard <= self._pack_stride
+            return largest_shard <= pack_stride
         alignment = self.row_elems * self.world_size
         if self.world_size == 9:
             return _align_up(numel, alignment) <= self.max_rows * self.row_elems

--- a/b12x/moe/_shared/qsrt_sharding.py
+++ b/b12x/moe/_shared/qsrt_sharding.py
@@ -1,0 +1,38 @@
+"""Whole-H128 ownership for the coupled K2 QSRT expert representation.
+
+Source atom indices select the rotation signs and ordinary input scale, so
+they remain part of the loading contract after rank ownership changes.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QSRTAtomExtent:
+    first_atom: int
+    atom_count: int
+
+    @property
+    def intermediate_channels(self) -> int:
+        return self.atom_count * 32
+
+
+def plan_qsrt_tp9_rank(layer: int, rank: int) -> QSRTAtomExtent:
+    """Assign all atoms once and rotate smaller extents across model layers.
+
+    This policy balances resident bytes. Six ranks still own three H128 blocks
+    per expert, so it does not imply lower per-layer critical-path work.
+    """
+    if not 1 <= layer <= 92:
+        raise ValueError("coupled K2 QSRT layer must lie in 1..92")
+    if not 0 <= rank < 9:
+        raise ValueError("TP9 rank must lie in 0..8")
+    owner = (rank - (layer - 1)) % 9
+    if owner < 5:
+        half, half_rank, ranks_in_half = 0, owner, 5
+    else:
+        half, half_rank, ranks_in_half = 1, owner - 5, 4
+    quotient, remainder = divmod(12, ranks_in_half)
+    blocks = quotient + int(half_rank < remainder)
+    begin = half_rank * quotient + min(half_rank, remainder)
+    return QSRTAtomExtent(48 * half + 4 * begin, 4 * blocks)

--- a/benchmarks/benchmark_pcie_tp9_allreduce.py
+++ b/benchmarks/benchmark_pcie_tp9_allreduce.py
@@ -1,0 +1,209 @@
+"""Per-call latency of the PCIe all-reduce paths on nine physical GPUs.
+
+Times the B12X one-shot pool, the BF16 two-shot runtime and the PyNCCL
+all-reduce for Kimi-K3 decode payloads (``T`` rows of 7168 or 3584 bf16
+elements) on the full nine-rank exchange group, eager and inside a replayed
+CUDA graph. Every path is checked bit-exactly against an fp32 reference before
+it is timed. Rank 0 prints one JSON line per (path, shape, mode) with the
+median and p90 microseconds over ``--iters`` synchronized calls.
+
+Run with nine idle GPUs::
+
+    CUDA_VISIBLE_DEVICES=1,2,3,4,5,6,7,8,0 python benchmarks/benchmark_pcie_tp9_allreduce.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import statistics
+import time
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+DEFAULT_SHAPES = "4x7168,8x7168,16x7168,32x7168,4x3584,8x3584,16x3584"
+
+
+def _shapes(raw: str) -> tuple[tuple[int, int], ...]:
+    shapes = []
+    for item in raw.split(","):
+        rows, width = item.lower().split("x", 1)
+        shapes.append((int(rows), int(width)))
+    return tuple(shapes)
+
+
+def _pattern(rows: int, width: int, rank: int, device: torch.device) -> torch.Tensor:
+    base = torch.arange(rows * width, device=device).remainder(5) + 1
+    return (base * (rank + 1)).to(torch.bfloat16).view(rows, width)
+
+
+def _expected(rows: int, width: int, world: int, device: torch.device) -> torch.Tensor:
+    total = world * (world + 1) // 2
+    return _pattern(rows, width, 0, device) * total
+
+
+def _time(fn, device: torch.device, iters: int, warmup: int) -> tuple[float, float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize(device)
+    dist.barrier()
+    samples = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0)
+    samples.sort()
+    return statistics.median(samples), samples[min(len(samples) - 1, int(len(samples) * 0.9))]
+
+
+def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
+    from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+    from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
+
+    world = args.world_size
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world,
+        timeout=timedelta(seconds=300),
+        device_id=device,
+    )
+    group = dist.group.WORLD
+    shapes = _shapes(args.shapes)
+    results = []
+
+    def emit(path: str, rows: int, width: int, mode: str, median: float, p90: float):
+        record = {
+            "path": path, "rows": rows, "width": width,
+            "bytes": rows * width * 2, "mode": mode,
+            "median_us": round(median, 2), "p90_us": round(p90, 2),
+            "world_size": world,
+        }
+        results.append(record)
+        if rank == 0:
+            print(json.dumps(record), flush=True)
+
+    def verify(out: torch.Tensor, rows: int, width: int, path: str) -> None:
+        torch.cuda.synchronize(device)
+        expected = _expected(rows, width, world, device)
+        if not torch.equal(out, expected):
+            raise AssertionError(f"{path} {rows}x{width} mismatch on rank {rank}")
+
+    # PyNCCL baseline.
+    for rows, width in shapes:
+        inp = _pattern(rows, width, rank, device)
+        work = inp.clone()
+
+        def nccl_call():
+            work.copy_(inp)
+            dist.all_reduce(work, group=group)
+
+        nccl_call()
+        verify(work, rows, width, "nccl")
+        median, p90 = _time(nccl_call, device, args.iters, args.warmup)
+        emit("nccl", rows, width, "eager", median, p90)
+
+    # B12X one-shot pool (all-peer pull).
+    pool = PCIeOneshotAllReducePool.from_process_group(
+        process_group=group,
+        device=device,
+        max_input_bytes=max(rows * width * 2 for rows, width in shapes),
+        max_concurrent_channels=2,
+    )
+    pool.prepare_channels(("eager", "graph"))
+    for rows, width in shapes:
+        inp = _pattern(rows, width, rank, device)
+        out = torch.empty_like(inp)
+        pool.all_reduce(inp, out=out, channel_id="eager")
+        verify(out, rows, width, "oneshot")
+        median, p90 = _time(
+            lambda: pool.all_reduce(inp, out=out, channel_id="eager"),
+            device, args.iters, args.warmup,
+        )
+        emit("oneshot", rows, width, "eager", median, p90)
+        stream = torch.cuda.Stream(device=device)
+        stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(stream):
+            pool.all_reduce(inp, out=out, channel_id="graph")
+        stream.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with pool.capture(stream, channel_id="graph"), torch.cuda.graph(graph, stream=stream):
+            pool.all_reduce(inp, out=out, channel_id="graph")
+        graph.replay()
+        verify(out, rows, width, "oneshot-graph")
+        median, p90 = _time(graph.replay, device, args.iters, args.warmup)
+        emit("oneshot", rows, width, "graph", median, p90)
+        del graph
+    pool.close()
+
+    # B12X BF16 two-shot (pull reduce-scatter + pull all-gather).
+    twoshot = PCIeTwoShotBF16.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_rows=args.twoshot_max_rows,
+        row_elems=args.twoshot_row_elems,
+    )
+    for rows, width in shapes:
+        inp = _pattern(rows, width, rank, device)
+        out = torch.empty_like(inp)
+        if not twoshot.accepts(inp):
+            if rank == 0:
+                print(json.dumps({"path": "twoshot", "rows": rows, "width": width,
+                                  "skipped": "not accepted"}), flush=True)
+            continue
+        twoshot.all_reduce(inp, out=out)
+        verify(out, rows, width, "twoshot")
+        median, p90 = _time(
+            lambda: twoshot.all_reduce(inp, out=out), device, args.iters, args.warmup
+        )
+        emit("twoshot", rows, width, "eager", median, p90)
+        graph = torch.cuda.CUDAGraph()
+        with twoshot.capture(), torch.cuda.graph(graph):
+            twoshot.all_reduce(inp, out=out)
+        graph.replay()
+        verify(out, rows, width, "twoshot-graph")
+        median, p90 = _time(graph.replay, device, args.iters, args.warmup)
+        emit("twoshot", rows, width, "graph", median, p90)
+        del graph
+    twoshot.close()
+
+    if rank == 0 and args.output:
+        with open(args.output, "w") as stream_out:
+            json.dump({"shapes": shapes, "iters": args.iters, "results": results},
+                      stream_out, indent=2)
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--world-size", type=int, default=torch.cuda.device_count())
+    parser.add_argument("--shapes", default=DEFAULT_SHAPES)
+    parser.add_argument("--iters", type=int, default=200)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--twoshot-max-rows", type=int, default=49149)
+    parser.add_argument("--twoshot-row-elems", type=int, default=8)
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+    if torch.cuda.device_count() < args.world_size:
+        raise SystemExit(f"need {args.world_size} visible GPUs")
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_worker, args=(port, args), nprocs=args.world_size, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_pcie_tp9_allreduce.py
+++ b/benchmarks/benchmark_pcie_tp9_allreduce.py
@@ -126,7 +126,15 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
     for rows, width in shapes:
         inp = _pattern(rows, width, rank, device)
         out = torch.empty_like(inp)
-        pool.all_reduce(inp, out=out, channel_id="eager")
+        # Acceptance is a deterministic function of the shape, so a rejection
+        # happens on every rank before any peer traffic.
+        try:
+            pool.all_reduce(inp, out=out, channel_id="eager")
+        except Exception as error:
+            if rank == 0:
+                print(json.dumps({"path": "oneshot", "rows": rows, "width": width,
+                                  "skipped": repr(error)[:200]}), flush=True)
+            continue
         verify(out, rows, width, "oneshot")
         median, p90 = _time(
             lambda: pool.all_reduce(inp, out=out, channel_id="eager"),

--- a/benchmarks/benchmark_pcie_tp9_allreduce.py
+++ b/benchmarks/benchmark_pcie_tp9_allreduce.py
@@ -26,7 +26,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
-DEFAULT_SHAPES = "4x7168,8x7168,16x7168,32x7168,4x3584,8x3584,16x3584"
+DEFAULT_SHAPES = "1x1024,1x4096,1x7168,2x7168,4x7168,8x7168,16x7168,32x7168,4x3584,8x3584,16x3584"
 
 
 def _shapes(raw: str) -> tuple[tuple[int, int], ...]:
@@ -67,6 +67,7 @@ def _time(fn, device: torch.device, iters: int, warmup: int) -> tuple[float, flo
 
 def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
     from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+    from b12x.comm.pcie.pcie_island9 import PCIeIsland9AllReduce
     from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
 
     world = args.world_size
@@ -216,6 +217,35 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
         emit("twoshot-push-fused", rows, width, "graph", median, p90)
         del graph
     pushed.close()
+
+    # Two-island push all-reduce (ranks 0-3 / 4-7 reduce quarters inside
+    # their switch clusters; rank 8 contributes through island 0).
+    island9 = PCIeIsland9AllReduce.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_rows=args.twoshot_max_rows,
+        row_elems=args.twoshot_row_elems,
+    )
+    for rows, width in shapes:
+        inp = _pattern(rows, width, rank, device)
+        out = torch.empty_like(inp)
+        if not island9.accepts(inp):
+            continue
+        island9.all_reduce(inp, out=out)
+        verify(out, rows, width, "island9-push")
+        median, p90 = _time(
+            lambda: island9.all_reduce(inp, out=out), device, args.iters, args.warmup
+        )
+        emit("island9-push", rows, width, "eager", median, p90)
+        graph = torch.cuda.CUDAGraph()
+        with island9.capture(), torch.cuda.graph(graph):
+            island9.all_reduce(inp, out=out)
+        graph.replay()
+        verify(out, rows, width, "island9-push-graph")
+        median, p90 = _time(graph.replay, device, args.iters, args.warmup)
+        emit("island9-push", rows, width, "graph", median, p90)
+        del graph
+    island9.close()
 
     # Push-based reduce-scatter followed by push-based all-gather (two
     # launches, posted PCIe writes instead of remote reads). Rows are padded

--- a/benchmarks/benchmark_pcie_tp9_allreduce.py
+++ b/benchmarks/benchmark_pcie_tp9_allreduce.py
@@ -115,17 +115,19 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
         median, p90 = _time(nccl_call, device, args.iters, args.warmup)
         emit("nccl", rows, width, "eager", median, p90)
 
-    # B12X one-shot pool (all-peer pull).
-    pool = PCIeOneshotAllReducePool.from_process_group(
-        process_group=group,
-        device=device,
-        max_input_bytes=max(rows * width * 2 for rows, width in shapes),
-        max_concurrent_channels=2,
-    )
-    pool.prepare_channels(("eager", "graph"))
+    # B12X one-shot pool (all-peer pull). Every independently replayable
+    # graph needs its own logical channel and the pool's resident-CTA budget
+    # bounds concurrent channels, so each shape gets a fresh two-channel pool.
     for rows, width in shapes:
         inp = _pattern(rows, width, rank, device)
         out = torch.empty_like(inp)
+        pool = PCIeOneshotAllReducePool.from_process_group(
+            process_group=group,
+            device=device,
+            max_input_bytes=rows * width * 2,
+            max_concurrent_channels=2,
+        )
+        pool.prepare_channels(("eager", "graph"))
         # Acceptance is a deterministic function of the shape, so a rejection
         # happens on every rank before any peer traffic.
         try:
@@ -134,6 +136,7 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
             if rank == 0:
                 print(json.dumps({"path": "oneshot", "rows": rows, "width": width,
                                   "skipped": repr(error)[:200]}), flush=True)
+            pool.close()
             continue
         verify(out, rows, width, "oneshot")
         median, p90 = _time(
@@ -154,7 +157,7 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
         median, p90 = _time(graph.replay, device, args.iters, args.warmup)
         emit("oneshot", rows, width, "graph", median, p90)
         del graph
-    pool.close()
+        pool.close()
 
     # B12X BF16 two-shot (pull reduce-scatter + pull all-gather).
     twoshot = PCIeTwoShotBF16.from_exchange_group(
@@ -184,6 +187,69 @@ def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
         verify(out, rows, width, "twoshot-graph")
         median, p90 = _time(graph.replay, device, args.iters, args.warmup)
         emit("twoshot", rows, width, "graph", median, p90)
+        del graph
+    # Fused push all-reduce: one launch built on posted PCIe writes.
+    pushed = PCIeTwoShotBF16.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_rows=args.twoshot_max_rows,
+        row_elems=args.twoshot_row_elems,
+    )
+    pushed.all_reduce_mode = "push"
+    for rows, width in shapes:
+        inp = _pattern(rows, width, rank, device)
+        out = torch.empty_like(inp)
+        if not pushed.accepts(inp):
+            continue
+        pushed.all_reduce(inp, out=out)
+        verify(out, rows, width, "twoshot-push-fused")
+        median, p90 = _time(
+            lambda: pushed.all_reduce(inp, out=out), device, args.iters, args.warmup
+        )
+        emit("twoshot-push-fused", rows, width, "eager", median, p90)
+        graph = torch.cuda.CUDAGraph()
+        with pushed.capture(), torch.cuda.graph(graph):
+            pushed.all_reduce(inp, out=out)
+        graph.replay()
+        verify(out, rows, width, "twoshot-push-fused-graph")
+        median, p90 = _time(graph.replay, device, args.iters, args.warmup)
+        emit("twoshot-push-fused", rows, width, "graph", median, p90)
+        del graph
+    pushed.close()
+
+    # Push-based reduce-scatter followed by push-based all-gather (two
+    # launches, posted PCIe writes instead of remote reads). Rows are padded
+    # to a multiple of the world size, which is the row contract of the
+    # push kernels; the reference only covers the unpadded prefix.
+    for rows, width in shapes:
+        packs = rows * width // 8
+        padded_rows = -(-packs // world) * world
+        payload = torch.zeros(padded_rows, 8, dtype=torch.bfloat16, device=device)
+        payload.view(-1)[: rows * width].copy_(_pattern(rows, width, rank, device).view(-1))
+        shard = torch.empty(padded_rows // world, 8, dtype=torch.bfloat16, device=device)
+        out = torch.empty_like(payload)
+
+        def push_call():
+            twoshot.reduce_scatter(payload, out=shard)
+            twoshot.all_gather(shard, out=out)
+
+        try:
+            push_call()
+        except Exception as error:
+            if rank == 0:
+                print(json.dumps({"path": "twoshot-push", "rows": rows, "width": width,
+                                  "skipped": repr(error)[:200]}), flush=True)
+            continue
+        verify(out.view(-1)[: rows * width].view(rows, width), rows, width, "twoshot-push")
+        median, p90 = _time(push_call, device, args.iters, args.warmup)
+        emit("twoshot-push", rows, width, "eager", median, p90)
+        graph = torch.cuda.CUDAGraph()
+        with twoshot.capture(), torch.cuda.graph(graph):
+            push_call()
+        graph.replay()
+        verify(out.view(-1)[: rows * width].view(rows, width), rows, width, "twoshot-push-graph")
+        median, p90 = _time(graph.replay, device, args.iters, args.warmup)
+        emit("twoshot-push", rows, width, "graph", median, p90)
         del graph
     twoshot.close()
 

--- a/benchmarks/benchmark_qsrt_tp9_extent.py
+++ b/benchmarks/benchmark_qsrt_tp9_extent.py
@@ -28,17 +28,32 @@ def main():
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--max-tokens", type=int, default=16)
     parser.add_argument("--block-m", type=int, default=8, choices=(8, 32, 48, 64))
+    parser.add_argument(
+        "--m-values",
+        default="1,2,4,8,16,1536",
+        help="comma-separated token counts; values above --max-tokens are skipped",
+    )
+    parser.add_argument(
+        "--rank",
+        type=int,
+        default=None,
+        help="TP9 rank whose extent is loaded (default: first rank with 256 channels)",
+    )
     args = parser.parse_args()
     torch.cuda.set_device(0)
     torch.manual_seed(71903)
     metadata = read_qsrt_atom_v2_layer_metadata(
         args.model / f"qsrt-layer-{args.layer:05d}.safetensors", layer=args.layer
     )
-    rank = next(
-        r
-        for r in range(9)
-        if plan_qsrt_tp9_rank(args.layer, r).intermediate_channels == 256
-    )
+    if args.rank is None:
+        rank = next(
+            r
+            for r in range(9)
+            if plan_qsrt_tp9_rank(args.layer, r).intermediate_channels == 256
+        )
+    else:
+        rank = args.rank
+    m_values = tuple(int(value) for value in args.m_values.split(","))
     runtimes = {}
     for width in (384, 256):
         before = torch.cuda.memory_allocated()
@@ -95,7 +110,7 @@ def main():
         )
     expert_map = torch.arange(896, dtype=torch.int32, device="cuda")
     records = []
-    for m in (value for value in (1, 2, 4, 8, 16, 1536) if value <= args.max_tokens):
+    for m in (value for value in m_values if value <= args.max_tokens):
         x = (torch.randn((m, 3584), device="cuda") * 0.1).to(torch.bfloat16)
         ids = torch.stack(
             [torch.randperm(896, device="cuda")[:16] for _ in range(m)]

--- a/benchmarks/benchmark_qsrt_tp9_extent.py
+++ b/benchmarks/benchmark_qsrt_tp9_extent.py
@@ -8,6 +8,7 @@ read-only and both arms use the identical source atoms, scales, and rotations.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
@@ -27,7 +28,13 @@ def main():
     parser.add_argument("--layer", type=int, default=1)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--max-tokens", type=int, default=16)
-    parser.add_argument("--block-m", type=int, default=8, choices=(8, 32, 48, 64))
+    parser.add_argument("--block-m", type=int, default=8, choices=(8, 32, 48, 64, 96, 128))
+    parser.add_argument(
+        "--time-iters",
+        type=int,
+        default=0,
+        help="when > 0, time the graph replay of each width (median of this many iterations)",
+    )
     parser.add_argument(
         "--m-values",
         default="1,2,4,8,16,1536",
@@ -117,6 +124,7 @@ def main():
         ).to(torch.int32)
         routing = torch.softmax(torch.randn((m, 16), device="cuda"), dim=-1)
         outputs = {}
+        timings: dict[int, float] = {}
         for width, (weights, plan, scratch, output, _) in runtimes.items():
             binding = fused_moe.bind(
                 plan,
@@ -137,6 +145,22 @@ def main():
             torch.cuda.synchronize()
             torch.testing.assert_close(replay_output, eager, rtol=0, atol=0)
             outputs[width] = eager
+            if args.time_iters > 0:
+                for _ in range(3):
+                    graph.replay()
+                torch.cuda.synchronize()
+                samples = []
+                for _ in range(args.time_iters):
+                    begin = torch.cuda.Event(enable_timing=True)
+                    end = torch.cuda.Event(enable_timing=True)
+                    begin.record()
+                    graph.replay()
+                    end.record()
+                    end.synchronize()
+                    samples.append(begin.elapsed_time(end) * 1000.0)
+                samples.sort()
+                timings[width] = samples[len(samples) // 2]
+            del graph
         reference = outputs[384]
         difference = outputs[256] - reference
         record = {
@@ -151,6 +175,17 @@ def main():
                 ).item()
             ),
             "graph_eager_exact": True,
+        }
+        if timings:
+            record["graph_replay_us"] = {str(w): round(t, 1) for w, t in timings.items()}
+            record["block_m"] = args.block_m
+        # Digests let runs with different route blocks be compared for
+        # bit-identical outputs without keeping the tensors.
+        record["output_sha256"] = {
+            str(width): hashlib.sha256(
+                tensor.contiguous().view(torch.uint8).cpu().numpy().tobytes()
+            ).hexdigest()[:16]
+            for width, tensor in outputs.items()
         }
         records.append(record)
         print(json.dumps(record), flush=True)

--- a/benchmarks/benchmark_qsrt_tp9_extent.py
+++ b/benchmarks/benchmark_qsrt_tp9_extent.py
@@ -1,0 +1,161 @@
+"""Compare a real QSRT extent at compact and zero-padded runtime widths.
+
+This exercises the serving plan/prepare/bind/run path on one GPU. It does not
+measure nine-GPU collectives or end-to-end serving latency. The checkpoint is
+read-only and both arms use the identical source atoms, scales, and rotations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from b12x.moe import fused_moe
+from b12x.moe._shared.qsrt_sharding import plan_qsrt_tp9_rank
+from vllm.model_executor.layers.quantization.kquant_qsrt_atoms_v2 import (
+    open_qsrt_atom_v2_extent,
+    read_qsrt_atom_v2_layer_metadata,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--layer", type=int, default=1)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--block-m", type=int, default=8, choices=(8, 32, 48, 64))
+    args = parser.parse_args()
+    torch.cuda.set_device(0)
+    torch.manual_seed(71903)
+    metadata = read_qsrt_atom_v2_layer_metadata(
+        args.model / f"qsrt-layer-{args.layer:05d}.safetensors", layer=args.layer
+    )
+    rank = next(
+        r
+        for r in range(9)
+        if plan_qsrt_tp9_rank(args.layer, r).intermediate_channels == 256
+    )
+    runtimes = {}
+    for width in (384, 256):
+        before = torch.cuda.memory_allocated()
+        weight_plan = fused_moe.plan_weights(
+            quant_modes="w4a16",
+            source_format="qsrt_sqg_e4m3",
+            activation="situ",
+            params_dtype=torch.bfloat16,
+            num_experts=896,
+            hidden_size=3584,
+            intermediate_size=width,
+            w13_layout="w13",
+            trellis_bits=2,
+            trellis_tile_config=(128, 128, 128, 128),
+            qsrt_storage_format="qsrt_atoms_v2",
+            qsrt_profile=metadata.profile,
+        )
+        with open_qsrt_atom_v2_extent(
+            metadata, shard_count=9, shard_index=rank, device=None
+        ) as (first, atoms):
+            weights = fused_moe.prepare_weights(
+                plan=weight_plan,
+                params_dtype=torch.bfloat16,
+                qsrt_atom_payload=atoms,
+                qsrt_first_atom_slot=first,
+                qsrt_layer_index=args.layer,
+                gate_suh=metadata.gate_suh.unsqueeze(0).cuda(),
+                up_suh=metadata.up_suh.unsqueeze(0).cuda(),
+                down_svh=metadata.down_svh.unsqueeze(0).cuda(),
+                qsrt_rotation_draws=metadata.rotation_draws,
+            )
+        weight_bytes = torch.cuda.memory_allocated() - before
+        plan = fused_moe.plan(
+            fused_moe.Caps(
+                max_tokens=args.max_tokens,
+                num_topk=16,
+                device=0,
+                weight_plan=weights.plan,
+                quant_mode="w4a16",
+                route_num_experts=896,
+                w4a16_block_size_m=args.block_m,
+            )
+        )
+        spec = plan.scratch_specs()[0]
+        scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+        output = torch.empty(
+            (args.max_tokens, 3584), dtype=torch.float32, device="cuda"
+        )
+        runtimes[width] = (weights, plan, scratch, output, weight_bytes)
+        print(
+            f"width={width} source=[{first},{first + atoms.shape[0]}) "
+            f"weight_bytes={weight_bytes}",
+            flush=True,
+        )
+    expert_map = torch.arange(896, dtype=torch.int32, device="cuda")
+    records = []
+    for m in (value for value in (1, 2, 4, 8, 16, 1536) if value <= args.max_tokens):
+        x = (torch.randn((m, 3584), device="cuda") * 0.1).to(torch.bfloat16)
+        ids = torch.stack(
+            [torch.randperm(896, device="cuda")[:16] for _ in range(m)]
+        ).to(torch.int32)
+        routing = torch.softmax(torch.randn((m, 16), device="cuda"), dim=-1)
+        outputs = {}
+        for width, (weights, plan, scratch, output, _) in runtimes.items():
+            binding = fused_moe.bind(
+                plan,
+                scratch=scratch,
+                a=x,
+                experts=weights,
+                topk_weights=routing,
+                topk_ids=ids,
+                route_expert_map=expert_map,
+                output=output[:m],
+            )
+            eager = fused_moe.run(binding=binding).clone()
+            torch.cuda.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                replay_output = fused_moe.run(binding=binding)
+            graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(replay_output, eager, rtol=0, atol=0)
+            outputs[width] = eager
+        reference = outputs[384]
+        difference = outputs[256] - reference
+        record = {
+            "m": m,
+            "finite": bool(torch.isfinite(outputs[256]).all().item()),
+            "reference_norm": float(reference.norm().item()),
+            "max_abs_error": float(difference.abs().max().item()),
+            "relative_l2": float((difference.norm() / reference.norm()).item()),
+            "cosine": float(
+                torch.nn.functional.cosine_similarity(
+                    outputs[256].flatten(), reference.flatten(), dim=0
+                ).item()
+            ),
+            "graph_eager_exact": True,
+        }
+        records.append(record)
+        print(json.dumps(record), flush=True)
+    result = {
+        "status": "research-only",
+        "layer": args.layer,
+        "tp9_rank": rank,
+        "gpu": torch.cuda.get_device_name(),
+        "torch": torch.__version__,
+        "runtime_weight_bytes": {str(w): values[-1] for w, values in runtimes.items()},
+        "records": records,
+        "limitation": "one actual source extent; no full-model or TP9 collective validation",
+    }
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    if any(
+        not row["finite"] or row["reference_norm"] == 0 or row["relative_l2"] > 0.001
+        for row in records
+    ):
+        raise RuntimeError("compact extent exceeded the declared 0.1% relative-L2 gate")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/precision_pcie_tp9_allreduce.py
+++ b/benchmarks/precision_pcie_tp9_allreduce.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Numerical comparison of the nine-rank PCIe all-reduce kernels.
+
+Every kernel accumulates the nine bf16 contributions in fp32 and rounds once
+to bf16, but in different orders: the one-shot in ascending rank order, the
+two-shot (pull/push) from the shard owner onwards, the island9 kernel as
+(ranks 0-3 + 8) + (ranks 4-7). The script feeds heavy-tailed activations
+(Gaussian bulk, sparse outliers up to 1e4, per-rank scale spread) through
+each kernel and measures, against the correctly rounded fp64 sum:
+
+* elements whose bf16 output differs from the correctly rounded sum,
+* the largest error in bf16 ulps and the relative L2 error,
+* elements on which the kernels differ from each other.
+
+The result is a JSON record per kernel (rank 0 prints and writes it).
+
+    B12X_RUN_PCIE_TP9_TEST=1 python benchmarks/precision_pcie_tp9_allreduce.py --output out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+WORLD = 9
+
+
+def _activations(rows: int, width: int, rank: int, seed: int, device: torch.device) -> torch.Tensor:
+    """Heavy-tailed bf16 activations with per-rank scale and sparse outliers."""
+    generator = torch.Generator(device="cpu").manual_seed(seed * 1000 + rank)
+    bulk = torch.randn(rows, width, generator=generator, dtype=torch.float32)
+    scale = 2.0 ** (rank - 4)  # per-rank magnitude spread of 2^-4 .. 2^4
+    bulk = bulk * scale
+    outlier_mask = torch.rand(rows, width, generator=generator) < 0.01
+    outliers = torch.randn(rows, width, generator=generator, dtype=torch.float32) * 1.0e4
+    bulk = torch.where(outlier_mask, outliers, bulk)
+    return bulk.to(torch.bfloat16).to(device)
+
+
+def _ulps(actual: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+    """Distance in bf16 ulps (of the reference) between two bf16 tensors."""
+    exponent = torch.floor(torch.log2(reference.abs().float().clamp_min(2.0 ** -126)))
+    ulp = torch.pow(2.0, exponent - 7)
+    return (actual.float() - reference.float()).abs() / ulp
+
+
+def _worker(rank: int, port: int, args: argparse.Namespace) -> None:
+    from b12x.comm.pcie.pcie_island9 import PCIeIsland9AllReduce
+    from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+    from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
+
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=WORLD,
+        timeout=timedelta(seconds=240),
+        device_id=device,
+    )
+    group = dist.group.WORLD
+    rows, width = args.rows, args.width
+    results: dict[str, dict] = {}
+    outputs: dict[str, list[torch.Tensor]] = {}
+
+    kernels = {}
+    pool = PCIeOneshotAllReducePool.from_process_group(
+        process_group=group, device=device, max_input_bytes=rows * width * 2,
+        max_concurrent_channels=1,
+    )
+    pool.prepare_channels(("eager",))
+    kernels["oneshot"] = lambda inp, out: pool.all_reduce(inp, out=out, channel_id="eager")
+    twoshot = PCIeTwoShotBF16.from_exchange_group(
+        exchange_group=group, device=device, max_rows=49149, row_elems=8,
+    )
+    twoshot.all_reduce_mode = "push"
+    kernels["twoshot-push"] = lambda inp, out: twoshot.all_reduce(inp, out=out)
+    island9 = PCIeIsland9AllReduce.from_exchange_group(
+        exchange_group=group, device=device, max_rows=49149, row_elems=8,
+    )
+    kernels["island9-push"] = lambda inp, out: island9.all_reduce(inp, out=out)
+
+    for seed in range(args.samples):
+        inp = _activations(rows, width, rank, seed, device)
+        # Correctly rounded reference: fp64 sum of the nine bf16 inputs.
+        gathered = [torch.empty_like(inp) for _ in range(WORLD)]
+        dist.all_gather(gathered, inp, group=group)
+        reference64 = sum(t.double() for t in gathered)
+        reference = reference64.to(torch.bfloat16)
+        for name, call in kernels.items():
+            out = torch.empty_like(inp)
+            call(inp, out)
+            torch.cuda.synchronize(device)
+            outputs.setdefault(name, []).append(out.clone())
+            record = results.setdefault(name, {"mismatch_elements": 0, "elements": 0,
+                                               "max_ulp": 0.0, "rel_l2_sum": 0.0, "samples": 0})
+            diff = out != reference
+            record["mismatch_elements"] += int(diff.sum().item())
+            record["elements"] += out.numel()
+            record["max_ulp"] = max(record["max_ulp"], float(_ulps(out, reference).max().item()))
+            err = (out.double() - reference64).norm() / reference64.norm().clamp_min(1e-30)
+            record["rel_l2_sum"] += float(err.item())
+            record["samples"] += 1
+    for name, record in results.items():
+        record["rel_l2_mean"] = record["rel_l2_sum"] / max(record["samples"], 1)
+        del record["rel_l2_sum"]
+    names = list(kernels)
+    cross = {}
+    for i, a in enumerate(names):
+        for b in names[i + 1:]:
+            differing = sum(int((x != y).sum().item()) for x, y in zip(outputs[a], outputs[b]))
+            cross[f"{a} vs {b}"] = differing
+    # Every rank must hold the same output for a given kernel and sample.
+    consistency = {}
+    for name in names:
+        mismatch = 0
+        for out in outputs[name]:
+            peers = [torch.empty_like(out) for _ in range(WORLD)]
+            dist.all_gather(peers, out, group=group)
+            mismatch += sum(int((p != peers[0]).sum().item()) for p in peers[1:])
+        consistency[name] = mismatch
+    twoshot.close()
+    island9.close()
+    if rank == 0:
+        summary = {"rows": rows, "width": width, "samples": args.samples,
+                   "per_kernel": results, "kernels_differ_on": cross,
+                   "cross_rank_inconsistent_elements": consistency}
+        print(json.dumps(summary, indent=2), flush=True)
+        if args.output:
+            with open(args.output, "w") as stream:
+                json.dump(summary, stream, indent=2)
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=16)
+    parser.add_argument("--width", type=int, default=7168)
+    parser.add_argument("--samples", type=int, default=64)
+    parser.add_argument("--output", default="")
+    args = parser.parse_args()
+    if os.getenv("B12X_RUN_PCIE_TP9_TEST") != "1":
+        raise SystemExit("requires nine idle GPUs and B12X_RUN_PCIE_TP9_TEST=1")
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    mp.spawn(_worker, args=(port, args), nprocs=WORLD, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/comm/test_pcie_dcp_a2a.py
+++ b/tests/comm/test_pcie_dcp_a2a.py
@@ -658,6 +658,15 @@ def test_runtime_accepts_head_major_input_and_output():
     torch.testing.assert_close(actual, partial_output[:, :16])
 
 
+def test_runtime_accepts_token_major_head_tail_capacity():
+    runtime = _make_runtime()
+    storage = torch.arange(2 * 40 * 64, dtype=torch.bfloat16).reshape(2, 40, 64)
+    partial_output = storage[:, :32]
+    partial_lse = torch.zeros(2, 32, dtype=torch.float32)
+    actual = runtime.lse_reduce_scatter(partial_output, partial_lse)
+    torch.testing.assert_close(actual, partial_output[:, :16])
+
+
 @pytest.mark.parametrize("world_size", (2, 4, 8, 16))
 def test_kimi_pair_topk_dispatches_compact_outputs(world_size: int) -> None:
     ext = _FakeExt()
@@ -803,7 +812,7 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
             torch.zeros(5, 32, 64, dtype=torch.bfloat16),
             torch.zeros(5, 32, dtype=torch.float32),
         )
-    unsupported_view = torch.zeros(1, 33, 64, dtype=torch.bfloat16)[:, :32]
+    unsupported_view = torch.zeros(1, 32, 128, dtype=torch.bfloat16)[:, :, ::2]
     with pytest.raises(ValueError, match="packed token-major or head-major"):
         runtime.lse_reduce_scatter(unsupported_view, good_lse)
 

--- a/tests/comm/test_pcie_hierarchical.py
+++ b/tests/comm/test_pcie_hierarchical.py
@@ -31,7 +31,7 @@ from b12x.comm.pcie.pcie_hierarchical import (
 from b12x.comm.pcie.pcie_island_rs import PCIeIslandRSAllReduce
 
 
-@pytest.mark.parametrize("world_size", [2, 4, 6, 8])
+@pytest.mark.parametrize("world_size", [2, 4, 6, 8, 9])
 def test_allreduce_uses_direct_path_for_peer_safe_worlds(world_size: int) -> None:
     assert _algorithm_for_world_size(world_size) == "oneshot"
 

--- a/tests/comm/test_pcie_nine_rank_math_gpu.py
+++ b/tests/comm/test_pcie_nine_rank_math_gpu.py
@@ -1,0 +1,84 @@
+"""Nine-rank arithmetic with pre-arrived peers; no physical link/barrier test.
+
+The collective's inputs are resident before each launch and peer-arrival slots
+are seeded to that state. This isolates rank-indexed loads and graph arithmetic
+without requiring nine mutually waiting kernels to co-reside on one GPU.
+"""
+
+import os
+
+import pytest
+import torch
+
+from b12x.comm.pcie.pcie_oneshot import _CuTeOneshotBackend
+from b12x.comm.pcie._oneshot_cute import _SELF_COUNTER_BYTES
+
+
+@pytest.mark.skipif(
+    os.getenv("B12X_PCIE_TEST_NINE_RANK_MATH") != "1",
+    reason="set B12X_PCIE_TEST_NINE_RANK_MATH=1 for the single-GPU kernel test",
+)
+def test_nine_rank_oneshot_eager_and_graph_include_every_peer():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    torch.cuda.set_device(0)
+    backend = _CuTeOneshotBackend()
+    signals = [
+        torch.zeros(backend.meta_size(), dtype=torch.uint8, device="cuda")
+        for _ in range(9)
+    ]
+    tables = [torch.empty(4096, dtype=torch.uint8, device="cuda") for _ in range(9)]
+    inputs = [
+        (torch.arange(1024, device="cuda") % 7 + rank - 7).to(torch.bfloat16)
+        for rank in range(9)
+    ]
+    outputs = [torch.empty_like(item) for item in inputs]
+    handles = []
+    for rank in range(9):
+        handle = backend.init_custom_ar(
+            [item.data_ptr() for item in signals], tables[rank], rank
+        )
+        backend.register_buffer(handle, [item.data_ptr() for item in inputs])
+        backend.prepare_all_reduce(handle, inputs[rank])
+        handles.append(handle)
+    torch.cuda.synchronize()
+
+    def seed_arrived_peers():
+        for signal in signals:
+            words = signal.view(torch.int32)
+            words.zero_()
+            words[_SELF_COUNTER_BYTES // 4 :].fill_(1)
+
+    def ordered_reference():
+        result = inputs[0].float()
+        for value in inputs[1:]:
+            result.add_(value.float())
+        return result.to(torch.bfloat16)
+
+    for rank in range(9):
+        seed_arrived_peers()
+        backend.all_reduce(handles[rank], inputs[rank], outputs[rank], 0, 0)
+        torch.cuda.synchronize()
+        for owner, signal in enumerate(signals):
+            expected_count = 1 if owner == rank else 0
+            assert torch.equal(
+                signal.view(torch.int32)[:9].cpu(),
+                torch.full((9,), expected_count, dtype=torch.int32),
+            )
+        expected = ordered_reference()
+        torch.testing.assert_close(outputs[rank], expected, atol=0, rtol=0)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            backend.all_reduce(handles[rank], inputs[rank], outputs[rank], 0, 0)
+        for iteration in range(4):
+            inputs[8].fill_(iteration + 1)
+            if iteration == 3:
+                inputs[0].fill_(65536)
+                inputs[1].fill_(-65536)
+                for value in inputs[2:]:
+                    value.fill_(2**-13)
+            seed_arrived_peers()
+            graph.replay()
+            torch.cuda.synchronize()
+            expected = ordered_reference()
+            torch.testing.assert_close(outputs[rank], expected, atol=0, rtol=0)

--- a/tests/comm/test_pcie_nine_rank_protocol_gpu.py
+++ b/tests/comm/test_pcie_nine_rank_protocol_gpu.py
@@ -1,0 +1,87 @@
+"""Nine-rank kernel arithmetic on one GPU; this does not qualify PCIe links."""
+
+import os
+
+import pytest
+import torch
+
+from b12x.comm.pcie.pcie_oneshot import _CuTeOneshotBackend
+
+
+@pytest.mark.skipif(
+    os.getenv("B12X_PCIE_TEST_NINE_RANK_MATH") != "1",
+    reason="set B12X_PCIE_TEST_NINE_RANK_MATH=1 for the single-GPU kernel test",
+)
+def test_nine_rank_registered_protocol_and_graphs():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    torch.cuda.set_device(0)
+    backend = _CuTeOneshotBackend()
+    signals = [
+        torch.zeros(backend.meta_size(), dtype=torch.uint8, device="cuda")
+        for _ in range(9)
+    ]
+    tables = [torch.empty(4096, dtype=torch.uint8, device="cuda") for _ in range(9)]
+    inputs = [
+        (torch.arange(1024, device="cuda") % 7 + rank - 7).to(torch.bfloat16)
+        for rank in range(9)
+    ]
+    outputs = [torch.empty_like(item) for item in inputs]
+    streams = [torch.cuda.Stream() for _ in range(9)]
+    handles = []
+    for rank in range(9):
+        handle = backend.init_custom_ar(
+            [item.data_ptr() for item in signals], tables[rank], rank
+        )
+        backend.register_buffer(handle, [item.data_ptr() for item in inputs])
+        backend.prepare_all_reduce(handle, inputs[rank])
+        handles.append(handle)
+    torch.cuda.synchronize()
+
+    from b12x.comm.pcie._oneshot_cute import _SELF_COUNTER_BYTES
+
+    def reset_signals(arrived=False):
+        for signal in signals:
+            signal.zero_()
+            if arrived:
+                signal.view(torch.int32)[_SELF_COUNTER_BYTES // 4 :].fill_(1)
+
+    # Warm execution as well as compilation before any rank waits for peers.
+    for rank in range(9):
+        reset_signals(arrived=True)
+        backend.all_reduce(handles[rank], inputs[rank], outputs[rank], 0, 0)
+        torch.cuda.synchronize()
+    reset_signals()
+    torch.cuda.synchronize()
+
+    def launch(rank):
+        with torch.cuda.stream(streams[rank]):
+            backend.all_reduce(handles[rank], inputs[rank], outputs[rank], 0, 0)
+
+    for rank in range(9):
+        launch(rank)
+    torch.cuda.synchronize()
+    expected = torch.stack(inputs).float().sum(0).to(torch.bfloat16)
+    for output in outputs:
+        torch.testing.assert_close(output, expected, atol=0, rtol=0)
+
+    graphs = [torch.cuda.CUDAGraph() for _ in range(9)]
+    for rank in range(9):
+        with torch.cuda.graph(graphs[rank], stream=streams[rank]):
+            backend.all_reduce(handles[rank], inputs[rank], outputs[rank], 0, 0)
+        reset_signals(arrived=True)
+        torch.cuda.synchronize()
+        graphs[rank].replay()
+        torch.cuda.synchronize()
+    reset_signals()
+    torch.cuda.synchronize()
+    for iteration in range(4):
+        inputs[8].fill_(iteration + 1)
+        torch.cuda.synchronize()
+        for rank in range(9):
+            with torch.cuda.stream(streams[rank]):
+                graphs[rank].replay()
+        torch.cuda.synchronize()
+        expected = torch.stack(inputs).float().sum(0).to(torch.bfloat16)
+        for output in outputs:
+            torch.testing.assert_close(output, expected, atol=0, rtol=0)

--- a/tests/comm/test_pcie_tp9_physical.py
+++ b/tests/comm/test_pcie_tp9_physical.py
@@ -80,22 +80,42 @@ def _worker(rank: int, port: int) -> None:
         max_rows=49149,
         row_elems=8,
     )
-    for rows in (8, 16, 32):
-        inp = torch.full((rows, 7168), rank + 1, dtype=torch.bfloat16, device=device)
+
+    def position_pattern(rows: int, width: int) -> torch.Tensor:
+        # Position-dependent integers keep every partial sum exact in bf16
+        # (at most 5 * 45 = 225) and expose misplaced or dropped shards,
+        # which uniform fills cannot.
+        return (
+            torch.arange(rows * width, device=device).remainder(5) + 1
+        ).to(torch.bfloat16).view(rows, width)
+
+    def check_pattern(tensor: torch.Tensor, scale: float) -> None:
+        torch.cuda.synchronize(device)
+        expected = position_pattern(*tensor.shape) * scale
+        torch.testing.assert_close(tensor, expected, rtol=0, atol=0)
+
+    # Kimi-K3 decode payloads: 7168 wide rows (T tokens) and the 3584 wide
+    # latent projection. Their pack counts are multiples of nine only when
+    # 9 | T, so most shapes exercise the balanced (uneven) shard partition.
+    for rows, width in ((4, 7168), (8, 7168), (9, 7168), (16, 7168), (32, 7168),
+                        (4, 3584), (16, 3584)):
+        inp = position_pattern(rows, width) * (rank + 1)
         out = torch.empty_like(inp)
         assert twoshot.accepts(inp)
         twoshot.all_reduce(inp, out=out)
-        check(out, 45)
+        check_pattern(out, 45)
+    inp = position_pattern(16, 7168) * (rank + 1)
+    out = torch.empty_like(inp)
     graph = torch.cuda.CUDAGraph()
     with twoshot.capture(), torch.cuda.graph(graph):
         twoshot.all_reduce(inp, out=out)
     for iteration in range(3):
-        inp.fill_(rank + 1 + (iteration if rank == 8 else 0))
+        inp.copy_(position_pattern(16, 7168) * (rank + 1 + (iteration if rank == 8 else 0)))
         graph.replay()
-        check(out, 45 + iteration)
+        check_pattern(out, 45 + iteration)
     del graph
     twoshot.close()
-    record("twoshot_wire_tail_eager_graph_passed")
+    record("twoshot_balanced_partition_eager_graph_passed")
 
     dma = PCIeDmaAllReduce(
         exchange_group=group,

--- a/tests/comm/test_pcie_tp9_physical.py
+++ b/tests/comm/test_pcie_tp9_physical.py
@@ -17,6 +17,7 @@ def _worker(rank: int, port: int) -> None:
     from b12x.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A
     from b12x.comm.pcie.pcie_dma import PCIeDmaAllReduce
     from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+    from b12x.comm.pcie.pcie_island9 import PCIeIsland9AllReduce
     from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
 
     torch.cuda.set_device(rank)
@@ -120,6 +121,51 @@ def _worker(rank: int, port: int) -> None:
         del graph
         twoshot.close()
         record(f"twoshot_{mode}_balanced_partition_eager_graph_passed")
+
+    # Two-island push all-reduce with rank 8 contributing through island 0.
+    # Quarter boundaries are not divisible by the launch stride for most of
+    # these shapes, and the odd widths leave short last quarters.
+    island9 = PCIeIsland9AllReduce.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_rows=49149,
+        row_elems=8,
+    )
+    assert island9.mapped_peers == (
+        (0, 1, 2, 3) if rank == 8 else tuple(
+            sorted(({(rank // 4) * 4 + p for p in range(4)} - {rank})
+                   | {((1 - rank // 4) * 4 + rank % 4)}
+                   | ({8} if rank < 4 else set()))
+        )
+    )
+    for rows, width in ((1, 7168), (2, 7168), (4, 7168), (8, 7168), (9, 7168),
+                        (16, 7168), (32, 7168), (4, 3584), (16, 3584), (1, 1030)):
+        inp = position_pattern(rows, width) * (rank + 1)
+        out = torch.empty_like(inp)
+        assert island9.accepts(inp)
+        island9.all_reduce(inp, out=out)
+        check_pattern(out, 45)
+    # The island-0 partial (4 x 64 + rank 8's 1 = 257) is not representable
+    # in bf16; only fp32 partials give the representable total 258.
+    value = {8: 1.0, 4: 1.0}.get(rank, 64.0 if rank < 4 else 0.0)
+    inp = torch.full((4, 7168), value, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    island9.all_reduce(inp, out=out)
+    check(out, 258.0)
+    inp = position_pattern(16, 7168) * (rank + 1)
+    out = torch.empty_like(inp)
+    graph = torch.cuda.CUDAGraph()
+    with island9.capture(), torch.cuda.graph(graph):
+        island9.all_reduce(inp, out=out)
+    for iteration in range(3):
+        inp.copy_(
+            position_pattern(16, 7168) * (rank + 1 + (iteration if rank == 8 else 0))
+        )
+        graph.replay()
+        check_pattern(out, 45 + iteration)
+    del graph
+    island9.close()
+    record("island9_push_eager_graph_passed")
 
     dma = PCIeDmaAllReduce(
         exchange_group=group,

--- a/tests/comm/test_pcie_tp9_physical.py
+++ b/tests/comm/test_pcie_tp9_physical.py
@@ -1,0 +1,185 @@
+"""Qualify TP9 collectives on nine physical GPUs with Kimi-K3 tensor shapes."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def _worker(rank: int, port: int) -> None:
+    from b12x.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A
+    from b12x.comm.pcie.pcie_dma import PCIeDmaAllReduce
+    from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
+    from b12x.comm.pcie.pcie_twoshot_bf16 import PCIeTwoShotBF16
+
+    torch.cuda.set_device(rank)
+    device = torch.device("cuda", rank)
+    dist.init_process_group(
+        "nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=9,
+        timeout=timedelta(seconds=240),
+        device_id=device,
+    )
+    group = dist.group.WORLD
+
+    def record(stage: str) -> None:
+        torch.cuda.synchronize(device)
+        dist.barrier()
+        if rank == 0:
+            print(json.dumps({"stage": stage, "world_size": 9}), flush=True)
+
+    def check(tensor: torch.Tensor, expected: float) -> None:
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(
+            tensor, torch.full_like(tensor, expected), rtol=0, atol=0
+        )
+
+    record("process_group_ready")
+    pool = PCIeOneshotAllReducePool.from_process_group(
+        process_group=group,
+        device=device,
+        max_input_bytes=1 << 20,
+        max_concurrent_channels=2,
+    )
+    pool.prepare_channels(("eager", "graph"))
+    inp = torch.full((4, 7168), rank + 1, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    pool.all_reduce(inp, out=out, channel_id="eager")
+    check(out, 45)
+    stream = torch.cuda.Stream(device=device)
+    stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(stream):
+        pool.all_reduce(inp, out=out, channel_id="graph")
+    stream.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with (
+        pool.capture(stream, channel_id="graph"),
+        torch.cuda.graph(graph, stream=stream),
+    ):
+        pool.all_reduce(inp, out=out, channel_id="graph")
+    for iteration in range(3):
+        inp.fill_(rank + 1 + (iteration if rank == 8 else 0))
+        graph.replay()
+        check(out, 45 + iteration)
+    del graph
+    pool.close()
+    record("oneshot_eager_graph_passed")
+
+    twoshot = PCIeTwoShotBF16.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_rows=49149,
+        row_elems=8,
+    )
+    for rows in (8, 16, 32):
+        inp = torch.full((rows, 7168), rank + 1, dtype=torch.bfloat16, device=device)
+        out = torch.empty_like(inp)
+        assert twoshot.accepts(inp)
+        twoshot.all_reduce(inp, out=out)
+        check(out, 45)
+    graph = torch.cuda.CUDAGraph()
+    with twoshot.capture(), torch.cuda.graph(graph):
+        twoshot.all_reduce(inp, out=out)
+    for iteration in range(3):
+        inp.fill_(rank + 1 + (iteration if rank == 8 else 0))
+        graph.replay()
+        check(out, 45 + iteration)
+    del graph
+    twoshot.close()
+    record("twoshot_wire_tail_eager_graph_passed")
+
+    dma = PCIeDmaAllReduce(
+        exchange_group=group,
+        device=device,
+        max_bytes=32 << 20,
+        fp8="0",
+    )
+    inp = torch.full((1536, 7168), rank + 1, dtype=torch.bfloat16, device=device)
+    out = torch.empty_like(inp)
+    assert dma.should_allreduce(inp)
+    retained = dma.all_reduce(inp)
+    check(retained, 45)
+    for iteration in range(3):
+        inp.fill_(rank + 1 + (iteration if rank == 8 else 0))
+        dma.all_reduce(inp, out=out)
+        check(out, 45 + iteration)
+        check(retained, 45)
+    assert dma._replay_entries, "DMA graph replay must include the wire-tail copies"
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        dma.all_reduce(inp, out=out)
+    for iteration in range(3):
+        inp.fill_(rank + 1 + (iteration if rank == 8 else 0))
+        graph.replay()
+        check(out, 45 + iteration)
+    del graph
+    dma.close()
+    record("dma_wire_tail_eager_cached_graph_external_graph_passed")
+
+    dcp = PCIeDCPA2A.from_exchange_group(
+        exchange_group=group,
+        device=device,
+        max_batch_size=4,
+        total_heads=99,
+        head_dim=512,
+        query_head_dim=576,
+        stream_affine=False,
+    )
+    q = torch.full((2, 11, 576), rank + 1, dtype=torch.bfloat16, device=device)
+    gathered = dcp.all_gather_heads(q)
+    for source in range(9):
+        check(gathered[:, source * 11 : (source + 1) * 11], source + 1)
+    padded = torch.full((2, 104, 512), rank + 1, dtype=torch.bfloat16, device=device)
+    partial = padded[:, :99]
+    lse = torch.zeros((2, 99), dtype=torch.float32, device=device)
+    reduced = torch.empty((2, 11, 512), dtype=torch.bfloat16, device=device)
+    dcp.lse_reduce_scatter(partial, lse, out=reduced)
+    check(reduced, 5)
+    dcp.prepare_graph_lse_reduce_scatter()
+    dcp.prepare_graph_all_gather_heads()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        dcp.all_gather_heads(q, out=gathered)
+        dcp.lse_reduce_scatter(partial, lse, out=reduced)
+    for iteration in range(3):
+        partial.fill_(rank + 1 + iteration)
+        graph.replay()
+        check(reduced, 5 + iteration)
+    if rank == 8:
+        partial.fill_(float("nan"))
+        lse.fill_(float("-inf"))
+    else:
+        partial.fill_(rank + 1)
+    graph.replay()
+    check(reduced, 4.5)
+    del graph
+    dcp.close()
+    record("dcp_gather_lse_head_tail_and_empty_rank_graph_passed")
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    os.getenv("B12X_RUN_PCIE_TP9_TEST") != "1",
+    reason="requires nine idle GPUs and B12X_RUN_PCIE_TP9_TEST=1",
+)
+def test_tp9_physical_collectives() -> None:
+    assert torch.cuda.device_count() == 9
+    os.environ["B12X_PCIE_DMA_GRAPH_REPLAY"] = "1"
+    os.environ["B12X_PCIE_DMA_GRAPH_REPLAY_MAX_ENTRIES"] = "1"
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(_worker, args=(port,), nprocs=9, join=True)
+
+
+if __name__ == "__main__":
+    test_tp9_physical_collectives()

--- a/tests/comm/test_pcie_tp9_physical.py
+++ b/tests/comm/test_pcie_tp9_physical.py
@@ -183,7 +183,10 @@ def _worker(rank: int, port: int) -> None:
         dma.all_reduce(inp, out=out)
         check(out, 45 + iteration)
         check(retained, 45)
-    assert dma._replay_entries, "DMA graph replay must include the wire-tail copies"
+    if hasattr(dma, "_replay_entries"):
+        # The serving lineage caches wire-tail copies for graph replay; master
+        # replays the ring without host patching and keeps no such table.
+        assert dma._replay_entries, "DMA graph replay must include the wire-tail copies"
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         dma.all_reduce(inp, out=out)

--- a/tests/comm/test_pcie_tp9_physical.py
+++ b/tests/comm/test_pcie_tp9_physical.py
@@ -74,13 +74,6 @@ def _worker(rank: int, port: int) -> None:
     pool.close()
     record("oneshot_eager_graph_passed")
 
-    twoshot = PCIeTwoShotBF16.from_exchange_group(
-        exchange_group=group,
-        device=device,
-        max_rows=49149,
-        row_elems=8,
-    )
-
     def position_pattern(rows: int, width: int) -> torch.Tensor:
         # Position-dependent integers keep every partial sum exact in bf16
         # (at most 5 * 45 = 225) and expose misplaced or dropped shards,
@@ -97,25 +90,36 @@ def _worker(rank: int, port: int) -> None:
     # Kimi-K3 decode payloads: 7168 wide rows (T tokens) and the 3584 wide
     # latent projection. Their pack counts are multiples of nine only when
     # 9 | T, so most shapes exercise the balanced (uneven) shard partition.
-    for rows, width in ((4, 7168), (8, 7168), (9, 7168), (16, 7168), (32, 7168),
-                        (4, 3584), (16, 3584)):
-        inp = position_pattern(rows, width) * (rank + 1)
+    # The pull (remote read) and push (posted write) kernels share it.
+    for mode in ("pull", "push"):
+        twoshot = PCIeTwoShotBF16.from_exchange_group(
+            exchange_group=group,
+            device=device,
+            max_rows=49149,
+            row_elems=8,
+        )
+        twoshot.all_reduce_mode = mode
+        for rows, width in ((4, 7168), (8, 7168), (9, 7168), (16, 7168), (32, 7168),
+                            (4, 3584), (16, 3584)):
+            inp = position_pattern(rows, width) * (rank + 1)
+            out = torch.empty_like(inp)
+            assert twoshot.accepts(inp)
+            twoshot.all_reduce(inp, out=out)
+            check_pattern(out, 45)
+        inp = position_pattern(16, 7168) * (rank + 1)
         out = torch.empty_like(inp)
-        assert twoshot.accepts(inp)
-        twoshot.all_reduce(inp, out=out)
-        check_pattern(out, 45)
-    inp = position_pattern(16, 7168) * (rank + 1)
-    out = torch.empty_like(inp)
-    graph = torch.cuda.CUDAGraph()
-    with twoshot.capture(), torch.cuda.graph(graph):
-        twoshot.all_reduce(inp, out=out)
-    for iteration in range(3):
-        inp.copy_(position_pattern(16, 7168) * (rank + 1 + (iteration if rank == 8 else 0)))
-        graph.replay()
-        check_pattern(out, 45 + iteration)
-    del graph
-    twoshot.close()
-    record("twoshot_balanced_partition_eager_graph_passed")
+        graph = torch.cuda.CUDAGraph()
+        with twoshot.capture(), torch.cuda.graph(graph):
+            twoshot.all_reduce(inp, out=out)
+        for iteration in range(3):
+            inp.copy_(
+                position_pattern(16, 7168) * (rank + 1 + (iteration if rank == 8 else 0))
+            )
+            graph.replay()
+            check_pattern(out, 45 + iteration)
+        del graph
+        twoshot.close()
+        record(f"twoshot_{mode}_balanced_partition_eager_graph_passed")
 
     dma = PCIeDmaAllReduce(
         exchange_group=group,

--- a/tests/comm/test_pcie_twoshot_bf16.py
+++ b/tests/comm/test_pcie_twoshot_bf16.py
@@ -34,9 +34,9 @@ MAX_ROWS = int(os.getenv("B12X_TEST_TWOSHOT_BF16_MAX_ROWS", "512"))
 ROWS = (8, 16, 32, 64, 96, 128, 192, 256)
 
 
-def test_layout_is_tp4_only_and_scales_with_capacity() -> None:
-    for world_size in (2, 8):
-        with pytest.raises(ValueError, match="supports only world size 4"):
+def test_layout_rejects_unsupported_world_sizes_and_scales_with_capacity() -> None:
+    for world_size in (3, 16):
+        with pytest.raises(ValueError, match="supports world sizes"):
             _make_layout(64, ROW_ELEMS, world_size)
 
     base = _make_layout(64, ROW_ELEMS, 4)
@@ -48,9 +48,9 @@ def test_layout_is_tp4_only_and_scales_with_capacity() -> None:
     assert wider.slab_bytes > base.slab_bytes
 
 
-@pytest.mark.parametrize("world_size", (2, 8))
+@pytest.mark.parametrize("world_size", (3, 16))
 def test_private_launchers_reject_unsupported_world_sizes(world_size: int) -> None:
-    with pytest.raises(ValueError, match="require world size 4"):
+    with pytest.raises(ValueError, match="require a world size in"):
         get_twoshot_bf16_launcher(
             "reduce_scatter",
             world_size,
@@ -61,7 +61,7 @@ def test_private_launchers_reject_unsupported_world_sizes(world_size: int) -> No
             ROW_ELEMS,
             0,
         )
-    with pytest.raises(ValueError, match="require world size 4"):
+    with pytest.raises(ValueError, match="require a world size in"):
         get_twoshot_bf16_allreduce_launcher(
             world_size,
             0,

--- a/tests/comm/test_pcie_twoshot_bf16_tp9.py
+++ b/tests/comm/test_pcie_twoshot_bf16_tp9.py
@@ -1,0 +1,39 @@
+"""The BF16 collective retains all nine peers in its host/kernel ABI."""
+
+import os
+
+import pytest
+import torch
+
+from b12x.comm.pcie.pcie_twoshot_bf16 import _make_layout, _pad_scalar_peer_ptrs
+
+
+def test_ninth_peer_is_preserved_and_eight_rank_calls_pad_with_self():
+    pointers = tuple(4096 * (rank + 1) for rank in range(9))
+    assert _pad_scalar_peer_ptrs(pointers, rank=8, world_size=9) == pointers
+    assert _pad_scalar_peer_ptrs(pointers[:8], rank=3, world_size=8) == (
+        *pointers[:8],
+        pointers[3],
+    )
+    layout = _make_layout(max_rows=27, row_elems=896, world_size=9)
+    assert layout.slot_bytes >= 27 * 896 * 2
+    assert layout.slab_bytes == layout.signal_bytes + 2 * layout.slot_bytes
+
+
+@pytest.mark.skipif(
+    os.getenv("B12X_PCIE_TEST_NINE_RANK_MATH") != "1",
+    reason="set the GPU gate to compile the nine-peer ABI",
+)
+def test_bf16_nine_peer_launchers_compile_for_rank_eight():
+    from b12x.comm.pcie._twoshot_bf16_cute import (
+        get_twoshot_bf16_allreduce_launcher,
+        get_twoshot_bf16_launcher,
+    )
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    for operation in ("reduce_scatter", "all_gather"):
+        assert callable(
+            get_twoshot_bf16_launcher(operation, 9, 8, False, 0, 256, 896, 0)
+        )
+    assert callable(get_twoshot_bf16_allreduce_launcher(9, 8, False, 0, 256, 896, 0))

--- a/tests/moe/test_qsrt_tp9_sharding.py
+++ b/tests/moe/test_qsrt_tp9_sharding.py
@@ -1,0 +1,34 @@
+"""Source ownership and resident-byte balance for whole-H128 TP9."""
+
+import pytest
+
+from b12x.moe._shared.qsrt_sharding import plan_qsrt_tp9_rank
+
+
+def test_tp9_extents_cover_every_atom_without_crossing_scale_halves():
+    totals = [0] * 9
+    for layer in range(1, 93):
+        owned = []
+        channels = []
+        for rank in range(9):
+            extent = plan_qsrt_tp9_rank(layer, rank)
+            first, count = extent.first_atom, extent.atom_count
+            assert first % 4 == 0
+            assert count in (8, 12)
+            assert first // 48 == (first + count - 1) // 48
+            owned.extend(range(first, first + count))
+            channels.append(extent.intermediate_channels)
+            totals[rank] += count
+        assert sorted(owned) == list(range(96))
+        assert sorted(channels) == [256] * 3 + [384] * 6
+    # Full nine-layer cycles balance exactly. The two residual layers differ
+    # by at most two H128 blocks, without padded expert payload.
+    assert max(totals) - min(totals) <= 8
+    assert sum(totals) == 92 * 96
+    assert max(totals) < 92 * 12
+
+
+@pytest.mark.parametrize("layer,rank", [(0, 0), (93, 0), (1, -1), (1, 9)])
+def test_tp9_rejects_indices_outside_checkpoint_geometry(layer, rank):
+    with pytest.raises(ValueError):
+        plan_qsrt_tp9_rank(layer, rank)


### PR DESCRIPTION
## Behavior

Nine-rank PCIe collectives and compact QSRT extents for the Kimi-K3 TP9/DCP9 serving configuration (local-inference-lab/vllm #654; served in production since 2026-09-05 14:08 UTC).

- `42d7a5fd`, `86cc7fe9`: the one-shot, BF16 two-shot and DMA all-reduces and the PCIe DCP pool accept world size 9; the two-shot/DMA wire tails align 7168-wide payloads with fixed buffers and CUDA-graph replay; DCP head-tail capacity (99 heads in a 104-head tile); QSRT rank extents of 256/384 channels that keep the H128 transform unit and rotate ownership per layer (weight allocation 928,994,816 -> 619,337,216 bytes per rank on the measured layer).
- `1aa3556e`: the BF16 two-shot partitions shards at 16-byte pack granularity (per-rank length differs by at most one pack), removing the copy-in/zero/copy-out padding path at row_elems = 8. Numerics unchanged.
- `e6e280c1`: push-based single-launch two-shot all-reduce (`all_reduce_mode="push"`): each rank posts its contribution into the peers' payload slots, reduces its own shard in fp32 with the same partition and accumulation order as the pull kernel (single rounding), and posts the reduced shard back. Bit-identical to the pull kernel.
- `97422b9b`, `5a8412bc`: `benchmark_qsrt_tp9_extent.py --m-values/--rank`; `benchmark_pcie_tp9_allreduce.py` (nine-rank one-shot / two-shot pull and push / NCCL latency, JSON output).

## Validation

- `B12X_RUN_PCIE_TP9_TEST=1 python tests/comm/test_pcie_tp9_physical.py` on nine RTX PRO 6000 (`CUDA_VISIBLE_DEVICES=1,2,3,4,5,6,7,8,0`): one-shot, two-shot pull and push, DMA and DCP, eager and graph replay, position-dependent data bit-identical to the fp32 reference for 4/8/9/16/32x7168 and 4/16x3584 rows; ninth-rank mutation, 1536x7168, retained output, 99/104 head-tail and empty shards.
- Focused numeric/plan/ABI tests: 314 passed; wire-path regressions: 70 passed.
- QSRT layer 1/46 256/384-channel extents: decode and 1536-token prefill bit-exact against the padded reference; rank 4's extent at M = 1/16/61/240/244/245/255/256 bit-identical, compute-sanitizer memcheck at M = 61/240 reports 0 errors.
- Latency (graph replay, median us; `benchmark_pcie_tp9_allreduce.py`): 28 KB one-shot 38.8 / pull 28.0 / push 17.7 / NCCL 46.0; 57 KB 66.8 / 38.3 / 20.4 / 47.0; 114 KB 123.3 / 48.9 / 31.3 / 47.9; 229 KB 240.6 / 71.0 / 53.6 / 66.5. In serving the push all-reduce costs 16.8 us per call (rank-0 trace); single-request decode 34.3 ms/step (TP8 + remote draft 34.7), four concurrent requests 59.7 ms/step (TP8 66-68).

## Compatibility

World sizes 2/4/8 are unchanged. This branch is the six TP9 commits rebased onto `master` (`de64982d` reconciles them with the TP4-only BF16 two-shot contract of `fe80900c`: the runtime, layout and launchers now share the tuple (2, 4, 8, 9) of topologies with retained evidence, and `accepts()` derives the reduced-region capacity from the layout when a runtime object carries no slab). The served Kimi-K3 build runs the same six commits on the TP8 runtime snapshot (`myshytf/b12x` branch `feat/kimi-k3-tp9-colocated`, `e6e280c1`). Requires local-inference-lab/vllm #654 for use.

Rebased-tree validation: 327 CPU tests of `tests/comm` (dcp_a2a, hierarchical, twoshot_bf16, twoshot_bf16_tp9, launch_geometry, oneshot, pcie, dma_mode) and `tests/moe/test_qsrt_tp9_sharding.py` pass in the serving image without a GPU; the nine-GPU physical test of this exact tree runs in the next maintenance window (all nine GPUs serve production now).

Not a duplicate of an open PR (`gh pr list --search "nine-rank tp9"` returns nothing). AI assistance (Codex, Claude Code) was used; the submitter reviews the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aPCVZBsteYgs4PTAQYuE5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds TP9 support for PCIe collectives used by Kimi-K3 serving.

- Supports world size 9 in one-shot, BF16 two-shot, DMA all-reduce, and PCIe DCP paths.
- Adds push-mode BF16 two-shot all-reduce and pack-granular shard partitioning.
- Aligns 7168-wide wire tails for fixed buffers and CUDA-graph replay.
- Adds compact 256/384-channel QSRT TP9 extents with rotating layer ownership.
- Preserves support for world sizes 2, 4, and 8.
- Adds TP9 all-reduce and QSRT benchmark tools.

The changes maintain exact BF16 reductions across eager and CUDA-graph paths. They also accept token-major buffers with aligned tail capacity. QSRT sharding covers all 92 layers and balances ownership across nine ranks.

Validation includes 327 CPU tests, CUDA-gated protocol and math tests, QSRT sharding tests, and nine-GPU physical collective coverage for one-shot, BF16 two-shot, DMA, and DCP paths. Benchmark tools verify bit-exact results and report latency. Exact validation on the rebased tree requires a later nine-GPU maintenance window. The implementation requires `local-inference-lab/vllm#654`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->