### PR TITLE
fix(qsa): plan caller-owned draft anchors for complete-operation reuse

### DIFF
--- a/b12x/attention/qsa/__init__.py
+++ b/b12x/attention/qsa/__init__.py
@@ -82,6 +82,50 @@ selected order, followed by the causally visible incomplete-group tail.
 The selected-position reader supports widths of at least 2051. Width is a
 planned specialization; changing live rows preserves the warmed callable
 within each split or direct reader regime.
+
+Draft layers may bind persistent selection anchors for reuse within one MTP
+round. B12X describes the layout; the caller allocates the storage::
+
+    anchor_plan = plan.draft_selection_plan()
+    anchor_storage = {
+        spec.name: torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+        for spec in anchor_plan.storage_specs()
+    }
+    anchors = anchor_plan.bind(storage=anchor_storage)
+    anchors.reset()
+    binding = qsa.bind(plan, **buffers, draft_selection=anchors)
+
+``buffers`` includes the caller allocations required by ``plan.scratch_specs``
+and the ordinary cache, output, and selected-position buffers. Temporary
+anchor-gather and causal-tail buffers are included in that scratch contract.
+Binding creates views without allocating or initializing tensor storage.
+Prewarm preserves anchors and allocates only its synthetic warmup inputs.
+
+An ordinary ``qsa.run(binding, **inputs)`` records an independent copy of the
+selection, logical positions, error mask, and valid row count. Subsequent draft
+steps supply a caller-owned int32/int64 vector mapping batch request IDs to
+accepted rows of that recording::
+
+    output = qsa.run(
+        binding, query=query, request_ids=request_ids,
+        query_positions=query_positions,
+        reuse=qsa.DraftSelectionReuse(source_rows=accepted_rows),
+    )
+
+Reuse requires one query per request and omits selector inputs and
+``index_ready``. It preserves anchors and selector caches, appends the causal
+suffix bounded by ``max_speculative_tokens``, and poisons invalid active rows.
+The caller must reset at round boundaries and request recycling, and map each
+request to an anchor from the same request, model layer, and round. Bounds and
+causal positions are checked; request identity and round provenance are not.
+Returned anchor views are for inspection; ``reset`` and ``run`` own mutations.
+
+Capacity variants of a layer's plan may share anchors when device, selection
+width, and cache/request assignment match. Pass ``max_source_rows`` to
+``draft_selection_plan`` to cover the largest recording plan. Each plan reports
+its own scratch requirements. Order resets, recordings, map writes, and reuse
+on the calling stream or join them with caller-owned events; keep all storage
+alive through graph replay and do not overlap operations sharing mutable state.
 """
 
 from __future__ import annotations
@@ -97,6 +141,8 @@ META = OpMeta(
     entry_points=(
         "CacheRequirements",
         "Caps",
+        "DraftSelectionPlan",
+        "DraftSelectionReuse",
         "DraftSelectionState",
         "Plan",
         "Binding",
@@ -137,6 +183,8 @@ if TYPE_CHECKING:
         Binding,
         CacheRequirements,
         Caps,
+        DraftSelectionPlan,
+        DraftSelectionReuse,
         DraftSelectionState,
         Plan,
         QsaConfig,

--- a/b12x/attention/qsa/__init__.py
+++ b/b12x/attention/qsa/__init__.py
@@ -97,6 +97,7 @@ META = OpMeta(
     entry_points=(
         "CacheRequirements",
         "Caps",
+        "DraftSelectionState",
         "Plan",
         "Binding",
         "QsaConfig",
@@ -136,6 +137,7 @@ if TYPE_CHECKING:
         Binding,
         CacheRequirements,
         Caps,
+        DraftSelectionState,
         Plan,
         QsaConfig,
         QsaQuery,

--- a/b12x/attention/qsa/_contract.py
+++ b/b12x/attention/qsa/_contract.py
@@ -2907,21 +2907,12 @@ def run(
                 dtype=dtype,
                 contiguous=True,
             )
-        _require_mutation_alias_contract(
-            mutable=(
-                ("scratch", binding.scratch),
-                ("output", binding.output),
-                ("draft work_positions", state.work_positions),
-                ("draft work_errors", state.work_errors),
-            ),
-            read_only=(
-                ("query", query),
-                ("request_ids", request_ids),
-                ("query_positions", query_positions),
-            ),
-        )
-        from ._draft_selection import prepare_selection
+        from ._draft_selection import prepare_selection, validate_buffers
 
+        validate_buffers(
+            [binding.scratch, binding.output, state.work_positions, state.work_errors],
+            [query, request_ids, query_positions],
+        )
         prepare_selection(
             state.logical_positions,
             state.errors,
@@ -2967,14 +2958,17 @@ def run(
         is_prefilling=is_prefilling,
     )
     if binding.draft_selection is not None:
+        from ._draft_selection import validate_buffers
+
         state = binding.draft_selection
-        _require_mutation_alias_contract(
-            mutable=(
-                ("draft logical_positions", state.logical_positions),
-                ("draft errors", state.errors),
-                ("draft num_source_rows", state.num_source_rows),
-            ),
-            read_only=tuple(inputs.items()),
+        validate_buffers(
+            [
+                state.logical_positions,
+                state.errors,
+                state.num_source_rows,
+                binding.selected_positions,
+            ],
+            list(inputs.values()),
         )
     stream = binding.selection_stream
     if stream is None:
@@ -3014,7 +3008,8 @@ def _record_draft_anchors(binding: Binding, positions: torch.Tensor) -> None:
         state = binding.draft_selection
         record_anchors(
             positions,
-            binding.state_errors,
+            binding.scratch,
+            binding.plan._layout.state_errors_offset_bytes,
             state.logical_positions,
             state.errors,
             state.num_source_rows,

--- a/b12x/attention/qsa/_contract.py
+++ b/b12x/attention/qsa/_contract.py
@@ -406,6 +406,8 @@ class _ScratchLayout:
     partial_lse_nbytes: int
     work_metadata_offset_bytes: int
     work_metadata_nbytes: int
+    draft_positions_offset_bytes: int
+    draft_errors_offset_bytes: int
     total_nbytes: int
 
 
@@ -432,25 +434,139 @@ class Plan:
     def bind(self, **kwargs: object) -> Binding:
         return bind(self, **kwargs)
 
+    def draft_selection_plan(
+        self, *, max_source_rows: int | None = None
+    ) -> DraftSelectionPlan:
+        """Describe persistent anchor storage without allocating or initializing it."""
+        if self.caps.max_speculative_tokens < 1:
+            raise ValueError("draft selection reuse requires speculative capacity")
+        rows = self.caps.max_q_rows if max_source_rows is None else int(max_source_rows)
+        if rows < self.caps.max_q_rows:
+            raise ValueError("draft selection state must cover planned query rows")
+        return DraftSelectionPlan(self.caps.device, rows, self.caps.selection_width)
+
+
+@dataclass(frozen=True)
+class DraftSelectionPlan:
+    """B12X-defined persistent storage layout for draft-selection anchors.
+
+    Compatible bindings may share this storage when device and selection width
+    match and source capacity covers each plan of the same model layer and
+    request/cache assignment. Storage must outlive all bound
+    operations and captured graphs. Planning and binding allocate no tensors.
+    """
+
+    device: torch.device
+    max_source_rows: int
+    selection_width: int
+
+    def __post_init__(self) -> None:
+        if self.max_source_rows < 1 or self.selection_width < 1:
+            raise ValueError("draft selection capacity and width must be positive")
+        object.__setattr__(self, "device", _canonical_device(self.device))
+
+    def _regions(self) -> tuple[tuple[str, tuple[int, ...], torch.dtype, int], ...]:
+        offset = 0
+        regions = []
+        for name, shape, dtype in (
+            (
+                "selected_positions",
+                (self.max_source_rows, self.selection_width),
+                torch.int32,
+            ),
+            ("logical_positions", (self.max_source_rows,), torch.int64),
+            ("errors", (self.max_source_rows,), torch.int32),
+            ("num_source_rows", (1,), torch.int32),
+        ):
+            offset = _align_up(offset)
+            regions.append((name, shape, dtype, offset))
+            offset += math.prod(shape) * dtype.itemsize
+        return tuple(regions)
+
+    def storage_specs(self) -> tuple[ScratchBufferSpec, ...]:
+        """Return caller allocation requirements for persistent, non-scratch storage."""
+        _, shape, dtype, offset = self._regions()[-1]
+        return (
+            scratch_buffer_spec(
+                "qsa_draft_selection",
+                nbytes=_align_up(offset + math.prod(shape) * dtype.itemsize),
+                device=self.device,
+            ),
+        )
+
+    def bind(
+        self,
+        *,
+        storage: torch.Tensor | Mapping[str, torch.Tensor] | Sequence[torch.Tensor],
+    ) -> DraftSelectionState:
+        """Create views only; call ``reset`` before the first use of uninitialized storage."""
+        buffer = scratch_tensor(
+            storage, self.storage_specs(), owner="qsa draft selection"
+        )
+        return DraftSelectionState(plan=self, _storage=buffer)
+
 
 @dataclass(frozen=True)
 class DraftSelectionState:
-    """Caller-owned anchors for selection reuse inside one MTP draft round.
+    """Persistent caller-owned anchors created by ``DraftSelectionPlan.bind``.
 
-    Ordinary ``run`` writes selected positions and their logical positions/errors.
-    The caller maps each compacted request to its accepted anchor in ``source_rows``.
-    A reuse run gathers those anchors and adds its causal tail into work buffers;
-    it never updates selector caches or exposes a split selection transaction.
-    Source rows have no lifetime across draft rounds or unrelated request batches.
+    Ordinary ``run`` replaces the valid anchor prefix. Reuse preserves it.
+    The caller must reset before first use, at round boundaries, and before
+    recycling requests; it must map each request to an anchor from that same
+    request and round. Bounds, recorded row count, error bits, and causal tail
+    positions are checked on device. Request identity and round provenance are
+    caller invariants and cannot be inferred from logical positions.
+
+    Reset, recording, map updates, and reuse must be ordered on the calling
+    stream or joined with caller-established events. Concurrent operations
+    must not share mutable storage or scratch. Captured reset and record calls
+    execute on every replay, so capture must preserve the round lifecycle.
+    Tensor properties expose inspection views; use ``reset`` and ``run`` for mutation.
     """
 
-    selected_positions: torch.Tensor
-    logical_positions: torch.Tensor
-    errors: torch.Tensor
+    plan: DraftSelectionPlan
+    _storage: torch.Tensor
+
+    def _view(self, index: int) -> torch.Tensor:
+        _, shape, dtype, offset = self.plan._regions()[index]
+        return _scratch_view(
+            self._storage, offset_bytes=offset, shape=shape, dtype=dtype
+        )
+
+    @property
+    def selected_positions(self) -> torch.Tensor:
+        return self._view(0)
+
+    @property
+    def logical_positions(self) -> torch.Tensor:
+        return self._view(1)
+
+    @property
+    def errors(self) -> torch.Tensor:
+        return self._view(2)
+
+    @property
+    def num_source_rows(self) -> torch.Tensor:
+        return self._view(3)
+
+    def reset(self) -> None:
+        """Invalidate all anchors on the calling stream without allocating storage."""
+        from ._draft_selection import reset_anchors
+
+        reset_anchors(self._storage, self.plan._regions()[3][3])
+
+
+@dataclass(frozen=True)
+class DraftSelectionReuse:
+    """Live request-to-anchor row map for one reuse transaction.
+
+    ``source_rows[request_id]`` names a row of the last ordinary run. The caller
+    supplies a contiguous int32/int64 vector of ``max_batch`` entries and keeps
+    it stable until the operation completes. Invalid active mappings poison
+    output. The caller is responsible for request identity and round lifetime.
+    """
+
     source_rows: torch.Tensor
-    num_source_rows: torch.Tensor
-    work_positions: torch.Tensor
-    work_errors: torch.Tensor
 
 
 @dataclass(frozen=True)
@@ -498,6 +614,9 @@ class Binding:
     selection_stream: torch.cuda.Stream | None = None
     _selection_done: torch.cuda.Event | None = None
     draft_selection: DraftSelectionState | None = None
+    _draft_work_positions: torch.Tensor | None = None
+    _draft_work_errors: torch.Tensor | None = None
+    _record_draft_enabled: bool = True
 
 
 @dataclass(frozen=True)
