### PR TITLE
perf(engram): retain original scales and add bounded NVMe prefetch

### DIFF
--- a/b12x/sequence/_shared/disk_table.py
+++ b/b12x/sequence/_shared/disk_table.py
@@ -12,14 +12,18 @@ import operator
 import os
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, suppress
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import torch
-from cuda.bindings import runtime as cudart
+if TYPE_CHECKING:
+    from cuda.bindings import runtime as cudart
 
 
 def _check_cuda(error: cudart.cudaError_t, operation: str) -> None:
+    from cuda.bindings import runtime as cudart
+
     if error != cudart.cudaError_t.cudaSuccess:
         raise RuntimeError(f"{operation} failed: {error}")
 
@@ -58,6 +62,8 @@ class MappedHostAllocation:
     def __init__(
         self, shape: tuple[int, ...], dtype: torch.dtype, device: torch.device
     ) -> None:
+        from cuda.bindings import runtime as cudart
+
         self._host_pointer = 0
         self._closed = True
         if device.type != "cuda" or device.index is None:
@@ -102,6 +108,8 @@ class MappedHostAllocation:
                 raise
 
     def close(self) -> None:
+        from cuda.bindings import runtime as cudart
+
         if self._closed:
             return
         torch.cuda.synchronize(self.device)
@@ -265,6 +273,10 @@ class DiskRowCache:
                     self._transaction_thread = None
 
     def read_rows(self, ids: torch.Tensor, count: int) -> None:
+        self._stage_ids(ids, count)
+        self._read_staged(count)
+
+    def _stage_ids(self, ids: torch.Tensor, count: int) -> None:
         if self._transaction_thread != threading.get_ident():
             raise RuntimeError("read_rows requires an active disk row transaction")
         count = operator.index(count)
@@ -282,15 +294,18 @@ class DiskRowCache:
             raise ValueError("disk row IDs do not cover the requested count")
         self.ids_host[:count].copy_(ids.view(-1)[:count], non_blocking=True)
         self._ids_ready.record(self._transaction_stream)
+
+    def _read_staged(self, count: int) -> None:
         # Completes ID production and all prior cache readers before host writes.
-        self._ids_ready.synchronize()
-        self._native.ple_reader_run(
-            self._reader,
-            self._ids_buffer,
-            self._weight_buffer,
-            self._scale_buffer,
-            count,
-        )
+        with torch.cuda.device(self.device):
+            self._ids_ready.synchronize()
+            self._native.ple_reader_run(
+                self._reader,
+                self._ids_buffer,
+                self._weight_buffer,
+                self._scale_buffer,
+                count,
+            )
 
     def stats(self) -> dict[str, int | float]:
         with self._lock:
@@ -311,3 +326,79 @@ class DiskRowCache:
                 + result["cache_bytes"]
             )
             return result
