### PR TITLE
fix(gemm): support K32-aligned block-FP8 TP shards

### DIFF
--- a/b12x/_lib/quant/mxfp8_rows.py
+++ b/b12x/_lib/quant/mxfp8_rows.py
@@ -43,8 +43,10 @@ class _MXFP8RowsQuantLaunch:
         threads: int,
         trellis_native_mma_order: bool,
         min_amax: float,
+        source_k: int,
     ) -> None:
         self._k = int(k)
+        self._source_k = int(source_k)
         self._groups_k = self._k // 32
         self._source_type = source_type
         self._subgroup_width = int(subgroup_width)
@@ -66,7 +68,7 @@ class _MXFP8RowsQuantLaunch:
     ) -> None:
         source = cute.make_tensor(
             source_ptr,
-            cute.make_ordered_layout((m, self._k), order=(1, 0)),
+            cute.make_ordered_layout((m, self._source_k), order=(1, 0)),
         )
         values_u32 = cute.make_tensor(
             values_ptr,
@@ -116,7 +118,7 @@ class _MXFP8RowsQuantLaunch:
                     values = cute.make_rmem_tensor((8,), cutlass.Float32)
                     k0 = group * Int32(32) + lane8 * Int32(8)
                     for elem in cutlass.range_constexpr(8):
-                        values[elem] = cutlass.Float32(source[row, k0 + Int32(elem)])
+                        values[elem] = self._load(source, row, k0 + Int32(elem))
 
                     max_abs = fabs_f32(values[0])
                     for elem in cutlass.range_constexpr(1, 8):
@@ -188,16 +190,14 @@ class _MXFP8RowsQuantLaunch:
                             )
                             tile = Int32(16)
                         base = k0 + tile + (r << Int32(1))
-                        values[0] = cutlass.Float32(source[row, base])
-                        values[1] = cutlass.Float32(source[row, base + Int32(1)])
-                        values[2] = cutlass.Float32(source[row, base + Int32(8)])
-                        values[3] = cutlass.Float32(source[row, base + Int32(9)])
+                        values[0] = self._load(source, row, base)
+                        values[1] = self._load(source, row, base + Int32(1))
+                        values[2] = self._load(source, row, base + Int32(8))
+                        values[3] = self._load(source, row, base + Int32(9))
                     else:
                         k0 += lane4 * Int32(4)
                         for elem in cutlass.range_constexpr(4):
-                            values[elem] = cutlass.Float32(
-                                source[row, k0 + Int32(elem)]
-                            )
+                            values[elem] = self._load(source, row, k0 + Int32(elem))
 
                     max_abs = fabs_f32(values[0])
                     for elem in cutlass.range_constexpr(1, 4):
@@ -236,7 +236,7 @@ class _MXFP8RowsQuantLaunch:
                 values = cute.make_rmem_tensor((32,), cutlass.Float32)
                 k0 = group * Int32(32)
                 for elem in cutlass.range_constexpr(32):
-                    values[elem] = cutlass.Float32(source[row, k0 + Int32(elem)])
+                    values[elem] = self._load(source, row, k0 + Int32(elem))
 
                 max_abs = max_abs_32(values)
                 if cutlass.const_expr(self._min_amax > 0.0):
@@ -250,6 +250,16 @@ class _MXFP8RowsQuantLaunch:
                     values_u32[row, word0 + Int32(word)] = payload[word]
                 self._store_scale(scale_rows, scale_mma, row, group, scale_byte)
                 block += Int32(gdim) * Int32(self._threads)