@@ -670,6 +789,17 @@ def _scratch_layout(
     offset = partial_lse_offset + partial_lse_nbytes
     work_metadata_offset = _align_up(offset)
     offset = work_metadata_offset + work_metadata_nbytes
+    draft_positions_offset = _align_up(offset)
+    if caps.max_speculative_tokens > 0:
+        offset = (
+            draft_positions_offset
+            + caps.max_batch
+            * (caps.selection_width + caps.max_speculative_tokens)
+            * torch.int32.itemsize
+        )
+    draft_errors_offset = _align_up(offset)
+    if caps.max_speculative_tokens > 0:
+        offset = draft_errors_offset + caps.max_batch * torch.int32.itemsize
     total_nbytes = _align_up(offset)
     return (
         _ScratchLayout(
@@ -701,6 +831,8 @@ def _scratch_layout(
             partial_lse_nbytes=partial_lse_nbytes,
             work_metadata_offset_bytes=work_metadata_offset,
             work_metadata_nbytes=work_metadata_nbytes,
+            draft_positions_offset_bytes=draft_positions_offset,
+            draft_errors_offset_bytes=draft_errors_offset,
             total_nbytes=total_nbytes,
         ),
         score_chunk_groups,
@@ -1405,27 +1537,9 @@ def bind(
             ),
             (draft_selection.errors, "draft errors", (source_capacity,), torch.int32),
             (
-                draft_selection.source_rows,
-                "draft source_rows",
-                (caps.max_batch,),
-                (torch.int32, torch.int64),
-            ),
-            (
                 draft_selection.num_source_rows,
                 "draft num_source_rows",
                 (1,),
-                torch.int32,
-            ),
-            (
-                draft_selection.work_positions,
-                "draft work_positions",
-                (caps.max_batch, caps.selection_width + caps.max_speculative_tokens),
-                torch.int32,
-            ),
-            (
-                draft_selection.work_errors,
-                "draft work_errors",
-                (caps.max_batch,),
                 torch.int32,
             ),
         ):
@@ -1437,30 +1551,37 @@ def bind(
                 dtype=dtype,
                 contiguous=True,
             )
-        if (
-            draft_selection.selected_positions.data_ptr()
-            != selected_positions.data_ptr()
-            or draft_selection.selected_positions.stride()
-            != selected_positions.stride()
-        ):
-            raise ValueError("bound selection must be the draft state's row prefix")
         _require_mutation_alias_contract(
             mutable=(
-                ("scratch", scratch_storage),
-                ("output", output),
+                ("draft selected_positions", draft_selection.selected_positions),
                 ("draft logical_positions", draft_selection.logical_positions),
                 ("draft errors", draft_selection.errors),
                 ("draft num_source_rows", draft_selection.num_source_rows),
-                ("draft work_positions", draft_selection.work_positions),
-                ("draft work_errors", draft_selection.work_errors),
             ),
-            read_only=(
-                ("draft selected_positions", draft_selection.selected_positions),
-                ("draft source_rows", draft_selection.source_rows),
-                ("main_k_cache", main_k_cache),
-                ("main_v_cache", main_v_cache),
-                ("compressed_k_cache", compressed_k_cache),
-                ("raw_k_ring", raw_k_ring),
+            read_only=tuple(
+                (name, tensor)
+                for name, tensor in (
+                    ("scratch", scratch_storage),
+                    ("output", output),
+                    ("selected_positions", selected_positions),
+                    ("main_k_cache", main_k_cache),
+                    ("main_v_cache", main_v_cache),
+                    ("k_descale", k_descale),
+                    ("v_descale", v_descale),
+                    ("main_block_table", main_block_table),
+                    ("compressed_k_cache", compressed_k_cache),
+                    ("compressed_block_table", compressed_block_table),
+                    ("raw_k_ring", raw_k_ring),
+                    ("raw_logical_positions", raw_logical_positions),
+                    ("raw_rope_positions", raw_rope_positions),
+                    ("raw_interval_start_positions", raw_interval_start_positions),
+                    ("raw_state_slot_ids", raw_state_slot_ids),
+                    ("index_q_norm_weight", index_q_norm_weight),
+                    ("index_k_norm_weight", index_k_norm_weight),
+                    ("rope_cos", rope_cos),
+                    ("rope_sin", rope_sin),
+                )
+                if tensor is not None
             ),
         )
     if selection_stream is not None:
@@ -1486,6 +1607,22 @@ def bind(
         selection_stream=selection_stream,
         _selection_done=selection_done,
         draft_selection=draft_selection,
+        _draft_work_positions=_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.draft_positions_offset_bytes,
+            shape=(caps.max_batch, caps.selection_width + caps.max_speculative_tokens),
+            dtype=torch.int32,
+        )
+        if caps.max_speculative_tokens > 0
+        else None,
+        _draft_work_errors=_scratch_view(
+            scratch_storage,
+            offset_bytes=layout.draft_errors_offset_bytes,
+            shape=(caps.max_batch,),
+            dtype=torch.int32,
+        )
+        if caps.max_speculative_tokens > 0
+        else None,
         plan=plan,
         shared_compressed_raw_pool=_overlaps(compressed_k_cache, raw_k_ring),
         scratch=scratch_storage,
@@ -2807,7 +2944,7 @@ def run(
     num_accepted_tokens: torch.Tensor | None = None,
     is_prefilling: torch.Tensor | None = None,
     index_ready: torch.cuda.Event | None = None,
-    reuse_draft_selection: bool = False,
+    reuse: DraftSelectionReuse | None = None,
 ) -> torch.Tensor:
     """Run one packed QSA decode transaction after main K/V writes are enqueued.
 
@@ -2821,12 +2958,14 @@ def run(
     and record the readiness event inside the graph for captured producers.
 
     A bound ``draft_selection`` records anchors during ordinary execution.
-    ``reuse_draft_selection=True`` uses the accepted anchors selected by its
-    caller-owned request-to-source map and appends only the causal draft tail.
+    ``reuse=DraftSelectionReuse(source_rows)`` uses the accepted anchors selected
+    by the caller-owned request-to-source map and appends only the causal draft tail.
     This mode requires one query per request inside the same draft round;
     selector projections/metadata and ``index_ready`` must be omitted. It
     preserves selector caches and the anchor buffers. Invalid anchors poison
-    output instead of reading stale positions. Target layers must not use it.
+    output for invalid bounds or causal positions. Request identity and round
+    lifetime are caller invariants; see ``DraftSelectionState``. Target layers
+    must not use it.
 
     Active request intervals are the dense prefix encoded by
     ``query_start_loc``.  Remaining boundaries repeat the live-row count and
@@ -2865,7 +3004,9 @@ def run(
     """
     if not isinstance(binding, Binding):
         raise TypeError("binding must be a qsa.Binding")
-    if reuse_draft_selection:
+    if reuse is not None:
+        if not isinstance(reuse, DraftSelectionReuse):
+            raise TypeError("reuse must be a qsa.DraftSelectionReuse")
         state = binding.draft_selection
         if state is None:
             raise ValueError("draft selection reuse requires bound draft state")
@@ -2907,30 +3048,39 @@ def run(
                 dtype=dtype,
                 contiguous=True,
             )
+        _check_tensor(
+            reuse.source_rows,
+            name="source_rows",
+            device=caps.device,
+            shape=(caps.max_batch,),
+            dtype=(torch.int32, torch.int64),
+            contiguous=True,
+        )
         from ._draft_selection import prepare_selection, validate_buffers
 
         validate_buffers(
-            [binding.scratch, binding.output, state.work_positions, state.work_errors],
-            [query, request_ids, query_positions],
+            [binding.scratch, binding.output],
+            [query, request_ids, query_positions, reuse.source_rows],
         )
         prepare_selection(
-            state.logical_positions,
-            state.errors,
-            state.selected_positions,
-            state.source_rows,
-            state.num_source_rows,
+            state._storage,
+            state.plan.max_source_rows,
+            state.plan.selection_width,
+            reuse.source_rows,
             request_ids,
             query_positions,
-            state.work_positions,
-            state.work_errors,
+            binding.scratch,
+            binding.plan._layout.draft_positions_offset_bytes,
+            binding.plan._layout.draft_errors_offset_bytes,
+            caps.max_batch,
+            caps.max_speculative_tokens,
         )
         return _run_attention(
             binding,
             query=query,
             request_ids=request_ids,
             query_positions=query_positions,
-            selected_positions=state.work_positions,
-            selection_errors=state.work_errors,
+            reuse=True,
         )
     if any(
         value is None
@@ -2963,9 +3113,7 @@ def run(
         state = binding.draft_selection
         validate_buffers(
             [
-                state.logical_positions,
-                state.errors,
-                state.num_source_rows,
+                state._storage,
                 binding.selected_positions,
             ],
             list(inputs.values()),
@@ -3010,9 +3158,11 @@ def _record_draft_anchors(binding: Binding, positions: torch.Tensor) -> None:
             positions,
             binding.scratch,
             binding.plan._layout.state_errors_offset_bytes,
-            state.logical_positions,
-            state.errors,
-            state.num_source_rows,
+            binding.selected_positions,
+            state._storage,
+            state.plan.max_source_rows,
+            state.plan.selection_width,
+            binding._record_draft_enabled,
         )
 
 
@@ -3026,7 +3176,7 @@ def _qsa_attention_op(
     k_descale: torch.Tensor | None,
     v_descale: torch.Tensor | None,
     main_block_table: torch.Tensor,
-    selected_positions: torch.Tensor,
+    selected_positions: torch.Tensor | None,
     scratch: torch.Tensor,
     output: torch.Tensor,
     work_rows: int,
@@ -3035,7 +3185,9 @@ def _qsa_attention_op(
     partial_output_offset: int,
     partial_lse_offset: int,
     direct_kv_warps: int,
-    selection_errors: torch.Tensor | None,
+    draft_positions_offset: int,
+    draft_width: int,
+    draft_capacity: int,
 ) -> None:
     from ._kernels import launch_poison_failed_rows
     from ._sparse_gqa import launch_sparse_paged_gqa
@@ -3048,24 +3200,28 @@ def _qsa_attention_op(
             ("query", query),
             ("request_ids", request_ids),
             ("query_positions", query_positions),
-            ("selected_positions", selected_positions),
         )
         + (
             ()
-            if selection_errors is None
-            else (("selection_errors", selection_errors),)
+            if selected_positions is None
+            else (("selected_positions", selected_positions),)
         ),
     )
     rows, q_heads, head_dim = map(int, query.shape)
-    errors = (
-        selection_errors
-        if selection_errors is not None
-        else _scratch_view(
+    if selected_positions is None:
+        selected_positions = _scratch_view(
             scratch,
-            offset_bytes=state_errors_offset,
-            shape=(int(output.shape[0]),),
+            offset_bytes=draft_positions_offset,
+            shape=(draft_capacity, draft_width),
             dtype=torch.int32,
         )
+    errors = _scratch_view(
+        scratch,
+        offset_bytes=state_errors_offset,
+        shape=(
+            draft_capacity if draft_positions_offset >= 0 else int(output.shape[0]),
+        ),
+        dtype=torch.int32,
     )
     partial_output = _scratch_view(
         scratch,
@@ -3125,7 +3281,7 @@ def _qsa_attention_fake(
     k_descale: torch.Tensor | None,
     v_descale: torch.Tensor | None,
     main_block_table: torch.Tensor,
-    selected_positions: torch.Tensor,
+    selected_positions: torch.Tensor | None,
     scratch: torch.Tensor,
     output: torch.Tensor,
     work_rows: int,
@@ -3134,7 +3290,9 @@ def _qsa_attention_fake(
     partial_output_offset: int,
     partial_lse_offset: int,
     direct_kv_warps: int,
-    selection_errors: torch.Tensor | None,
+    draft_positions_offset: int,
+    draft_width: int,
+    draft_capacity: int,
 ) -> None:
     return None
 
@@ -3145,8 +3303,7 @@ def _run_attention(
     query: torch.Tensor,
     request_ids: torch.Tensor,
     query_positions: torch.Tensor,
-    selected_positions: torch.Tensor | None = None,
-    selection_errors: torch.Tensor | None = None,
+    reuse: bool = False,
 ) -> torch.Tensor:
     """Consume the bound selection and error mask within one run call."""
 
@@ -3181,18 +3338,18 @@ def _run_attention(
         binding.k_descale,
         binding.v_descale,
         binding.main_block_table,
-        binding.selected_positions
-        if selected_positions is None
-        else selected_positions,
+        None if reuse else binding.selected_positions,
         binding.scratch,
         binding.output,
         binding.plan.workspace_q_rows,
         binding.plan.max_split_row_product,
-        layout.state_errors_offset_bytes,
+        layout.draft_errors_offset_bytes if reuse else layout.state_errors_offset_bytes,
         layout.partial_output_offset_bytes,
         layout.partial_lse_offset_bytes,
         binding.plan.policy_resolution.config.sparse_gqa_direct_kv_warps,
-        selection_errors,
+        layout.draft_positions_offset_bytes if reuse else -1,
+        caps.selection_width + caps.max_speculative_tokens,
+        caps.max_batch,
     )
     return binding.output[:rows]
 
@@ -3206,7 +3363,7 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
     and persistent selector-state writes remain masked. Scratch, output, and
     selected-position buffers are transient and have unspecified contents
     after this call, except for a bound draft state's anchor buffers, which
-    are preserved. Draft metadata stages use temporary anchors during warmup.
+    are preserved. The record kernel is warmed with persistent writes disabled.
     """
     if not isinstance(binding, Binding):
         raise TypeError("binding must be a qsa.Binding")
@@ -3217,22 +3374,7 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
     if not 0 < requested_rows <= output_capacity:
         raise ValueError("prewarm rows must fit the bound QSA output capacity")
     device = caps.device
-    if binding.draft_selection is not None:
-        state = binding.draft_selection
-        warm_state = replace(
-            state,
-            selected_positions=torch.empty_like(state.selected_positions),
-            logical_positions=torch.empty_like(state.logical_positions),
-            errors=torch.empty_like(state.errors),
-            num_source_rows=torch.empty_like(state.num_source_rows),
-        )
-        binding = replace(
-            binding,
-            selected_positions=warm_state.selected_positions[
-                : binding.selected_positions.shape[0]
-            ],
-            draft_selection=warm_state,
-        )
+    binding = replace(binding, _record_draft_enabled=False)
     ready = torch.cuda.Event() if binding.selection_stream is not None else None
     sequence_lengths = torch.zeros(
         int(caps.max_batch), dtype=torch.int32, device=device
@@ -3298,13 +3440,17 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
             )
             if binding.draft_selection is not None:
                 draft_rows = min(warm_row_count, int(caps.max_batch))
-                run(
-                    binding,
-                    query=query[:draft_rows],
-                    request_ids=request_ids[:draft_rows],
-                    query_positions=query_positions[:draft_rows],
-                    reuse_draft_selection=True,
-                )
+                for source_rows in (
+                    sequence_lengths,
+                    binding.draft_selection.logical_positions[: caps.max_batch],
+                ):
+                    run(
+                        binding,
+                        query=query[:draft_rows],
+                        request_ids=request_ids[:draft_rows],
+                        query_positions=query_positions[:draft_rows],
+                        reuse=DraftSelectionReuse(source_rows),
+                    )
 
 
 def is_supported(device: torch.device | str | None = None) -> bool:
@@ -3321,6 +3467,8 @@ __all__ = [
     "Plan",
     "Binding",
     "DraftSelectionState",
+    "DraftSelectionPlan",
+    "DraftSelectionReuse",
     "cache_requirements",
     "plan",
     "bind",

--- a/b12x/attention/qsa/_contract.py
+++ b/b12x/attention/qsa/_contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import torch
 
@@ -434,6 +434,26 @@ class Plan:
 
 
 @dataclass(frozen=True)
+class DraftSelectionState:
+    """Caller-owned anchors for selection reuse inside one MTP draft round.
+
+    Ordinary ``run`` writes selected positions and their logical positions/errors.
+    The caller maps each compacted request to its accepted anchor in ``source_rows``.
+    A reuse run gathers those anchors and adds its causal tail into work buffers;
+    it never updates selector caches or exposes a split selection transaction.
+    Source rows have no lifetime across draft rounds or unrelated request batches.
+    """
+
+    selected_positions: torch.Tensor
+    logical_positions: torch.Tensor
+    errors: torch.Tensor
+    source_rows: torch.Tensor
+    num_source_rows: torch.Tensor
+    work_positions: torch.Tensor
+    work_errors: torch.Tensor
+
+
+@dataclass(frozen=True)
 class Binding:
     """Caller-owned QSA cache, state, output, and scratch views.
 
@@ -477,6 +497,7 @@ class Binding:
     partial_lse: torch.Tensor
     selection_stream: torch.cuda.Stream | None = None
     _selection_done: torch.cuda.Event | None = None
+    draft_selection: DraftSelectionState | None = None
 
 
 @dataclass(frozen=True)
@@ -1030,6 +1051,8 @@ def bind(
     output: torch.Tensor,
     selected_positions: torch.Tensor,
     selection_stream: torch.cuda.Stream | None = None,
+    selection_done: torch.cuda.Event | None = None,
+    draft_selection: DraftSelectionState | None = None,
 ) -> Binding:
     """Bind runtime storage and optional selection-stream resources.
 
@@ -1045,6 +1068,9 @@ def bind(
     covering all selector inputs, metadata, and bound state. Bind and prewarm
     before graph capture. Main Q/K/V producers execute on the calling stream;
     run joins selection before attention. Calls sharing state must be ordered.
+    Supplying a caller-established ``selection_done`` event makes rebinding
+    allocation-free, including during CUDA capture. Its lifetime must cover
+    every binding and graph that uses it.
     """
     if not isinstance(plan, Plan):
         raise TypeError("plan must be a qsa.Plan")
@@ -1356,20 +1382,110 @@ def bind(
         shape=(int(plan.max_split_row_product), int(caps.q_heads)),
         dtype=torch.float32,
     )
-    selection_done = None
+    if draft_selection is not None:
+        if not isinstance(draft_selection, DraftSelectionState):
+            raise TypeError("draft_selection must be a qsa.DraftSelectionState")
+        if caps.max_speculative_tokens < 1:
+            raise ValueError("draft selection reuse requires speculative capacity")
+        source_capacity = int(draft_selection.selected_positions.shape[0])
+        if source_capacity < caps.max_q_rows:
+            raise ValueError("draft selection state must cover planned query rows")
+        for tensor, name, shape, dtype in (
+            (
+                draft_selection.selected_positions,
+                "draft selected_positions",
+                (source_capacity, caps.selection_width),
+                torch.int32,
+            ),
+            (
+                draft_selection.logical_positions,
+                "draft logical_positions",
+                (source_capacity,),
+                torch.int64,
+            ),
+            (draft_selection.errors, "draft errors", (source_capacity,), torch.int32),
+            (
+                draft_selection.source_rows,
+                "draft source_rows",
+                (caps.max_batch,),
+                (torch.int32, torch.int64),
+            ),
+            (
+                draft_selection.num_source_rows,
+                "draft num_source_rows",
+                (1,),
+                torch.int32,
+            ),
+            (
+                draft_selection.work_positions,
+                "draft work_positions",
+                (caps.max_batch, caps.selection_width + caps.max_speculative_tokens),
+                torch.int32,
+            ),
+            (
+                draft_selection.work_errors,
+                "draft work_errors",
+                (caps.max_batch,),
+                torch.int32,
+            ),
+        ):
+            _check_tensor(
+                tensor,
+                name=name,
+                device=caps.device,
+                shape=shape,
+                dtype=dtype,
+                contiguous=True,
+            )
+        if (
+            draft_selection.selected_positions.data_ptr()
+            != selected_positions.data_ptr()
+            or draft_selection.selected_positions.stride()
+            != selected_positions.stride()
+        ):
+            raise ValueError("bound selection must be the draft state's row prefix")
+        _require_mutation_alias_contract(
+            mutable=(
+                ("scratch", scratch_storage),
+                ("output", output),
+                ("draft logical_positions", draft_selection.logical_positions),
+                ("draft errors", draft_selection.errors),
+                ("draft num_source_rows", draft_selection.num_source_rows),
+                ("draft work_positions", draft_selection.work_positions),
+                ("draft work_errors", draft_selection.work_errors),
+            ),
+            read_only=(
+                ("draft selected_positions", draft_selection.selected_positions),
+                ("draft source_rows", draft_selection.source_rows),
+                ("main_k_cache", main_k_cache),
+                ("main_v_cache", main_v_cache),
+                ("compressed_k_cache", compressed_k_cache),
+                ("raw_k_ring", raw_k_ring),
+            ),
+        )
     if selection_stream is not None:
         if not isinstance(selection_stream, torch.cuda.Stream):
             raise TypeError("selection_stream must be a CUDA stream")
         if selection_stream.device != caps.device:
             raise ValueError("selection_stream must match the QSA plan device")
-        with torch.cuda.device(caps.device):
-            if torch.cuda.is_current_stream_capturing():
-                raise RuntimeError("bind selection-stream resources before graph capture")
-            selection_done = torch.cuda.Event()
-            selection_done.record(selection_stream)
+        if selection_done is None:
+            with torch.cuda.device(caps.device):
+                if torch.cuda.is_current_stream_capturing():
+                    raise RuntimeError(
+                        "bind selection-stream resources before graph capture"
+                    )
+                selection_done = torch.cuda.Event()
+                selection_done.record(selection_stream)
+        elif not isinstance(selection_done, torch.cuda.Event):
+            raise TypeError("selection_done must be a caller-established CUDA event")
+        elif selection_done.device != caps.device:
+            raise ValueError("selection_done must be recorded on the QSA plan device")
+    elif selection_done is not None:
+        raise ValueError("selection_done requires selection_stream")
     return Binding(
         selection_stream=selection_stream,
         _selection_done=selection_done,
+        draft_selection=draft_selection,
         plan=plan,
         shared_compressed_raw_pool=_overlaps(compressed_k_cache, raw_k_ring),
         scratch=scratch_storage,
@@ -2681,16 +2797,17 @@ def run(
     binding: Binding,
     *,
     query: torch.Tensor,
-    index_query: torch.Tensor,
-    raw_index_key: torch.Tensor,
+    index_query: torch.Tensor | None = None,
+    raw_index_key: torch.Tensor | None = None,
     request_ids: torch.Tensor,
     query_positions: torch.Tensor,
-    rope_positions: torch.Tensor,
-    sequence_lengths: torch.Tensor,
-    query_start_loc: torch.Tensor,
-    num_accepted_tokens: torch.Tensor,
-    is_prefilling: torch.Tensor,
+    rope_positions: torch.Tensor | None = None,
+    sequence_lengths: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    is_prefilling: torch.Tensor | None = None,
     index_ready: torch.cuda.Event | None = None,
+    reuse_draft_selection: bool = False,
 ) -> torch.Tensor:
     """Run one packed QSA decode transaction after main K/V writes are enqueued.
 
@@ -2702,6 +2819,14 @@ def run(
     joins it on the calling stream. Intermediate positions/errors remain an
     internal handoff within this call. Bind and prewarm before graph capture,
     and record the readiness event inside the graph for captured producers.
+
+    A bound ``draft_selection`` records anchors during ordinary execution.
+    ``reuse_draft_selection=True`` uses the accepted anchors selected by its
+    caller-owned request-to-source map and appends only the causal draft tail.
+    This mode requires one query per request inside the same draft round;
+    selector projections/metadata and ``index_ready`` must be omitted. It
+    preserves selector caches and the anchor buffers. Invalid anchors poison
+    output instead of reading stale positions. Target layers must not use it.
 
     Active request intervals are the dense prefix encoded by
     ``query_start_loc``.  Remaining boundaries repeat the live-row count and
@@ -2740,6 +2865,95 @@ def run(
     """
     if not isinstance(binding, Binding):
         raise TypeError("binding must be a qsa.Binding")
+    if reuse_draft_selection:
+        state = binding.draft_selection
+        if state is None:
+            raise ValueError("draft selection reuse requires bound draft state")
+        if any(
+            value is not None
+            for value in (
+                index_query,
+                raw_index_key,
+                rope_positions,
+                sequence_lengths,
+                query_start_loc,
+                num_accepted_tokens,
+                is_prefilling,
+                index_ready,
+            )
+        ):
+            raise ValueError("draft selection reuse does not accept selector inputs")
+        rows = int(query.shape[0])
+        if not 0 < rows <= min(binding.plan.caps.max_batch, binding.output.shape[0]):
+            raise ValueError("draft selection reuse requires one row per request")
+        caps = binding.plan.caps
+        _check_tensor(
+            query,
+            name="query",
+            device=caps.device,
+            shape=(rows, caps.q_heads, caps.head_dim),
+            dtype=torch.bfloat16,
+            contiguous=True,
+        )
+        for tensor, name, dtype in (
+            (request_ids, "request_ids", (torch.int32, torch.int64)),
+            (query_positions, "query_positions", torch.int64),
+        ):
+            _check_tensor(
+                tensor,
+                name=name,
+                device=binding.plan.caps.device,
+                shape=(rows,),
+                dtype=dtype,
+                contiguous=True,
+            )
+        _require_mutation_alias_contract(
+            mutable=(
+                ("scratch", binding.scratch),
+                ("output", binding.output),
+                ("draft work_positions", state.work_positions),
+                ("draft work_errors", state.work_errors),
+            ),
+            read_only=(
+                ("query", query),
+                ("request_ids", request_ids),
+                ("query_positions", query_positions),
+            ),
+        )
+        from ._draft_selection import prepare_selection
+
+        prepare_selection(
+            state.logical_positions,
+            state.errors,
+            state.selected_positions,
+            state.source_rows,
+            state.num_source_rows,
+            request_ids,
+            query_positions,
+            state.work_positions,
+            state.work_errors,
+        )
+        return _run_attention(
+            binding,
+            query=query,
+            request_ids=request_ids,
+            query_positions=query_positions,
+            selected_positions=state.work_positions,
+            selection_errors=state.work_errors,
+        )
+    if any(
+        value is None
+        for value in (
+            index_query,
+            raw_index_key,
+            rope_positions,
+            sequence_lengths,
+            query_start_loc,
+            num_accepted_tokens,
+            is_prefilling,
+        )
+    ):
+        raise ValueError("ordinary QSA execution requires every selector input")
     inputs = dict(
         query=query,
         index_query=index_query,
@@ -2752,11 +2966,23 @@ def run(
         num_accepted_tokens=num_accepted_tokens,
         is_prefilling=is_prefilling,
     )
+    if binding.draft_selection is not None:
+        state = binding.draft_selection
+        _require_mutation_alias_contract(
+            mutable=(
+                ("draft logical_positions", state.logical_positions),
+                ("draft errors", state.errors),
+                ("draft num_source_rows", state.num_source_rows),
+            ),
+            read_only=tuple(inputs.items()),
+        )
     stream = binding.selection_stream
     if stream is None:
         if index_ready is not None:
             raise ValueError("index_ready requires a binding with selection_stream")
-        return _run(binding, **inputs)
+        result = _run(binding, **inputs)
+        _record_draft_anchors(binding, query_positions)
+        return result
     if index_ready is None:
         raise ValueError("selection_stream requires an index_ready event")
     if not torch.compiler.is_compiling():
@@ -2771,11 +2997,27 @@ def run(
             _run(binding, **inputs, selection_only=True)
             binding._selection_done.record(stream)
         main_stream.wait_event(binding._selection_done)
-        return _run_attention(
+        result = _run_attention(
             binding,
             query=query,
             request_ids=request_ids,
             query_positions=query_positions,
+        )
+        _record_draft_anchors(binding, query_positions)
+        return result
+
+
+def _record_draft_anchors(binding: Binding, positions: torch.Tensor) -> None:
+    if binding.draft_selection is not None:
+        from ._draft_selection import record_anchors
+
+        state = binding.draft_selection
+        record_anchors(
+            positions,
+            binding.state_errors,
+            state.logical_positions,
+            state.errors,
+            state.num_source_rows,
         )
 
 
@@ -2798,6 +3040,7 @@ def _qsa_attention_op(
     partial_output_offset: int,
     partial_lse_offset: int,
     direct_kv_warps: int,
+    selection_errors: torch.Tensor | None,
 ) -> None:
     from ._kernels import launch_poison_failed_rows
     from ._sparse_gqa import launch_sparse_paged_gqa
@@ -2811,14 +3054,23 @@ def _qsa_attention_op(
             ("request_ids", request_ids),
             ("query_positions", query_positions),
             ("selected_positions", selected_positions),
+        )
+        + (
+            ()
+            if selection_errors is None
+            else (("selection_errors", selection_errors),)
         ),
     )
     rows, q_heads, head_dim = map(int, query.shape)
-    errors = _scratch_view(
-        scratch,
-        offset_bytes=state_errors_offset,
-        shape=(int(output.shape[0]),),
-        dtype=torch.int32,
+    errors = (
+        selection_errors
+        if selection_errors is not None
+        else _scratch_view(
+            scratch,
+            offset_bytes=state_errors_offset,
+            shape=(int(output.shape[0]),),
+            dtype=torch.int32,
+        )
     )
     partial_output = _scratch_view(
         scratch,
@@ -2887,6 +3139,7 @@ def _qsa_attention_fake(
     partial_output_offset: int,
     partial_lse_offset: int,
     direct_kv_warps: int,
+    selection_errors: torch.Tensor | None,
 ) -> None:
     return None
 
@@ -2897,6 +3150,8 @@ def _run_attention(
     query: torch.Tensor,
     request_ids: torch.Tensor,
     query_positions: torch.Tensor,
+    selected_positions: torch.Tensor | None = None,
+    selection_errors: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Consume the bound selection and error mask within one run call."""
 
@@ -2931,7 +3186,9 @@ def _run_attention(
         binding.k_descale,
         binding.v_descale,
         binding.main_block_table,
-        binding.selected_positions,
+        binding.selected_positions
+        if selected_positions is None
+        else selected_positions,
         binding.scratch,
         binding.output,
         binding.plan.workspace_q_rows,
@@ -2940,6 +3197,7 @@ def _run_attention(
         layout.partial_output_offset_bytes,
         layout.partial_lse_offset_bytes,
         binding.plan.policy_resolution.config.sparse_gqa_direct_kv_warps,
+        selection_errors,
     )
     return binding.output[:rows]
 
@@ -2952,7 +3210,8 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
     workspace, selection, and attention specializations. Cache accesses
     and persistent selector-state writes remain masked. Scratch, output, and
     selected-position buffers are transient and have unspecified contents
-    after this call.
+    after this call, except for a bound draft state's anchor buffers, which
+    are preserved. Draft metadata stages use temporary anchors during warmup.
     """
     if not isinstance(binding, Binding):
         raise TypeError("binding must be a qsa.Binding")
@@ -2963,6 +3222,22 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
     if not 0 < requested_rows <= output_capacity:
         raise ValueError("prewarm rows must fit the bound QSA output capacity")
     device = caps.device
+    if binding.draft_selection is not None:
+        state = binding.draft_selection
+        warm_state = replace(
+            state,
+            selected_positions=torch.empty_like(state.selected_positions),
+            logical_positions=torch.empty_like(state.logical_positions),
+            errors=torch.empty_like(state.errors),
+            num_source_rows=torch.empty_like(state.num_source_rows),
+        )
+        binding = replace(
+            binding,
+            selected_positions=warm_state.selected_positions[
+                : binding.selected_positions.shape[0]
+            ],
+            draft_selection=warm_state,
+        )
     ready = torch.cuda.Event() if binding.selection_stream is not None else None
     sequence_lengths = torch.zeros(
         int(caps.max_batch), dtype=torch.int32, device=device
@@ -3026,6 +3301,15 @@ def prewarm(binding: Binding, *, rows: int | None = None) -> None:
                 is_prefilling=is_prefilling,
                 index_ready=ready,
             )
+            if binding.draft_selection is not None:
+                draft_rows = min(warm_row_count, int(caps.max_batch))
+                run(
+                    binding,
+                    query=query[:draft_rows],
+                    request_ids=request_ids[:draft_rows],
+                    query_positions=query_positions[:draft_rows],
+                    reuse_draft_selection=True,
+                )
 
 
 def is_supported(device: torch.device | str | None = None) -> bool:
@@ -3041,6 +3325,7 @@ __all__ = [
     "Caps",
     "Plan",
     "Binding",
+    "DraftSelectionState",
     "cache_requirements",
     "plan",
     "bind",

--- a/b12x/attention/qsa/_draft_selection.py
+++ b/b12x/attention/qsa/_draft_selection.py
@@ -1,0 +1,159 @@
+"""Metadata stages for draft-round selection reuse inside the QSA operation."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit(do_not_specialize=["rows"])
+def _record_kernel(
+    positions,
+    errors,
+    saved_positions,
+    saved_errors,
+    saved_rows,
+    rows,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    active = row < rows
+    tl.store(saved_positions + row, tl.load(positions + row, active, other=-1), active)
+    tl.store(saved_errors + row, tl.load(errors + row, active, other=0), active)
+    if tl.program_id(0) == 0:
+        tl.store(saved_rows, rows)
+
+
+@torch.library.custom_op(
+    "b12x::qsa_record_draft_anchors",
+    mutates_args=("saved_positions", "saved_errors", "saved_rows"),
+)
+def record_anchors(
+    positions: torch.Tensor,
+    errors: torch.Tensor,
+    saved_positions: torch.Tensor,
+    saved_errors: torch.Tensor,
+    saved_rows: torch.Tensor,
+) -> None:
+    rows = int(positions.shape[0])
+    _record_kernel[(triton.cdiv(rows, 128),)](
+        positions,
+        errors,
+        saved_positions,
+        saved_errors,
+        saved_rows,
+        rows,
+        BLOCK=128,
+    )
+
+
+@record_anchors.register_fake
+def _record_fake(positions, errors, saved_positions, saved_errors, saved_rows) -> None:
+    return None
+
+
+@triton.jit(do_not_specialize=["rows", "source_capacity", "max_requests"])
+def _prepare_kernel(
+    source_positions,
+    source_errors,
+    source_selection,
+    source_rows,
+    num_source_rows,
+    request_ids,
+    query_positions,
+    selected,
+    errors,
+    rows,
+    source_capacity,
+    max_requests,
+    WIDTH: tl.constexpr,
+    TAIL: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    column = tl.arange(0, BLOCK)
+    request = tl.load(request_ids + row, row < rows, other=-1).to(tl.int64)
+    active = request >= 0
+    mapped = active & (request < max_requests)
+    source = tl.load(source_rows + request, mapped, other=-1).to(tl.int64)
+    source_valid = (
+        mapped
+        & (source >= 0)
+        & (source < source_capacity)
+        & (source < tl.load(num_source_rows))
+    )
+    anchor = tl.load(source_positions + source, source_valid, other=-1)
+    source_error = tl.load(source_errors + source, source_valid, other=1)
+    position = tl.load(query_positions + row, row < rows, other=-1)
+    start = anchor + 1
+    valid = (
+        source_valid & (anchor >= 0) & (position >= start) & (position < start + TAIL)
+    )
+    original = tl.load(
+        source_selection + source * tl.full((), WIDTH, tl.int64) + column,
+        valid & (column < WIDTH),
+        other=-1,
+    )
+    tail = start + column - WIDTH
+    value = tl.where(
+        column < WIDTH, original, tl.where(valid & (tail <= position), tail, -1)
+    )
+    tl.store(
+        selected + row * tl.full((), WIDTH + TAIL, tl.int64) + column,
+        value,
+        column < WIDTH + TAIL,
+    )
+    tl.store(errors + row, tl.where(active, source_error | tl.where(valid, 0, 1), 0))
+
+
+@torch.library.custom_op(
+    "b12x::qsa_prepare_draft_selection", mutates_args=("selected", "errors")
+)
+def prepare_selection(
+    source_positions: torch.Tensor,
+    source_errors: torch.Tensor,
+    source_selection: torch.Tensor,
+    source_rows: torch.Tensor,
+    num_source_rows: torch.Tensor,
+    request_ids: torch.Tensor,
+    query_positions: torch.Tensor,
+    selected: torch.Tensor,
+    errors: torch.Tensor,
+) -> None:
+    rows = int(query_positions.shape[0])
+    width = int(source_selection.shape[1])
+    tail = int(selected.shape[1]) - width
+    _prepare_kernel[(rows,)](
+        source_positions,
+        source_errors,
+        source_selection,
+        source_rows,
+        num_source_rows,
+        request_ids,
+        query_positions,
+        selected,
+        errors,
+        rows,
+        int(source_selection.shape[0]),
+        int(source_rows.shape[0]),
+        WIDTH=width,
+        TAIL=tail,
+        BLOCK=triton.next_power_of_2(width + tail),
+        num_warps=4,
+    )
+
+
+@prepare_selection.register_fake
+def _prepare_fake(
+    source_positions,
+    source_errors,
+    source_selection,
+    source_rows,
+    num_source_rows,
+    request_ids,
+    query_positions,
+    selected,
+    errors,
+) -> None:
+    return None

--- a/b12x/attention/qsa/_draft_selection.py
+++ b/b12x/attention/qsa/_draft_selection.py
@@ -27,56 +27,94 @@ def _validate_fake(mutable, inputs) -> None:
     return None
 
 
-@triton.jit(do_not_specialize=["rows"])
+@triton.jit(do_not_specialize=["rows", "enabled"])
 def _record_kernel(
     positions,
     errors,
     saved_positions,
     saved_errors,
     saved_rows,
+    selection,
+    saved_selection,
     rows,
+    enabled,
+    WIDTH: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
-    active = row < rows
+    row = tl.program_id(0).to(tl.int64)
+    column = tl.arange(0, BLOCK)
+    active = (row < rows) & (enabled != 0)
     tl.store(saved_positions + row, tl.load(positions + row, active, other=-1), active)
     tl.store(saved_errors + row, tl.load(errors + row, active, other=0), active)
+    offset = row * tl.full((), WIDTH, tl.int64) + column
+    value = tl.load(selection + offset, active & (column < WIDTH), other=-1)
+    tl.store(saved_selection + offset, value, active & (column < WIDTH))
     if tl.program_id(0) == 0:
-        tl.store(saved_rows, rows)
+        tl.store(saved_rows, rows, enabled != 0)
+
+
+@torch.library.custom_op("b12x::qsa_reset_draft_anchors", mutates_args=("storage",))
+def reset_anchors(storage: torch.Tensor, count_offset: int) -> None:
+    from ._contract import _scratch_view
+
+    _scratch_view(
+        storage, offset_bytes=count_offset, shape=(1,), dtype=torch.int32
+    ).zero_()
+
+
+@reset_anchors.register_fake
+def _reset_fake(storage, count_offset) -> None:
+    return None
 
 
 @torch.library.custom_op(
     "b12x::qsa_record_draft_anchors",
-    mutates_args=("saved_positions", "saved_errors", "saved_rows"),
+    mutates_args=("storage",),
 )
 def record_anchors(
     positions: torch.Tensor,
     scratch: torch.Tensor,
     errors_offset: int,
-    saved_positions: torch.Tensor,
-    saved_errors: torch.Tensor,
-    saved_rows: torch.Tensor,
+    selection: torch.Tensor,
+    storage: torch.Tensor,
+    source_capacity: int,
+    width: int,
+    enabled: bool,
 ) -> None:
-    from ._contract import _scratch_view
+    from ._contract import DraftSelectionPlan, _scratch_view
 
+    state = DraftSelectionPlan(storage.device, source_capacity, width).bind(
+        storage=storage
+    )
     rows = int(positions.shape[0])
     errors = _scratch_view(
         scratch, offset_bytes=errors_offset, shape=(rows,), dtype=torch.int32
     )
-    _record_kernel[(triton.cdiv(rows, 128),)](
+    _record_kernel[(rows,)](
         positions,
         errors,
-        saved_positions,
-        saved_errors,
-        saved_rows,
+        state.logical_positions,
+        state.errors,
+        state.num_source_rows,
+        selection,
+        state.selected_positions,
         rows,
-        BLOCK=128,
+        int(enabled),
+        WIDTH=width,
+        BLOCK=triton.next_power_of_2(width),
     )
 
 
 @record_anchors.register_fake
 def _record_fake(
-    positions, scratch, errors_offset, saved_positions, saved_errors, saved_rows
+    positions,
+    scratch,
+    errors_offset,
+    selection,
+    storage,
+    source_capacity,
+    width,
+    enabled,
 ) -> None:
     return None
 
@@ -135,36 +173,51 @@ def _prepare_kernel(
     tl.store(errors + row, tl.where(active, source_error | tl.where(valid, 0, 1), 0))
 
 
-@torch.library.custom_op(
-    "b12x::qsa_prepare_draft_selection", mutates_args=("selected", "errors")
-)
+@torch.library.custom_op("b12x::qsa_prepare_draft_selection", mutates_args=("scratch",))
 def prepare_selection(
-    source_positions: torch.Tensor,
-    source_errors: torch.Tensor,
-    source_selection: torch.Tensor,
+    storage: torch.Tensor,
+    source_capacity: int,
+    width: int,
     source_rows: torch.Tensor,
-    num_source_rows: torch.Tensor,
     request_ids: torch.Tensor,
     query_positions: torch.Tensor,
-    selected: torch.Tensor,
-    errors: torch.Tensor,
+    scratch: torch.Tensor,
+    selected_offset: int,
+    errors_offset: int,
+    max_requests: int,
+    tail: int,
 ) -> None:
+    from ._contract import DraftSelectionPlan, _scratch_view
+
+    state = DraftSelectionPlan(storage.device, source_capacity, width).bind(
+        storage=storage
+    )
+    selected = _scratch_view(
+        scratch,
+        offset_bytes=selected_offset,
+        shape=(max_requests, width + tail),
+        dtype=torch.int32,
+    )
+    errors = _scratch_view(
+        scratch,
+        offset_bytes=errors_offset,
+        shape=(max_requests,),
+        dtype=torch.int32,
+    )
     rows = int(query_positions.shape[0])
-    width = int(source_selection.shape[1])
-    tail = int(selected.shape[1]) - width
     _prepare_kernel[(rows,)](
-        source_positions,
-        source_errors,
-        source_selection,
+        state.logical_positions,
+        state.errors,
+        state.selected_positions,
         source_rows,
-        num_source_rows,
+        state.num_source_rows,
         request_ids,
         query_positions,
         selected,
         errors,
         rows,
-        int(source_selection.shape[0]),
-        int(source_rows.shape[0]),
+        source_capacity,
+        max_requests,
         WIDTH=width,
         TAIL=tail,
         BLOCK=triton.next_power_of_2(width + tail),
@@ -174,14 +227,16 @@ def prepare_selection(
 
 @prepare_selection.register_fake
 def _prepare_fake(
-    source_positions,
-    source_errors,
-    source_selection,
+    storage,
+    source_capacity,
+    width,
     source_rows,
-    num_source_rows,
     request_ids,
     query_positions,
-    selected,
-    errors,
+    scratch,
+    selected_offset,
+    errors_offset,
+    max_requests,
+    tail,
 ) -> None:
     return None

--- a/b12x/attention/qsa/_draft_selection.py
+++ b/b12x/attention/qsa/_draft_selection.py
@@ -7,6 +7,26 @@ import triton
 import triton.language as tl
 
 
+@torch.library.custom_op("b12x::qsa_validate_draft_buffers", mutates_args=("mutable",))
+def validate_buffers(mutable: list[torch.Tensor], inputs: list[torch.Tensor]) -> None:
+    """Check addresses before writes, outside Dynamo's symbolic tracing.
+
+    The mutation annotation orders validation before consumers of these buffers.
+    The check launches no GPU work and does not change buffer contents.
+    """
+    from ._contract import _require_mutation_alias_contract
+
+    _require_mutation_alias_contract(
+        mutable=tuple((f"draft buffer {i}", t) for i, t in enumerate(mutable)),
+        read_only=tuple((f"draft input {i}", t) for i, t in enumerate(inputs)),
+    )
+
+
+@validate_buffers.register_fake
+def _validate_fake(mutable, inputs) -> None:
+    return None
+
+
 @triton.jit(do_not_specialize=["rows"])
 def _record_kernel(
     positions,
@@ -31,12 +51,18 @@ def _record_kernel(
 )
 def record_anchors(
     positions: torch.Tensor,
-    errors: torch.Tensor,
+    scratch: torch.Tensor,
+    errors_offset: int,
     saved_positions: torch.Tensor,
     saved_errors: torch.Tensor,
     saved_rows: torch.Tensor,
 ) -> None:
+    from ._contract import _scratch_view
+
     rows = int(positions.shape[0])
+    errors = _scratch_view(
+        scratch, offset_bytes=errors_offset, shape=(rows,), dtype=torch.int32
+    )
     _record_kernel[(triton.cdiv(rows, 128),)](
         positions,
         errors,
@@ -49,7 +75,9 @@ def record_anchors(
 
 
 @record_anchors.register_fake
-def _record_fake(positions, errors, saved_positions, saved_errors, saved_rows) -> None:
+def _record_fake(
+    positions, scratch, errors_offset, saved_positions, saved_errors, saved_rows
+) -> None:
     return None
 
 

--- a/b12x/attention/qsa/api.py
+++ b/b12x/attention/qsa/api.py
@@ -6,6 +6,7 @@ from ._contract import (
     Binding,
     CacheRequirements,
     Caps,
+    DraftSelectionState,
     Plan,
     bind,
     cache_requirements,
@@ -19,6 +20,7 @@ from ._policy import QsaConfig, QsaQuery
 __all__ = [
     "CacheRequirements",
     "Caps",
+    "DraftSelectionState",
     "Plan",
     "Binding",
     "QsaConfig",

--- a/b12x/attention/qsa/api.py
+++ b/b12x/attention/qsa/api.py
@@ -6,6 +6,8 @@ from ._contract import (
     Binding,
     CacheRequirements,
     Caps,
+    DraftSelectionPlan,
+    DraftSelectionReuse,
     DraftSelectionState,
     Plan,
     bind,
@@ -20,6 +22,8 @@ from ._policy import QsaConfig, QsaQuery
 __all__ = [
     "CacheRequirements",
     "Caps",
+    "DraftSelectionPlan",
+    "DraftSelectionReuse",
     "DraftSelectionState",
     "Plan",
     "Binding",

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -3820,6 +3820,16 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
         max_speculative_tokens=3,
         kv_dtype=kv_dtype,
     )
+    if high_page:
+        pool_bytes = (
+            2
+            * caps.num_main_cache_pages
+            * caps.main_page_size
+            * caps.kv_heads
+            * caps.head_dim
+            * caps.kv_dtype.itemsize
+        )
+        _require_free_cuda_bytes(device, pool_bytes + 2**29)
     binding = _allocate_binding(caps)
     state = _draft_selection_state(binding)
     binding = _rebind(binding, draft_selection=state)

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -3764,24 +3764,14 @@ def test_qsa_run_selection_forks_before_main_producer_and_joins_before_attention
 
 
 def _draft_selection_state(binding):
-    caps = binding.plan.caps
-    device = caps.device
-    return qsa.DraftSelectionState(
-        selected_positions=binding.selected_positions,
-        logical_positions=torch.full(
-            (caps.max_q_rows,), -1, dtype=torch.int64, device=device
-        ),
-        errors=torch.zeros(caps.max_q_rows, dtype=torch.int32, device=device),
-        source_rows=torch.full((caps.max_batch,), -1, dtype=torch.int64, device=device),
-        num_source_rows=torch.zeros(1, dtype=torch.int32, device=device),
-        work_positions=torch.full(
-            (caps.max_batch, caps.selection_width + caps.max_speculative_tokens),
-            -1,
-            dtype=torch.int32,
-            device=device,
-        ),
-        work_errors=torch.zeros(caps.max_batch, dtype=torch.int32, device=device),
-    )
+    storage_plan = binding.plan.draft_selection_plan()
+    storage = {
+        spec.name: torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
+        for spec in storage_plan.storage_specs()
+    }
+    state = storage_plan.bind(storage=storage)
+    state.reset()
+    return state
 
 
 @pytest.mark.parametrize("kv_dtype", [torch.bfloat16, torch.float8_e4m3fn])
@@ -3850,12 +3840,26 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
         not high_page and kv_dtype == torch.bfloat16 and request_dtype == torch.int64
     )
     if compiled:
-        torch.compile(lambda: qsa.run(binding, **initial), fullgraph=True)()
+
+        def record_round():
+            state.reset()
+            return qsa.run(binding, **initial)
+
+        torch.compile(record_round, fullgraph=True)()
     else:
         qsa.run(binding, **initial)
     assert state.num_source_rows.item() == 16
     torch.testing.assert_close(state.logical_positions, initial["query_positions"])
-    state.source_rows.copy_(torch.tensor([3, 7, 11, 15], device=device))
+    assert torch.equal(state.selected_positions, binding.selected_positions)
+    if compiled:
+        reuse_plan = qsa.plan(replace(caps, max_q_rows=4))
+        binding = _rebind(
+            replace(binding, plan=reuse_plan),
+            selected_positions=binding.selected_positions[:4],
+            output=binding.output[:4],
+            draft_selection=state,
+        )
+    source_rows = torch.tensor([3, 7, 11, 15], dtype=request_dtype, device=device)
     state.errors[7] = 512
     query = initial["query"][:4].clone()
     requests = torch.tensor([2, 0, -1, 1], device=device, dtype=request_dtype)
@@ -3880,8 +3884,8 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
         for t in (
             binding.output,
             binding.scratch,
-            state.work_positions,
-            state.work_errors,
+            binding._draft_work_positions,
+            binding._draft_work_errors,
         )
     )
 
@@ -3891,7 +3895,7 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
             query=query[:rows],
             request_ids=requests[:rows],
             query_positions=positions[:rows],
-            reuse_draft_selection=True,
+            reuse=qsa.DraftSelectionReuse(source_rows),
         )
 
     if compiled:
@@ -3919,19 +3923,23 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
                     assert torch.all(result[2] == 0)
                 if rows == 4:
                     assert torch.isnan(result[3]).all()
-                assert state.work_positions[0, caps.selection_width :].tolist() == (
-                    [4, 5, -1] if tail_end == 5 else [4, -1, -1]
-                )
+                assert binding._draft_work_positions[
+                    0, caps.selection_width :
+                ].tolist() == ([4, 5, -1] if tail_end == 5 else [4, -1, -1])
             positions[0] = 7
             graph.replay()
             assert torch.isnan(result[0]).all()
             positions[0] = 4
             # A row outside the last ordinary run must not reuse older state.
-            state.source_rows[2] = 16
+            source_rows[2] = 16
             graph.replay()
             assert torch.isnan(result[0]).all()
-            state.source_rows[2] = 11
+            source_rows[2] = 11
             state.num_source_rows.fill_(11)
+            graph.replay()
+            assert torch.isnan(result[0]).all()
+            state.num_source_rows.fill_(16)
+            state.reset()
             graph.replay()
             assert torch.isnan(result[0]).all()
             state.num_source_rows.fill_(16)
@@ -3948,13 +3956,14 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
         for t in (
             binding.output,
             binding.scratch,
-            state.work_positions,
-            state.work_errors,
+            binding._draft_work_positions,
+            binding._draft_work_errors,
         )
     )
 
 
-def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch):
+@pytest.mark.parametrize("draft", [False, True])
+def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch, draft):
     """Fresh bindings may not construct synchronization resources inside capture."""
     device = require_sm120()
     binding = _allocate_binding(
@@ -3965,6 +3974,7 @@ def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch):
             index_heads=4,
             index_head_dim=128,
             index_rotary_dim=64,
+            max_speculative_tokens=3 if draft else 0,
         )
     )
     stream = torch.cuda.Stream(device=device)
@@ -3978,7 +3988,10 @@ def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch):
     binding.main_v_cache.fill_(3)
     binding.raw_k_ring.zero_()
     binding.compressed_k_cache.zero_()
-    warmed = _rebind(binding, selection_stream=stream, selection_done=done)
+    state = _draft_selection_state(binding) if draft else None
+    warmed = _rebind(
+        binding, selection_stream=stream, selection_done=done, draft_selection=state
+    )
     qsa.prewarm(warmed)
     before_event = torch.cuda.Event
 
@@ -3989,7 +4002,17 @@ def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch):
     monkeypatch.setattr(before_event, "__new__", forbid_event)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        rebound = _rebind(binding, selection_stream=stream, selection_done=done)
+        allocations = torch.cuda.memory_stats()["allocation.all.allocated"]
+        capture_state = state.plan.bind(storage=state._storage) if state else None
+        rebound = _rebind(
+            binding,
+            selection_stream=stream,
+            selection_done=done,
+            draft_selection=capture_state,
+        )
+        assert torch.cuda.memory_stats()["allocation.all.allocated"] == allocations
+        if capture_state is not None:
+            capture_state.reset()
         assert rebound is not warmed
         assert rebound._selection_done is done
         ready.record()
@@ -4039,3 +4062,89 @@ def test_qsa_run_stream_resources_use_plan_device() -> None:
         assert torch.cuda.current_device() == other
     assert torch.all(result == 2)
     assert binding.state_errors[0] == 0
+
+
+def test_qsa_draft_storage_binding_is_caller_owned_and_preserves_contents():
+    device = require_sm120()
+    caps = _caps(
+        device,
+        q_heads=24,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
+        index_rotary_dim=64,
+        max_speculative_tokens=3,
+    )
+    binding = _allocate_binding(caps)
+    storage_plan = binding.plan.draft_selection_plan(max_source_rows=8)
+    (spec,) = storage_plan.storage_specs()
+    storage = torch.full(spec.shape, 37, dtype=spec.dtype, device=spec.device)
+    expected = storage.clone()
+    torch.cuda.synchronize()
+    allocations = torch.cuda.memory_stats()["allocation.all.allocated"]
+    state = storage_plan.bind(storage=storage)
+    rebound = _rebind(binding, draft_selection=state)
+    assert torch.cuda.memory_stats()["allocation.all.allocated"] == allocations
+    assert torch.equal(storage, expected)
+    assert rebound.draft_selection is state
+    assert state.selected_positions.shape == (8, caps.selection_width)
+    for tensor in (
+        state.selected_positions,
+        state.logical_positions,
+        state.errors,
+        state.num_source_rows,
+    ):
+        assert tensor.untyped_storage().data_ptr() == storage.data_ptr()
+    for tensor in (rebound._draft_work_positions, rebound._draft_work_errors):
+        assert tensor.untyped_storage().data_ptr() == binding.scratch.data_ptr()
+    with pytest.raises(ValueError, match="requires"):
+        storage_plan.bind(storage=storage[:1])
+    with pytest.raises(ValueError, match="cover planned query rows"):
+        binding.plan.draft_selection_plan(max_source_rows=1)
+    for aliased_storage in (binding.main_k_cache.view(torch.uint8), binding.scratch):
+        with pytest.raises(ValueError, match="overlap"):
+            _rebind(binding, draft_selection=storage_plan.bind(storage=aliased_storage))
+    allocations = torch.cuda.memory_stats()["allocation.all.allocated"]
+    state.reset()
+    assert torch.cuda.memory_stats()["allocation.all.allocated"] == allocations
+    assert state.num_source_rows.item() == 0
+
+
+def test_qsa_draft_reuse_validates_live_input_contract_before_mutation():
+    device = require_sm120()
+    binding = _allocate_binding(
+        _caps(
+            device,
+            q_heads=24,
+            head_dim=256,
+            index_heads=4,
+            index_head_dim=128,
+            index_rotary_dim=64,
+            max_speculative_tokens=3,
+        )
+    )
+    state = _draft_selection_state(binding)
+    binding = _rebind(binding, draft_selection=state)
+    dynamic = _dynamic_inputs(binding, positions=(0,), request_ids=(0,))
+    common = {
+        name: dynamic[name] for name in ("query", "request_ids", "query_positions")
+    }
+    with pytest.raises(TypeError, match="DraftSelectionReuse"):
+        qsa.run(binding, **common, reuse=True)
+    with pytest.raises(ValueError, match="shape"):
+        qsa.run(
+            binding,
+            **common,
+            reuse=qsa.DraftSelectionReuse(
+                dynamic["request_ids"][:1],
+            ),
+        )
+    source_rows = torch.zeros(
+        binding.plan.caps.max_batch, dtype=torch.int64, device=device
+    )
+    with pytest.raises(ValueError, match="does not accept selector inputs"):
+        qsa.run(binding, **dynamic, reuse=qsa.DraftSelectionReuse(source_rows))
+    aliased_rows = binding.scratch[: 8 * binding.plan.caps.max_batch].view(torch.int64)
+    with pytest.raises(ValueError, match="overlap"):
+        qsa.run(binding, **common, reuse=qsa.DraftSelectionReuse(aliased_rows))
+    assert state.num_source_rows.item() == 0

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -1236,8 +1236,6 @@ def test_qsa_shared_pool_runs_under_fullgraph_compile_and_checks_runtime_aliases
         compiled(binding.output[:1], *arguments[1:])
 
 
-
-
 def test_qsa_shared_pool_cuda_graph_replay_has_stable_addresses_and_allocation() -> (
     None
 ):
@@ -2176,7 +2174,8 @@ def test_qsa_cute_scores_preserve_chunked_selection_and_attention_graph_replay(
     torch.manual_seed(98903)
     binding = _allocate_binding(caps)
     binding = _rebind(
-        binding, selection_stream=torch.cuda.Stream(device=device) if overlap else None,
+        binding,
+        selection_stream=torch.cuda.Stream(device=device) if overlap else None,
     )
     ready = torch.cuda.Event() if overlap else None
 
@@ -2999,10 +2998,16 @@ def test_qsa_run_streams_match_combined_across_graph_replay(
     def stream_call():
         ready.record()
         projected_query.copy_(dynamic["query"])
-        return qsa.run(candidate, **attention_args, **{
-            name: value for name, value in select_args.items()
-            if name not in attention_args
-        }, index_ready=ready)
+        return qsa.run(
+            candidate,
+            **attention_args,
+            **{
+                name: value
+                for name, value in select_args.items()
+                if name not in attention_args
+            },
+            index_ready=ready,
+        )
 
     reset(reference)
     qsa.run(reference, **dynamic)
@@ -3055,8 +3060,6 @@ def test_qsa_run_streams_match_combined_across_graph_replay(
             atol=0,
             equal_nan=True,
         )
-
-
 
 
 def test_qsa_rejects_insufficient_live_output_before_mutation() -> None:
@@ -3414,8 +3417,6 @@ def test_qsa_decode_full_path_matches_exact_gqa_and_keeps_main_cache_read_only()
     assert torch.all(binding.selected_positions[0, 4:] == -1)
 
 
-
-
 def test_qsa_score_uses_tensor_device_and_stream() -> None:
     from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
     from b12x.attention.qsa import _score_cute as implementation
@@ -3436,10 +3437,16 @@ def test_qsa_score_uses_tensor_device_and_stream() -> None:
         request_ids=torch.zeros(1, dtype=torch.int32, device=device),
         sequence_lengths=torch.full((1,), 64, dtype=torch.int32, device=device),
         compressed_cache=cache,
-        compressed_block_table=torch.arange(4, dtype=torch.int32, device=device).view(1, 4),
-        state_errors=errors, scores=output,
-        eligible_counts=torch.empty_like(errors), merge_lengths=torch.empty_like(errors),
-        group_offset=0, group_count=16, caps=caps,
+        compressed_block_table=torch.arange(4, dtype=torch.int32, device=device).view(
+            1, 4
+        ),
+        state_errors=errors,
+        scores=output,
+        eligible_counts=torch.empty_like(errors),
+        merge_lengths=torch.empty_like(errors),
+        group_offset=0,
+        group_count=16,
+        caps=caps,
     )
     stream = torch.cuda.Stream(device=device)
     stream.wait_stream(torch.cuda.current_stream(device))
@@ -3449,7 +3456,9 @@ def test_qsa_score_uses_tensor_device_and_stream() -> None:
         assert torch.cuda.current_device() == other
     stream.synchronize()
     warmed = tuple(implementation._CACHE.items())
-    freeze_kernel_resolution("QSA scorer retains tensor device under ambient device changes")
+    freeze_kernel_resolution(
+        "QSA scorer retains tensor device under ambient device changes"
+    )
     try:
         with torch.cuda.stream(stream), torch.cuda.device(other):
             graph = torch.cuda.CUDAGraph()
@@ -3465,7 +3474,9 @@ def test_qsa_score_uses_tensor_device_and_stream() -> None:
                     output.fill_(float("nan"))
                 graph.replay()
                 stream.synchronize()
-                torch.testing.assert_close(output, torch.full_like(output, 4 * 128**0.5 * value))
+                torch.testing.assert_close(
+                    output, torch.full_like(output, 4 * 128**0.5 * value)
+                )
         assert tuple(implementation._CACHE.items()) == warmed
         assert not errors.any()
     finally:
@@ -3476,19 +3487,28 @@ def test_qsa_score_uses_tensor_device_and_stream() -> None:
 @pytest.mark.parametrize("budget", [2048, 8192])
 @pytest.mark.parametrize("output_rows", [4, 66])
 def test_qsa_run_prewarm_covers_bound_capacity_and_graph_replay(
-    overlap: bool, budget: int, output_rows: int,
+    overlap: bool,
+    budget: int,
+    output_rows: int,
 ) -> None:
     from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
 
     device = require_sm120()
     caps = _caps(
-        device, max_q_rows=128, q_heads=24, head_dim=256, index_heads=4,
-        index_head_dim=128, index_rotary_dim=64, max_speculative_tokens=3,
+        device,
+        max_q_rows=128,
+        q_heads=24,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
+        index_rotary_dim=64,
+        max_speculative_tokens=3,
         budget=budget,
     )
     binding = _allocate_binding(caps)
     binding = _rebind(
-        binding, output=binding.output[:output_rows],
+        binding,
+        output=binding.output[:output_rows],
         selection_stream=torch.cuda.Stream(device=device) if overlap else None,
     )
     binding.main_k_cache.zero_()
@@ -3497,9 +3517,13 @@ def test_qsa_run_prewarm_covers_bound_capacity_and_graph_replay(
     binding.compressed_k_cache.zero_()
     binding.raw_k_ring.zero_()
     persistent = (
-        binding.main_k_cache, binding.main_v_cache, binding.compressed_k_cache,
-        binding.raw_k_ring, binding.raw_logical_positions,
-        binding.raw_rope_positions, binding.raw_interval_start_positions,
+        binding.main_k_cache,
+        binding.main_v_cache,
+        binding.compressed_k_cache,
+        binding.raw_k_ring,
+        binding.raw_logical_positions,
+        binding.raw_rope_positions,
+        binding.raw_interval_start_positions,
     )
     saved = [t.clone() for t in persistent]
     qsa.prewarm(binding)
@@ -3516,10 +3540,11 @@ def test_qsa_run_prewarm_covers_bound_capacity_and_graph_replay(
         for dtype in (torch.int32, torch.int64):
             for rows in sorted({1, min(4, output_rows), output_rows}):
                 dynamic = _dynamic_inputs(
-                    binding, positions=(0,) + (-1,) * (rows - 1),
+                    binding,
+                    positions=(0,) + (-1,) * (rows - 1),
                     request_ids=(0,) + (-1,) * (rows - 1),
                 )
-                dynamic['request_ids'] = dynamic['request_ids'].to(dtype)
+                dynamic["request_ids"] = dynamic["request_ids"].to(dtype)
 
                 def invoke():
                     if ready is not None:
@@ -3532,13 +3557,16 @@ def test_qsa_run_prewarm_covers_bound_capacity_and_graph_replay(
                 for value in (1, 2):
                     binding.raw_interval_start_positions.fill_(-1)
                     binding.main_v_cache.fill_(value)
-                    binding.output.fill_(float('nan'))
+                    binding.output.fill_(float("nan"))
                     torch.cuda.synchronize()
                     before = torch.cuda.memory_stats()
                     graph.replay()
                     torch.cuda.synchronize()
                     after = torch.cuda.memory_stats()
-                    for key in ('allocation.all.allocated', 'allocated_bytes.all.allocated'):
+                    for key in (
+                        "allocation.all.allocated",
+                        "allocated_bytes.all.allocated",
+                    ):
                         assert after[key] == before[key]
                     assert torch.all(result[0] == value)
                     assert torch.all(result[1:] == 0)
@@ -3549,21 +3577,31 @@ def test_qsa_run_prewarm_covers_bound_capacity_and_graph_replay(
         unfreeze_kernel_resolution()
 
 
-@pytest.mark.parametrize('overlap', [False, True])
-@pytest.mark.parametrize('shared_pool', [False, True])
+@pytest.mark.parametrize("overlap", [False, True])
+@pytest.mark.parametrize("shared_pool", [False, True])
 def test_qsa_run_streams_fullgraph_preserves_state_and_alias_checks(
-    overlap: bool, shared_pool: bool,
+    overlap: bool,
+    shared_pool: bool,
 ) -> None:
     device = require_sm120()
     caps = _caps(
-        device, max_batch=1, max_raw_state_slots=1, max_q_rows=1,
-        q_heads=24, head_dim=256, index_heads=4, index_head_dim=128,
+        device,
+        max_batch=1,
+        max_raw_state_slots=1,
+        max_q_rows=1,
+        q_heads=24,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
         index_rotary_dim=64,
     )
-    allocate = _allocate_shared_compressed_raw_binding if shared_pool else _allocate_binding
+    allocate = (
+        _allocate_shared_compressed_raw_binding if shared_pool else _allocate_binding
+    )
     binding = allocate(caps)
     binding = _rebind(
-        binding, selection_stream=torch.cuda.Stream(device=device) if overlap else None,
+        binding,
+        selection_stream=torch.cuda.Stream(device=device) if overlap else None,
     )
     binding.main_block_table[0, 0] = 0
     binding.main_k_cache.zero_()
@@ -3579,26 +3617,26 @@ def test_qsa_run_streams_fullgraph_preserves_state_and_alias_checks(
     def invoke(query):
         if ready is not None:
             ready.record()
-        return qsa.run(binding, **{**dynamic, 'query': query}, index_ready=ready)
+        return qsa.run(binding, **{**dynamic, "query": query}, index_ready=ready)
 
     compiled = torch.compile(invoke, fullgraph=True)
     for launch in (invoke, compiled):
         for value in (2, 3):
             binding.raw_interval_start_positions.fill_(-1)
             binding.main_v_cache.fill_(value)
-            result = launch(dynamic['query'])
+            result = launch(dynamic["query"])
             assert torch.all(result == value)
             assert result.data_ptr() == binding.output.data_ptr()
             assert binding.state_errors[0] == 0
         binding.raw_interval_start_positions.fill_(-1)
         before = binding.raw_interval_start_positions.clone()
-        with pytest.raises(ValueError, match='output.*query'):
+        with pytest.raises(ValueError, match="output.*query"):
             launch(binding.output)
         assert torch.equal(binding.raw_interval_start_positions, before)
     binding.raw_interval_start_positions.fill_(-1)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        result = compiled(dynamic['query'])
+        result = compiled(dynamic["query"])
     for value in (4, 5):
         binding.raw_interval_start_positions.fill_(-1)
         binding.main_v_cache.fill_(value)
@@ -3608,32 +3646,39 @@ def test_qsa_run_streams_fullgraph_preserves_state_and_alias_checks(
 
 def test_qsa_run_stream_options_validate_before_mutation() -> None:
     device = require_sm120()
-    binding = _allocate_binding(_caps(
-        device, q_heads=24, head_dim=256, index_heads=4, index_head_dim=128,
-        index_rotary_dim=64,
-    ))
+    binding = _allocate_binding(
+        _caps(
+            device,
+            q_heads=24,
+            head_dim=256,
+            index_heads=4,
+            index_head_dim=128,
+            index_rotary_dim=64,
+        )
+    )
     dynamic = _dynamic_inputs(binding, positions=(0,), request_ids=(0,))
     binding.scratch.fill_(173)
     binding.output.fill_(23)
     ready = torch.cuda.Event()
-    with pytest.raises(ValueError, match='requires a binding'):
+    with pytest.raises(ValueError, match="requires a binding"):
         qsa.run(binding, **dynamic, index_ready=ready)
     binding = _rebind(binding, selection_stream=torch.cuda.Stream(device=device))
-    with pytest.raises(ValueError, match='requires an index_ready'):
+    with pytest.raises(ValueError, match="requires an index_ready"):
         qsa.run(binding, **dynamic)
-    with pytest.raises(ValueError, match='must be recorded'):
+    with pytest.raises(ValueError, match="must be recorded"):
         qsa.run(binding, **dynamic, index_ready=ready)
     ready.record()
-    with pytest.raises(TypeError, match='query must be a tensor'):
-        qsa.run(binding, **{**dynamic, 'query': None}, index_ready=ready)
+    with pytest.raises(TypeError, match="query must be a tensor"):
+        qsa.run(binding, **{**dynamic, "query": None}, index_ready=ready)
     assert torch.all(binding.scratch == 173)
     assert torch.all(binding.output == 23)
-    assert not hasattr(qsa, 'select')
-    assert not hasattr(qsa, 'run_selected')
+    assert not hasattr(qsa, "select")
+    assert not hasattr(qsa, "run_selected")
 
 
 @torch.library.custom_op(
-    "b12x_tests::qsa_delayed_producer", mutates_args=("query", "value_cache"),
+    "b12x_tests::qsa_delayed_producer",
+    mutates_args=("query", "value_cache"),
 )
 def _qsa_delayed_producer(query: torch.Tensor, value_cache: torch.Tensor) -> None:
     # Model an opaque cache writer; Torch functionalization must not defer writes.
@@ -3647,15 +3692,22 @@ def _qsa_delayed_producer_fake(query: torch.Tensor, value_cache: torch.Tensor) -
     return None
 
 
-@pytest.mark.parametrize('compiled', [False, True])
+@pytest.mark.parametrize("compiled", [False, True])
 def test_qsa_run_selection_forks_before_main_producer_and_joins_before_attention(
-    monkeypatch, compiled: bool,
+    monkeypatch,
+    compiled: bool,
 ) -> None:
     """A delayed producer proves stream ordering; this is not a speed benchmark."""
     device = require_sm120()
     caps = _caps(
-        device, max_batch=1, max_raw_state_slots=1, max_q_rows=1,
-        q_heads=24, head_dim=256, index_heads=4, index_head_dim=128,
+        device,
+        max_batch=1,
+        max_raw_state_slots=1,
+        max_q_rows=1,
+        q_heads=24,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
         index_rotary_dim=64,
     )
     binding = _allocate_binding(caps)
@@ -3677,14 +3729,14 @@ def test_qsa_run_selection_forks_before_main_producer_and_joins_before_attention
         if args[0] is None:
             selected.record()
 
-    monkeypatch.setattr(qsa_contract, '_qsa_decode_impl', observe)
+    monkeypatch.setattr(qsa_contract, "_qsa_decode_impl", observe)
     qsa.prewarm(binding)
     ready.record()
 
     def invoke():
         started.record()
         ready.record()
-        _qsa_delayed_producer(dynamic['query'], binding.main_v_cache)
+        _qsa_delayed_producer(dynamic["query"], binding.main_v_cache)
         produced.record()
         return qsa.run(binding, **dynamic, index_ready=ready)
 
@@ -3699,8 +3751,8 @@ def test_qsa_run_selection_forks_before_main_producer_and_joins_before_attention
                 result = launch()
         for _ in range(2):
             binding.raw_interval_start_positions.fill_(-1)
-            dynamic['query'].fill_(float('nan'))
-            binding.main_v_cache.fill_(float('nan'))
+            dynamic["query"].fill_(float("nan"))
+            binding.main_v_cache.fill_(float("nan"))
             if graph_mode:
                 graph.replay()
             else:
@@ -3711,15 +3763,238 @@ def test_qsa_run_selection_forks_before_main_producer_and_joins_before_attention
             assert 0 <= started.elapsed_time(selected) < started.elapsed_time(produced)
 
 
+def _draft_selection_state(binding):
+    caps = binding.plan.caps
+    device = caps.device
+    return qsa.DraftSelectionState(
+        selected_positions=binding.selected_positions,
+        logical_positions=torch.full(
+            (caps.max_q_rows,), -1, dtype=torch.int64, device=device
+        ),
+        errors=torch.zeros(caps.max_q_rows, dtype=torch.int32, device=device),
+        source_rows=torch.full((caps.max_batch,), -1, dtype=torch.int64, device=device),
+        num_source_rows=torch.zeros(1, dtype=torch.int32, device=device),
+        work_positions=torch.full(
+            (caps.max_batch, caps.selection_width + caps.max_speculative_tokens),
+            -1,
+            dtype=torch.int32,
+            device=device,
+        ),
+        work_errors=torch.zeros(caps.max_batch, dtype=torch.int32, device=device),
+    )
+
+
+@pytest.mark.parametrize("kv_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("request_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize("high_page", [False, True])
+def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
+    kv_dtype,
+    request_dtype,
+    high_page,
+    monkeypatch,
+):
+    """Accepted-row mapping, causal tails and errors survive changed-input replay."""
+    from b12x._lib.runtime_control import (
+        freeze_kernel_resolution,
+        unfreeze_kernel_resolution,
+    )
+
+    device = require_sm120()
+    first_page = 2**31 // (3008 * 2 * 256) + 1 if high_page else 0
+    caps = _caps(
+        device,
+        max_batch=4,
+        max_raw_state_slots=4,
+        max_q_rows=16,
+        max_seq_len=3008,
+        main_page_size=3008,
+        compressed_page_size=752,
+        num_main_cache_pages=first_page + 4,
+        num_compressed_cache_pages=4,
+        q_heads=24,
+        kv_heads=2,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
+        index_rotary_dim=64,
+        max_speculative_tokens=3,
+        kv_dtype=kv_dtype,
+    )
+    binding = _allocate_binding(caps)
+    state = _draft_selection_state(binding)
+    binding = _rebind(binding, draft_selection=state)
+    for request in range(4):
+        page = first_page + request
+        binding.main_block_table[request, 0] = page
+        binding.compressed_block_table[request, 0] = request
+        binding.main_k_cache[page].zero_()
+        binding.main_v_cache[page].fill_(request + 1)
+    binding.raw_k_ring.zero_()
+    binding.compressed_k_cache.zero_()
+    initial = _dynamic_inputs(
+        binding,
+        positions=tuple(i % 4 for i in range(16)),
+        request_ids=tuple(i // 4 for i in range(16)),
+    )
+    qsa.run(binding, **initial)
+    assert state.num_source_rows.item() == 16
+    torch.testing.assert_close(state.logical_positions, initial["query_positions"])
+    state.source_rows.copy_(torch.tensor([3, 7, 11, 15], device=device))
+    state.errors[7] = 512
+    query = initial["query"][:4].clone()
+    requests = torch.tensor([2, 0, -1, 1], device=device, dtype=request_dtype)
+    positions = torch.tensor([4, 5, -1, 4], device=device, dtype=torch.int64)
+    persistent = (
+        binding.compressed_k_cache,
+        binding.raw_k_ring,
+        binding.raw_logical_positions,
+        binding.raw_rope_positions,
+        binding.raw_interval_start_positions,
+        state.selected_positions,
+        state.logical_positions,
+        state.errors,
+        state.num_source_rows,
+    )
+    snapshots = [t.clone() for t in persistent]
+    qsa.prewarm(binding)
+    for tensor, expected in zip(persistent, snapshots, strict=True):
+        assert torch.equal(tensor, expected)
+    pointers = tuple(
+        t.data_ptr()
+        for t in (
+            binding.output,
+            binding.scratch,
+            state.work_positions,
+            state.work_errors,
+        )
+    )
+
+    def invoke(rows=4):
+        return qsa.run(
+            binding,
+            query=query[:rows],
+            request_ids=requests[:rows],
+            query_positions=positions[:rows],
+            reuse_draft_selection=True,
+        )
+
+    for rows in (1, 3, 4):
+        invoke(rows)
+    freeze_kernel_resolution("QSA draft reuse must retain prewarmed reader capacity")
+    try:
+        for rows in (1, 3, 4):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                result = invoke(rows)
+            for tail_end in (5, 4):
+                positions[0] = tail_end
+                torch.cuda.synchronize()
+                allocated = torch.cuda.memory_stats()["allocation.all.allocated"]
+                graph.replay()
+                torch.cuda.synchronize()
+                assert (
+                    torch.cuda.memory_stats()["allocation.all.allocated"] == allocated
+                )
+                assert torch.all(result[0] == 3)
+                if rows >= 3:
+                    assert torch.all(result[1] == 1)
+                    assert torch.all(result[2] == 0)
+                if rows == 4:
+                    assert torch.isnan(result[3]).all()
+                assert state.work_positions[0, caps.selection_width :].tolist() == (
+                    [4, 5, -1] if tail_end == 5 else [4, -1, -1]
+                )
+            positions[0] = 7
+            graph.replay()
+            assert torch.isnan(result[0]).all()
+            positions[0] = 4
+            # A row outside the last ordinary run must not reuse older state.
+            state.source_rows[2] = 16
+            graph.replay()
+            assert torch.isnan(result[0]).all()
+            state.source_rows[2] = 11
+            state.num_source_rows.fill_(11)
+            graph.replay()
+            assert torch.isnan(result[0]).all()
+            state.num_source_rows.fill_(16)
+            requests[0] = caps.max_batch
+            graph.replay()
+            assert torch.isnan(result[0]).all()
+            requests[0] = 2
+    finally:
+        unfreeze_kernel_resolution()
+    for tensor, expected in zip(persistent, snapshots, strict=True):
+        assert torch.equal(tensor, expected)
+    assert pointers == tuple(
+        t.data_ptr()
+        for t in (
+            binding.output,
+            binding.scratch,
+            state.work_positions,
+            state.work_errors,
+        )
+    )
+
+
+def test_qsa_rebind_uses_caller_events_during_capture(monkeypatch):
+    """Fresh bindings may not construct synchronization resources inside capture."""
+    device = require_sm120()
+    binding = _allocate_binding(
+        _caps(
+            device,
+            q_heads=24,
+            head_dim=256,
+            index_heads=4,
+            index_head_dim=128,
+            index_rotary_dim=64,
+        )
+    )
+    stream = torch.cuda.Stream(device=device)
+    done = torch.cuda.Event()
+    done.record(stream)
+    ready = torch.cuda.Event()
+    dynamic = _dynamic_inputs(binding, positions=(0,), request_ids=(0,))
+    binding.main_block_table[0, 0] = 0
+    binding.compressed_block_table[0, 0] = 0
+    binding.main_k_cache.zero_()
+    binding.main_v_cache.fill_(3)
+    binding.raw_k_ring.zero_()
+    binding.compressed_k_cache.zero_()
+    warmed = _rebind(binding, selection_stream=stream, selection_done=done)
+    qsa.prewarm(warmed)
+    before_event = torch.cuda.Event
+
+    def forbid_event(*args, **kwargs):
+        raise AssertionError("fresh QSA binding allocated a CUDA event")
+
+    # Keep isinstance checks valid while failing any attempted construction.
+    monkeypatch.setattr(before_event, "__new__", forbid_event)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        rebound = _rebind(binding, selection_stream=stream, selection_done=done)
+        assert rebound is not warmed
+        assert rebound._selection_done is done
+        ready.record()
+        result = qsa.run(rebound, **dynamic, index_ready=ready)
+    graph.replay()
+    assert torch.all(result == 3)
+
+
 def test_qsa_run_stream_resources_use_plan_device() -> None:
     device = require_sm120()
     if torch.cuda.device_count() < 2:
-        pytest.skip('requires two explicitly assigned CUDA devices')
-    device = torch.device('cuda', torch.cuda.current_device())
+        pytest.skip("requires two explicitly assigned CUDA devices")
+    device = torch.device("cuda", torch.cuda.current_device())
     other = (device.index + 1) % torch.cuda.device_count()
     caps = _caps(
-        device, max_batch=1, max_raw_state_slots=1, max_q_rows=1,
-        q_heads=24, head_dim=256, index_heads=4, index_head_dim=128,
+        device,
+        max_batch=1,
+        max_raw_state_slots=1,
+        max_q_rows=1,
+        q_heads=24,
+        head_dim=256,
+        index_heads=4,
+        index_head_dim=128,
         index_rotary_dim=64,
     )
     binding = _allocate_binding(caps)
@@ -3733,10 +4008,10 @@ def test_qsa_run_stream_resources_use_plan_device() -> None:
         wrong_stream = torch.cuda.Stream()
         wrong_ready = torch.cuda.Event()
         wrong_ready.record()
-    with pytest.raises(ValueError, match='selection_stream must match'):
+    with pytest.raises(ValueError, match="selection_stream must match"):
         _rebind(binding, selection_stream=wrong_stream)
     binding = _rebind(binding, selection_stream=torch.cuda.Stream(device=device))
-    with pytest.raises(ValueError, match='index_ready must be recorded on'):
+    with pytest.raises(ValueError, match="index_ready must be recorded on"):
         qsa.run(binding, **dynamic, index_ready=wrong_ready)
     with torch.cuda.device(other):
         qsa.prewarm(binding)

--- a/tests/attention/test_qsa_contract.py
+++ b/tests/attention/test_qsa_contract.py
@@ -3836,7 +3836,13 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
         positions=tuple(i % 4 for i in range(16)),
         request_ids=tuple(i // 4 for i in range(16)),
     )
-    qsa.run(binding, **initial)
+    compiled = (
+        not high_page and kv_dtype == torch.bfloat16 and request_dtype == torch.int64
+    )
+    if compiled:
+        torch.compile(lambda: qsa.run(binding, **initial), fullgraph=True)()
+    else:
+        qsa.run(binding, **initial)
     assert state.num_source_rows.item() == 16
     torch.testing.assert_close(state.logical_positions, initial["query_positions"])
     state.source_rows.copy_(torch.tensor([3, 7, 11, 15], device=device))
@@ -3878,6 +3884,8 @@ def test_qsa_run_reuses_draft_anchors_without_mutating_selector_state(
             reuse_draft_selection=True,
         )
 
+    if compiled:
+        invoke = torch.compile(invoke, fullgraph=True)
     for rows in (1, 3, 4):
         invoke(rows)
     freeze_kernel_resolution("QSA draft reuse must retain prewarmed reader capacity")


### PR DESCRIPTION
## Behavior

QSA supports draft-round anchor reuse through complete `qsa.run` operations. B12X describes persistent anchor layout through `Plan.draft_selection_plan().storage_specs()`; callers allocate and bind that storage. Gather/tail buffers live in the plan's caller-owned scratch. Ordinary runs record independent anchors, and `DraftSelectionReuse(source_rows=...)` supplies the accepted-row map for reuse without mutating selector caches.

`DraftSelectionState.reset()` invalidates anchors without allocation. Bounds, recorded counts, causal tail positions and error bits are checked; callers own request identity, model-layer/cache assignment and draft-round lifetime. Caller-established completion events permit fresh binding during capture. Prewarm preserves anchors and warms both metadata integer widths. Opaque metadata operations reconstruct typed views from storage bases to support fullgraph mutation tracking.

## Compatibility

Existing valid ordinary `qsa.run` calls retain their behavior. The removed split `select` and `run_selected` exports remain removed. Speculative plans report additional gather scratch; callers must allocate from the plan's reported requirements.

The vLLM consumer in local-inference-lab/vllm#697 requires migration to the planned storage API and explicit `DraftSelectionReuse` input. Its seven-tensor state constructor and reuse boolean are unsupported. Persistent storage, accepted-row maps and execution scratch remain caller-owned; prewarm retains its synthetic warmup allocations.

## Validation

All 49 selected QSA GPU tests executed successfully on RTX PRO 6000 Blackwell Max-Q: 47 cases in the focused run and the two device/stream-affinity cases in a separate run with two explicitly assigned GPUs. Coverage includes BF16/FP8 KV, int32/int64 metadata, four real high-page-ID cases, fullgraph reset/record/reuse, changed live counts under frozen reader resolution, allocation-free replay and rebinding, prewarm anchor preservation, and sharing anchors between compatible 16-row and 4-row plans. Ruff and diff checks passed.

```sh
python -m pytest -q -rs tests/attention/test_qsa_contract.py -k 'reuses_draft_anchors or rebind_uses_caller or run_prewarm or stream or draft_storage or draft_reuse_validates'
```

Registry/policy/architecture checks: 19 passed, one catalog failure because `sequence.kda_prefill` is missing a policy registration. That failure reproduces on the unchanged landing base. The entire QSA file is not claimed to pass; its generic head-dimension-16 fixtures violate the existing production geometry guard.

Status: qualified for targeted GPU contracts and TP2 serving with the migrated vLLM consumer. The consumer suite passed 45 tests. The prepared pair loaded the Qwen3.8 Flash Next NVFP4/MXFP8 checkpoint with MTP3, FP8 KV, mapped-host PLE and b12x PCIe all-reduce; both ranks completed CUDA graph capture. Short (32-token) and long (22,541-token) chat prompts each produced correct, identical text across two requests.

Bounded GSM8K evaluation: 27/32 correct, zero invalid answers, five shots, maximum 256 output tokens, temperature zero, seed 42, concurrency one, checkpoint chat template with thinking disabled. Four of five misses reached the output limit. Raw-completion evaluation returned immediate EOS for all 32 prompts; that failure is retained. Initial launch limitations were TP1 weight-allocation OOM without PLE offload and TP2 custom-all-reduce IPC export failure; the qualified configuration uses mapped-host PLE and b12x PCIe all-reduce.

No matched model baseline or performance improvement is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

QSA draft-selection reuse now uses caller-owned persistent anchor storage. `DraftSelectionPlan.storage_specs()` describes the required storage without allocation, and `DraftSelectionState` provides typed views plus allocation-free `reset()`.

Ordinary runs record anchors. Reuse runs accept `DraftSelectionReuse(source_rows=...)` and rebuild accepted-row mappings without mutating selector caches. Gather and tail buffers remain caller-owned scratch. The contract validates bounds, counts, causal-tail positions, error bits, stream ordering, request identity, and draft-round lifetime.

Prewarm preserves anchors and warms metadata widths. Opaque metadata operations reconstruct typed storage views to preserve fullgraph mutation tracking. Existing valid ordinary calls remain compatible. Removed `select` and `run_selected` exports remain unavailable.

The change adds public exports and updates custom operations, binding, attention execution, and tests for storage ownership, aliasing, reset replay, reuse validation, caller events, and CUDA graph capture. Validation includes 49 selected QSA GPU tests, the migrated vLLM consumer suite, TP2 serving, CUDA graph capture, and bounded GSM8K results of 27/32. No performance improvement is claimed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->