### PR TITLE
perf(deepseek-v41): accelerate packed indexing and prefill projections

### DIFF
--- a/b12x/attention/_shared/mla/decode_math.py
+++ b/b12x/attention/_shared/mla/decode_math.py
@@ -77,6 +77,8 @@ from b12x._lib.intrinsics import (
     mma_m16n8k16_f32_bf16,
     mma_m16n8k32_f32_e4m3,
     mxfp8_mma_m16n8k32_f32_e4m3,
+    mxfp8_pair_to_bf16x2_sm120,
+    nvfp4_pair_to_bf16x2_sm120,
     pack_f32x2_to_bfloat2,
     pow2_ceil_ue8m0,
     rcp_approx_ftz,
@@ -1456,6 +1458,11 @@ def _nvfp4_pair_bfloat2(
     ``latent_scale_per_token`` -- the record's own fp32 second-level scale,
     staged per candidate into the contiguous kv_sc buffer by the IO gather
     (record bytes [292, 296)).
+
+    The 544-byte mixed-source staging layout uses native SM120 packed
+    conversion with no outer scale: full-post-RoPE MXFP8 for SWA and NVFP4
+    for indexed candidates. UE8M0 byte zero represents 2**-127, not zero;
+    byte 255 represents NaN. Invalid source tags produce zero.
     """
     swa = Int32(0)
     if cutlass.const_expr(kv_smem_stride == 544):
@@ -1463,6 +1470,24 @@ def _nvfp4_pair_bfloat2(
         swa = ld_shared_u32(kv_fp4_base_addr + entry * Int32(544) + Int32(528)).to(
             Int32
         )
+        result = Uint32(0)
+        if swa == Int32(1):
+            packed = _ld_u16_zext(kv_fp4_base_addr, entry * Int32(544) + dim_even)
+            scale = _ld_u8_zext(
+                kv_fp4_base_addr,
+                entry * Int32(544) + Int32(512) + dim_even // Int32(32),
+            )
+            result = mxfp8_pair_to_bf16x2_sm120(packed, scale)
+        elif swa == Int32(0):
+            packed = _ld_u8_zext(
+                kv_fp4_base_addr, entry * Int32(544) + dim_even // Int32(2)
+            )
+            scale = _ld_u8_zext(
+                kv_fp4_base_addr,
+                entry * Int32(544) + Int32(256) + dim_even // Int32(16),
+            )
+            result = nvfp4_pair_to_bf16x2_sm120(packed, scale)
+        return result
     v0 = Float32(0.0)
     v1 = Float32(0.0)
     scale_f = Float32(0.0)
@@ -1506,6 +1531,29 @@ def _nvfp4_pair_bfloat2(
         (v0 * scale_f) * outer,
         (v1 * scale_f) * outer,
     )
+
+
+@cute.jit
+def _nvfp4_scalar_bf16_u16(
+    kv_fp4_base_addr: Int32,
+    entry: Int32,
+    dim: Int32,
+    latent_scale: Float32,
+    *,
+    kv_smem_stride: cutlass.Constexpr,
+    latent_scale_per_token: cutlass.Constexpr = False,
+    kv_sc_base_addr: Int32 = Int32(0),
+) -> Uint32:
+    pair = _nvfp4_pair_bfloat2(
+        kv_fp4_base_addr,
+        entry,
+        dim & ~Int32(1),
+        latent_scale,
+        kv_smem_stride=kv_smem_stride,
+        latent_scale_per_token=latent_scale_per_token,
+        kv_sc_base_addr=kv_sc_base_addr,
+    )
+    return _bf16x2_extract_lane_u16(pair, dim & Int32(1))
 
 
 @cute.jit

--- a/b12x/attention/dsa_indexer/mxfp4.py
+++ b/b12x/attention/dsa_indexer/mxfp4.py
@@ -15,7 +15,9 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import torch
-from cutlass import BFloat16, Float32, Int32, Int64, Uint8, Uint32
+from cutlass import BFloat16, Float32, Int32, Int64, Uint8, Uint16, Uint32
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
 
 from ..._lib.compiler import KernelCompileSpec, compile as b12x_compile
 from ..._lib.intrinsics import (
@@ -24,6 +26,8 @@ from ..._lib.intrinsics import (
     fabs_f32,
     fmax_f32,
     fp4_decode_2,
+    get_ptr_as_int64,
+    ld_global_nc_u32,
     pow2_ceil_ue8m0,
     u32_as_f32,
     ue8m0_to_output_scale,
@@ -310,6 +314,227 @@ class _PagedScore:
             col += Int32(8)
 
 
+@dsl_user_op
+def _mxfp4_mma(d0, d1, d2, d3, a0, a1, a2, a3, b0, b1, sfa, sfb, *, loc=None, ip=None):
+    """Packed E2M1 m16n8k64 with two UE8M0 group scales per operand row."""
+    operands = [Uint32(v).ir_value(loc=loc, ip=ip) for v in (a0, a1, a2, a3, b0, b1)]
+    for scale in (sfa, sfb):
+        operands.extend(
+            (
+                Uint32(scale).ir_value(loc=loc, ip=ip),
+                Uint16(0).ir_value(loc=loc, ip=ip),
+                Uint16(0).ir_value(loc=loc, ip=ip),
+            )
+        )
+    operands.extend(Float32(v).ir_value(loc=loc, ip=ip) for v in (d0, d1, d2, d3))
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32()] * 4),
+        operands,
+        """
+        mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue8m0
+        {$0,$1,$2,$3}, {$4,$5,$6,$7}, {$8,$9}, {$0,$1,$2,$3},
+        {$10}, {$11,$12}, {$13}, {$14,$15};
+        """,
+        "=f,=f,=f,=f,r,r,r,r,r,r,r,h,h,r,h,h,0,1,2,3",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Float32(llvm.extractvalue(T.f32(), result, [i], loc=loc, ip=ip))
+        for i in range(4)
+    )
+
+
+@cute.jit
+def _packed_word(data: cute.Tensor, offset: Int64):
+    return ld_global_nc_u32(get_ptr_as_int64(data, offset))
+
+
+@cute.jit
+def _scale_pair(data: cute.Tensor, offset: Int64):
+    return Uint32(data[offset]) | (Uint32(data[offset + Int64(1)]) << Uint32(8))
+
+
+class _TensorCorePagedScore(_PagedScore):
+    """Sixteen keys by eight heads per warp, with the staged BF16 score contract.
+
+    Packed MXFP4 operands enter block-scaled FP32-accumulating MMA directly.
+    ReLU, weighted-product rounding and ordered head summation remain separate;
+    tensor cores do not fuse away the model's BF16 stage boundaries.
+    """
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Pointer,
+        qs: cute.Pointer,
+        weights: cute.Pointer,
+        pool: cute.Pointer,
+        pages: cute.Pointer,
+        lengths: cute.Pointer,
+        active: cute.Pointer,
+        candidates: cute.Pointer,
+        candidate_lengths: cute.Pointer,
+        scores: cute.Pointer,
+        rows: Int32,
+        width: Int32,
+        page_width: Int32,
+        page_row_stride: Int64,
+        pool_stride: Int64,
+        pool_pages: Int64,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(
+            _flat(q),
+            _flat(qs),
+            _flat(weights),
+            _flat(pool),
+            _flat(pages),
+            _flat(lengths),
+            _flat(active),
+            _flat(candidates),
+            _flat(candidate_lengths),
+            _flat(scores),
+            rows,
+            width,
+            page_width,
+            page_row_stride,
+            pool_stride,
+            pool_pages,
+        ).launch(grid=((width + 63) // 64, rows, 1), block=(128, 1, 1), stream=stream)
+
+    @cute.kernel
+    def kernel(
+        self,
+        q: cute.Tensor,
+        qs: cute.Tensor,
+        weights: cute.Tensor,
+        pool: cute.Tensor,
+        pages: cute.Tensor,
+        lengths: cute.Tensor,
+        active: cute.Tensor,
+        candidates: cute.Tensor,
+        candidate_lengths: cute.Tensor,
+        scores: cute.Tensor,
+        rows: Int32,
+        width: Int32,
+        page_width: Int32,
+        page_row_stride: Int64,
+        pool_stride: Int64,
+        pool_pages: Int64,
+    ):
+        tx, _, _ = cute.arch.thread_idx()
+        bx, row, _ = cute.arch.block_idx()
+        lane = Int32(tx) % Int32(32)
+        col = (
+            Int32(bx) * Int32(64)
+            + (Int32(tx) // Int32(32)) * Int32(16)
+            + lane // Int32(4)
+        )
+        kb = cute.make_rmem_tensor((2,), Int64)
+        sb = cute.make_rmem_tensor((2,), Int64)
+        valid_key = cute.make_rmem_tensor((2,), cutlass.Boolean)
+        totals = cute.make_rmem_tensor((2,), Float32)
+        totals.fill(0.0)
+        for part in cutlass.range_constexpr(2):
+            column = col + Int32(part * 8)
+            pos = column
+            valid = column < width
+            if cutlass.const_expr(self.candidates):
+                valid = valid and column < candidate_lengths[row]
+                if valid:
+                    pos = candidates[Int64(row) * Int64(width) + Int64(column)]
+            valid = valid and pos >= Int32(0) and pos < lengths[row] and pos < active[0]
+            valid = valid and pos // Int32(self.page_size) < page_width
+            page = Int64(-1)
+            if valid:
+                page = Int64(
+                    pages[
+                        Int64(row) * page_row_stride
+                        + Int64(pos // Int32(self.page_size))
+                    ]
+                )
+            valid = valid and page >= Int64(0) and page < pool_pages
+            token = Int64(pos % Int32(self.page_size))
+            valid_key[part] = valid
+            kb[part] = page * pool_stride + token * Int64(64)
+            sb[part] = (
+                page * pool_stride + Int64(self.page_size * 64) + token * Int64(4)
+            )
+        for head_tile in cutlass.range_constexpr((self.heads + 7) // 8):
+            head = Int32(head_tile * 8) + lane // Int32(4)
+            qb = (Int64(row) * Int64(self.heads) + Int64(head)) * Int64(64)
+            qsb = (Int64(row) * Int64(self.heads) + Int64(head)) * Int64(4)
+            d0, d1, d2, d3 = Float32(0), Float32(0), Float32(0), Float32(0)
+            for kstep in cutlass.range_constexpr(2):
+                byte_col = Int64(kstep * 32) + Int64(lane % Int32(4)) * Int64(4)
+                a0, a1, a2, a3 = Uint32(0), Uint32(0), Uint32(0), Uint32(0)
+                if valid_key[0]:
+                    a0 = _packed_word(pool, kb[0] + byte_col)
+                    a2 = _packed_word(pool, kb[0] + byte_col + Int64(16))
+                if valid_key[1]:
+                    a1 = _packed_word(pool, kb[1] + byte_col)
+                    a3 = _packed_word(pool, kb[1] + byte_col + Int64(16))
+                b0, b1 = Uint32(0), Uint32(0)
+                sfa, sfb = Uint32(0x7F7F), Uint32(0x7F7F)
+                scale_row = lane % Int32(2)
+                if valid_key[scale_row]:
+                    sfa = _scale_pair(pool, sb[scale_row] + Int64(kstep * 2))
+                if head < Int32(self.heads):
+                    b0 = _packed_word(q, qb + byte_col)
+                    b1 = _packed_word(q, qb + byte_col + Int64(16))
+                    sfb = _scale_pair(qs, qsb + Int64(kstep * 2))
+                d0, d1, d2, d3 = _mxfp4_mma(
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    a0,
+                    a1,
+                    a2,
+                    a3,
+                    b0,
+                    b1,
+                    sfa,
+                    sfb,
+                )
+            contributions = cute.make_rmem_tensor((4,), Float32)
+            dots = cute.make_rmem_tensor((4,), Float32)
+            dots[0], dots[1], dots[2], dots[3] = d0, d1, d2, d3
+            for part in cutlass.range_constexpr(4):
+                output_head = (
+                    Int32(head_tile * 8)
+                    + (lane % Int32(4)) * Int32(2)
+                    + Int32(part % 2)
+                )
+                weight = Float32(0)
+                if output_head < Int32(self.heads):
+                    weight = Float32(
+                        weights[Int64(row) * Int64(self.heads) + Int64(output_head)]
+                    )
+                dot = fmax_f32(Float32(BFloat16(dots[part])), Float32(0))
+                contributions[part] = Float32(BFloat16(dot * weight))
+            # Preserve the scalar kernel's increasing-head FP32 sum order.
+            for head_pair in cutlass.range_constexpr(4):
+                source_lane = lane // Int32(4) * Int32(4) + Int32(head_pair)
+                for part in cutlass.range_constexpr(4):
+                    contribution = cute.arch.shuffle_sync(
+                        contributions[part], source_lane
+                    )
+                    totals[part // 2] = totals[part // 2] + contribution
+        if lane % Int32(4) == Int32(0):
+            for part in cutlass.range_constexpr(2):
+                column = col + Int32(part * 8)
+                if column < width:
+                    value = BFloat16(-float("inf"))
+                    if valid_key[part]:
+                        value = BFloat16(totals[part])
+                    scores[Int64(row) * Int64(width) + Int64(column)] = value
+
+
 class _SelectPrepare:
     def __init__(self, candidates: bool, blocks: bool):
         self.candidates = candidates
@@ -503,8 +728,10 @@ def _compile(kind: str, recipe: tuple, device_index: int):
         obj = _Quantize(*recipe)
         dtypes = (BFloat16, Uint8, Uint8, Int64)
         scalars = (Int32(1), Int64(1), Int64(4352))
-    elif kind == "score":
-        obj = _PagedScore(*recipe)
+    elif kind in ("score", "score_tensorcore"):
+        obj = (_TensorCorePagedScore if kind == "score_tensorcore" else _PagedScore)(
+            *recipe
+        )
         dtypes = (
             Uint8,
             Uint8,
@@ -735,7 +962,11 @@ def bind_mxfp4(
 
     caps = plan.caps
     width_capacity = caps.max_candidates or caps.max_page_table_width * caps.page_size
-    score_width = width_capacity if score_width is None else int(score_width)
+    if score_width is not None and (
+        isinstance(score_width, bool) or not isinstance(score_width, int)
+    ):
+        raise TypeError("score_width must be an integer")
+    score_width = width_capacity if score_width is None else score_width
     if not 0 < score_width <= width_capacity:
         raise ValueError("score_width must be positive and within planned capacity")
     if caps.max_candidates and score_width != caps.max_candidates:
@@ -845,8 +1076,9 @@ def score_mxfp4(binding):
         rt.candidate_lengths if caps.max_candidates else rt.cache_lengths
     )
     page_stride = 0 if rt.page_table.shape[0] == 1 else rt.page_table.stride(0)
+    kind = "score_tensorcore" if caps.mode == "prefill" else "score"
     _launch(
-        "score",
+        kind,
         (caps.num_q_heads, bool(caps.max_candidates), caps.page_size),
         (
             binding.q_mxfp4,

--- a/b12x/comm/pcie/pcie_dma.py
+++ b/b12x/comm/pcie/pcie_dma.py
@@ -41,6 +41,35 @@ SCRATCH_ALIGN = 256
 FP8_QUANT_BLOCK = 128
 
 
+def _eager_replay_capacities(
+    max_bytes: int,
+    min_bytes: int,
+    itemsize: int,
+    world_size: int,
+    *,
+    max_elements: int | None = None,
+) -> tuple[int, ...]:
+    """Fixed element capacities with eight-value shards on every supported ring."""
+    multiple = world_size * 8
+    elements = max_bytes // itemsize
+    if max_elements is not None:
+        if max_elements <= 0 or max_elements > elements:
+            raise ValueError("DMA dtype capacity must fit the positive ring byte bound")
+        elements = max_elements
+    elements -= elements % multiple
+    if elements <= 0:
+        raise ValueError("DMA replay capacity is too small")
+    size_bytes = 1 << (max(1 << 20, min_bytes) - 1).bit_length()
+    capacities = []
+    while size_bytes < elements * itemsize:
+        capacity = size_bytes // itemsize
+        capacity -= capacity % multiple
+        if capacity > 0:
+            capacities.append(capacity)
+        size_bytes *= 2
+    return (*capacities, elements)
+
+
 def _fp8_mode() -> str:
     """Opt-in compressed wire transport mode.
 
@@ -177,7 +206,8 @@ class PCIeDmaAllReduce:
         self._ipc.cudaSetDevice(self.device.index or 0)
         self._closed = False
         self._eager_replays: dict[
-            torch.dtype, tuple[torch.Tensor, torch.Tensor, torch.cuda.CUDAGraph]
+            torch.dtype,
+            tuple[tuple[torch.Tensor, torch.Tensor, torch.cuda.CUDAGraph], ...],
         ] = {}
 
         self.shard_capacity = _align_up(
@@ -342,17 +372,15 @@ class PCIeDmaAllReduce:
     def prepare_eager_replay(
         self, dtype: torch.dtype, *, max_elements: int | None = None
     ) -> None:
-        """Capture a planned-capacity lossless ring for later eager calls.
+        """Precapture bounded-capacity lossless rings for later eager calls.
 
-        Call collectively before serving, with the same dtype order and bounds
-        on every rank. None uses max_bytes // dtype.itemsize; an explicit bound
-        must fit max_bytes before rounding down to a positive multiple of
-        world_size * 8. Repeated equivalent bounds reuse the graph; changing an
-        already prepared dtype's effective bound is an error.
-
-        Exact-capacity inputs reuse private source/result buffers without
-        aliasing retained outputs. Other supported sizes use the raw ring:
-        padding a large replay graph for a small input wastes wire bandwidth.
+        Call collectively before serving. Powers-of-two capacities, capped at
+        max_bytes, bound padding traffic without capturing on a request path.
+        Graphs borrow one private input/output allocation per dtype. Live sizes
+        select a covering graph, not a compilation or allocation cache entry.
+        The private output cannot alias a retained result.
+        max_elements bounds this dtype independently of the ring byte capacity,
+        so preparing FP32 reductions does not double BF16 replay storage.
         """
         if self._closed or self._fp8:
             raise ValueError("eager replay requires an open lossless DMA ring")
@@ -377,22 +405,31 @@ class PCIeDmaAllReduce:
             )
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError("prepare DMA eager replay before CUDA graph capture")
-        replay = self._eager_replays.get(dtype)
-        if replay is not None:
-            prepared_elements = replay[0].numel()
-            if prepared_elements != elements:
+        capacities = _eager_replay_capacities(
+            self.max_bytes,
+            self.min_bytes,
+            dtype.itemsize,
+            self.world_size,
+            max_elements=max_elements,
+        )
+        if dtype in self._eager_replays:
+            if capacities[-1] != self._eager_replays[dtype][-1][0].numel():
                 raise ValueError(
-                    f"DMA eager replay for {dtype} already prepared with "
-                    f"{prepared_elements} elements, requested {elements}"
+                    "DMA dtype replay capacity cannot change after preparation"
                 )
             return
+        elements = capacities[-1]
         with torch.cuda.device(self.device):
             source = torch.zeros(elements, dtype=dtype, device=self.device)
             result = torch.empty_like(source)
-            graph = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(graph):
-                self._all_reduce_on_device(source, out=result)
-        self._eager_replays[dtype] = (source, result, graph)
+            replays = []
+            for capacity in capacities:
+                source_view, result_view = source[:capacity], result[:capacity]
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graph):
+                    self._all_reduce_on_device(source_view, out=result_view)
+                replays.append((source_view, result_view, graph))
+        self._eager_replays[dtype] = tuple(replays)
 
     def all_reduce(
         self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
@@ -421,14 +458,17 @@ class PCIeDmaAllReduce:
             raise ValueError(
                 "output must match input shape/dtype/device and be contiguous"
             )
-        replay = self._eager_replays.get(inp.dtype)
-        if replay is not None and not torch.cuda.is_current_stream_capturing():
-            source, result, graph = replay
+        replays = self._eager_replays.get(inp.dtype)
+        if replays is not None and not torch.cuda.is_current_stream_capturing():
             elements = inp.numel()
-            if elements == source.numel():
-                source.copy_(inp.view(-1))
+            replay = next(
+                (item for item in replays if item[0].numel() >= elements), None
+            )
+            if replay is not None:
+                source, result, graph = replay
+                source[:elements].copy_(inp.view(-1))
                 graph.replay()
-                out.view(-1).copy_(result)
+                out.view(-1).copy_(result[:elements])
                 return out
         kernels = self._kernels
         world = self.world_size

--- a/b12x/gemm/bf16_gemv/__init__.py
+++ b/b12x/gemm/bf16_gemv/__init__.py
@@ -5,7 +5,9 @@ FP32 accumulation and bias addition happen before the final BF16/FP32 cast.
 Caller-owned row-strided ``out`` avoids allocation. BF16/BF16 projections
 use tiled tensor-core GEMM when their row/output geometry provides sufficient
 parallelism; small-row/skinny projections and any FP32 operand retain SIMT.
-One geometry/type-specialized compiled callable owns both GPU entrypoints.
+BF16 [M,5120] projections to 384/512/1024 outputs with M >= 256 use a
+specialized TMA path with compensated FP32 carry. Other eligible broad shapes
+use the general tensor-core/SIMT dispatcher.
 Live rows and input strides are runtime arguments. ``precompile`` warm-runs
 all eligible entrypoints before capture. There is no quantization or cuBLAS fallback.
 

--- a/b12x/gemm/bf16_gemv/_kernel.py
+++ b/b12x/gemm/bf16_gemv/_kernel.py
@@ -33,6 +33,7 @@ from b12x._lib.intrinsics import (
 )
 from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
 from b12x._lib.utils import current_cuda_stream, make_ptr
+from ._prefill import prefill_mm, supports_prefill
 
 _THREADS = 128
 SMALL_M_MAX = 8  # Rows sharing a weight load, not a live-row support limit.
@@ -518,7 +519,9 @@ class ProjectionKernel:
             stream,
         )
         if cutlass.const_expr(self.has_mma):
-            if warm_all != Int32(0):
+            if warm_all == Int32(2):
+                self.simt(*arguments)
+            elif warm_all != Int32(0):
                 self.mma(*arguments)
                 self.simt(*arguments)
             elif rows >= Int32(self.minimum_mma_rows):
@@ -644,6 +647,26 @@ def _validate(x, weight, out, bias):
 
 
 def _launch(x, weight, out, bias=None):
+    # The 1024-column projection reaches the general MMA crossover at 128
+    # rows. Keep its qualified FP32 accumulation accuracy through that range.
+    prefill_min_rows = 128 if weight.ndim == 2 and weight.shape[0] == 1024 else 256
+    if (
+        x.ndim == weight.ndim == 2
+        and x.shape[0] >= prefill_min_rows
+        and supports_prefill(x, weight, out, bias)
+    ):
+        _validate(x, weight, out, bias)
+        prefill_mm(x, weight, out)
+        return
+    _launch_projection(x, weight, out, bias)
+
+
+def _launch_scalar(x, weight, out, bias=None):
+    """Invoke the SIMT reference explicitly, regardless of the MMA crossover."""
+    _launch_projection(x, weight, out, bias, force_simt=True)
+
+
+def _launch_projection(x, weight, out, bias=None, *, force_simt=False):
     _validate(x, weight, out, bias)
     if x.shape[0] == 0:
         return
@@ -687,7 +710,7 @@ def _launch(x, weight, out, bias=None):
             int(x.stride(1)),
             int(weight.stride(1)),
             vector_loads,
-            0,
+            2 if force_simt else 0,
             current_cuda_stream(),
         )
         # The same compiled host program owns both GPU entrypoints. Its row
@@ -757,9 +780,11 @@ def precompile_bf16_gemv_small_n(
         )
         key = _key(x, weight, out, bias)
         with _LOCK:
-            if key in _WARMED:
-                return
-        _launch(x, weight, out, bias)
+            scalar_warm = key in _WARMED
+        if not scalar_warm:
+            _launch(x, weight, out, bias)
+        if supports_prefill(x, weight, out, bias):
+            prefill_mm(x, weight, out)
         torch.cuda.current_stream(weight.device).synchronize()
     if log is not None:
         log.debug(

--- a/b12x/gemm/bf16_gemv/_prefill.py
+++ b/b12x/gemm/bf16_gemv/_prefill.py
@@ -1,0 +1,406 @@
+"""BF16 prefill projection with compensated FP32 tensor-core accumulation.
+
+Inputs remain BF16 without activation or weight quantization. Output belongs
+to the caller. Tensor descriptors keep live row counts dynamic for graph reuse.
+The TMA pipeline follows B12X's MHC BF16 projection implementation.
+"""
+from functools import cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as cutlass_utils
+import cutlass.utils.hopper_helpers as sm90_utils_basic
+import torch
+from cutlass import Float32, Int32, Int64, const_expr
+from cutlass.cute.nvgpu import cpasync, warp, warpgroup
+from cutlass.cute.runtime import from_dlpack
+from cutlass.utils import LayoutEnum
+
+from b12x._lib.compiler import DimKey, KernelCompileSpec, launch, tensor_key
+from b12x._lib.utils import current_cuda_stream
+
+def _to_kernel_tensor(tensor, dtype, *, dynamic_layout=False):
+    result = from_dlpack(tensor.detach(), assumed_align=16)
+    result.element_type = dtype
+    if dynamic_layout:
+        result = result.mark_layout_dynamic(leading_dim=1)
+        result.element_type = dtype
+    return result
+
+
+def _assume_tma_source_aligned(tensor):
+    row_stride = tensor.stride[0]
+    if not isinstance(row_stride, int):
+        row_stride = cute.assume(row_stride, divby=8)
+    return cute.make_tensor(tensor.iterator, cute.make_layout(
+        tensor.shape, stride=(row_stride, 1)))
+
+
+@cute.jit
+def _warp_gemm(tiled_mma, acc, correction, fragment_a, fragment_b, shared_a, shared_b,
+               copy_a, copy_b):
+    target_a = copy_a.retile(fragment_a)
+    target_b = copy_b.retile(fragment_b)
+    cute.copy(copy_a, shared_a[None, None, 0], target_a[None, None, 0])
+    cute.copy(copy_b, shared_b[None, None, 0], target_b[None, None, 0])
+    segment = cute.make_rmem_tensor(acc.shape, Float32)
+    for k in cutlass.range_constexpr(cute.size(shared_a.shape[2])):
+        if k < cute.size(shared_a.shape[2]) - 1:
+            cute.copy(copy_a, shared_a[None, None, k + 1],
+                      target_a[None, None, k + 1])
+            cute.copy(copy_b, shared_b[None, None, k + 1],
+                      target_b[None, None, k + 1])
+        # Limit tensor-core accumulation to 16 products; retain the complete
+        # projection sum in FP32 ALU registers. Compensated addition retains
+        # small terms across the long reduction without tensor-core carry loss.
+        segment.fill(0.0)
+        cute.gemm(tiled_mma, segment, fragment_a[None, None, k],
+                  fragment_b[None, None, k], segment)
+        addend = segment.load() - correction.load()
+        total = acc.load() + addend
+        correction.store((total - acc.load()) - addend)
+        acc.store(total)
+
+
+class Bf16PrefillKernel:
+    """TMA-fed BF16 matrix product with FP32 accumulators and runtime rows."""
+
+    num_threads = 160
+    num_compute_warps = 4
+    producer_warp = 4
+    tile_m = 64
+    tile_n = 64
+    tile_k = 64
+    num_stages = 2
+    buffer_align_bytes = 1024
+
+    def __init__(self, n: int, k: int):
+        self.n, self.k = int(n), int(k)
+        if self.n <= 0 or self.k <= 0 or self.k % self.tile_k:
+            raise ValueError("BF16 prefill needs positive N and K divisible by 64")
+        self.k_tiles = self.k // self.tile_k
+        self.n_tiles = (self.n + self.tile_n - 1) // self.tile_n
+
+    def _get_tiled_mma(self) -> cute.TiledMma:
+        return cute.make_tiled_mma(
+            warp.MmaF16BF16Op(cutlass.BFloat16, Float32, (16, 8, 16)),
+            (self.num_compute_warps, 1, 1),
+            permutation_mnk=(self.num_compute_warps * 16, self.tile_n, 16),
+        )
+
+    def _get_smem_layouts(self) -> tuple[cute.ComposedLayout, cute.ComposedLayout]:
+        a_layout_atom = warpgroup.make_smem_layout_atom(
+            sm90_utils_basic.get_smem_layout_atom(
+                LayoutEnum.ROW_MAJOR,
+                cutlass.BFloat16,
+                self.tile_k,
+            ),
+            cutlass.BFloat16,
+        )
+        b_layout_atom = a_layout_atom
+        sA_layout = cute.tile_to_shape(
+            a_layout_atom,
+            (self.tile_m, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        sB_layout = cute.tile_to_shape(
+            b_layout_atom,
+            (self.tile_n, self.tile_k, self.num_stages),
+            order=(0, 1, 2),
+        )
+        return sA_layout, sB_layout
+
+    def _get_shared_storage_cls(
+        self,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+    ):
+        class SharedStorage:
+            pass
+
+        SharedStorage.__annotations__ = {
+            "mbar_ptr": cute.struct.MemRange[
+                cutlass.Int64,
+                self.num_stages * 2,
+            ],
+            "sA": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(sA_layout)],
+                self.buffer_align_bytes,
+            ],
+            "sB": cute.struct.Align[
+                cute.struct.MemRange[cutlass.BFloat16, cute.cosize(sB_layout)],
+                self.buffer_align_bytes,
+            ],
+        }
+        return cute.struct(SharedStorage)
+
+    @cute.jit
+    def __call__(
+        self,
+        source: cute.Tensor,
+        weight: cute.Tensor,
+        output: cute.Tensor,
+        num_tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        if const_expr(source.element_type != cutlass.BFloat16):
+            raise TypeError("source must be BFloat16")
+        if const_expr(weight.element_type != cutlass.BFloat16):
+            raise TypeError("weight must be BFloat16")
+        if const_expr(output.element_type not in (cutlass.Float32, cutlass.BFloat16)):
+            raise TypeError("output must be Float32 or BFloat16")
+
+        sA_layout, sB_layout = self._get_smem_layouts()
+        tiled_mma = self._get_tiled_mma()
+        SharedStorage = self._get_shared_storage_cls(sA_layout, sB_layout)
+        sA_tma_layout = cute.slice_(sA_layout, (None, None, 0))
+        sB_tma_layout = cute.slice_(sB_layout, (None, None, 0))
+        out_tma = _assume_tma_source_aligned(source)
+        fn_tma = _assume_tma_source_aligned(weight)
+        tma_atom_A, tma_tensor_A = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            out_tma,
+            sA_tma_layout,
+            (self.tile_m, self.tile_k),
+            num_multicast=1,
+        )
+        tma_atom_B, tma_tensor_B = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileG2SOp(),
+            fn_tma,
+            sB_tma_layout,
+            (self.tile_n, self.tile_k),
+            num_multicast=1,
+        )
+        grid_m = (num_tokens + Int32(self.tile_m - 1)) // Int32(self.tile_m)
+        self.kernel(
+            tma_tensor_A,
+            tma_tensor_B,
+            output,
+            tma_atom_A,
+            tma_atom_B,
+            sA_layout,
+            sB_layout,
+            tiled_mma,
+            SharedStorage,
+            num_tokens,
+        ).launch(
+            grid=(grid_m, self.n_tiles, 1),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        source: cute.Tensor,
+        weight: cute.Tensor,
+        output: cute.Tensor,
+        tma_atom_A: cute.CopyAtom,
+        tma_atom_B: cute.CopyAtom,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+        tiled_mma: cute.TiledMma,
+        SharedStorage: cutlass.Constexpr,
+        num_tokens: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        m_tile, n_tile, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_idx == 0:
+            cpasync.prefetch_descriptor(tma_atom_A)
+            cpasync.prefetch_descriptor(tma_atom_B)
+
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sA = storage.sA.get_tensor(sA_layout.outer, swizzle=sA_layout.inner)
+        sB = storage.sB.get_tensor(sB_layout.outer, swizzle=sB_layout.inner)
+
+        tma_copy_bytes = (
+            (self.tile_m + self.tile_n) * self.tile_k * cutlass.BFloat16.width // 8
+        )
+        load_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.num_stages,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_compute_warps,
+            ),
+            tx_count=tma_copy_bytes,
+            barrier_storage=storage.mbar_ptr.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        cute.arch.sync_threads()
+
+        gA = cute.local_tile(
+            source,
+            (self.tile_m, self.tile_k),
+            (None, None),
+        )
+        gB = cute.local_tile(
+            weight,
+            (self.tile_n, self.tile_k),
+            (None, None),
+        )
+        cta_layout = cute.make_layout(1)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_A,
+            0,
+            cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA, 0, 2),
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_B,
+            0,
+            cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB, 0, 2),
+        )
+
+        if warp_idx < Int32(self.num_compute_warps):
+            consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer,
+                self.num_stages,
+            )
+            thr_mma = tiled_mma.get_slice(tidx)
+            tCsA = thr_mma.partition_A(sA)
+            tCsB = thr_mma.partition_B(sB)
+            tCrA = thr_mma.make_fragment_A(tCsA[None, None, None, 0])
+            tCrB = thr_mma.make_fragment_B(tCsB[None, None, None, 0])
+            acc_shape = thr_mma.partition_shape_C((self.tile_m, self.tile_n))
+            acc = cute.make_rmem_tensor(acc_shape, Float32)
+            acc.fill(0.0)
+            correction = cute.make_rmem_tensor(acc_shape, Float32)
+            correction.fill(0.0)
+            smem_copy_atom_A = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                cutlass.BFloat16,
+            )
+            smem_copy_atom_B = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                cutlass.BFloat16,
+            )
+            smem_thr_copy_A = cute.make_tiled_copy_A(
+                smem_copy_atom_A,
+                tiled_mma,
+            ).get_slice(tidx)
+            smem_thr_copy_B = cute.make_tiled_copy_B(
+                smem_copy_atom_B,
+                tiled_mma,
+            ).get_slice(tidx)
+            tSsA = smem_thr_copy_A.partition_S(sA)
+            tSsB = smem_thr_copy_B.partition_S(sB)
+
+            for _k_tile in cutlass.range_constexpr(self.k_tiles):
+                load_pipeline.consumer_wait(consumer_state)
+                _warp_gemm(
+                    thr_mma,
+                    acc,
+                    correction,
+                    tCrA,
+                    tCrB,
+                    tSsA[None, None, None, consumer_state.index],
+                    tSsB[None, None, None, consumer_state.index],
+                    smem_thr_copy_A,
+                    smem_thr_copy_B,
+                )
+                load_pipeline.consumer_release(consumer_state)
+                consumer_state.advance()
+
+            coordinates = thr_mma.partition_C(
+                cute.make_identity_tensor((self.tile_m, self.tile_n))
+            )
+            for index in cutlass.range_constexpr(cute.size(acc)):
+                coord = coordinates[index]
+                token = m_tile * Int32(self.tile_m) + coord[0]
+                column = n_tile * Int32(self.tile_n) + coord[1]
+                if token < num_tokens and column < Int32(self.n):
+                    output[Int64(token), Int64(column)] = acc[index].to(
+                        output.element_type)
+
+        elif warp_idx == Int32(self.producer_warp):
+            producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer,
+                self.num_stages,
+            )
+            for k_tile in cutlass.range_constexpr(self.k_tiles):
+                load_pipeline.producer_acquire(producer_state)
+                cute.copy(
+                    tma_atom_A,
+                    tAgA[(None, m_tile, k_tile)],
+                    tAsA[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                cute.copy(
+                    tma_atom_B,
+                    tBgB[(None, n_tile, k_tile)],
+                    tBsB[(None, producer_state.index)],
+                    tma_bar_ptr=load_pipeline.producer_get_barrier(producer_state),
+                )
+                load_pipeline.producer_commit(producer_state)
+                producer_state.advance()
+            load_pipeline.producer_tail(producer_state)
+
+
+
+@cache
+def _kernel(n, k):
+    return Bf16PrefillKernel(n, k)
+
+
+def supports_prefill(x, weight, out, bias) -> bool:
+    """Static projection geometry and layout qualified for the tensor-core path.
+
+    Live rows only select the scalar/tensor-core dispatch at execution. They
+    never specialize a compiled callable. Smaller rows retain the scalar kernel.
+    """
+    return (
+        bias is None
+        and tuple(weight.shape) in ((384, 5120), (512, 5120), (1024, 5120))
+        and x.dtype == weight.dtype == torch.bfloat16
+        and all(t.is_contiguous() and t.data_ptr() % 16 == 0
+                for t in (x, weight, out))
+    )
+
+
+def prefill_mm(x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor) -> None:
+    """Write a contiguous BF16 matrix product into caller-owned BF16/FP32 output."""
+    if x.ndim != 2 or weight.ndim != 2 or x.shape[1] != weight.shape[1]:
+        raise ValueError("requires x[M,K] and weight[N,K]")
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        raise TypeError("input and weight must be BF16")
+    if out.dtype not in (torch.bfloat16, torch.float32):
+        raise TypeError("output must be BF16 or FP32")
+    if tuple(out.shape) != (x.shape[0], weight.shape[0]):
+        raise ValueError("output must have shape [M,N]")
+    if not x.is_cuda or weight.device != x.device or out.device != x.device:
+        raise ValueError("all operands must share a CUDA device")
+    if any(not t.is_contiguous() or t.data_ptr() % 16 for t in (x, weight, out)):
+        raise ValueError("operands must be contiguous and 16-byte aligned")
+    if torch._C._overlaps(out, x) or torch._C._overlaps(out, weight):
+        raise ValueError("output must not alias either input")
+    if not x.shape[0]:
+        return
+    args = (
+        _to_kernel_tensor(x, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(weight, cutlass.BFloat16),
+        _to_kernel_tensor(out, cutlass.Float32 if out.dtype == torch.float32
+                          else cutlass.BFloat16, dynamic_layout=True),
+        Int32(x.shape[0]), current_cuda_stream(),
+    )
+    key = tuple(
+        tensor_key(name, t, dims=(
+            (DimKey.dynamic() if name != "weight" else DimKey.exact(t.shape[0])),
+            DimKey.exact(t.shape[1]),
+        ))
+        for name, t in (("source", x), ("weight", weight), ("output", out))
+    )
+    launch(
+        _kernel(weight.shape[0], weight.shape[1]),
+        compile_spec=KernelCompileSpec.from_key("gemm.bf16_prefill", 1, key),
+        compile_args=args, runtime_args=args,
+    )

--- a/b12x/norm/mhc/_impl.py
+++ b/b12x/norm/mhc/_impl.py
@@ -745,6 +745,7 @@ def _b12x_mhc_pre_impl(
         or pre_out is not None
     )
     partials = None
+    planned_config: MhcConfig | None = None
     if binding is not None:
         extras = [
             name
@@ -763,6 +764,7 @@ def _b12x_mhc_pre_impl(
                 f"do not also pass {', '.join(extras)}"
             )
         partials = binding.partials
+        planned_config = binding.plan.config
         residual_out = binding.out
         y_out = binding.y
         post_out = binding.post_buffer
@@ -917,6 +919,7 @@ def _b12x_mhc_pre_impl(
     ):
         from b12x.norm.mhc._kernels import (
             run_mhc_finalize_gram,
+            run_mhc_prefill_tf32_project,
             run_mhc_pre_functional,
             run_mhc_pre_partial,
         )
@@ -937,13 +940,29 @@ def _b12x_mhc_pre_impl(
                 norm_eps=float(norm_eps),
             )
 
-        run_mhc_pre_partial(
-            residual=residual,
-            fn=fn,
-            partials=partials,
-            out=residual_out,
-            compute_gram=norm_weight is not None and pre_mix is None,
+        use_lagged_prefill = (
+            planned_config is not None
+            and planned_config.backend == "tf32_tma"
+            and residual.ndim == 3
+            and pre_mix is not None
+            and norm_weight is not None
         )
+        if use_lagged_prefill:
+            from b12x.norm.mhc._pre_prefill import prepare_lagged_prefill
+
+            prepare_lagged_prefill(residual, residual_out, partials)
+            run_mhc_prefill_tf32_project(
+                out=residual_out, fn=fn, partials=partials,
+                config=planned_config, split_fp32_fn=True,
+            )
+        else:
+            run_mhc_pre_partial(
+                residual=residual,
+                fn=fn,
+                partials=partials,
+                out=residual_out,
+                compute_gram=norm_weight is not None and pre_mix is None,
+            )
         run_mhc_finalize_gram(
             residual=residual_out,
             partials=partials,
@@ -959,6 +978,10 @@ def _b12x_mhc_pre_impl(
             sinkhorn_iters=sinkhorn_iters,
             norm_weight=norm_weight,
             norm_eps=float(norm_eps),
+            compact_partials=use_lagged_prefill,
+            compact_projection_splits=(
+                planned_config.projection_k_splits if use_lagged_prefill else 1
+            ),
         )
         return residual_out, post_out, comb_out, y_out
 

--- a/b12x/norm/mhc/_kernels.py
+++ b/b12x/norm/mhc/_kernels.py
@@ -2958,6 +2958,11 @@ class MHCPrefillTf32ProjectTmaKernel:
                     Float32,
                 )
                 acc_low.fill(0.0)
+                acc_sum = cute.make_rmem_tensor(
+                    cute.make_layout((self.n_mma_tiles_per_warp, 4), stride=(4, 1)),
+                    Float32,
+                )
+                acc_sum.fill(0.0)
             consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer,
                 self.num_stages,
@@ -3030,13 +3035,27 @@ class MHCPrefillTf32ProjectTmaKernel:
                         acc[warp_mma_n, 1] = d1
                         acc[warp_mma_n, 2] = d2
                         acc[warp_mma_n, 3] = d3
+                        if const_expr(self.split_fp32_fn and kk % 4 == 3):
+                            # Bound tensor-core accumulation length, then add
+                            # the high/low projection through FP32 ALU sums.
+                            for column in cutlass.range_constexpr(4):
+                                acc_sum[warp_mma_n, column] += (
+                                    acc[warp_mma_n, column]
+                                    + acc_low[warp_mma_n, column]
+                                )
+                                acc[warp_mma_n, column] = Float32(0)
+                                acc_low[warp_mma_n, column] = Float32(0)
                 load_pipeline.consumer_release(consumer_state)
                 consumer_state.advance()
 
             for warp_mma_n in cutlass.range_constexpr(self.n_mma_tiles_per_warp):
                 if const_expr(self.split_fp32_fn):
                     for column in cutlass.range_constexpr(4):
-                        acc[warp_mma_n, column] += acc_low[warp_mma_n, column]
+                        acc[warp_mma_n, column] = (
+                            acc_sum[warp_mma_n, column]
+                            + acc[warp_mma_n, column]
+                            + acc_low[warp_mma_n, column]
+                        )
                 mma_n = Int32(warp_mma_n * self.num_n_warps) + warp_n
                 mix0 = n_tile * Int32(self.tile_n) + Int32(mma_n * 8) + lane_pair_base
                 mix1 = mix0 + Int32(1)

--- a/b12x/norm/mhc/_pre_prefill.py
+++ b/b12x/norm/mhc/_pre_prefill.py
@@ -1,0 +1,147 @@
+"""Caller-owned preparation for lagged four-stream MHC prefill projection.
+
+The residual is already post-mixed. Copy its BF16 bits and compute the squared
+norm; the incoming lagged mix lets the finalizer omit pairwise Gram statistics.
+"""
+
+from functools import cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import torch
+from cutlass import Float32, Int32, Int64, Uint32
+
+from b12x._lib.compiler import DimKey, KernelCompileSpec, launch, tensor_key
+from b12x._lib.intrinsics import bfloat2_to_float2_scaled
+from b12x._lib.utils import current_cuda_stream
+from ._kernels import _to_kernel_tensor, _warp_allreduce_sum
+
+
+class _PrepareLaggedPrefill:
+    def __init__(self, hidden: int):
+        self.hidden = hidden
+
+    @cute.jit
+    def __call__(
+        self,
+        residual: cute.Tensor,
+        output: cute.Tensor,
+        partials: cute.Tensor,
+        tokens: Int32,
+        stream: cuda.CUstream,
+    ):
+        self.kernel(residual, output, partials).launch(
+            grid=(tokens, 1, 1), block=(512, 1, 1), stream=stream
+        )
+
+    @cute.kernel
+    def kernel(self, residual: cute.Tensor, output: cute.Tensor, partials: cute.Tensor):
+        row, _, _ = cute.arch.block_idx()
+        tid, _, _ = cute.arch.thread_idx()
+        lane, warp = Int32(tid) % Int32(32), Int32(tid) // Int32(32)
+        source = cute.recast_tensor(residual, Uint32)
+        target = cute.recast_tensor(output, Uint32)
+        smem = utils.SmemAllocator()
+        sums = smem.allocate_tensor(Float32, cute.make_layout((16,)), 16)
+        total = Float32(0)
+        for offset in cutlass.range_constexpr((self.hidden * 2 + 511) // 512):
+            pair = Int32(offset * 512) + Int32(tid)
+            if pair < Int32(self.hidden * 2):
+                stream_id = pair // Int32(self.hidden // 2)
+                column = pair % Int32(self.hidden // 2)
+                value = source[Int64(row), stream_id, column]
+                target[Int64(row), stream_id, column] = value
+                lo, hi = bfloat2_to_float2_scaled(value, Float32(1))
+                total += lo * lo
+                total += hi * hi
+        total = _warp_allreduce_sum(total)
+        if lane == Int32(0):
+            sums[warp] = total
+        cute.arch.sync_threads()
+        if tid == Int32(0):
+            square_sum = Float32(0)
+            for index in cutlass.range_constexpr(16):
+                square_sum += sums[index]
+            partials[Int64(row), 0, 0] = square_sum
+
+
+@cache
+def _kernel(hidden):
+    return _PrepareLaggedPrefill(hidden)
+
+
+@torch.library.custom_op(
+    "b12x::mhc_prepare_lagged_prefill", mutates_args=("output", "partials")
+)
+def prepare_lagged_prefill(
+    residual: torch.Tensor, output: torch.Tensor, partials: torch.Tensor
+) -> None:
+    if (
+        residual.ndim != 3
+        or residual.shape[1] != 4
+        or residual.shape[2] <= 0
+        or residual.shape[2] % 2
+        or residual.dtype != torch.bfloat16
+        or not residual.is_cuda
+    ):
+        raise ValueError("lagged MHC prefill requires BF16 [tokens,4,hidden] residual")
+    if not residual.is_contiguous() or not output.is_contiguous():
+        raise ValueError("lagged MHC prefill requires contiguous residual and output")
+    if output.shape != residual.shape or output.dtype != residual.dtype:
+        raise ValueError("lagged MHC output must match the residual")
+    if (
+        partials.dtype != torch.float32
+        or partials.ndim != 3
+        or partials.shape[0] != residual.shape[0]
+        or partials.shape[1] < 1
+        or partials.shape[2] < 1
+        or not partials.is_contiguous()
+    ):
+        raise ValueError("lagged MHC partials require FP32 [tokens,splits,statistics]")
+    if output.device != residual.device or partials.device != residual.device:
+        raise ValueError("lagged MHC inputs and outputs must share a CUDA device")
+    if (
+        torch._C._overlaps(residual, output)
+        or torch._C._overlaps(partials, output)
+        or torch._C._overlaps(residual, partials)
+    ):
+        raise ValueError(
+            "lagged MHC preparation outputs must not alias inputs or scratch"
+        )
+    tokens, _, hidden = residual.shape
+    if not tokens:
+        return
+    args = (
+        _to_kernel_tensor(residual, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(output, cutlass.BFloat16, dynamic_layout=True),
+        _to_kernel_tensor(partials, cutlass.Float32, dynamic_layout=True),
+        Int32(tokens),
+        current_cuda_stream(),
+    )
+    key = tuple(
+        tensor_key(
+            name,
+            tensor,
+            dims=(DimKey.dynamic(),) + tuple(DimKey.exact(v) for v in tensor.shape[1:]),
+        )
+        for name, tensor in (
+            ("residual", residual),
+            ("output", output),
+            ("partials", partials),
+        )
+    )
+    launch(
+        _kernel(hidden),
+        compile_spec=KernelCompileSpec.from_key(
+            "norm.mhc.lagged_prefill_prepare", 1, key
+        ),
+        compile_args=args,
+        runtime_args=args,
+    )
+
+
+@prepare_lagged_prefill.register_fake
+def _fake(residual, output, partials):
+    return None

--- a/benchmarks/benchmark_bf16_prefill.py
+++ b/benchmarks/benchmark_bf16_prefill.py
@@ -1,0 +1,80 @@
+"""Qualify BF16 tensor-core projection against the scalar path and FP64 math.
+
+Explicitly invokes scalar and tensor-core kernels rather than timing automatic
+serving dispatch. Timings include caller binding and retain raw graph samples.
+"""
+
+import json
+import statistics
+import argparse
+
+import torch
+
+from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.gemm import bf16_gemv
+from b12x.gemm.bf16_gemv._kernel import _launch_scalar
+from b12x.gemm.bf16_gemv._prefill import prefill_mm
+
+
+torch.manual_seed(415121)
+torch.backends.cuda.matmul.allow_tf32 = False
+device = "cuda"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--out-features", type=int, default=512)
+args = parser.parse_args()
+capacity, n, k = 4096, args.out_features, 5120
+x = torch.randn((capacity, k), device=device).bfloat16()
+weight = (torch.randn((n, k), device=device) / k**0.5).bfloat16()
+scalar = torch.empty((capacity, n), device=device)
+candidate = torch.empty_like(scalar)
+prefill_mm(x, weight, candidate)
+bf16_gemv.mm(x[:1], weight, out=scalar[:1])
+freeze_kernel_resolution("BF16 prefill dynamic-row qualification")
+try:
+    for rows in (1, 8, 64, 256, 513, 1024, 4096):
+        scalar.fill_(float("nan"))
+        candidate.fill_(float("nan"))
+        _launch_scalar(x[:rows], weight, scalar[:rows])
+        prefill_mm(x[:rows], weight, candidate[:rows])
+        oracle = x[:rows].double() @ weight.double().T
+        errors = {}
+        for name, value in (("scalar", scalar), ("tensorcore", candidate)):
+            delta = value[:rows].double() - oracle
+            errors[name] = {
+                "max_abs": float(delta.abs().max()),
+                "rmse": float(delta.square().mean().sqrt()),
+            }
+            assert torch.isfinite(value[:rows]).all()
+            assert torch.isnan(value[rows:]).all()
+            torch.testing.assert_close(value[:rows].double(), oracle,
+                                       atol=2e-5, rtol=2e-5)
+        graphs = {}
+        for name in ("scalar", "tensorcore"):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(5):
+                    if name == "scalar":
+                        _launch_scalar(x[:rows], weight, scalar[:rows])
+                    else:
+                        prefill_mm(x[:rows], weight, candidate[:rows])
+            graphs[name] = graph
+        samples = {name: [] for name in graphs}
+        for repeat in range(7):
+            order = ("scalar", "tensorcore") if repeat % 2 else ("tensorcore", "scalar")
+            for name in order:
+                graphs[name].replay()
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                for _ in range(20):
+                    graphs[name].replay()
+                end.record()
+                end.synchronize()
+                samples[name].append(start.elapsed_time(end) * 10)
+        print(json.dumps({
+            "rows": rows, "n": n, "k": k, "errors": errors,
+            "samples_us": samples,
+            "median_us": {name: statistics.median(v) for name, v in samples.items()},
+        }), flush=True)
+finally:
+    unfreeze_kernel_resolution()

--- a/benchmarks/benchmark_mhc_lagged_prefill.py
+++ b/benchmarks/benchmark_mhc_lagged_prefill.py
@@ -1,0 +1,161 @@
+"""Compare direct FP32 projection with split-TF32 lagged MHC prefill.
+
+This probe explicitly invokes the candidate and does not change serving
+dispatch. Both paths retain FP32 weights and use caller-owned scratch.
+"""
+
+import json
+import statistics
+import os
+from dataclasses import replace
+
+import torch
+
+from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.norm import mhc
+from b12x.norm.mhc._kernels import run_mhc_finalize_gram, run_mhc_prefill_tf32_project
+from b12x.norm.mhc._pre_prefill import prepare_lagged_prefill
+
+
+torch.manual_seed(415120)
+device = torch.device("cuda", torch.cuda.current_device())
+hidden = 5120
+capacity = 4096
+plan = mhc.plan(mhc.Caps(device=device, hidden_size=hidden, max_tokens=capacity))
+config = replace(
+    plan.config, projection_k_splits=int(os.getenv("MHC_PROBE_K_SPLITS", "1"))
+)
+plan = replace(plan, config=replace(plan.config, backend="native"))
+fn = torch.randn((24, 4 * hidden), device=device) / 64
+scale = torch.randn((3,), device=device) / 3
+bias = torch.randn((24,), device=device) / 5
+weight = torch.randn((hidden,), device=device).bfloat16()
+for rows in (64, 512, 1024, 4096):
+    residual = (torch.randn((rows, 4, hidden), device=device) / 3).bfloat16()
+    incoming = torch.sigmoid(torch.randn((rows, 4), device=device))
+    (spec,) = plan.scratch_specs()
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=device)
+    out = torch.empty_like(residual)
+    y = torch.empty((rows, hidden), device=device, dtype=torch.bfloat16)
+    post = torch.empty((rows, 4), device=device)
+    comb = torch.empty((rows, 4, 4), device=device)
+    pre = torch.empty((rows, 4), device=device)
+    binding = plan.bind(
+        scratch=scratch, tokens=rows, out=out, y=y, post=post, comb=comb, pre_out=pre
+    )
+
+    def baseline():
+        mhc.run_pre(
+            residual,
+            fn,
+            scale,
+            bias,
+            rms_eps=1e-20,
+            hc_eps=1e-6,
+            sinkhorn_iters=20,
+            norm_weight=weight,
+            norm_eps=1e-20,
+            pre_mix=incoming,
+            binding=binding,
+        )
+
+    def candidate():
+        prepare_lagged_prefill(residual, out, binding.partials)
+        run_mhc_prefill_tf32_project(
+            out=out, fn=fn, partials=binding.partials, config=config, split_fp32_fn=True
+        )
+        run_mhc_finalize_gram(
+            residual=out,
+            partials=binding.partials,
+            scale=scale,
+            bias=bias,
+            y=y,
+            post=post,
+            comb=comb,
+            rms_eps=1e-20,
+            hc_eps=1e-6,
+            sinkhorn_iters=20,
+            norm_weight=weight,
+            norm_eps=1e-20,
+            compact_partials=True,
+            compact_projection_splits=config.projection_k_splits,
+            pre_mix=incoming,
+            pre_out=pre,
+        )
+
+    baseline()
+    expected = [value.clone() for value in (out, y, post, comb, pre)]
+    scalar_projection = binding.partials[:, : hidden // 128].sum(1)[:, 1:].clone()
+    scratch.fill_(0xA5)
+    candidate()
+    tc_projection = binding.partials[:, 0, 1:].clone()
+    for part in range(1, config.projection_k_splits):
+        tc_projection += binding.partials[:, part + 1, 1:]
+    reference_projection = residual.flatten(1).double() @ fn.double().T
+    normalized = reference_projection * torch.rsqrt(
+        residual.double().flatten(1).square().mean(-1, keepdim=True) + 1e-20
+    )
+    reference_post = 2 * torch.sigmoid(
+        normalized[:, 4:8] * scale.double()[1] + bias.double()[4:8]
+    )
+    precision = {
+        "scalar_projection_rmse": float(
+            (scalar_projection.double() - reference_projection).square().mean().sqrt()
+        ),
+        "tensorcore_projection_rmse": float(
+            (tc_projection.double() - reference_projection).square().mean().sqrt()
+        ),
+        "scalar_post_max_abs": float(
+            (expected[2].double() - reference_post).abs().max()
+        ),
+        "tensorcore_post_max_abs": float((post.double() - reference_post).abs().max()),
+    }
+    errors = {}
+    for name, actual, reference in zip(
+        ("residual", "y", "post", "comb", "pre"), (out, y, post, comb, pre), expected,
+        strict=True,
+    ):
+        errors[name] = float((actual.float() - reference.float()).abs().max())
+        torch.testing.assert_close(actual, reference, rtol=0.003, atol=0.003)
+    graphs = {}
+    freeze_kernel_resolution("lagged MHC projection benchmark")
+    try:
+        for name, run in (("scalar", baseline), ("tensorcore", candidate)):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(5):
+                    run()
+            graphs[name] = graph
+        samples = {name: [] for name in graphs}
+        for repeat in range(7):
+            order = ("scalar", "tensorcore") if repeat % 2 else ("tensorcore", "scalar")
+            for name in order:
+                graphs[name].replay()
+                start, end = (
+                    torch.cuda.Event(enable_timing=True),
+                    torch.cuda.Event(enable_timing=True),
+                )
+                start.record()
+                for _ in range(10):
+                    graphs[name].replay()
+                end.record()
+                end.synchronize()
+                samples[name].append(start.elapsed_time(end) * 20)
+        print(
+            json.dumps(
+                {
+                    "rows": rows,
+                    "projection_k_splits": config.projection_k_splits,
+                    "max_abs_error": errors,
+                    "fp64_comparison": precision,
+                    "samples_us": samples,
+                    "median_us": {
+                        name: statistics.median(values)
+                        for name, values in samples.items()
+                    },
+                }
+            ),
+            flush=True,
+        )
+    finally:
+        unfreeze_kernel_resolution()

--- a/benchmarks/benchmark_mxfp4_indexer_score.py
+++ b/benchmarks/benchmark_mxfp4_indexer_score.py
@@ -1,0 +1,100 @@
+"""Compare staged scalar and BF16 tensor-core MXFP4 paged scoring.
+
+Both public plans read identical quantized operands and paged metadata. CUDA
+graphs exclude Python overhead; score output must be bitwise equal before any
+timing is reported. Selection and tensor-parallel communication are excluded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+
+import torch
+
+from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.attention import dsa_indexer as api
+
+
+def measure(rows: int, width: int, heads: int, repeats: int) -> dict:
+    device = torch.device("cuda", torch.cuda.current_device())
+    torch.manual_seed(4132)
+    q = torch.randn((rows, heads, 128), device=device).bfloat16()
+    keys = torch.randn((width, 128), device=device).bfloat16()
+    weights = torch.randn((rows, heads), device=device).bfloat16() / 64
+    pages = (width + 63) // 64
+    physical = torch.randperm(pages, device=device).int() + 7
+    pool = torch.empty((pages + 7, api.index_mxfp4_page_bytes()), device=device, dtype=torch.uint8)
+    positions = torch.arange(width, device=device)
+    slots = physical[positions // 64].long() * 64 + positions % 64
+    api.quantize_write_index_k_mxfp4(keys, index_k_cache=pool, slot_mapping=slots)
+    packed = torch.empty((rows, heads, 64), device=device, dtype=torch.uint8)
+    scales = torch.empty((rows, heads, 4), device=device, dtype=torch.uint8)
+    api.quantize_q_mxfp4(q, q_mxfp4=packed, q_scales=scales)
+    shared = dict(
+        q_mxfp4=packed, q_scales=scales, query_weights=weights,
+        index_k_cache=pool, page_table=physical[None],
+        cache_lengths=torch.full((rows,), width, device=device, dtype=torch.int32),
+        active_width=torch.tensor([width], device=device, dtype=torch.int32),
+        output_indices=torch.empty((rows, 512), device=device, dtype=torch.int32),
+    )
+    bindings = {}
+    for mode in ("decode", "prefill"):
+        plan = api.plan(api.Caps(
+            device=device, num_q_heads=heads, max_q_rows=max(256, rows),
+            max_page_table_width=pages, topk=512, cache_format="mxfp4", mode=mode,
+        ))
+        (spec,) = plan.scratch_specs()
+        scratch = torch.empty(spec.shape, dtype=spec.dtype, device=device)
+        bindings[mode] = api.bind(plan, scratch=scratch, **shared)
+    expected = api.score(bindings["decode"]).clone()
+    actual = api.score(bindings["prefill"])
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    graphs = {}
+    freeze_kernel_resolution("MXFP4 score benchmark fixed-capacity replay")
+    try:
+        for mode, binding in bindings.items():
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(10):
+                    api.score(binding)
+            graphs[mode] = graph
+        samples = {mode: [] for mode in bindings}
+        for repeat in range(repeats):
+            order = ("decode", "prefill") if repeat % 2 else ("prefill", "decode")
+            for mode in order:
+                graphs[mode].replay()
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                for _ in range(10):
+                    graphs[mode].replay()
+                end.record()
+                end.synchronize()
+                samples[mode].append(start.elapsed_time(end) * 10)
+        return {
+            "rows": rows, "keys": width, "heads": heads,
+            "device": torch.cuda.get_device_name(device),
+            "score_bitwise_equal": True, "samples_us": samples,
+            "median_us": {mode: statistics.median(values) for mode, values in samples.items()},
+            "scalar_over_tensorcore": statistics.median(samples["decode"]) / statistics.median(samples["prefill"]),
+        }
+    finally:
+        unfreeze_kernel_resolution()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, nargs="+", default=[64, 256])
+    parser.add_argument("--keys", type=int, nargs="+", default=[4096, 8192, 16384])
+    parser.add_argument("--heads", type=int, default=8)
+    parser.add_argument("--repeats", type=int, default=7)
+    args = parser.parse_args()
+    for rows in args.rows:
+        for width in args.keys:
+            print(json.dumps(measure(rows, width, args.heads, args.repeats)), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_v41_mla_mixed.py
+++ b/benchmarks/benchmark_v41_mla_mixed.py
@@ -1,0 +1,75 @@
+"""Graph timings for native full-post-RoPE FP8/FP4 sparse MLA.
+
+Use identical arguments, device clocks and this file across source revisions.
+The KV inputs retain the mixed cache ABI; this is a kernel microbenchmark,
+not a serving-throughput measurement.
+"""
+
+import json
+import statistics
+
+import torch
+
+from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+from b12x.attention import compressed_sparse_mla as mla
+from b12x.attention._shared.mla.compressed_reference import (
+    pack_deepseek_v41_cache_reference,
+)
+
+torch.manual_seed(41512)
+device = torch.device("cuda", torch.cuda.current_device())
+page, pool = 64, 32768
+cache_values = torch.randn((pool, 512), device=device, dtype=torch.bfloat16) / 3
+swa = pack_deepseek_v41_cache_reference(cache_values, page_size=page, cache_kind="swa")
+indexed = pack_deepseek_v41_cache_reference(cache_values, page_size=page, cache_kind="indexed")
+for mode, rows in (("decode", 1), ("decode", 8), ("extend", 64), ("extend", 1024)):
+    q = torch.randn((rows, 16, 512), device=device, dtype=torch.bfloat16) / 3
+    swa_indices = torch.randint(pool, (rows, 128), device=device, dtype=torch.int32)
+    indices = torch.randint(pool, (rows, 512), device=device, dtype=torch.int32)
+    swa_lengths = torch.full((rows,), 128, device=device, dtype=torch.int32)
+    lengths = torch.full((rows,), 512, device=device, dtype=torch.int32)
+    table = torch.arange(pool // page, device=device, dtype=torch.int32)[None].expand(rows, -1).contiguous()
+    plan = mla.plan(mla.Caps(
+        device=device, num_q_heads=16, max_q_rows=1024, max_width=640,
+        swa_width=128, indexed_width=512, max_page_table_width=pool // page,
+        swa_page_size=page, indexed_page_size=page,
+        cache_format="deepseek_v41", mode=mode, max_chunks_per_row=4,
+        use_cuda_graph=True,
+    ))
+    (spec,) = plan.scratch_specs()
+    scratch = torch.empty(spec.shape, dtype=spec.dtype, device=device)
+    binding = plan.bind(scratch=scratch, q=q, swa_indices=swa_indices,
+                       swa_lengths=swa_lengths, indexed_indices=indices,
+                       indexed_lengths=lengths, indexed_page_table=table)
+    out = torch.empty_like(q)
+
+    def run():
+        return mla.run(binding=binding, swa_k_cache=swa, swa_page_size=page,
+                       indexed_k_cache=indexed, indexed_page_size=page,
+                       sm_scale=512 ** -0.5, out=out)
+
+    run()
+    torch.cuda.synchronize()
+    assert bool(torch.isfinite(out).all())
+    freeze_kernel_resolution("native mixed MLA graph benchmark")
+    try:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for _ in range(5):
+                run()
+        samples = []
+        for _ in range(7):
+            graph.replay()
+            start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(10):
+                graph.replay()
+            end.record()
+            end.synchronize()
+            samples.append(start.elapsed_time(end) * 20)
+        print(json.dumps({"mode": mode, "rows": rows, "heads": 16,
+                          "samples_us": samples, "median_us": statistics.median(samples),
+                          "output_sum": float(out.float().sum()),
+                          "output_square_sum": float(out.float().square().sum())}), flush=True)
+    finally:
+        unfreeze_kernel_resolution()

--- a/tests/attention/test_dsa_indexer_mxfp4.py
+++ b/tests/attention/test_dsa_indexer_mxfp4.py
@@ -58,6 +58,7 @@ def _allocate(
     max_rows=None,
     page_order=None,
     page_size=64,
+    mode="decode",
 ):
     device = q.device
     rows, heads, _ = q.shape
@@ -90,6 +91,7 @@ def _allocate(
             max_candidates=max_candidates,
             candidate_topk_blocks=2048 if source else 0,
             page_size=page_size,
+            mode=mode,
         )
     )
     (spec,) = plan.scratch_specs()
@@ -141,7 +143,8 @@ def _assert_topk(scores, output, output_scores, logical_positions=None):
 
 
 @pytest.mark.parametrize("page_size", [64, 128, 256])
-def test_per_group_quantization_and_permuted_high_page_writer(page_size):
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_per_group_quantization_and_permuted_high_page_writer(page_size, mode):
     torch.manual_seed(128)
     device = torch.device("cuda")
     q = torch.randn((2, 4, 128), device=device, dtype=torch.bfloat16)
@@ -161,7 +164,7 @@ def test_per_group_quantization_and_permuted_high_page_writer(page_size):
     width = 2 * page_size + 2
     keys = torch.randn((width, 128), device=device, dtype=torch.bfloat16)
     lengths = torch.tensor([0, width - 1], dtype=torch.int32, device=device)
-    plan, args = _allocate(q, keys, lengths, high_pages=True, page_size=page_size)
+    plan, args = _allocate(q, keys, lengths, high_pages=True, page_size=page_size, mode=mode)
     packed, scales, _ = _oracle_quant(q)
     torch.testing.assert_close(args["q_mxfp4"], packed)
     torch.testing.assert_close(args["q_scales"], scales)
@@ -190,14 +193,15 @@ def test_per_group_quantization_and_permuted_high_page_writer(page_size):
     _assert_topk(expected, args["output_indices"], args["output_scores"])
 
 
-def test_bf16_stages_and_tp_reduce_before_selection():
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_bf16_stages_and_tp_reduce_before_selection(mode):
     torch.manual_seed(555)
     device = torch.device("cuda")
     q = torch.randn((2, 4, 128), dtype=torch.bfloat16, device=device)
     keys = torch.randn((768, 128), dtype=torch.bfloat16, device=device)
     weights = torch.randn((2, 4), dtype=torch.bfloat16, device=device) / 64
     lengths = torch.tensor([768, 517], dtype=torch.int32, device=device)
-    plan, args = _allocate(q, keys, lengths)
+    plan, args = _allocate(q, keys, lengths, mode=mode)
     binding = api.bind(plan, query_weights=weights, **args)
     scores = api.score(binding)
     expected = _oracle_scores(q, keys, weights)
@@ -213,14 +217,130 @@ def test_bf16_stages_and_tp_reduce_before_selection():
     _assert_topk(expected, args["output_indices"], args["output_scores"])
 
 
-def test_source_blockmax_newest_and_bounded_candidate_reindex():
+@pytest.mark.parametrize("source", [False, True])
+@pytest.mark.parametrize("high_pages", [False, True])
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_compact_score_extent_preserves_selection_and_frozen_replay(source, high_pages, mode):
+    """Invisible capacity columns must not be required by score or selection."""
+    torch.manual_seed(4141)
+    device = torch.device("cuda")
+    q = torch.randn((3, 8, 128), dtype=torch.bfloat16, device=device)
+    keys = torch.randn((2048, 128), dtype=torch.bfloat16, device=device)
+    weights = torch.randn((3, 8), dtype=torch.bfloat16, device=device) / 64
+    lengths = torch.tensor([641, 517, 12], dtype=torch.int32, device=device)
+    plan, args = _allocate(q, keys, lengths, source=source, high_pages=high_pages, mode=mode)
+    full = api.bind(plan, query_weights=weights, **args)
+    expected_scores = api.score(full).clone()
+    api.select(full)
+    expected_indices = args["output_indices"].clone()
+    expected_values = args["output_scores"].clone()
+    expected_candidates = args["candidate_output"].clone() if source else None
+    expected_lengths = args["candidate_output_lengths"].clone() if source else None
+    freeze_kernel_resolution("MXFP4 compact score extent replay")
+    try:
+        for width in (641, 768, 1024):
+            binding = api.bind(plan, query_weights=weights, score_width=width, **args)
+            scores = api.score(binding)
+            assert scores.shape == (3, width) and scores.is_contiguous()
+            torch.testing.assert_close(scores, expected_scores[:, :width], rtol=0, atol=0)
+            api.select(binding)
+            torch.testing.assert_close(args["output_indices"], expected_indices, rtol=0, atol=0)
+            torch.testing.assert_close(args["output_scores"], expected_values, rtol=0, atol=0)
+            if source:
+                torch.testing.assert_close(args["candidate_output"], expected_candidates, rtol=0, atol=0)
+                torch.testing.assert_close(args["candidate_output_lengths"], expected_lengths, rtol=0, atol=0)
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                api.score(binding)
+                api.select(binding)
+            torch.cuda.current_stream().wait_stream(stream)
+            args["scratch"].fill_(0xA5)
+            graph.replay()
+            torch.testing.assert_close(args["output_indices"], expected_indices, rtol=0, atol=0)
+    finally:
+        unfreeze_kernel_resolution()
+
+
+@pytest.mark.parametrize("width,exception", [(0, ValueError), (-1, ValueError),
+                                           (1025, ValueError), (False, TypeError),
+                                           (512.0, TypeError)])
+def test_compact_score_extent_rejects_invalid_reservations(width, exception):
+    q = torch.zeros((1, 8, 128), dtype=torch.bfloat16, device="cuda")
+    keys = torch.zeros((1024, 128), dtype=torch.bfloat16, device="cuda")
+    lengths = torch.tensor([1024], dtype=torch.int32, device="cuda")
+    plan, args = _allocate(q, keys, lengths)
+    weights = torch.ones((1, 8), dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(exception, match="score_width"):
+        api.bind(plan, query_weights=weights, score_width=width, **args)
+
+
+@pytest.mark.parametrize("heads", [1, 2, 4, 8, 16, 32])
+@pytest.mark.parametrize("high_pages", [False, True])
+def test_tensorcore_prefill_preserves_bf16_scores_and_selection(heads, high_pages):
+    torch.manual_seed(41016 + heads)
+    q = torch.randn((3, heads, 128), device="cuda", dtype=torch.bfloat16)
+    keys = torch.randn((768, 128), device="cuda", dtype=torch.bfloat16)
+    weights = torch.randn((3, heads), device="cuda", dtype=torch.bfloat16) / 64
+    lengths = torch.tensor([768, 531, 0], device="cuda", dtype=torch.int32)
+    plan, args = _allocate(q, keys, lengths, high_pages=high_pages, max_rows=256)
+    scalar = api.bind(plan, query_weights=weights, **args)
+    expected = api.score(scalar).clone()
+    tensorcore = api.plan(api.Caps(
+        device=q.device, num_q_heads=heads, max_q_rows=256,
+        max_page_table_width=12, topk=512, cache_format="mxfp4",
+        mode="prefill",
+    ))
+    binding = api.bind(tensorcore, query_weights=weights, **args)
+    actual = api.score(binding)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    api.select(binding)
+    _assert_topk(expected, args["output_indices"], args["output_scores"])
+
+
+@pytest.mark.parametrize("exponents", [(-40, -4, 6, 40), (-6, -2, 3, 7)])
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_varied_scales_preserve_staged_rounding_against_fp64(exponents, mode):
+    """Use FP64 dots so the oracle does not lose opposed exponent products.
+
+    A BF16 einsum differs from the FP64 dot rounded to BF16 at 130 output
+    positions in the opposed-exponent fixture. Both scoring kernels must
+    preserve the explicit BF16 stage boundaries and ordered FP32 head sum.
+    """
+    torch.manual_seed(41081)
+    scales = torch.exp2(torch.tensor(exponents, device="cuda", dtype=torch.float32))
+    q = (torch.randn((9, 8, 4, 32), device="cuda") * scales[None, None, :, None]).bfloat16().view(9, 8, 128)
+    keys = (torch.randn((641, 4, 32), device="cuda") / scales[None, :, None]).bfloat16().view(641, 128)
+    weights = torch.randn((9, 8), device="cuda").bfloat16() / 64
+    lengths = torch.tensor([0, 1, 63, 64, 65, 127, 512, 640, 641], device="cuda", dtype=torch.int32)
+    plan, args = _allocate(q, keys, lengths, mode=mode)
+    _, _, dq = _oracle_quant(q)
+    _, _, dk = _oracle_quant(keys)
+    dot = torch.einsum("rhd,kd->rhk", dq.double(), dk.double()).bfloat16()
+    products = (dot.relu() * weights[:, :, None]).float()
+    total = torch.zeros((9, 641), device="cuda")
+    for head in range(8):
+        total += products[:, head]
+    expected = total.bfloat16()
+    expected.masked_fill_(torch.arange(641, device="cuda")[None] >= lengths[:, None], -torch.inf)
+    binding = api.bind(plan, query_weights=weights, **args)
+    actual = api.score(binding)
+    torch.testing.assert_close(actual[:, :641], expected, rtol=0, atol=0)
+    assert bool(torch.isneginf(actual[:, 641:]).all())
+    api.select(binding)
+    _assert_topk(expected, args["output_indices"], args["output_scores"])
+
+
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_source_blockmax_newest_and_bounded_candidate_reindex(mode):
     torch.manual_seed(2048)
     device = torch.device("cuda")
     width = 16448  # More than 2048 blocks; the newest visible block is partial.
     q = torch.ones((3, 4, 128), dtype=torch.bfloat16, device=device)
     keys = torch.ones((width, 128), dtype=torch.bfloat16, device=device)
     lengths = torch.tensor([0, 9, 16441], dtype=torch.int32, device=device)
-    plan, args = _allocate(q, keys, lengths, source=True)
+    plan, args = _allocate(q, keys, lengths, source=True, mode=mode)
     binding = api.bind(
         plan,
         query_weights=torch.ones((3, 4), dtype=torch.bfloat16, device=device),
@@ -254,7 +374,7 @@ def test_source_blockmax_newest_and_bounded_candidate_reindex():
     # Reindex uses its own Q/weights and cannot read the excluded positions.
     rq = torch.randn_like(q)
     weights = torch.randn((3, 4), dtype=torch.bfloat16, device=device) / 64
-    rplan, rargs = _allocate(rq, keys, lengths, max_candidates=16384)
+    rplan, rargs = _allocate(rq, keys, lengths, max_candidates=16384, mode=mode)
     rargs.update(candidate_indices=candidates, candidate_lengths=candidate_lengths)
     reindex = api.bind(rplan, query_weights=weights, **rargs)
     rescored = api.score(reindex)
@@ -267,12 +387,13 @@ def test_source_blockmax_newest_and_bounded_candidate_reindex():
 
 
 @pytest.mark.parametrize("page_size", [64, 128, 256])
-def test_fixed_graph_buffers_multiple_live_rows_and_visibility(page_size):
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_fixed_graph_buffers_multiple_live_rows_and_visibility(page_size, mode):
     device = torch.device("cuda")
     q = torch.ones((4, 4, 128), dtype=torch.bfloat16, device=device)
     keys = torch.ones((256, 128), dtype=torch.bfloat16, device=device)
     lengths = torch.tensor([0, 1, 63, 256], dtype=torch.int32, device=device)
-    plan, args = _allocate(q, keys, lengths, max_candidates=128, page_size=page_size)
+    plan, args = _allocate(q, keys, lengths, max_candidates=128, page_size=page_size, mode=mode)
     candidates = (
         torch.arange(128, device=device, dtype=torch.int32).expand(4, -1).contiguous()
     )

--- a/tests/attention/test_v41_mixed_dequant.py
+++ b/tests/attention/test_v41_mixed_dequant.py
@@ -1,0 +1,88 @@
+"""Native mixed-cache staging must preserve the FP4/FP8 dequantization contract."""
+
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Uint32
+from cutlass.utils import SmemAllocator
+import pytest
+import torch
+
+from b12x._lib.compiler import compile as compile_kernel
+from b12x._lib.intrinsics import shared_ptr_to_u32
+from b12x._lib.utils import current_cuda_stream, make_ptr
+from b12x.attention._shared.mla.decode_math import _nvfp4_pair_bfloat2
+from tests._reference.helpers import require_b12x
+
+
+class StagedMixedPair:
+    """Exercise source tags and byte offsets through the production helper."""
+
+    @cute.jit
+    def __call__(self, q: cute.Pointer, sf: cute.Pointer,
+                 tag: cute.Pointer, out: cute.Pointer, stream):
+        self.kernel(q, sf, tag, out).launch(
+            grid=(2048, 1, 1), block=(32, 1, 1), stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, q: cute.Pointer, sf: cute.Pointer,
+               tag: cute.Pointer, out: cute.Pointer):
+        lane = Int32(cute.arch.thread_idx()[0])
+        i = Int64(cute.arch.block_idx()[0]) * Int64(32) + lane
+        staging = SmemAllocator().allocate_tensor(
+            Uint32, cute.make_layout(32 * 136), 16,
+        )
+        staging[lane * 136] = q[i]
+        staging[lane * 136 + 64] = sf[i]
+        staging[lane * 136 + 128] = sf[i]
+        staging[lane * 136 + 132] = tag[i]
+        cute.arch.sync_threads()
+        out[i] = _nvfp4_pair_bfloat2(
+            shared_ptr_to_u32(staging.iterator), lane, Int32(0), Float32(17.0),
+            kv_smem_stride=544,
+        )
+
+
+@pytest.mark.parametrize("source", ["indexed", "swa", "invalid"])
+def test_staged_pairs_exhaustive_and_graph_mutation(source):
+    """All scale bytes, including UE8M0 zero/subnormals/NaN, match FP64."""
+    require_b12x()
+    codes = torch.arange(256, device="cuda", dtype=torch.int64).repeat(256)
+    scales = torch.arange(256, device="cuda", dtype=torch.int64).repeat_interleave(256)
+    if source == "indexed":
+        lut = torch.tensor(
+            [0, .5, 1, 1.5, 2, 3, 4, 6, -0.0, -.5, -1, -1.5, -2, -3, -4, -6],
+            device="cuda", dtype=torch.float64,
+        )
+        values = torch.stack((lut[codes & 15], lut[codes >> 4]), -1)
+        factors = scales.to(torch.uint8).view(torch.float8_e4m3fn).double()
+        packed = codes
+        source_tag = 0
+    else:
+        values = torch.stack((codes, 255 - codes), -1).to(torch.uint8)
+        values = values.view(torch.float8_e4m3fn).double()
+        factors = torch.exp2(scales.double() - 127)
+        factors[scales == 255] = float("nan")
+        packed = codes | ((255 - codes) << 8)
+        source_tag = 1 if source == "swa" else 2
+    expected = (values * factors[:, None]).to(torch.bfloat16)
+    if source == "invalid":
+        expected.zero_()
+    packed = packed.to(torch.uint32)
+    scales = scales.to(torch.uint32)
+    tags = torch.full_like(scales, source_tag)
+    output = torch.empty_like(expected)
+    pointers = [
+        make_ptr(Uint32, t.data_ptr(), cute.AddressSpace.gmem, assumed_align=16)
+        for t in (packed, scales, tags, output)
+    ]
+    fn = compile_kernel(StagedMixedPair(), *pointers, current_cuda_stream())
+    fn(*pointers, current_cuda_stream())
+    torch.testing.assert_close(output, expected, rtol=0, atol=0, equal_nan=True)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn(*pointers, current_cuda_stream())
+    # Invalid source rows must become zero even when their payload contains NaNs.
+    tags.fill_(2)
+    output.fill_(float("nan"))
+    graph.replay()
+    torch.testing.assert_close(output, torch.zeros_like(output), rtol=0, atol=0)

--- a/tests/comm/test_pcie_dma_gpu.py
+++ b/tests/comm/test_pcie_dma_gpu.py
@@ -149,6 +149,17 @@ def _worker(rank: int, world_size: int, port: int) -> None:
                 )
                 ring.prepare_eager_replay(dtype, max_elements=planned_elements)
                 ring.prepare_eager_replay(dtype, max_elements=planned_elements)
+                replays = ring._eager_replays[dtype]
+                assert replays[-1][0].numel() == planned_elements
+                assert (
+                    len({item[0].untyped_storage().data_ptr() for item in replays}) == 1
+                )
+                capacities = [item[0].numel() * dtype.itemsize for item in replays]
+                assert capacities == (
+                    [1 << 20, 2 << 20, 3 << 20]
+                    if dtype.itemsize == 2
+                    else [1 << 20, 2 << 20, 4 << 20, 6 << 20]
+                )
                 with pytest.raises(ValueError):
                     ring.prepare_eager_replay(
                         dtype, max_elements=planned_elements + alignment

--- a/tests/comm/test_pcie_dma_mode.py
+++ b/tests/comm/test_pcie_dma_mode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from b12x.comm.pcie.pcie_dma import _normalize_fp8_mode
+from b12x.comm.pcie.pcie_dma import _eager_replay_capacities, _normalize_fp8_mode
 
 
 @pytest.mark.parametrize("value", [None, "", "0", "false", "off", "no"])
@@ -64,3 +64,45 @@ def test_supported_wire_mode_aliases(value: str, expected: str) -> None:
 def test_unknown_wire_mode_is_rejected() -> None:
     with pytest.raises(ValueError, match="unrecognized PCIe DMA wire mode"):
         _normalize_fp8_mode("mx_rnig")
+
+
+@pytest.mark.parametrize("world_size", [2, 4, 6, 8, 10])
+@pytest.mark.parametrize("itemsize", [2, 4])
+@pytest.mark.parametrize(
+    "min_bytes,max_bytes", [(0, 4096), (0, 12 << 20), (6 << 20, 40 << 20)]
+)
+def test_eager_capacities_preserve_shard_alignment(
+    world_size, itemsize, min_bytes, max_bytes
+):
+    capacities = _eager_replay_capacities(max_bytes, min_bytes, itemsize, world_size)
+    multiple = world_size * 8
+    assert capacities == tuple(sorted(set(capacities)))
+    assert all(value > 0 and value % multiple == 0 for value in capacities)
+    assert capacities[-1] == max_bytes // itemsize // multiple * multiple
+    for smaller, larger in zip(capacities, capacities[1:], strict=False):
+        assert larger <= 2 * smaller + multiple
+
+
+def test_eager_capacity_rejects_less_than_one_shard_vector():
+    with pytest.raises(ValueError, match="too small"):
+        _eager_replay_capacities(63, 0, 2, 4)
+
+
+@pytest.mark.parametrize("itemsize", [2, 4])
+def test_eager_dtype_bound_retains_intermediate_capacity_plans(itemsize):
+    elements = 4096 * 5120
+    capacities = _eager_replay_capacities(
+        elements * 4, 6 << 20, itemsize, 4, max_elements=elements
+    )
+    assert capacities[-1] == elements
+    assert tuple(capacity * itemsize for capacity in capacities) == (
+        (8 << 20, 16 << 20, 32 << 20, 40 << 20)
+        if itemsize == 2
+        else (8 << 20, 16 << 20, 32 << 20, 64 << 20, 80 << 20)
+    )
+
+
+@pytest.mark.parametrize("elements", [0, -1, 1025])
+def test_eager_dtype_bound_rejects_invalid_limits(elements):
+    with pytest.raises(ValueError, match="dtype capacity"):
+        _eager_replay_capacities(4096, 0, 4, 4, max_elements=elements)

--- a/tests/gemm/test_bf16_gemv.py
+++ b/tests/gemm/test_bf16_gemv.py
@@ -151,6 +151,61 @@ def test_unquantized_bias_and_live_rows_reuse_native_graph(
 
 
 @cuda_required
+@pytest.mark.parametrize("n", [384, 512, 1024])
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float32])
+def test_prefill_projection_reuses_warm_kernel_and_preserves_live_graph_inputs(
+    n,
+    output_dtype,
+):
+    """Both dispatch regimes share an unquantized contract and caller ownership."""
+    from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+    from b12x.gemm import bf16_gemv
+
+    torch.manual_seed(415122)
+    capacity, k = 4096, 5120
+    source = torch.randn(capacity, k, device="cuda").bfloat16()
+    weight = (torch.randn(n, k, device="cuda") / k**0.5).bfloat16()
+    output = torch.empty(capacity, n, device="cuda", dtype=output_dtype)
+    source_copy, weight_copy = source.clone(), weight.clone()
+    bf16_gemv.precompile(weight, output_dtype=output_dtype)
+    freeze_kernel_resolution("BF16 prefill and scalar projection row coverage")
+    try:
+        for rows in (1, 17, 255, 256, 513, capacity):
+            output.fill_(float("nan"))
+            bf16_gemv.mm(source[:rows], weight, out=output[:rows])
+            expected = source[:rows].double() @ weight.double().T
+            if output_dtype == torch.float32:
+                torch.testing.assert_close(
+                    output[:rows].double(), expected, atol=1e-6, rtol=1e-6
+                )
+            else:
+                torch.testing.assert_close(
+                    output[:rows].double(), expected, atol=0.004, rtol=0.004
+                )
+            assert torch.isnan(output[rows:]).all()
+        torch.testing.assert_close(source, source_copy, atol=0, rtol=0)
+        torch.testing.assert_close(weight, weight_copy, atol=0, rtol=0)
+        output.fill_(float("nan"))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            bf16_gemv.mm(source[:513], weight, out=output[:513])
+        source.mul_(0.5)
+        weight.mul_(0.25)
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = source[:513].double() @ weight.double().T
+        torch.testing.assert_close(
+            output[:513].double(),
+            expected,
+            atol=1e-6 if output_dtype == torch.float32 else 0.004,
+            rtol=1e-6 if output_dtype == torch.float32 else 0.004,
+        )
+        assert torch.isnan(output[513:]).all()
+    finally:
+        unfreeze_kernel_resolution()
+
+
+@cuda_required
 @pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("m,n,k", [(257, 2048, 1024), (129, 1025, 513)])
 def test_broad_bf16_projection(output_dtype, m, n, k):
@@ -281,6 +336,41 @@ def test_precompile_covers_live_rows_and_strides_under_freeze(output_dtype):
         )
     finally:
         unfreeze_kernel_resolution()
+
+
+@cuda_required
+def test_prefill_router_topk_agrees_with_fp64_and_scalar_projection():
+    """A 384-expert router keeps the same six selected expert identifiers."""
+    from b12x.gemm import bf16_gemv
+    from b12x.gemm.bf16_gemv._kernel import _launch_scalar
+
+    torch.manual_seed(415123)
+    source = torch.randn(4096, 5120, device="cuda").bfloat16()
+    weight = (torch.randn(384, 5120, device="cuda") / 5120**0.5).bfloat16()
+    scalar = torch.empty(4096, 384, device="cuda")
+    _launch_scalar(source, weight, scalar)
+    result = bf16_gemv.mm(source, weight, output_dtype=torch.float32)
+    oracle = source.double() @ weight.double().T
+    for value in (scalar, result):
+        torch.testing.assert_close(value.double(), oracle, rtol=1e-6, atol=1e-6)
+        assert torch.equal(
+            value.topk(6, dim=-1).indices, oracle.topk(6, dim=-1).indices
+        )
+
+
+@cuda_required
+def test_prefill_projection_retains_small_terms_between_cancelling_large_terms():
+    """Compensated carry preserves exact representable BF16 products in FP32."""
+    from b12x.gemm import bf16_gemv
+
+    source = torch.ones(256, 5120, device="cuda", dtype=torch.bfloat16)
+    weight = torch.zeros(512, 5120, device="cuda", dtype=torch.bfloat16)
+    weight[:, ::32] = 1024
+    weight[:, 1::32] = 0.015625
+    weight[:, 31::32] = -1024
+    result = bf16_gemv.mm(source, weight, output_dtype=torch.float32)
+    expected = source.double() @ weight.double().T
+    torch.testing.assert_close(result.double(), expected, atol=0, rtol=0)
 
 
 @cuda_required

--- a/tests/norm/test_mhc.py
+++ b/tests/norm/test_mhc.py
@@ -439,7 +439,8 @@ def test_mhc_lagged_rounded_variance_and_ownership():
 
 @pytest.mark.parametrize(
     ("phase", "capacity", "fuse_norm"),
-    [("pre", 17, False), ("pre", 17, True), ("post_pre", 17, True), ("post_pre", 389, True)],
+    [("pre", 17, False), ("pre", 17, True), ("pre", 389, True),
+     ("post_pre", 17, True), ("post_pre", 389, True)],
 )
 def test_mhc_lagged_frozen_multilive_graph(phase, capacity, fuse_norm, request):
     from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
@@ -506,6 +507,101 @@ def test_mhc_lagged_frozen_multilive_graph(phase, capacity, fuse_norm, request):
         for got, want in zip((*actual[1:], predicted[:live]), expected, strict=True):
             torch.testing.assert_close(got, want, rtol=2e-5, atol=0.008 if got.dtype == torch.bfloat16 else 4e-5)
         assert bool(torch.isnan(predicted[live:]).all())
+
+
+def test_lagged_prefill_fp32_projection_precision():
+    """Tensor-core projection retains FP32 mixing coefficients at long K."""
+    device = require_sm120()
+    hidden, rows = 5120, 513
+    residual, _, fn, scale, bias = _make_inputs(
+        tokens=rows, hidden_size=hidden, seed=415120, device=device
+    )
+    incoming = torch.full((rows, 4), 0.25, device=device)
+    weight = torch.ones(hidden, dtype=torch.bfloat16, device=device)
+    plan = mhc.plan(mhc.Caps(device=device, max_tokens=4096, hidden_size=hidden))
+    assert plan.config.backend == "tf32_tma"
+    scratch = tuple(torch.empty(shape, dtype=dtype, device=device)
+                    for shape, dtype in plan.shapes_and_dtypes())
+    predicted = torch.empty_like(incoming)
+    binding = mhc.bind(
+        plan, scratch=scratch, tokens=rows, pre_out=predicted,
+        y=torch.empty((rows, hidden), dtype=torch.bfloat16, device=device),
+        out=torch.empty_like(residual), post=torch.empty_like(incoming),
+        comb=torch.empty((rows, 4, 4), device=device),
+    )
+    _, post, _, _ = mhc.run_pre(
+        residual, fn, scale, bias, binding=binding,
+        pre_mix=incoming, norm_weight=weight, norm_eps=1e-20,
+        rms_eps=1e-20, hc_eps=1e-6, sinkhorn_iters=20,
+    )
+    flat = residual.flatten(1).double()
+    mixes = (flat @ fn.double().T) * torch.rsqrt(
+        flat.square().mean(dim=-1, keepdim=True) + 1e-20
+    )
+    expected = 2 * torch.sigmoid(mixes[:, 4:8] * scale.double()[1] + bias.double()[4:8])
+    torch.testing.assert_close(post.double(), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_lagged_prefill_scalar_parity_graph(request):
+    """Projection changes preserve scalar BF16 rounding and fixed-capacity replay.
+
+    The scalar finalizer defines BF16 normalization rounding. Independent Torch
+    norm reductions can straddle a BF16 midpoint; strict scalar parity prevents
+    a projection optimization from changing that rounding contract.
+    """
+    from dataclasses import replace
+    from b12x import freeze_kernel_resolution, unfreeze_kernel_resolution
+
+    device = require_sm120()
+    hidden, capacity = 5120, 4096
+    residual, x, fn, scale, bias = _make_inputs(
+        tokens=capacity, hidden_size=hidden, seed=92152, device=device
+    )
+    incoming = torch.zeros((capacity, 4), device=device)
+    incoming[:, 0] = 1
+    weight = torch.ones(hidden, dtype=torch.bfloat16, device=device)
+    plan = mhc.plan(mhc.Caps(device=device, max_tokens=capacity, hidden_size=hidden))
+    native = replace(plan, config=replace(plan.config, backend="native"))
+    bindings = []
+    for selected in (plan, native):
+        scratch = tuple(torch.empty(shape, dtype=dtype, device=device)
+                        for shape, dtype in selected.shapes_and_dtypes())
+        bindings.append(mhc.bind(
+            selected, scratch=scratch, out=torch.empty_like(residual),
+            y=torch.empty_like(x), pre_out=torch.empty_like(incoming),
+            post=torch.empty_like(incoming),
+            comb=torch.empty((capacity, 4, 4), device=device),
+        ))
+
+    def run(binding, live):
+        return mhc.run_pre(
+            residual[:live], fn, scale, bias, binding=binding,
+            pre_mix=incoming[:live], norm_weight=weight, norm_eps=1e-20,
+            rms_eps=1e-20, hc_eps=1e-6, sinkhorn_iters=20,
+        )
+
+    for binding in bindings:
+        run(binding, capacity)
+    torch.cuda.synchronize(device)
+    request.addfinalizer(unfreeze_kernel_resolution)
+    freeze_kernel_resolution("lagged prefill scalar parity")
+    for live in (3, capacity - 1, capacity):
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = run(bindings[0], live)
+        incoming.copy_(incoming.roll(1, dims=1))
+        for output in (*actual, bindings[0].pre_out):
+            output.fill_(float("nan"))
+        graph.replay()
+        expected = run(bindings[1], live)
+        torch.cuda.synchronize(device)
+        for got, want in zip((*actual, bindings[0].pre_out[:live]),
+                             (*expected, bindings[1].pre_out[:live]), strict=True):
+            if got.dtype == torch.bfloat16:
+                torch.testing.assert_close(got, want, rtol=0, atol=0)
+            else:
+                torch.testing.assert_close(got, want, rtol=2e-6, atol=2e-6)
+        assert bool(torch.isnan(bindings[0].pre_out[live:]).all())
 
 
 @pytest.mark.parametrize("hidden", [4096, 5120, 7168])


### PR DESCRIPTION
## Purpose

Accelerate native DeepSeek V4.1 packed index scoring and prefill projections while retaining caller-owned workspace, bounded plans and CUDA graph replay. The paired integration is **[vLLM #734](https://github.com/local-inference-lab/vllm/pull/734)**; merge B12X first, then vLLM. That PR includes the serving and benchmark reproduction parameters.

Status: implemented and qualified for the TP4/DCP1 DSpark K5 configuration below. **32K prefill improves by 16.5% in a matched A/B/A comparison. No stable decode-verifier speedup is established.** The measurement covers both repositories together, not B12X alone.

## Changes

| Operation | Resulting behavior |
|---|---|
| MXFP4 sparse index scoring | Packed tensor-core scoring with compact caller-owned score storage; retains the staged BF16 rounding contract and candidate/page addressing. |
| BF16 projection | Compensated tensor-core prefill for the supported projection geometries; keeps small decode plans and fixed-capacity replay. |
| Lagged multipath hyperconnection (MHC) prefill | Compensated projection with bounded FP32 accumulation. |
| Mixed FP4/FP8 attention-cache staging | Native paired conversion with source/scale, subnormal and special-value regression coverage. |
| PCIe DMA | Bounded capacity buckets per dtype; preparing FP32 communication does not double BF16 replay storage. |

No MoE, PDL, MHC profile, compiler, or external DeepGEMM/FlashInfer backend replacement is included. vLLM separately supplies replicated index heads, decode/prefill capacity selection and WO-A prefill dispatch.

## Measured serving result

Four RTX PRO 6000 Workstation GPUs on the **same physical quartet**, stock graphics/VRAM offsets, 600 W limits, PCIe Gen5 x16. TP4/DCP1 with expert parallelism, native DSpark K5/adaptive verification, scheduler budget **4096**, max sequences 4, temperature 1/top-p 0.95, greedy proposals and standard rejection. CUDA 13.3, PyTorch 2.13, CUTLASS DSL 4.6.2, full-and-piecewise graphs; strict runtime JIT error mode.

Both arms use the same compressed encoder-decoder (CED) algorithm and the same vLLM TP-confidence, verifier-capacity and sampler-warmup prerequisites. Reference B12X is unmodified `master` at `81544c5b76f869f2921b7f9f0438505846307f70`.

| Metric | Reference A | Optimized B | Reference return A |
|---|---:|---:|---:|
| 32K prefill, input tok/s | 10,539 median | 12,288 median | 10,548 |
| C1 output, 60-second control, tok/s | 130.118 | 147.400 | 133.196 |
| C1 verifier, 60-second control, steps/s | 52.417 | 51.767 | 51.978 |
| C1 output tokens per verifier step | 2.482 | 2.847 | 2.563 |

Prefill gain is **+16.60%** against A's initial median and **+16.50%** against the return control. Prefill means input tokens/client TTFT, not a sum of CUDA kernel times. Requests contain 32,770 tokens after the request envelope.

The C1 output difference accompanies different acceptance/adaptive work. Output tokens per step includes the bonus token. These samples do **not** establish a faster verifier or improved model quality. All measured requests completed without errors.

<details>
<summary>Raw samples and immutable comparison sources</summary>

After a 30-second prefill warmup, three 30-second measured cells:

- A prefill: 10,539 / 10,561 / 10,492 input tok/s.
- B prefill: 12,288 / 12,228 / 12,316 input tok/s.
- A return: separate warmup, then 10,548 input tok/s.

Three 30-second C1/context-0 cells, each requesting 15 seconds of warmup:

| Arm/repetition | Output tok/s | Verifier steps/s | Output tokens/step |
|---|---:|---:|---:|
| A1 | 120.879 | 50.686 | 2.385 |
| A2 | 117.650 | 51.022 | 2.306 |
| A3 | 58.224 | 25.944 | 2.244 |
| B1 | 121.217 | 53.974 | 2.246 |
| B2 | 122.364 | 54.099 | 2.262 |
| B3 | 138.617 | 52.619 | 2.634 |

A3 contains a low-utilization stall; it is retained, not silently removed. Another GPU quartet began loading a model during that cell, but timing overlap does not prove causation. The independent 60-second A/B/A controls above are why no decode-verifier improvement is claimed.

| Source | A | B |
|---|---|---|
| vLLM | `697c882788f482788eb1653cc7a8a07aec8d86f8` | `70e0633d7e79d5c072bc7d9e3c345d12bedae5a0` |
| B12X | `81544c5b76f869f2921b7f9f0438505846307f70` | `852303bca2e4f8b6f4bc520a63e3da9a5eda0727` |
| Local image ID | `sha256:211b85205b1fac083927560d536addea22524fe687b92835367b392ad08b6fb8` | `sha256:1be8ae355868f434b717f8c0973d6449dc39435125e2183174284efbbae2b784` |

All packaged Python sources match their Git exports; all ten compiled vLLM extensions and serving CLI/environment mappings match between arms. No serving source mounts. The shared runtime image ID is `sha256:7bef1371c96ad5e160ddf969d8a313c4659079930087ecab4f8ed8affaaa2a7b`; these are local research images, not published Docker tags.

The target is `deepseek-ai/DeepSeek-V4.1-Flash`, revision `fb2764a5cf321eaa5070ca8f9e892818f477c16d`. Native cache payloads are MXFP8 sliding-window and NVFP4 indexed KV despite the public `--kv-cache-dtype fp8` spelling. Engram tables use disk storage.

</details>

## Correctness validation

**202 B12X tests passed** in the exact optimized image; the paired vLLM workspace/binding suite passed **18 tests**. Coverage includes numerical projection oracles, packed index selection, graph replay with mutated inputs, frozen kernel resolution, poisoned storage, page byte offsets beyond 2 GiB, and dtype-specific DMA plan bounds.

Commands executed from the packaged B12X source with its isolated `/opt/venv/bin/python`:

```bash
export CUTE_DSL_ARCH=sm_120a OMP_NUM_THREADS=1
export NVIDIA_TF32_OVERRIDE=0 TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=0
/opt/venv/bin/python -m pytest -q \
  tests/attention/test_dsa_indexer_mxfp4.py \
  tests/attention/test_v41_mixed_dequant.py \
  tests/gemm/test_bf16_gemv.py \
  tests/norm/test_mhc.py \
  tests/comm/test_pcie_dma_mode.py
# 202 passed
```

The NVIDIA runtime forces TF32 in the nominally FP32 Torch MHC reference unless these **test-only** overrides are supplied. That reference fails in both A and B under the forced-TF32 environment. Restoring the FP32 oracle passes without changing kernel code or test tolerances; both serving environments remain identical and unchanged.

Both serving arms returned `703` for a deterministic `371 + 332` smoke request. This is not a quality benchmark. CED's bounded 128-row decoder replay intentionally differs from full-decoder prefill and is shared by both arms. Full-decoder quality parity, TP8, vision, 1M context and cache restore are **not qualified** by this PR.

## Review scope and credit

Open native-DS41/indexer/MHC/DMA PRs were checked before submission. This does not replace #281's eager-ring replay proposal, #310/#356's MHC scheduling policies, or #279's PDL work: it extends the native DS41 operations already present in the target master revision. No unrelated integration stack is included.

Luke Alonso's master history is retained. The exact measured implementation commit retains Martin Vit's authorship/sign-off and Codex co-authorship, with its component commit lineage recorded. AI assistance was used for implementation, analysis, testing and this description; publication was requested by Martin Vit for Luke's review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Accelerates native DeepSeek V4.1 prefill with tensor-core MXFP4 index scoring and compensated BF16 and TF32 projections.
- Adds mixed FP4/FP8 attention-cache dequantization with source-tag handling.
- Adds bounded, dtype-specific PCIe DMA replay capacities while preserving caller-owned buffers and CUDA graph replay.
- Preserves existing MoE, PDL, MHC policy, compiler, and external backend behavior.
- Adds benchmarks and coverage for accuracy, graph replay, capacity planning, mixed dequantization, and scalar parity.

## Validation

- B12X: 202 tests passed.
- Paired vLLM suite: 18 tests passed.
- Deterministic smoke requests returned `703` from both serving arms.
- Matched TP4/DCP1 DSpark K5 32K prefill increased from 10,548 to 12,288 input tokens/s, a reported 16.50% gain.
- No stable decode-verifier speedup was established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->