+
+    @cute.jit
+    def _load(self, source: cute.Tensor, row: Int32, column: Int32) -> cutlass.Float32:
+        value = cutlass.Float32(0.0)
+        # Aligned kernels eliminate the mask at compile time.
+        if cutlass.const_expr(self._source_k == self._k):  # noqa: SIM114
+            value = cutlass.Float32(source[row, column])
+        elif column < Int32(self._source_k):
+            value = cutlass.Float32(source[row, column])
+        return value
 
     @cute.jit
     def _store_scale(
@@ -285,10 +295,14 @@ def _get_compiled_mxfp8_rows_quant(
     threads: int,
     value_order: str,
     min_amax: float = 0.0,
+    source_k: int | None = None,
 ) -> Callable:
     k = int(k)
+    source_k = k if source_k is None else int(source_k)
     if k <= 0 or k % 32 != 0:
         raise ValueError(f"MXFP8 CuTe quantizer requires K divisible by 32, got {k}")
+    if source_k <= 0 or source_k % 32 or source_k > k:
+        raise ValueError(f"MXFP8 source K must be K32-aligned and within output K={k}, got {source_k}")
     if source_dtype == torch.bfloat16:
         source_type = cutlass.BFloat16
         source_dtype_name = "bf16"
@@ -325,6 +339,7 @@ def _get_compiled_mxfp8_rows_quant(
         threads,
         value_order == "trellis_native_mma",
         min_amax,
+        source_k,
     )
     cache_key = (
         k,
@@ -333,6 +348,7 @@ def _get_compiled_mxfp8_rows_quant(
         int(threads),
         value_order,
         min_amax,
+        source_k,
     )
     raise_if_kernel_resolution_frozen(
         "cute.compile",
@@ -350,7 +366,7 @@ def _get_compiled_mxfp8_rows_quant(
         current_cuda_stream(),
         compile_spec=KernelCompileSpec.from_key(
             "gemm.mxfp8_quant_cute",
-            4,
+            5,
             cache_key,
         ),
     )
@@ -426,6 +442,8 @@ def quantize_mxfp8_rows_cute(
 
     expected_m fixes the row bound used for lane-layout specialization.
     min_amax=1e-4 selects the DeepSeek V4.1 activation scale floor.
+    Output rows may be wider than the source by whole K32 groups. The same
+    kernel writes zero payloads and finite scales for that physical K tail.
     """
 
     if source.dtype not in (torch.bfloat16, torch.float16):
@@ -444,12 +462,13 @@ def quantize_mxfp8_rows_cute(
     else:
         subgroup_width = _WARP_SUBGROUP_WIDTH
     _get_compiled_mxfp8_rows_quant(
-        int(source.shape[1]),
+        int(values.shape[1]),
         source.dtype,
         subgroup_width,
         threads,
         value_order,
         min_amax,
+        int(source.shape[1]),
     )(
         source,
         values,

--- a/b12x/gemm/_shared/block_fp8.py
+++ b/b12x/gemm/_shared/block_fp8.py
@@ -62,6 +62,11 @@ class BlockFP8LinearWeight:
     out_features: int
     block_size: tuple[int, int]
 
+    @property
+    def padded_in_features(self) -> int:
+        """Physical GEMM width; in_features retains the checkpoint's TP shard."""
+        return int(self.weight.values.shape[1])
+
 
 @dataclass(frozen=True, kw_only=True)
 class BlockFP8LinearBinding:
@@ -96,8 +101,8 @@ class BlockFP8LinearScratchCaps:
         object.__setattr__(self, "max_tokens", max(int(self.max_tokens), 1))
         object.__setattr__(self, "in_features", max(int(self.in_features), 1))
         object.__setattr__(self, "out_features", max(int(self.out_features), 1))
-        _check_mxfp8_k(self.in_features)
         object.__setattr__(self, "block_size", _check_block_size(self.block_size))
+        _block_fp8_padded_k(self.in_features, self.block_size)
         if self.output_dtype not in (torch.bfloat16, torch.float16):
             raise ValueError(f"output_dtype must be bf16/fp16, got {self.output_dtype}")
 
@@ -157,7 +162,7 @@ class BlockFP8LinearScratchPlan:
         x_q = _block_fp8_linear_x_q_from_scratch(
             scratch,
             tokens=tokens,
-            in_features=self.caps.in_features,
+            in_features=_block_fp8_padded_k(self.caps.in_features, self.caps.block_size),
             output_dtype=self.caps.output_dtype,
         )
         return build_block_fp8_linear_binding(
@@ -199,6 +204,14 @@ def _c_dtype_name(dtype: torch.dtype) -> str:
     raise ValueError(
         f"b12x block FP8 linear output dtype must be bf16/fp16, got {dtype}"
     )
+
+
+def _block_fp8_padded_k(k: int, block_size: tuple[int, int]) -> int:
+    if k <= 0 or k % block_size[1]:
+        raise ValueError(
+            f"block FP8 linear K must be a positive multiple of {block_size[1]}, got {k}"
+        )
+    return _align_up(k, 128)
 
 
 def _dtype_nbytes(dtype: torch.dtype) -> int:
@@ -353,7 +366,7 @@ def _check_block_fp8_linear_tensors(
     _check_mxfp8_rows_storage(
         x_q,
         m=tokens,
-        k=packed_weight.in_features,
+        k=packed_weight.padded_in_features,
         num_groups=1,
     )
     if output.shape != (tokens, packed_weight.out_features, 1):
@@ -428,7 +441,7 @@ def plan_block_fp8_linear_scratch(
     )
     layout = _block_fp8_linear_scratch_layout(
         tokens=caps.max_tokens,
-        in_features=caps.in_features,
+        in_features=_block_fp8_padded_k(caps.in_features, caps.block_size),
         out_features=caps.out_features,
         output_dtype=caps.output_dtype,
     )
@@ -457,6 +470,8 @@ def pack_block_fp8_linear_weight_mxfp8(
 
     The checkpoint weight stays in E4M3 for UE8M0 scales. The 128x128 DSV4 or
     32x32 DSV4.1 scales expand once into the row/32-column SM120 MMA layout.
+    K32-aligned TP shards retain their logical width; zero weight columns and
+    unit scales extend the physical GEMM width to a multiple of 128.
     """
 
     _check_gpu_tensor("weight", weight)
@@ -465,14 +480,40 @@ def pack_block_fp8_linear_weight_mxfp8(
     if weight.ndim != 2:
         raise ValueError(f"weight must have shape [N,K], got {tuple(weight.shape)}")
     out_features, in_features = weight.shape
-    _check_mxfp8_k(in_features)
+    padded_k = _block_fp8_padded_k(in_features, block_size)
     if out_features <= 0:
         raise ValueError("out_features must be positive")
+    if padded_k != in_features:
+        if weight.dtype != torch.float8_e4m3fn:
+            raise ValueError(f"weight must be float8_e4m3fn, got {weight.dtype}")
+        scale_shape = (math.ceil(out_features / block_size[0]), in_features // block_size[1])
+        if weight_scale.shape not in (scale_shape, (1, *scale_shape)):
+            raise ValueError(
+                f"block scale must have shape {scale_shape} or {(1, *scale_shape)}, "
+                f"got {tuple(weight_scale.shape)}"
+            )
+        # Packing is load-time only. Preserve every serialized byte and TP
+        # shard offset; the runtime quantizer writes the activation tail.
+        weight_bytes = torch.zeros(
+            (out_features, padded_k), dtype=torch.uint8, device=weight.device
+        )
+        weight_bytes[:, :in_features].copy_(weight.view(torch.uint8))
+        weight = weight_bytes.view(torch.float8_e4m3fn)
+        byte_scales = weight_scale.dtype in (torch.uint8, torch.float8_e8m0fnu)
+        scale_source = weight_scale.view(torch.uint8) if byte_scales else weight_scale
+        scale_padded = torch.full(
+            (*weight_scale.shape[:-1], padded_k // block_size[1]),
+            127 if byte_scales else 1.0,
+            dtype=scale_source.dtype,
+            device=weight_scale.device,
+        )
+        scale_padded[..., :scale_shape[-1]].copy_(scale_source)
+        weight_scale = scale_padded.view(weight_scale.dtype)
     packed = pack_fp8_block_scaled_weight_mxfp8(
         weight.detach(),
         weight_scale.detach(),
         m=out_features,
-        k=in_features,
+        k=padded_k,
         num_groups=1,
         block_size=block_size,
     )
@@ -574,7 +615,7 @@ def quantize_block_fp8_linear_input_mxfp8(
     tokens, in_features = source_tk.shape
     if tokens <= 0:
         raise ValueError("tokens must be positive")
-    _check_mxfp8_k(in_features)
+    in_features = _block_fp8_padded_k(in_features, block_size)
     if out is None:
         values_base, scale_rows_base, scale_physical_base = (
             torch.ops.b12x.quantize_block_fp8_linear_input_mxfp8_alloc(
@@ -613,6 +654,7 @@ def _quantize_block_fp8_linear_input_for_immediate_gemm(
     """
 
     tokens, in_features = source_tk.shape
+    in_features = _align_up(in_features, 128)
     values_base, scale_rows_base, scale_physical_base = empty_mxfp8_rows_bases(
         tokens,
         in_features,
@@ -780,7 +822,7 @@ def block_fp8_linear_mxfp8(
             packed_weight.weight.values,
             packed_weight.weight.scale_rows,
             packed_weight.weight.scale_mma,
-            packed_weight.in_features,
+            packed_weight.padded_in_features,
             packed_weight.out_features,
             int(expected_m) if expected_m is not None else 0,
             packed_weight.block_size[1] == 128,
@@ -838,11 +880,11 @@ def block_fp8_linear_mxfp8(
     )
     t_quant = time.perf_counter() if _B12X_TIMING else 0.0
     output = dense_gemm(
-        (x_q.values.reshape(tokens, packed_weight.in_features, 1), x_q.scale_mma),
+        (x_q.values.reshape(tokens, packed_weight.padded_in_features, 1), x_q.scale_mma),
         (
             packed_weight.weight.values.reshape(
                 packed_weight.out_features,
-                packed_weight.in_features,
+                packed_weight.padded_in_features,
                 1,
             ),
             packed_weight.weight.scale_mma,

--- a/b12x/gemm/block_fp8_linear/_policy.py
+++ b/b12x/gemm/block_fp8_linear/_policy.py
@@ -95,10 +95,10 @@ def _validate(
         raise ValueError("unsupported block-FP8 MMA tile")
     if query.output_dtype not in ("bfloat16", "float16"):
         raise ValueError(f"unsupported output dtype {query.output_dtype!r}")
-    if query.in_features % 128:
-        raise ValueError("block-FP8 in_features must be a multiple of 128")
     if query.weight_block_size not in (32, 128):
         raise ValueError("block-FP8 weight_block_size must be 32 or 128")
+    if query.in_features <= 0 or query.in_features % query.weight_block_size:
+        raise ValueError("block-FP8 in_features must be a positive multiple of the weight block size")
 
 
 BLOCK_FP8_LINEAR_POLICY = ComponentPolicy(

--- a/tests/gemm/test_gemm_block_fp8_linear.py
+++ b/tests/gemm/test_gemm_block_fp8_linear.py
@@ -535,7 +535,8 @@ def test_block_fp8_linear_expected_m_short_k_large_n_matches_reference() -> None
     "tokens,in_features,out_features",
     [(1, 5120, 1280), (8, 5120, 512), (9, 256, 96),
      (129, 256, 160), (33, 1280, 8192), (7, 1024, 5120),
-     (9, 6144, 25600)],
+     (9, 6144, 25600), (1, 32, 256), (1, 576, 5120),
+     (8, 576, 5120), (17, 576, 5120), (4096, 576, 5120)],
 )
 def test_block_fp8_linear_v41_independent_k32_n32_scales(
     tokens: int, in_features: int, out_features: int,
@@ -551,7 +552,7 @@ def test_block_fp8_linear_v41_independent_k32_n32_scales(
     weight, scale = _make_block_fp8_weight(out_features, in_features, 32)
     packed = bfl.pack_weight(weight, scale, block_size=(32, 32))
     torch.testing.assert_close(
-        packed.weight.values.view(torch.uint8), weight.view(torch.uint8),
+        packed.weight.values[:, :in_features].view(torch.uint8), weight.view(torch.uint8),
         rtol=0, atol=0,
     )
     from tests.gemm.test_fp8_quant_deepgemm_parity import (
@@ -561,19 +562,73 @@ def test_block_fp8_linear_v41_independent_k32_n32_scales(
     x_values, x_scales = _per_token_cast_to_fp8(source, 32)
     x_q = bfl.quantize_input(source, block_size=(32, 32))
     torch.testing.assert_close(
-        x_q.values.view(torch.uint8), x_values.view(torch.uint8), rtol=0, atol=0,
+        x_q.values[:, :in_features].view(torch.uint8), x_values.view(torch.uint8), rtol=0, atol=0,
     )
     torch.testing.assert_close(
-        x_q.scale_rows.view(torch.uint8)[0], _sf_fp32_to_e8m0_u8(x_scales),
+        x_q.scale_rows.view(torch.uint8)[0, :, :in_features // 32], _sf_fp32_to_e8m0_u8(x_scales),
         rtol=0, atol=0,
     )
     torch.testing.assert_close(
-        packed.weight.scale_rows.view(torch.uint8)[0],
+        packed.weight.scale_rows.view(torch.uint8)[0, :, :in_features // 32],
         scale.view(torch.uint8).repeat_interleave(32, dim=0)[:out_features],
         rtol=0, atol=0,
     )
     actual = bfl.run(source, packed, expected_m=tokens)
     _assert_v41_accumulation_matches_reference(source, weight, scale, actual)
+    assert packed.in_features == in_features
+    assert packed.padded_in_features == (in_features + 127) // 128 * 128
+    assert not torch.count_nonzero(packed.weight.values[:, in_features:].view(torch.uint8))
+    assert not torch.count_nonzero(x_q.values[:, in_features:].view(torch.uint8))
+    assert torch.isfinite(x_q.scale_rows.float()).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_block_fp8_linear_k32_tail_scratch_graph_replay(dtype) -> None:
+    """TP shard padding is rewritten in caller scratch on every graph replay."""
+    require_b12x()
+    torch.manual_seed(1337)
+    capacity, in_features, out_features = 128, 576, 5120
+    source = torch.randn((capacity, in_features), device="cuda", dtype=dtype).mul_(0.25)
+    weight, scale = _make_block_fp8_weight(out_features, in_features, 32)
+    packed = bfl.pack_weight(weight, scale, block_size=(32, 32))
+    plan = bfl.plan(bfl.Caps(
+        device=source.device, max_tokens=capacity, in_features=in_features,
+        out_features=out_features, output_dtype=dtype, block_size=(32, 32),
+    ))
+    scratch = tuple(torch.empty(shape, dtype=dt, device=source.device)
+                    for shape, dt in plan.shapes_and_dtypes())
+    output = torch.empty((capacity, out_features, 1), device=source.device, dtype=dtype)
+    # Warm both the planned and functional paths at one fixed capacity. Live
+    # row counts must not create another compiled specialization afterward.
+    plan.bind(scratch=scratch, source=source, packed_weight=packed, output=output).run()
+    bfl.run(source, packed, expected_m=capacity)
+    torch.cuda.synchronize()
+    freeze_kernel_resolution()
+    try:
+        for tokens in (1, 8, 17, 128):
+            live_source, live_output = source[:tokens], output[:tokens]
+            binding = plan.bind(scratch=scratch, source=live_source,
+                                packed_weight=packed, output=live_output)
+            binding.run()
+            torch.cuda.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                binding.run()
+            for poison in (0, 255):
+                for storage in scratch:
+                    storage.fill_(poison)
+                live_source.neg_()
+                graph.replay()
+                torch.cuda.synchronize()
+                _assert_v41_accumulation_matches_reference(
+                    live_source, weight, scale, live_output[:, :, 0],
+                )
+                assert not torch.count_nonzero(binding.x_q.values[:, in_features:].view(torch.uint8))
+                assert torch.isfinite(binding.x_q.scale_rows.float()).all()
+                functional = bfl.run(live_source, packed, expected_m=capacity)
+                _assert_v41_accumulation_matches_reference(live_source, weight, scale, functional)
+    finally:
+        unfreeze_kernel_resolution()
 
 
 def test_block_fp8_linear_v41_rejects_lossy_weight_scale_repacking() -> None:


### PR DESCRIPTION
## Behavior

Block-FP8 linear projections accept checkpoint shards whose input width is a
multiple of their 32-column scale block, even when it is not a multiple of the
128-column MXFP8 GEMM tile. The logical input width and tensor-parallel shard
offsets remain unchanged.

DeepSeek V4.1 Flash has a 2,304-wide shared expert. At TP4 its row-parallel
down projection has K=576. B12X master `081b2359` rejects that valid checkpoint
shape after loading the model because its block-FP8 packer requires K128.
The standalone TP loading regression also exposes the same defect at K=32.

## Implementation and compatibility

- Pad packed weights to K640 for the K576 shard, preserving serialized FP8
  values and UE8M0 scales. Additional weight columns are zero with unit scales.
- Quantize the logical activation directly into physically padded caller-owned
  scratch. The existing CuTe quantization launch writes the zero tail and
  finite scales; there is no separate runtime padding copy or fill.
- Keep the aligned K128 path mask-free through compile-time specialization.
- Size and validate the scratch and GEMM operands by physical width, while
  public input validation and policy queries retain the logical model width.
- Preserve the FP8 activation-scale floor, exact UE8M0 requirement, functional
  compile path, and caller-owned graph replay contract. No backend fallback or
  vLLM tensor-parallel loader change is introduced.

## Validation

Qualified on RTX PRO 6000 Workstation (SM120), CUDA 13.3 / PyTorch 2.13:

- 105 B12X tests pass: block-FP8 GEMM, scratch/capacity/policy, quantization
  parity, and DeepSeek V4.1 experts.
- 11 vLLM tests pass at JJ `377c93be`: TP4 shard loading and graph replay,
  the independent MoE oracle, mapped-RAM Engram aliases, capacity accounting,
  and checkpoint descriptor loading.
- Added independent K32-scale tests for K32 and K576, including
  `[4096,576] @ [5120,576].T`, BF16/FP16 poisoned-scratch graph replay, and
  multiple live row counts with kernel resolution frozen after warmup.
- Ruff and `git diff --check` pass.

The isolated vLLM TP fixture uses native NCCL because it captures a raw Torch
graph without a model-owned B12X collective pool. The separate serving test
below qualifies B12X PCIe graph capture. GB10 is not qualified.

## Serving qualification

The source-locked two-layer image contains unmodified vLLM JJ `377c93be`
and B12X `fcecbfe6` (master `081b2359` plus this PR), without source mounts.
All tracked files and modes match the Git trees. Local image ID:
`sha256:da403ee8ceff7b510aeae1a04ca751478b2413099cfde4b45b99b96397ea0bd4`.

Native DeepSeek V4.1 Flash starts at TP4/DCP1 with DSpark K7, 188.833 GiB
mapped pinned host-RAM Engram tables, 4,096 scheduler tokens, OMP8,
NCCL16/2 MiB, and B12X attention/MoE/linear/PCIe collectives. Target
PIECEWISE/FULL and DSpark FULL graph captures succeed. Deterministic arithmetic
and pigeon-image smoke requests pass, and the service stays healthy.

Two warmed C1/context-zero runs (15-second warmup, 30-second cells) on the
same RTX PRO 6000 quartet at +6000 VRAM, temperature 1/top-p 0.95:

| Measurement | Run 1 | Run 2 |
|---|---:|---:|
| Output tok/s | 237.57 | 240.98 |
| Verifier steps/s | 92.04 | 90.89 |
| Emitted tokens per step | 2.581 | 2.652 |
| Uncached 32K prefill tok/s, median | 12,836.71 | 13,332.42 |

Each prefill repetition includes an excluded warmup and 30 measured seconds
(12 and 13 requests respectively). Every request computes 32,768 tokens,
with zero cache reuse or external restore. No request errors or recorded GPU
throttle masks occur. These numbers qualify the complete serving composition;
they are not an isolated speedup claim for padding, since master alone cannot
start this TP4 model shape.
