### PR TITLE
fix(ple): use checkpoint token-lag order for embedding hashes

### DIFF
--- a/b12x/sequence/ple_hash/__init__.py
+++ b/b12x/sequence/ple_hash/__init__.py
@@ -5,6 +5,11 @@ geometry together with serving capacity. ``bind`` maps caller-owned runtime
 tensors and scratch without allocation. ``run`` will write logical embedding
 IDs while leaving committed history immutable.
 
+Checkpoint multiplier indices denote token lag: the hash of an order-``n``
+window is ``xor(token[t-i] * multipliers[i] for i in range(n))``. Predecessors
+behind an EOS boundary are replaced by EOS before hashing. Chronological
+history buffers retain oldest-to-current storage order.
+
 Exact PyTorch oracles are available from
 :mod:`b12x.sequence.ple_hash.reference` and are never runtime fallbacks.
 """

--- a/b12x/sequence/ple_hash/_kernels.py
+++ b/b12x/sequence/ple_hash/_kernels.py
@@ -183,7 +183,9 @@ def _hash_ids_kernel(
 
     for position in tl.static_range(0, MAX_ORDER):
         in_order = position < order
-        distance_from_current = order - 1 - position
+        # Checkpoint multiplier indices are token lags: index zero belongs
+        # to the current token for every n-gram order.
+        distance_from_current = position
         relative_position = -distance_from_current
         value = _source_token(
             token_ids_ptr,

--- a/b12x/sequence/ple_hash/reference.py
+++ b/b12x/sequence/ple_hash/reference.py
@@ -161,7 +161,11 @@ def ple_hash_ids_reference(
     table_offsets: torch.Tensor,
     heads_per_order: int,
 ) -> torch.Tensor:
-    """Return one logical embedding ID per token and n-gram head."""
+    """Hash chronological windows with multipliers indexed by token lag.
+
+    ``multipliers[0]`` belongs to the current token, the last column in each
+    window; ``multipliers[i]`` belongs to its predecessor at distance ``i``.
+    """
     if not windows:
         raise ValueError("windows must contain at least one n-gram order")
     orders = sorted(windows)
@@ -190,11 +194,11 @@ def ple_hash_ids_reference(
                 f"windows[{order}] must have shape {(token_count, order)}, "
                 f"got {tuple(token_window.shape)}"
             )
-        mixed = token_window[:, 0] * multipliers[0]
+        mixed = token_window[:, -1] * multipliers[0]
         for index in range(1, order):
             mixed = torch.bitwise_xor(
                 mixed,
-                token_window[:, index] * multipliers[index],
+                token_window[:, -1 - index] * multipliers[index],
             )
         first = (order - 2) * heads_per_order
         last = first + heads_per_order

--- a/tests/sequence/test_ple_hash_checkpoint_order.py
+++ b/tests/sequence/test_ple_hash_checkpoint_order.py
@@ -1,0 +1,125 @@
+"""PLE checkpoint multipliers index token lag, independently of window width."""
+
+import pytest
+import torch
+
+from b12x.sequence import ple_hash
+from b12x.sequence.ple_hash.reference import ple_hash_packed_reference
+
+from ..conftest import require_b12x
+
+
+def _fixture(device):
+    return dict(
+        token_ids=torch.tensor([7, 9, 11], dtype=torch.int64, device=device),
+        query_start_loc=torch.tensor([0, 3], dtype=torch.int32, device=device),
+        committed_history=torch.tensor([[99, 99]], dtype=torch.int64, device=device),
+        eos_token_id=99,
+        multipliers=torch.tensor([3, 5, 7], dtype=torch.int64, device=device),
+        prime_sizes=torch.tensor([101, 103], dtype=torch.int64, device=device),
+        table_offsets=torch.tensor([0, 101], dtype=torch.int64, device=device),
+        heads_per_order=1,
+    )
+
+
+def test_checkpoint_multipliers_index_current_token_then_predecessors():
+    # At token 11, the bigram hash is (11*3) XOR (9*5) = 12, and
+    # the trigram hash adds XOR (7*7) = 61 before the second head offset.
+    expected = torch.tensor([[1, 124], [56, 136], [12, 162]])
+    actual = ple_hash_packed_reference(**_fixture("cpu"))
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def _lag_oracle(tokens, starts, histories, eos, multipliers, sizes, offsets, heads):
+    """Integer-only checkpoint equation with an explicit EOS boundary scan."""
+    result = []
+    order_max = len(multipliers)
+    for request, (start, end) in enumerate(zip(starts[:-1], starts[1:], strict=True)):
+        history = list(histories[request]) + list(tokens[start:end])
+        for position in range(order_max - 1, len(history)):
+            lagged = [history[position]]
+            crossed_eos = False
+            for lag in range(1, order_max):
+                token = eos if crossed_eos else history[position - lag]
+                lagged.append(token)
+                crossed_eos |= token == eos
+            row = []
+            mixed = lagged[0] * multipliers[0]
+            for order in range(2, order_max + 1):
+                mixed ^= lagged[order - 1] * multipliers[order - 1]
+                for local_head in range(heads):
+                    head = (order - 2) * heads + local_head
+                    row.append(mixed % sizes[head] + offsets[head])
+            result.append(row)
+    return torch.tensor(result, dtype=torch.int64)
+
+
+@pytest.mark.parametrize("max_order", [2, 3, 4])
+def test_checkpoint_hash_crosses_chunk_boundaries_but_not_eos(max_order):
+    tokens = [7, 99, 11, 99, 13, 17]
+    starts = [0, 3, 6]
+    histories = [[19] * (max_order - 1), [23] * (max_order - 1)]
+    multipliers = [3, 5, 7, 11][:max_order]
+    sizes = [101, 103, 107, 109, 113, 127][: (max_order - 1) * 2]
+    offsets = [sum(sizes[:i]) for i in range(len(sizes))]
+    actual = ple_hash_packed_reference(
+        torch.tensor(tokens),
+        torch.tensor(starts, dtype=torch.int32),
+        torch.tensor(histories),
+        eos_token_id=99,
+        multipliers=torch.tensor(multipliers),
+        prime_sizes=torch.tensor(sizes),
+        table_offsets=torch.tensor(offsets),
+        heads_per_order=2,
+    )
+    expected = _lag_oracle(
+        tokens, starts, histories, 99, multipliers, sizes, offsets, 2
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_checkpoint_hash_gpu_and_graph_replay_use_lag_order():
+    device = require_b12x()
+    data = _fixture(device)
+    plan = ple_hash.plan(
+        ple_hash.Caps(
+            device=device,
+            max_tokens=3,
+            max_seqs=1,
+            vocab_size=100,
+            eos_token_id=99,
+            max_order=3,
+            heads_per_order=1,
+            dense_layer_ordinal=0,
+            base_table_size=101,
+        ),
+        multipliers=data["multipliers"],
+        prime_sizes=data["prime_sizes"],
+        table_offsets=data["table_offsets"],
+    )
+    spec = plan.scratch_specs()[0]
+    output = torch.empty(3, 2, dtype=torch.int64, device=device)
+    binding = plan.bind(
+        scratch=torch.empty(spec.shape, dtype=spec.dtype, device=spec.device),
+        token_ids=data["token_ids"],
+        query_start_loc=data["query_start_loc"],
+        committed_history=data["committed_history"],
+        num_seqs=torch.tensor([1], dtype=torch.int32, device=device),
+        num_tokens=torch.tensor([3], dtype=torch.int32, device=device),
+        out=output,
+    )
+    ple_hash.run(binding)
+    torch.testing.assert_close(
+        output.cpu(), torch.tensor([[1, 124], [56, 136], [12, 162]]), rtol=0, atol=0
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        ple_hash.run(binding)
+    for tokens in ([11, 9, 7], [99, 13, 17], [7, 9, 11]):
+        data["token_ids"].copy_(torch.tensor(tokens, device=device))
+        graph.replay()
+        expected = _lag_oracle(
+            tokens, [0, 3], [[99, 99]], 99, [3, 5, 7], [101, 103], [0, 101], 1
+        )
+        torch.testing.assert_close(output.cpu(), expected, rtol=0, atol=0)
+        assert int(binding.error_code) == 0


### PR DESCRIPTION
## Correct PLE embedding addresses

Status: implemented; qualified by independent CPU/GPU regression tests and
checkpoint-backed full-model controls. This fixes embedding selection, not all
long-reasoning repetition.

Qwen's per-layer n-gram embedding (PLE) chooses learned embedding rows from
the current token and its predecessors. Checkpoint multiplier `0` belongs to
the current token, multiplier `1` to its immediate predecessor, and so on.
The B12X kernel and its PyTorch oracle instead paired multiplier `0` with the
oldest token in each window. Their mutual parity therefore missed a checkpoint
compatibility defect.

The kernel and reference now index multipliers by token lag. History storage
remains chronological; EOS boundaries, checkpoint buffers, table layout,
quantization, CPU offload, workspace ownership, and graph interfaces do not
change. Restart serving with empty prefix/recurrent caches: states computed
with the incorrect embedding addresses cannot be reused.

## Reproducer and validation

For tokens `[7, 9, 11]`, EOS `99`, multipliers `[3, 5, 7]`, prime sizes
`[101, 103]`, and table offsets `[0, 101]`, the expected rows are
`[[1, 124], [56, 136], [12, 162]]`. At token `11`, the bigram hash is
`(11*3) XOR (9*5) = 12`; the trigram adds `XOR (7*7)` and offset `101`,
giving `162`. The added tests use literal expectations and an independent
integer-only lag/EOS equation, not the B12X reference as their oracle.

- All five added regression cases fail on the uncorrected implementation.
- The corrected hash, PLE math, and embedding suite passes **92 tests** on
  RTX PRO 6000 Blackwell, including EOS/chunk boundaries, BF16/FP8/NVFP4
  embedding paths, and CUDA graph replay with changed token contents.
  The same 92 tests also pass on the standalone PR commit based on master
  `a1bbd027`, with no serving process occupying the test GPU.
- On 1,823 real token IDs from `Qwen/Qwen3.8-Flash-Next`, hash-address
  mismatches against the checkpoint equation fall from **28,480 / 29,168
  (97.64%) to zero**. This is an address mismatch rate, not an answer error rate.
- Independent PLE evaluation uses unmodified Transformers PLE class bodies
  and serialized BF16 checkpoint weights. Corrected B12X PLE output differs
  by about **0.4% relative RMS**, versus about **99%** with incorrect addresses.
  Fused BF16 arithmetic is not claimed to be bitwise equivalent.
- BF16 full-model controls with TP4/EP4, BF16 KV, FP32 recurrent state and
  **no MTP** restore the native implementation's next-token choice on both
  retained histories. The concrete prefix `Qin Jiush` changes from continuation
  `u` to `ao`, completing `Qin Jiushao`; another prefix changes from ` bone`
  to `,`. Each corrected capture agrees exactly with its uninstrumented control.
- The corrected serving image captures V2 `FULL_AND_PIECEWISE` graphs.

Run the component suite with:

```bash
python -m pytest -q \
  tests/sequence/test_ple_hash_checkpoint_order.py \
  tests/sequence/test_ple.py \
  tests/sequence/test_ple_embedding.py
```

The full-model control uses checkpoint revision
`de4b8e4d43b917e7706784d8bb445c9af86a3540`, Transformers reference revision
`4177486a9f199bd7be520eff14431071d5d41ec5`, and serving source
`b4cee9c7ff6d11d08a31d87e1339becca4924908` plus only the three hash-package
file changes in this PR. The PR itself contains no other serving optimizations.

## Limits

This defect affects target computation without speculative decoding and is
not specific to NVFP4 weights or offload. It is a correctness fix; no throughput
gain or general answer-quality score is claimed. No checkpoint conversion is
needed.

Greedy generation still enters a reasoning loop with corrected hashes on the
retained 119-token long-reasoning prompt. Native upstream vLLM, whose PLE hash
order is correct, also repeats. Three corrected-hash runs with the checkpoint's
sampling settings (`temperature=1`, `top_p=0.95`, `top_k=20`) have no detected
exact periodic suffix within 16,384 output tokens, but all reach the token
limit without final-answer content. These results do not establish a complete
repetition remedy or successful answer completion.