+
+
+class DiskPrefetch:
+    """One in-flight read, retaining its owner's transaction until consumption.
+
+    begin/consume/abort must run on the same host thread outside capture. The
+    caller must not mutate the ID tensor before consume. Only the I/O worker
+    runs concurrently; it never launches the downstream GPU decoder.
+    """
+
+    def __init__(self, cache: DiskRowCache) -> None:
+        self.cache = cache
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="b12x-disk")
+        self._pending = None
+        self._closed = False
+
+    @property
+    def pending(self) -> bool:
+        return self._pending is not None
+
+    def begin(self, ids: torch.Tensor, count: int) -> None:
+        if self._closed or self._pending is not None:
+            raise RuntimeError("disk prefetch is closed or has unconsumed rows")
+        transaction = self.cache.transaction()
+        transaction.__enter__()
+        try:
+            self.cache._stage_ids(ids, count)
+            future = self._executor.submit(self.cache._read_staged, count)
+            self._pending = (future, transaction, threading.get_ident(), ids, count)
+        except BaseException:
+            transaction.__exit__(*sys.exc_info())
+            raise
+
+    @contextmanager
+    def consume(self, ids: torch.Tensor, count: int) -> Iterator[None]:
+        if self._pending is None:
+            raise RuntimeError("disk prefetch has no rows to consume")
+        future, transaction, thread, prepared_ids, prepared_count = self._pending
+        if thread != threading.get_ident():
+            raise RuntimeError("disk prefetch must be consumed on its preparing thread")
+        if ids is not prepared_ids or count != prepared_count:
+            raise ValueError("disk prefetch IDs/count do not match its preparation")
+        with torch.cuda.device(self.cache.device):
+            if torch.compiler.is_compiling() or torch.cuda.is_current_stream_capturing():
+                raise RuntimeError("disk prefetch consume must run outside compile/capture")
+            # transaction records completion on the preparing stream. Requiring
+            # that stream prevents staging reuse before the GPU decoder finishes.
+            if torch.cuda.current_stream(self.cache.device) != self.cache._transaction_stream:
+                raise RuntimeError("disk prefetch must be consumed on its preparing stream")
+            try:
+                future.result()
+                yield
+            finally:
+                self._pending = None
+                transaction.__exit__(*sys.exc_info())
+
+    def abort(self) -> None:
+        if self._pending is None:
+            return
+        future, transaction, thread, _, _ = self._pending
+        if thread != threading.get_ident():
+            raise RuntimeError("disk prefetch must be aborted on its preparing thread")
+        try:
+            future.result()
+        finally:
+            self._pending = None
+            transaction.__exit__(*sys.exc_info())
+
+    def close(self) -> None:
+        if self._pending is not None and self._pending[2] != threading.get_ident():
+            raise RuntimeError("disk prefetch must be closed on its preparing thread")
+        try:
+            self.abort()
+        finally:
+            self._closed = True
+            self._executor.shutdown(wait=True)

--- a/b12x/sequence/engram/_kernels.py
+++ b/b12x/sequence/engram/_kernels.py
@@ -125,6 +125,7 @@ def _lookup(
     START: tl.constexpr,
     END: tl.constexpr,
     COMPACT: tl.constexpr,
+    RESIDENT_SCALES: tl.constexpr,
 ):
     t, head = tl.program_id(0), tl.program_id(1)
     col = tl.arange(0, 256)
