### PR TITLE
fix(gemm): honor expected row bounds in block-FP8 dispatch

### DIFF
--- a/b12x/_lib/dense_gemm.py
+++ b/b12x/_lib/dense_gemm.py
@@ -414,6 +414,9 @@ def _dense_gemm_policy_for(
     generalize_mxfp8_split_k: bool = False,
     generalize_block_fp8_split_k: bool = False,
 ) -> _DenseGemmPolicy:
+    # A declared row bound owns scheduling as well as tile and unroll tuning.
+    if expected_m is not None:
+        m = expected_m
     max_active_clusters = _max_active_clusters_for(cluster_shape_mn, sm_count)
     tile_m, tile_n = mma_tiler_mn
     one_work_tile_per_cta = ((m + tile_m - 1) // tile_m) * (
@@ -6203,7 +6206,7 @@ def dense_gemm_fused_quant_a_grouped(
         int(head_dim),
         int(nope_dim),
         int(rope_dim),
-        m == 1,
+        (expected_m if expected_m is not None else m) == 1,
         positions_dtype,
         cos_sin_dtype,
     )
@@ -7659,7 +7662,7 @@ def dense_gemm_fused_quant_a(
         rhs_values_tiled is not None,
         a_inner_span,
         kernel_c_l,
-        m == 1,
+        (expected_m if expected_m is not None else m) == 1,
     )
     compiled(
         source,

--- a/b12x/_lib/quant/mxfp8_rows.py
+++ b/b12x/_lib/quant/mxfp8_rows.py
@@ -402,12 +402,15 @@ def quantize_mxfp8_rows_cute(
     scale_mma: torch.Tensor,
     *,
     value_order: str = "linear",
+    expected_m: int | None = None,
 ) -> None:
     """Quantize contiguous BF16 rows into dense-GEMM MXFP8 layouts.
 
     ``trellis_native_mma`` applies the fixed within-K32 byte permutation used
     by direct native-trellis E4M3 B fragments.  It changes neither values nor
     scale groups and avoids a separate activation transpose kernel.
+
+    expected_m fixes the row bound used for lane-layout specialization.
     """
 
     if source.dtype not in (torch.bfloat16, torch.float16):
@@ -419,7 +422,8 @@ def quantize_mxfp8_rows_cute(
     if value_order == "trellis_native_mma":
         subgroup_width = 8
     else:
-        subgroup_width = _WARP_SUBGROUP_WIDTH if int(source.shape[0]) > 8 else 0
+        planned_rows = int(source.shape[0]) if expected_m is None else expected_m
+        subgroup_width = _WARP_SUBGROUP_WIDTH if planned_rows > 8 else 0
     _get_compiled_mxfp8_rows_quant(
         int(source.shape[1]),
         source.dtype,

--- a/b12x/gemm/_shared/block_fp8.py
+++ b/b12x/gemm/_shared/block_fp8.py
@@ -70,9 +70,8 @@ class BlockFP8LinearBinding:
     x_q: MXFP8Rows
     output: torch.Tensor
     bias: torch.Tensor | None = None
-    # DeepGEMM-style regime hint forwarded to dense_gemm (decode vs prefill tile).
-    # None keeps the M-independent default; set it at bind time so the warmed
-    # kernel matches the regime this binding serves.
+    # Fixed row bound forwarded to dense_gemm for decode/prefill specialization.
+    # Plan.bind defaults it to scratch capacity; an explicit value takes precedence.
     expected_m: int | None = None
     mma_tiler_mn: tuple[int, int] | None = None
 
@@ -160,7 +159,7 @@ class BlockFP8LinearScratchPlan:
             x_q=x_q,
             output=output,
             bias=bias,
-            expected_m=expected_m,
+            expected_m=self.caps.max_tokens if expected_m is None else expected_m,
             mma_tiler_mn=self.mma_tiler_mn,
         )
 
@@ -483,6 +482,8 @@ def _run_block_fp8_quant_kernel(
     out_scale_mma: torch.Tensor,
     tokens: int,
     in_features: int,
+    *,
+    expected_m: int | None = None,
 ) -> None:
     del tokens, in_features
     quantize_mxfp8_rows_cute(
@@ -490,6 +491,7 @@ def _run_block_fp8_quant_kernel(
         out_values,
         out_scale_rows,
         out_scale_mma,
+        expected_m=expected_m,
     )
 
 
@@ -576,6 +578,8 @@ def quantize_block_fp8_linear_input_mxfp8(
 
 def _quantize_block_fp8_linear_input_for_immediate_gemm(
     source_tk: torch.Tensor,
+    *,
+    expected_m: int | None = None,
 ) -> MXFP8Rows:
     """Quantize into fresh storage whose physical padding stays unspecified.
 
@@ -608,6 +612,7 @@ def _quantize_block_fp8_linear_input_for_immediate_gemm(
         out.scale_mma,
         tokens,
         in_features,
+        expected_m=expected_m,
     )
     return out
 
@@ -633,7 +638,8 @@ def _block_fp8_linear_mxfp8_fused_op(
     # shapes). The weight views passed in are static-shaped, so they don't hit
     # that path. Returns a contiguous [tokens, out_features] base.
     tokens = int(source_2d.shape[0])
-    if tokens <= 8 and source_2d.dtype == torch.bfloat16:
+    planned_tokens = expected_m if expected_m > 0 else tokens
+    if planned_tokens <= 8 and source_2d.dtype == torch.bfloat16:
         return dense_gemm_fused_quant_a(
             source_2d,
             weight_values.reshape(out_features, in_features, 1),
@@ -642,7 +648,9 @@ def _block_fp8_linear_mxfp8_fused_op(
             sfb_k_replicated=True,
             stream=stream_int,
         )[:, :, 0]
-    x_q = _quantize_block_fp8_linear_input_for_immediate_gemm(source_2d)
+    x_q = _quantize_block_fp8_linear_input_for_immediate_gemm(
+        source_2d, expected_m=None if expected_m == 0 else expected_m
+    )
     return dense_gemm(
         (x_q.values.reshape(tokens, in_features, 1), x_q.scale_mma),
         (weight_values.reshape(out_features, in_features, 1), weight_scale_mma),
@@ -688,9 +696,9 @@ def block_fp8_linear_mxfp8(
 ) -> torch.Tensor:
     """Run a serialized block-FP8 linear through the native b12x MXFP8 GEMM.
 
-    expected_m forwards a DeepGEMM-style regime hint to dense_gemm (decode vs
-    prefill tile); None keeps the M-independent default. When a binding is given
-    its stored expected_m is used.
+    expected_m is the fixed row bound used for decode/prefill specialization.
+    A binding owns this value; Plan.bind defaults it to scratch capacity while
+    preserving an explicit expected_m supplied by the caller.
     """
 
     mma_tiler_mn = None
@@ -770,7 +778,8 @@ def block_fp8_linear_mxfp8(
     assert x_q_storage is not None
     assert output_storage is not None
     t0 = time.perf_counter() if _B12X_TIMING else 0.0
-    if tokens <= 8 and source_2d.dtype == torch.bfloat16:
+    planned_tokens = expected_m if expected_m is not None else tokens
+    if planned_tokens <= 8 and source_2d.dtype == torch.bfloat16:
         output = dense_gemm_fused_quant_a(
             source_2d,
             packed_weight.weight.values.reshape(
@@ -788,7 +797,13 @@ def block_fp8_linear_mxfp8(
         if bias is not None:
             output += bias
         return output.view(*source.shape[:-1], packed_weight.out_features)
-    x_q = quantize_block_fp8_linear_input_mxfp8(source_2d, out=x_q_storage)
+    if tokens <= 0:
+        raise ValueError("tokens must be positive")
+    x_q = x_q_storage
+    _run_block_fp8_quant_kernel(
+        source_2d, x_q.values, x_q.scale_rows, x_q.scale_mma,
+        tokens, in_features, expected_m=expected_m,
+    )
     t_quant = time.perf_counter() if _B12X_TIMING else 0.0
     output = dense_gemm(
         (x_q.values.reshape(tokens, packed_weight.in_features, 1), x_q.scale_mma),
@@ -887,6 +902,9 @@ def prewarm_block_fp8_linear_mxfp8(
                 expected_m=expected_m,
             )
             block_fp8_linear_mxfp8(binding=binding, stream=stream)
+            block_fp8_linear_mxfp8(
+                source, packed_weight, expected_m=expected_m, stream=stream
+            )
         torch.cuda.synchronize(device)
 
 

--- a/b12x/gemm/block_fp8_linear/__init__.py
+++ b/b12x/gemm/block_fp8_linear/__init__.py
@@ -7,6 +7,9 @@ graph capture safe); ``run`` quantizes the BF16/FP16 input to MXFP8 inline
 and launches the GEMM.  ``prewarm`` compiles the kernels for a capacity ahead
 of serving.
 
+Bindings default ``expected_m`` to ``Caps.max_tokens``. An explicit row bound
+takes precedence, including when separate captured regimes share scratch.
+
 Example:
     from b12x.gemm import block_fp8_linear as bfl
 

--- a/b12x/quantization/mxfp8/__init__.py
+++ b/b12x/quantization/mxfp8/__init__.py
@@ -4,6 +4,9 @@ Writes packed e4m3 values plus both scale layouts (row-major e8m0 and the
 MMA-swizzled physical layout) into caller-provided output tensors — no
 allocation, CUDA-graph safe.
 
+Pass a fixed ``expected_m`` row bound to retain the quantizer specialization
+when live row counts vary. Omitting it preserves shape-based selection.
+
 Example:
     from b12x.quantization import mxfp8
 

--- a/tests/gemm/test_block_fp8_linear_capacity.py
+++ b/tests/gemm/test_block_fp8_linear_capacity.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.gemm import block_fp8_linear as bfl
+from tests._reference.helpers import require_b12x
+from tests.gemm.test_gemm_block_fp8_linear import (
+    _make_block_fp8_weight,
+    _reference_from_quantized_operands,
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_block_fp8_linear_scratch_reuse_across_row_tiles(dtype: torch.dtype) -> None:
+    require_b12x()
+    capacity, in_features, out_features = 129, 256, 384
+    source = torch.randn((capacity, in_features), device="cuda", dtype=dtype).mul_(0.25)
+    weight, scale = _make_block_fp8_weight(out_features, in_features)
+    packed = bfl.pack_weight(weight, scale)
+    plan = bfl.plan(bfl.Caps(device=source.device, max_tokens=capacity,
+                           in_features=in_features, out_features=out_features,
+                           output_dtype=dtype))
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    output = torch.empty((capacity, out_features, 1), dtype=dtype, device=source.device)
+    pointers = (source.data_ptr(), scratch.data_ptr(), output.data_ptr())
+
+    def bind(tokens: int):
+        return bfl.bind(plan, scratch=scratch, source=source[:tokens],
+                        packed_weight=packed, output=output[:tokens])
+
+    for tokens in (capacity, 8):
+        bfl.run(binding=bind(tokens))
+    freeze_kernel_resolution("block FP8 scratch reuse across row-tile boundaries")
+    try:
+        for tokens in (129, 9, 128, 8, 127):
+            binding = bind(tokens)
+            bfl.run(binding=binding)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                bfl.run(binding=binding)
+            source.normal_().mul_(0.25)
+            expected = _reference_from_quantized_operands(source[:tokens], weight, scale)
+            binding.x_q.scale_rows.view(torch.uint8).fill_(127)
+            binding.x_q.scale_mma.view(torch.uint8).fill_(127)
+            initialized = bfl.run(binding=binding).clone()
+            scratch.fill_(255)
+            output.fill_(float("nan"))
+            torch.cuda.synchronize()
+            before = torch.cuda.memory_stats()
+            graph.replay()
+            torch.cuda.synchronize()
+            after = torch.cuda.memory_stats()
+            for key in ("allocation.all.allocated", "allocated_bytes.all.allocated"):
+                assert before[key] == after[key]
+            assert pointers == (source.data_ptr(), scratch.data_ptr(), output.data_ptr())
+            actual = output[:tokens, :, 0]
+            assert torch.isfinite(actual).all() and torch.count_nonzero(actual) > 0
+            torch.testing.assert_close(actual, initialized, rtol=0, atol=0)
+            # Distinct accumulation orders may round to adjacent output values.
+            lower = torch.nextafter(expected, torch.full_like(expected, -float("inf")))
+            upper = torch.nextafter(expected, torch.full_like(expected, float("inf")))
+            assert torch.all((actual >= lower) & (actual <= upper))
+    finally:
+        unfreeze_kernel_resolution()

--- a/tests/gemm/test_block_fp8_linear_capacity.py
+++ b/tests/gemm/test_block_fp8_linear_capacity.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 import torch
 
+import b12x._lib.dense_gemm as dense_module
+import b12x._lib.quant.mxfp8_rows as quant_module
 from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
 from b12x.gemm import block_fp8_linear as bfl
 from tests._reference.helpers import require_b12x
@@ -13,9 +15,39 @@ from tests.gemm.test_gemm_block_fp8_linear import (
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_block_fp8_linear_scratch_reuse_across_row_tiles(dtype: torch.dtype) -> None:
+@pytest.mark.parametrize(
+    "capacity,expected_m,live_counts",
+    [
+        (1, None, (1,)),
+        (8, None, (8, 1, 7, 2)),
+        (129, None, (129, 9, 128, 8, 127, 1)),
+        (2048, None, (2048, 129, 9, 1, 1024)),
+        (129, 8, (8, 1, 2, 7)),
+        (2048, 129, (129, 9, 128, 1)),
+    ],
+)
+def test_block_fp8_linear_scratch_reuse_across_row_tiles(
+    dtype: torch.dtype, capacity: int, expected_m: int | None,
+    live_counts: tuple[int, ...], monkeypatch: pytest.MonkeyPatch,
+) -> None:
     require_b12x()
-    capacity, in_features, out_features = 129, 256, 384
+    resolved = []
+    quantized = []
+
+    def track(resolve, calls):
+        def wrapped(*args, **kwargs):
+            compiled = resolve(*args, **kwargs)
+            calls.append(compiled)
+            return compiled
+        return wrapped
+
+    for name in ("_get_compiled_dense_gemm", "_get_compiled_dense_gemm_fused_quant_a"):
+        monkeypatch.setattr(dense_module, name, track(getattr(dense_module, name), resolved))
+    monkeypatch.setattr(
+        quant_module, "_get_compiled_mxfp8_rows_quant",
+        track(quant_module._get_compiled_mxfp8_rows_quant, quantized),
+    )
+    in_features, out_features = 256, 384
     source = torch.randn((capacity, in_features), device="cuda", dtype=dtype).mul_(0.25)
     weight, scale = _make_block_fp8_weight(out_features, in_features)
     packed = bfl.pack_weight(weight, scale)
@@ -29,23 +61,37 @@ def test_block_fp8_linear_scratch_reuse_across_row_tiles(dtype: torch.dtype) -> 
 
     def bind(tokens: int):
         return bfl.bind(plan, scratch=scratch, source=source[:tokens],
-                        packed_weight=packed, output=output[:tokens])
+                        packed_weight=packed, output=output[:tokens],
+                        expected_m=expected_m)
 
-    for tokens in (capacity, 8):
-        bfl.run(binding=bind(tokens))
+    bound = capacity if expected_m is None else expected_m
+    # The reference uses standalone quantization even for fused decode plans.
+    _reference_from_quantized_operands(source[:1], weight, scale)
+    quantized.clear()
+    bfl.run(binding=bind(bound))
+    assert len(resolved) == 1
+    warmed = resolved[0]
+    warmed_quant = tuple(quantized)
+
+    def run(binding):
+        start = len(quantized)
+        result = bfl.run(binding=binding)
+        assert tuple(quantized[start:]) == warmed_quant
+        return result
+
     freeze_kernel_resolution("block FP8 scratch reuse across row-tile boundaries")
     try:
-        for tokens in (129, 9, 128, 8, 127):
+        for tokens in live_counts:
             binding = bind(tokens)
-            bfl.run(binding=binding)
+            run(binding)
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
-                bfl.run(binding=binding)
+                run(binding)
             source.normal_().mul_(0.25)
             expected = _reference_from_quantized_operands(source[:tokens], weight, scale)
             binding.x_q.scale_rows.view(torch.uint8).fill_(127)
             binding.x_q.scale_mma.view(torch.uint8).fill_(127)
-            initialized = bfl.run(binding=binding).clone()
+            initialized = run(binding).clone()
             scratch.fill_(255)
             output.fill_(float("nan"))
             torch.cuda.synchronize()
@@ -59,9 +105,87 @@ def test_block_fp8_linear_scratch_reuse_across_row_tiles(dtype: torch.dtype) -> 
             actual = output[:tokens, :, 0]
             assert torch.isfinite(actual).all() and torch.count_nonzero(actual) > 0
             torch.testing.assert_close(actual, initialized, rtol=0, atol=0)
+            assert all(compiled is warmed for compiled in resolved)
             # Distinct accumulation orders may round to adjacent output values.
             lower = torch.nextafter(expected, torch.full_like(expected, -float("inf")))
             upper = torch.nextafter(expected, torch.full_like(expected, float("inf")))
+            assert torch.all((actual >= lower) & (actual <= upper))
+    finally:
+        unfreeze_kernel_resolution()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("expected_m", (1, 8, 129, 2048))
+def test_block_fp8_linear_fixed_expected_m_functional_capture(
+    dtype: torch.dtype, expected_m: int,
+) -> None:
+    """The functional call used by vLLM retains its fixed capture-row bound."""
+    require_b12x()
+    source = torch.randn((expected_m, 256), device="cuda", dtype=dtype).mul_(0.25)
+    weight, scale = _make_block_fp8_weight(384, 256)
+    packed = bfl.pack_weight(weight, scale)
+
+    def run():
+        return bfl.run(source, packed, expected_m=expected_m)
+
+    _reference_from_quantized_operands(source, weight, scale)
+    run()
+    freeze_kernel_resolution("block FP8 functional capture with fixed expected_m")
+    try:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = run()
+        pointers = (source.data_ptr(), actual.data_ptr())
+        for _ in range(3):
+            source.normal_().mul_(0.25)
+            expected = _reference_from_quantized_operands(source, weight, scale)
+            actual.fill_(float("nan"))
+            torch.cuda.synchronize()
+            before = torch.cuda.memory_stats()
+            graph.replay()
+            torch.cuda.synchronize()
+            after = torch.cuda.memory_stats()
+            for key in ("allocation.all.allocated", "allocated_bytes.all.allocated"):
+                assert before[key] == after[key]
+            assert pointers == (source.data_ptr(), actual.data_ptr())
+            assert torch.isfinite(actual).all() and torch.count_nonzero(actual) > 0
+            lower = torch.nextafter(expected, torch.full_like(expected, -float("inf")))
+            upper = torch.nextafter(expected, torch.full_like(expected, float("inf")))
+            assert torch.all((actual >= lower) & (actual <= upper))
+    finally:
+        unfreeze_kernel_resolution()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("tokens,expected_m", ((8, None), (8, 8), (129, None), (129, 129)))
+def test_block_fp8_linear_prewarm_covers_bound_and_functional_capture(
+    dtype: torch.dtype, tokens: int, expected_m: int | None,
+) -> None:
+    require_b12x()
+    source = torch.randn((tokens, 256), dtype=dtype, device="cuda").mul_(0.25)
+    weight, scale = _make_block_fp8_weight(384, 256)
+    packed = bfl.pack_weight(weight, scale)
+    expected = _reference_from_quantized_operands(source, weight, scale)
+    plan = bfl.plan(bfl.Caps(device=source.device, max_tokens=tokens,
+                           in_features=256, out_features=384, output_dtype=dtype))
+    spec = plan.scratch_specs()[0]
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+    output = torch.empty((tokens, 384, 1), dtype=dtype, device=source.device)
+    binding = bfl.bind(plan, scratch=scratch, source=source, packed_weight=packed,
+                       output=output, expected_m=expected_m)
+    bfl.prewarm(packed, (tokens,), output_dtype=dtype, expected_m=expected_m)
+    freeze_kernel_resolution("block FP8 public prewarm covers both serving forms")
+    try:
+        for bound in (True, False):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                actual = (bfl.run(binding=binding) if bound else
+                          bfl.run(source, packed, expected_m=expected_m))
+            graph.replay()
+            torch.cuda.synchronize()
+            lower = torch.nextafter(expected, torch.full_like(expected, -float("inf")))
+            upper = torch.nextafter(expected, torch.full_like(expected, float("inf")))
+            assert torch.isfinite(actual).all() and torch.count_nonzero(actual) > 0
             assert torch.all((actual >= lower) & (actual <= upper))
     finally:
         unfreeze_kernel_resolution()

--- a/tests/gemm/test_block_fp8_linear_scratch_bindings.py
+++ b/tests/gemm/test_block_fp8_linear_scratch_bindings.py
@@ -50,7 +50,8 @@ def test_block_fp8_linear_scratch_plan_exposes_one_opaque_scratch_spec() -> None
     assert specs[0].nbytes == specs[0].shape[0]
 
 
-def test_block_fp8_linear_scratch_plan_binds_live_shape(monkeypatch) -> None:
+@pytest.mark.parametrize("expected_m", (None, 3, 4))
+def test_block_fp8_linear_scratch_plan_binds_live_shape(monkeypatch, expected_m) -> None:
     monkeypatch.setattr(block_impl, "_check_mxfp8_rows_storage", lambda *args, **kwargs: None)
     plan = plan_block_fp8_linear_scratch(
         BlockFP8LinearScratchCaps(
@@ -71,9 +72,11 @@ def test_block_fp8_linear_scratch_plan_binds_live_shape(monkeypatch) -> None:
         source=source,
         packed_weight=packed,
         output=output,
+        expected_m=expected_m,
     )
 
     assert isinstance(binding, BlockFP8LinearBinding)
+    assert binding.expected_m == (4 if expected_m is None else expected_m)
     assert binding.source is source
     assert binding.packed_weight is packed
     assert not hasattr(binding, "workspace")
@@ -136,10 +139,10 @@ def test_block_fp8_linear_binding_supplies_runtime_tensors(monkeypatch) -> None:
     )
     calls = {}
 
-    def fake_quantize(source_tk, *, out=None):
+    def fake_quantize(source_tk, values, scale_rows, scale_mma, tokens, in_features, *, expected_m=None):
         calls["source_tk"] = source_tk
-        calls["x_q_out"] = out
-        return out
+        calls["x_q_values"] = values
+        calls["quant_expected_m"] = expected_m
 
     def fake_dense_gemm(a, b, **kwargs):
         calls["a"] = a
@@ -148,13 +151,14 @@ def test_block_fp8_linear_binding_supplies_runtime_tensors(monkeypatch) -> None:
         kwargs["out"].zero_()
         return kwargs["out"]
 
-    monkeypatch.setattr(block_impl, "quantize_block_fp8_linear_input_mxfp8", fake_quantize)
+    monkeypatch.setattr(block_impl, "_run_block_fp8_quant_kernel", fake_quantize)
     monkeypatch.setattr(block_impl, "dense_gemm", fake_dense_gemm)
 
     out = block_impl.block_fp8_linear_mxfp8(binding=binding)
 
     assert calls["source_tk"].data_ptr() == source.data_ptr()
-    assert calls["x_q_out"] is binding.x_q
+    assert calls["x_q_values"] is binding.x_q.values
+    assert calls["quant_expected_m"] == plan.caps.max_tokens
     assert calls["dense_out"] is output
     assert out.shape == (9, 256)
 

--- a/tests/gemm/test_cute_migration_gemm_corpus.py
+++ b/tests/gemm/test_cute_migration_gemm_corpus.py
@@ -139,10 +139,15 @@ def test_cute_migration_dense_nvfp4_gpu_oracle_and_graph() -> None:
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
-def test_cute_migration_dense_fused_quant_gpu_oracle_and_graph() -> None:
+@pytest.mark.parametrize(
+    "m,expected_m,a_inner_span", ((2, None, 0), (8, 8, 32), (1, 8, 32), (1, 1, 32))
+)
+def test_cute_migration_dense_fused_quant_gpu_oracle_and_graph(
+    m: int, expected_m: int | None, a_inner_span: int,
+) -> None:
     require_b12x()
     generator = torch.Generator(device="cuda").manual_seed(46_002)
-    m, n, k = 2, 128, 128
+    n, k = 128, 128
     source = (
         torch.randn(
             (m, k),
@@ -152,6 +157,16 @@ def test_cute_migration_dense_fused_quant_gpu_oracle_and_graph() -> None:
         )
         / 4
     ).contiguous()
+    if a_inner_span:
+        physical = torch.empty(
+            (k // a_inner_span, m, a_inner_span), dtype=source.dtype, device=source.device
+        )
+        physical.copy_(source.view(m, k // a_inner_span, a_inner_span).permute(1, 0, 2))
+        source = physical.permute(1, 2, 0)
+
+    def logical_source():
+        return source if not a_inner_span else source.permute(0, 2, 1).reshape(m, k)
+
     b_source = (
         torch.randn(
             (n, k, 1),
@@ -171,12 +186,14 @@ def test_cute_migration_dense_fused_quant_gpu_oracle_and_graph() -> None:
             b_quant.scale_mma,
             out=out,
             mma_tiler_mn=(64, 64),
+            expected_m=expected_m,
+            a_inner_span=a_inner_span,
         )
 
     run()
     torch.cuda.synchronize()
     expected = _mxfp8_gemm_reference(
-        source.unsqueeze(-1), b_quant.values, b_quant.scale_rows
+        logical_source().unsqueeze(-1), b_quant.values, b_quant.scale_rows
     )
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
@@ -195,15 +212,18 @@ def test_cute_migration_dense_fused_quant_gpu_oracle_and_graph() -> None:
     graph.replay()
     torch.cuda.synchronize()
     expected = _mxfp8_gemm_reference(
-        source.unsqueeze(-1), b_quant.values, b_quant.scale_rows
+        logical_source().unsqueeze(-1), b_quant.values, b_quant.scale_rows
     )
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
-def test_cute_migration_dense_grouped_fused_quant_gpu_oracle_and_graph() -> None:
+@pytest.mark.parametrize("m,expected_m", ((2, None), (1, 1), (8, 8), (1, 8)))
+def test_cute_migration_dense_grouped_fused_quant_gpu_oracle_and_graph(
+    m: int, expected_m: int | None,
+) -> None:
     require_b12x()
     generator = torch.Generator(device="cuda").manual_seed(46_003)
-    m, n, k, groups = 2, 128, 128, 2
+    n, k, groups = 128, 128, 2
     source = (
         torch.randn(
             (m, groups, k),
@@ -237,6 +257,7 @@ def test_cute_migration_dense_grouped_fused_quant_gpu_oracle_and_graph() -> None
             groups=groups,
             out=out,
             mma_tiler_mn=(64, 64),
+            expected_m=expected_m,
         )
 
     run()

--- a/tests/gemm/test_dense_gemm_expected_m.py
+++ b/tests/gemm/test_dense_gemm_expected_m.py
@@ -35,6 +35,38 @@ LOW_SM = 48
 WIDE_N = 4096  # n > 1536 -> the MXFP8 wide-N regime that the hint tunes
 
 
+@pytest.mark.parametrize("expected_m", (1, 8, 16, 129, 2048, 8192))
+@pytest.mark.parametrize("sm_count", (LOW_SM, HIGH_SM))
+@pytest.mark.parametrize("c_dtype", (cutlass.BFloat16, cutlass.Float16))
+def test_expected_m_bounds_the_complete_scheduling_specialization(
+    expected_m: int, sm_count: int, c_dtype,
+) -> None:
+    n = k = 4096
+    plan = _select_default_dense_gemm_plan(
+        expected_m, n, k, sm_count, is_mxfp8=True, expected_m=expected_m
+    )
+    tile_k = _select_mxfp8_tile_k(expected_m, n, k, expected_m, sm_count)
+    policies = {
+        _dense_gemm_policy_for(
+            m=live_m,
+            n=n,
+            k=k,
+            l=1,
+            ab_dtype=cutlass.Float8E4M3FN,
+            c_dtype=c_dtype,
+            mma_tiler_mn=plan.mma_tiler_mn,
+            cluster_shape_mn=(1, 1),
+            sm_count=sm_count,
+            tile_k=tile_k,
+            expected_m=expected_m,
+            generalize_mxfp8_split_k=True,
+        )
+        for live_m in (1, 2, 8, 9, 15, 16, 128, 129, expected_m)
+        if live_m <= expected_m
+    }
+    assert len(policies) == 1
+
+
 @pytest.mark.parametrize("m", (1, 2, 4, 6, 8, 16, 32, 64, 128))
 @pytest.mark.parametrize(
     "n,k,expected_tile_k",


### PR DESCRIPTION
Block-FP8 linear calls can change compiled GEMM scheduling and quantizer lane layout when live rows cross decode boundaries, even though their declared row bound is fixed. A capacity-129 plan warmed at 129 rows can therefore fail under frozen resolution at nine or fewer rows.

Use the existing `expected_m` upper bound for scheduling flags, fused input layout, the fused-decode decision, and quantizer lane layout. Live rows still determine runtime grids and bounds checks. Fixed captured calls with `expected_m == input_rows`, including the inspected vLLM wrapper, retain their dispatch choices.

`Plan.bind` defaults an omitted `expected_m` to `Caps.max_tokens`; explicit bounds take precedence. `quantization.mxfp8.quantize_rows` accepts an optional `expected_m` keyword, preserving its existing selection when omitted. Public prewarm covers both bound and functional entry points. The implementation retains the existing planner, profiles, kernel math, and tensor formats.

Validation on physical GPU7, RTX PRO 6000 Blackwell Max-Q, SM120/188 SMs, PyTorch 2.12.0+cu130 and CUTLASS DSL 4.6.2:

- 348 selected tests pass with no skips across dispatch logic, quantization, block-FP8, scratch bindings, and representative CuTe GEMM paths.
- Frozen-resolution graph coverage includes BF16/FP16 capacities 1, 8, 129, and 2048, decode/row-tile boundaries, explicit bounds within larger scratch buffers, functional calls, and both public prewarm forms. Serving calls retain the same GEMM and quantizer callable identities. Replay consumes mutated inputs with stable addresses and zero allocations.
- Fused GEMM coverage includes grouped and blocked activation layouts, including one live row under an eight-row bound.
- The actual vLLM block-FP8 wrapper at revision ddf35ba4 passes ten BF16/FP16 capture/replay cases at M1/8/9/129/2048, K256/N384, using its existing expected_m and stream handling. This is component qualification; full-model serving throughput was not measured.
- Ruff and whitespace checks pass. CUTLASS deprecation warnings remain visible in the logs.

The scale-fill optimization is merged independently in #272.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Block-FP8 GEMM dispatch now uses the declared `expected_m` row bound for scheduling, fused input layout, decode/prefill selection, and MXFP8 quantizer lane layout. Runtime grids and bounds checks still use live rows.

`Plan.bind` defaults omitted `expected_m` to `Caps.max_tokens`. Explicit bounds take precedence. `quantize_rows` accepts optional `expected_m` and preserves existing behavior when omitted. Public prewarming covers both bound and functional entry points.

Added coverage for capacity-boundary dispatch, CUDA graph replay, workspace stability, scratch bindings, fused layouts, CuTe GEMM paths, quantization, decode/prefill boundaries, and frozen-resolution behavior. Reported GPU tests, lint, whitespace checks, and the inspected vLLM wrapper pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->