@@ -139,8 +140,11 @@ def _lookup(
     quant = tl.load(weight + local_row * 256 + col.to(tl.int64), local, 0.0).to(
         tl.float32
     )
+    scale_row = local_row
+    if RESIDENT_SCALES:
+        scale_row = tl.where(local, row - tl.full((), START, tl.int64), 0)
     exponent = tl.load(
-        scales + local_row * 8 + (col // 32).to(tl.int64), local, 127
+        scales + scale_row * 8 + (col // 32).to(tl.int64), local, 127
     ).to(tl.uint32)
     # E8M0 byte zero is 2^-127, not floating point zero; 255 is NaN.
     scale = (exponent << 23).to(tl.float32, bitcast=True)
@@ -257,6 +261,7 @@ def lookup_op(
     compact_rows: bool = False,
     prepared_tokens: int = -1,
     clear_tail: bool = True,
+    resident_scales: bool = False,
 ) -> None:
     capacity = hashes.shape[0] if prepared_tokens < 0 else prepared_tokens
     if not 0 <= capacity <= hashes.shape[0]:
@@ -274,6 +279,7 @@ def lookup_op(
             shard_start,
             shard_end,
             compact_rows,
+            resident_scales,
             num_warps=4,
         )
     if clear_tail and capacity < hashes.shape[0]:
@@ -293,5 +299,6 @@ def _lookup_fake(
     compact_rows=False,
     prepared_tokens=-1,
     clear_tail=True,
+    resident_scales=False,
 ):
     return None

--- a/b12x/sequence/engram/api.py
+++ b/b12x/sequence/engram/api.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from collections.abc import Sequence
 import operator
+import os
 
 import torch
 
@@ -124,19 +125,35 @@ class DiskTable:
     locate each plane's first byte, including inside a checkpoint container.
     Files must remain immutable for this owner's lifetime. Preparation is
     eager-only; downstream graphs consume the binding's stable BF16 output.
+
+    resident_scales retains the owned original E8M0 bytes in mapped host RAM
+    and removes scale-plane disk reads. prefetch allows one outstanding read
+    per table. Both are opt-in; callers must budget scale RAM and drain reads
+    before reusing request state.
     """
 
     def __init__(
-        self, plan: Plan, shard_rows: int | None = None, queue_depth: int = 128
+        self,
+        plan: Plan,
+        shard_rows: int | None = None,
+        queue_depth: int = 128,
+        *,
+        resident_scales: bool = False,
+        prefetch: bool = False,
     ) -> None:
-        from .._shared.disk_table import DiskRowCache
+        from .._shared.disk_table import DiskPrefetch, DiskRowCache, MappedHostAllocation
 
         if not isinstance(plan, Plan):
             raise TypeError("plan must be Plan")
         if plan.caps.device.type != "cuda":
             raise ValueError("disk Engram requires CUDA")
         _require_disk_eager(plan.caps.device)
+        if not isinstance(resident_scales, bool) or not isinstance(prefetch, bool):
+            raise TypeError("resident_scales and prefetch must be bool")
         self.plan = plan
+        self.resident_scales = resident_scales
+        self._scale_sources: set[int] = set()
+        self._scale_owner = None
         self._cache = DiskRowCache(
             device=plan.caps.device,
             max_lookups=plan.caps.max_tokens * 24,
@@ -145,21 +162,115 @@ class DiskTable:
             shard_end=min(plan.shard_end, plan.table_rows),
             shard_rows=plan.table_rows if shard_rows is None else shard_rows,
             weight_row_bytes=256,
-            scale_row_bytes=8,
+            scale_row_bytes=0 if resident_scales else 8,
             queue_depth=queue_depth,
         )
         self.weight = self._cache.weight.view(torch.float8_e4m3fn)
         self.scale_bytes = self._cache.scale
+        if resident_scales:
+            # Retain the original E8M0 bytes, not decoded/requantized scales.
+            # The caller must budget this allocation: ceil(rows/TP) * 8 bytes.
+            self._scale_owner = MappedHostAllocation(
+                plan.scale_shape, torch.uint8, plan.caps.device
+            )
+            self._scale_owner.host_view.zero_()
+            self.scale_bytes = self._scale_owner.device_view
+        self._prefetch = DiskPrefetch(self._cache) if prefetch else None
+        self._prefetch_binding = None
+
+    @property
+    def prefetch_pending(self) -> bool:
+        """Whether staging is still owned by an unconsumed prefetch."""
+        return self._prefetch is not None and self._prefetch.pending
+
+    def prefetch(self, binding: LookupBinding, token_count: int) -> None:
+        """Start a bounded read; run_lookup consumes it without repeating I/O.
+
+        All IDs and num_tokens must stay immutable until consumption. Independent
+        tables may begin reads before either is consumed. Both calls must be on
+        the same host thread and CUDA stream, outside compilation/capture.
+        """
+        if self._prefetch is None:
+            raise RuntimeError("disk prefetch must be enabled at construction")
+        if binding.disk_table is not self:
+            raise ValueError("binding belongs to another disk table")
+        if self._prefetch_binding is not None:
+            raise RuntimeError("disk table has an unconsumed prefetch")
+        token_count = operator.index(token_count)
+        if not 0 <= token_count <= self.plan.caps.max_tokens:
+            raise ValueError("token_count exceeds planned capacity")
+        self._prefetch.begin(binding.hash_ids, token_count * 24)
+        self._prefetch_binding = binding
+
+    def abort_prefetch(self) -> None:
+        """Drain a failed/cancelled request before its staging can be reused."""
+        try:
+            if self._prefetch is not None:
+                self._prefetch.abort()
+        finally:
+            if self._prefetch is None or not self._prefetch.pending:
+                self._prefetch_binding = None
+
+    def close(self) -> None:
+        """Join any outstanding I/O worker; existing GPU storage stays owned."""
+        try:
+            if self._prefetch is not None:
+                self._prefetch.close()
+        finally:
+            if self._prefetch is None or not self._prefetch.pending:
+                self._prefetch_binding = None
 
     def add_shard(
         self, index: int, path: str, offset: int, *, scale: bool = False
     ) -> None:
         """Register an immutable global source shard before binding."""
-        self._cache.add_shard(index, path, offset, scale=scale)
+        if not (scale and self.resident_scales):
+            self._cache.add_shard(index, path, offset, scale=scale)
+            return
+        with self._cache._lock:
+            if self._cache._frozen:
+                raise RuntimeError("cannot change disk shards after binding")
+            index, offset = operator.index(index), operator.index(offset)
+            if not 0 <= index < self._cache.shard_count or offset < 0:
+                raise ValueError("invalid scale shard index or offset")
+            if index in self._scale_sources:
+                raise ValueError("checkpoint scale shard is already registered")
+            start = index * self._cache.shard_rows
+            end = min(start + self._cache.shard_rows, self.plan.table_rows)
+            first, last = max(start, self.plan.shard_start), min(end, self.plan.shard_end)
+            if first >= last:
+                return
+            view = self._scale_owner.host_view[
+                first - self.plan.shard_start : last - self.plan.shard_start
+            ]
+            data = memoryview(view.numpy()).cast("B")
+            with open(os.fspath(path), "rb", buffering=0) as source:
+                if offset + (end - start) * 8 > os.fstat(source.fileno()).st_size:
+                    raise ValueError("scale plane exceeds checkpoint file bounds")
+                source.seek(offset + (first - start) * 8)
+                done = 0
+                while done < len(data):
+                    count = source.readinto(data[done : done + (16 << 20)])
+                    if not count:
+                        raise ValueError("short resident Engram scale read")
+                    done += count
+            self._scale_sources.add(index)
+
+    def _require_complete(self) -> None:
+        self._cache.require_complete()
+        if self.resident_scales:
+            first = self._cache.shard_start // self._cache.shard_rows
+            last = (self._cache.shard_end + self._cache.shard_rows - 1) // self._cache.shard_rows
+            for shard in range(first, last):
+                if shard not in self._scale_sources:
+                    raise ValueError(f"missing resident scale shard {shard}")
 
     def stats(self) -> dict[str, int | float]:
         """Return shared reader counters and batch-bounded staging sizes."""
-        return self._cache.stats()
+        result = self._cache.stats()
+        result["resident_scale_bytes"] = self._scale_owner.nbytes if self._scale_owner else 0
+        result["owned_host_bytes"] = result["owned_staging_bytes"] + result["resident_scale_bytes"]
+        return result
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -354,9 +465,11 @@ def bind_lookup(
         if weight is not None or scales is not None:
             raise ValueError("disk lookup requires weight=None and scales=None")
         _require_disk_eager(c.device)
-        disk_table._cache.require_complete()
+        disk_table._require_complete()
         weight, scales = disk_table.weight, disk_table.scale_bytes
         weight_shape, scale_shape = (c.max_tokens * 24, 256), (c.max_tokens * 24, 8)
+        if disk_table.resident_scales:
+            scale_shape = plan.scale_shape
     else:
         if weight is None or scales is None:
             raise ValueError("resident lookup requires weight and scales")
@@ -469,21 +582,34 @@ def run_lookup(
     else:
         _require_disk_eager(p.caps.device)
         cache = b.disk_table._cache
-        with cache.transaction():
-            cache.read_rows(b.hash_ids, prepared * 24)
-            lookup_op(
-                b.weight,
-                b.scale_bytes,
-                b.hash_ids,
-                b.num_tokens,
-                b.out,
-                p.table_rows,
-                p.shard_start,
-                p.shard_end,
-                compact_rows=True,
-                prepared_tokens=prepared,
-                clear_tail=clear_tail,
-            )
+        prefetched = b.disk_table._prefetch_binding
+        if prefetched is not None and prefetched is not b:
+            raise ValueError("disk table has a prefetch for a different binding")
+        context = (
+            b.disk_table._prefetch.consume(b.hash_ids, prepared * 24)
+            if prefetched is not None else cache.transaction()
+        )
+        try:
+            with context:
+                if prefetched is None:
+                    cache.read_rows(b.hash_ids, prepared * 24)
+                lookup_op(
+                    b.weight,
+                    b.scale_bytes,
+                    b.hash_ids,
+                    b.num_tokens,
+                    b.out,
+                    p.table_rows,
+                    p.shard_start,
+                    p.shard_end,
+                    compact_rows=True,
+                    resident_scales=b.disk_table.resident_scales,
+                    prepared_tokens=prepared,
+                    clear_tail=clear_tail,
+                )
+        finally:
+            if prefetched is not None and not b.disk_table._prefetch.pending:
+                b.disk_table._prefetch_binding = None
     return b.out
 
 

--- a/tests/sequence/test_engram.py
+++ b/tests/sequence/test_engram.py
@@ -13,6 +13,115 @@ from b12x._lib.runtime_control import (
 from ..conftest import require_b12x
 
 
+@pytest.mark.parametrize("fail_read", [False, True])
+def test_disk_prefetch_host_lifetime_drains_before_reuse(monkeypatch, fail_read):
+    """CPU state test: even a failed read must release its retained transaction."""
+    from concurrent.futures import ThreadPoolExecutor
+    from contextlib import contextmanager, nullcontext
+    from threading import Event
+    from b12x.sequence._shared.disk_table import DiskPrefetch
+
+    started, finish = Event(), Event()
+    stream = object()
+    monkeypatch.setattr(torch.cuda, "device", lambda *_: nullcontext())
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda *_: stream)
+
+    class Cache:
+        device = "cuda:0"
+        _transaction_stream = stream
+        active = False
+
+        @contextmanager
+        def transaction(self):
+            assert not self.active
+            self.active = True
+            try:
+                yield self
+            finally:
+                self.active = False
+
+        def _stage_ids(self, ids, count):
+            assert self.active
+
+        def _read_staged(self, count):
+            assert self.active
+            started.set()
+            assert finish.wait(timeout=5)
+            if fail_read:
+                raise OSError("injected I/O error")
+
+    cache, ids = Cache(), object()
+    prefetch = DiskPrefetch(cache)
+    try:
+        prefetch.begin(ids, 6)
+        assert started.wait(timeout=5)
+        assert cache.active and prefetch.pending
+        with pytest.raises(RuntimeError, match="unconsumed"):
+            prefetch.begin(ids, 6)
+        with (
+            pytest.raises(ValueError, match="do not match"),
+            prefetch.consume(ids, 5),
+        ):
+            pytest.fail("wrong count was accepted")
+        with (
+            ThreadPoolExecutor(max_workers=1) as pool,
+            pytest.raises(RuntimeError, match="preparing thread"),
+        ):
+            pool.submit(prefetch.abort).result(timeout=5)
+        finish.set()
+        if fail_read:
+            with pytest.raises(OSError, match="injected"):
+                prefetch.abort()
+        else:
+            with prefetch.consume(ids, 6):
+                assert cache.active
+        assert not cache.active and not prefetch.pending
+        fail_read = False
+        prefetch.begin(ids, 6)
+        with prefetch.consume(ids, 6):
+            assert cache.active
+        assert not cache.active
+    finally:
+        finish.set()
+        prefetch.close()
+
+
+def test_disk_prefetch_submission_failure_releases_transaction(monkeypatch):
+    from contextlib import contextmanager
+    from b12x.sequence._shared.disk_table import DiskPrefetch
+
+    class Cache:
+        active = False
+
+        @contextmanager
+        def transaction(self):
+            self.active = True
+            try:
+                yield
+            finally:
+                self.active = False
+
+        def _stage_ids(self, *args):
+            assert self.active
+
+        def _read_staged(self, *args):
+            pytest.fail("failed submission must not execute the reader")
+
+    def fail_submit(*args):
+        raise RuntimeError("injected submit error")
+
+    cache = Cache()
+    prefetch = DiskPrefetch(cache)
+    try:
+        monkeypatch.setattr(prefetch._executor, "submit", fail_submit)
+        with pytest.raises(RuntimeError, match="injected"):
+            prefetch.begin(object(), 6)
+        assert not cache.active and not prefetch.pending
+    finally:
+        prefetch.close()
+
+
 def _plan(device, *, layer=1, tokens=7, rank=0, tp=2, base=101):
     geometry = engram.build_geometry(base_table_size=base, compressed_vocab_size=32)
     return engram.plan(
@@ -308,7 +417,10 @@ def test_e8m0_extreme_bytes_and_missing_nan_row():
     assert torch.count_nonzero(out.view(24, 256)[2::3]) == 0
 
 
-def _disk_lookup_pair(plan, tmp_path, *, shard_rows=None, extreme_scales=False):
+def _disk_lookup_pair(
+    plan, tmp_path, *, shard_rows=None, extreme_scales=False,
+    resident_scales=False, prefetch=False,
+):
     rows = torch.arange(plan.table_rows)
     weight = ((rows[:, None] % 7 + 1) * torch.tensor([1, -1]).repeat(128)[None, :]).to(
         torch.float8_e4m3fn
@@ -323,7 +435,10 @@ def _disk_lookup_pair(plan, tmp_path, *, shard_rows=None, extreme_scales=False):
         .expand(plan.table_rows, -1)
         .contiguous()
     )
-    table = engram.DiskTable(plan, shard_rows=shard_rows, queue_depth=4)
+    table = engram.DiskTable(
+        plan, shard_rows=shard_rows, queue_depth=4,
+        resident_scales=resident_scales, prefetch=prefetch,
+    )
     source_rows = plan.table_rows if shard_rows is None else shard_rows
     for scale, payload, offset in ((False, weight, 4093), (True, scales, 19)):
         for index, start in enumerate(range(0, plan.table_rows, source_rows)):
@@ -368,13 +483,15 @@ def _disk_lookup_pair(plan, tmp_path, *, shard_rows=None, extreme_scales=False):
 @torch.inference_mode()
 @pytest.mark.parametrize("rank", [0, 3])
 @pytest.mark.parametrize("shard_rows", [None, 31])
+@pytest.mark.parametrize("resident_scales", [False, True])
 def test_disk_separate_planes_duplicates_tp_edges_and_raw_e8m0(
-    rank, shard_rows, tmp_path
+    rank, shard_rows, resident_scales, tmp_path
 ):
     device = require_b12x()
     p = _plan(device, tokens=3, rank=rank, tp=4, base=2)
     resident, disk = _disk_lookup_pair(
-        p, tmp_path, shard_rows=shard_rows, extreme_scales=True
+        p, tmp_path, shard_rows=shard_rows, extreme_scales=True,
+        resident_scales=resident_scales,
     )
     edge = (p.shard_start // 31 + 1) * 31
     row_ids = [
@@ -418,6 +535,49 @@ def test_disk_separate_planes_duplicates_tp_edges_and_raw_e8m0(
             assert torch.count_nonzero(disk.out[prepared:]) == 0
     with pytest.raises(ValueError):
         engram.run_lookup(disk, token_count=4)
+    stats = disk.disk_table.stats()
+    assert stats["resident_scale_bytes"] == (p.shard_rows * 8 if resident_scales else 0)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("resident_scales", [False, True])
+def test_disk_prefetch_matches_sync_and_recovers_after_read_failure(
+    resident_scales, tmp_path, monkeypatch,
+):
+    device = require_b12x()
+    p = _plan(device, tokens=3, tp=4, base=2)
+    resident, disk = _disk_lookup_pair(
+        p, tmp_path, resident_scales=resident_scales, prefetch=True,
+    )
+    table = disk.disk_table
+    disk.hash_ids.fill_(p.shard_start)
+    expected = engram.run_lookup(resident).clone()
+    try:
+        table.prefetch(disk, token_count=3)
+        with pytest.raises(RuntimeError, match="unconsumed"):
+            table.prefetch(disk, token_count=3)
+        with pytest.raises(ValueError, match="count do not match"):
+            engram.run_lookup(disk, token_count=2)
+        torch.testing.assert_close(engram.run_lookup(disk), expected, rtol=0, atol=0)
+        table.prefetch(disk, token_count=3)
+        table.abort_prefetch()
+        disk.hash_ids.fill_(p.shard_start + 5)
+        expected = engram.run_lookup(resident).clone()
+        table.prefetch(disk, token_count=3)
+        torch.testing.assert_close(engram.run_lookup(disk), expected, rtol=0, atol=0)
+
+        def fail_read(*args):
+            raise OSError("injected read failure")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(table._cache, "_read_staged", fail_read)
+            table.prefetch(disk, token_count=3)
+            with pytest.raises(OSError, match="injected"):
+                engram.run_lookup(disk)
+        table.prefetch(disk, token_count=3)
+        torch.testing.assert_close(engram.run_lookup(disk), expected, rtol=0, atol=0)
+    finally:
+        table.close()
 
 
 @torch.inference_mode()


### PR DESCRIPTION
Keep original E8M0 scale bytes in host RAM while Engram payloads stay on NVMe, and allow bounded prefetch across independent tables. Both options are opt-in; original-scale residency uses about 5.72 GiB host RAM for this TP4 model. Staging remains owned until consumption or abort. Prefetch overlaps table reads before target execution. Companion: [vLLM #736](https://github.com/local-inference-lab/vllm/pull/736).

Matched R37 comparison; **+ PRs means #360 and #736 together**. Four RTX PRO 6000 Max-Q GPUs, 300 W, memory +6000; TP4/DCP1, native precision, NVMe Engram, K7/adaptive, batch 4096, maxseq 32, 1M context, utilization 0.97, full target/draft graphs through 256. All four arms include R37’s existing dispatch/prefill improvements.

| Metric | R37 greedy | R37 probabilistic | + PRs greedy | + PRs probabilistic |
|---|---:|---:|---:|---:|
| 32K uncached prefill, client | 12,754 | 12,882 | 13,720 | 13,729 |
| C1 decode | 182.5 | 163.5 | 208.7 | 229.6 |
| C1 verifier steps/s | 69.1 | 69.8 | 82.9 | 82.4 |
| Pagoda thinking median | 178.1 | 205.2 | 218.8 | 261.3 |
| Sieve median | 274.8 | 297.1 | 318.5 | 337.3 |
| C32 aggregate decode | 1,106.5 | 1,147.6 | 1,226.2 | 1,220.1 |

Tok/s unless marked otherwise. llm_decode_bench 0.4.34: one 30s decode cell per concurrency after 15s warmup, context 0, T1/top-p.95/high75; 32K prefill has 2–3 uncached samples. Thinking: three 35s runs, first 3s excluded, max100/top-p1. Sieve: five runs after one warmup, 2000-token cap, normal EOS. Output includes reasoning tokens.

All C1–C32 cells passed isolation checks with zero errors/queues. Each arm passed 3 seeded answer checks and 32/32 concurrent badge checks. No reduced model precision; full model equivalence and individual PR ablations remain unmeasured.

16 B12X + 23 companion vLLM GPU checks passed on the R37 candidate; Ruff/diff checks passed.

<details>
<summary>GPU test command</summary>

```sh
/opt/venv/bin/python -m pytest --confcutdir=tests -p no:cacheprovider -x -q tests/sequence/test_engram.py -k 'disk or host_lifetime or submission_failure'
```

</details>

AI-assisted implementation/testing; owner requested ready-for-review status. The R37 source audit found these changes absent from the release; its dispatch/attention optimizations address different paths.
